### PR TITLE
feat: widen project check

### DIFF
--- a/internal/deploy/project_checks/project_checks.go
+++ b/internal/deploy/project_checks/project_checks.go
@@ -15,7 +15,7 @@ func isPlatformMissing(platform string) bool {
 }
 
 func isPlatformMismatch(platform string) bool {
-	return !strings.EqualFold(platform, linuxArm64Platform)
+	return !strings.HasPrefix(platform, linuxArm64Platform)
 }
 
 func EnsureProjectIsLinuxArm64Ready(composePath string) error {

--- a/internal/deploy/project_checks/project_checks_test.go
+++ b/internal/deploy/project_checks/project_checks_test.go
@@ -22,14 +22,27 @@ services:
 }
 
 func TestEnsureProjectIsLinuxArm64Ready_SucceedsWithValidPlatforms(t *testing.T) {
-	composeFile := writeComposeFile(t, `
+	t.Run("without variant", func(t *testing.T) {
+		composeFile := writeComposeFile(t, `
 services:
   app:
     image: alpine
     platform: linux/arm64
 `)
 
-	require.NoError(t, checks.EnsureProjectIsLinuxArm64Ready(composeFile))
+		require.NoError(t, checks.EnsureProjectIsLinuxArm64Ready(composeFile))
+	})
+
+	t.Run("with variant", func(t *testing.T) {
+		composeFile := writeComposeFile(t, `
+services:
+  app:
+    image: alpine
+    platform: linux/arm64/v8
+`)
+
+		require.NoError(t, checks.EnsureProjectIsLinuxArm64Ready(composeFile))
+	})
 }
 
 func TestEnsureProjectIsLinuxArm64Ready_FailsWhenPlatformMissing(t *testing.T) {


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- Widens the project check to match any `linux/arm64` target including variants like `linux/arm64/v8`
