### PR TITLE
Implement the Logger in the Deploy Command

### DIFF
--- a/cmd/topo/deploy.go
+++ b/cmd/topo/deploy.go
@@ -97,7 +97,7 @@ Use --dry-run to see what commands would be executed without actually running th
 		}
 
 		deployment, cleanup := docker.NewDeployment(composeFile, deployOpts)
-		stop := goperation.SetupExitCleanup(os.Stderr, cleanup, os.Exit)
+		stop := goperation.SetupExitCleanup(os.Stdout, cleanup, os.Exit)
 
 		defer func() {
 			entries := stop()
@@ -105,9 +105,9 @@ Use --dry-run to see what commands would be executed without actually running th
 		}()
 
 		if deployDryRun {
-			return deployment.DryRun(os.Stderr)
+			return deployment.DryRun(os.Stdout)
 		}
-		return deployment.Run(os.Stderr)
+		return deployment.Run(os.Stdout)
 	},
 }
 

--- a/cmd/topo/deploy.go
+++ b/cmd/topo/deploy.go
@@ -11,6 +11,9 @@ import (
 	"github.com/arm-debug/topo-cli/internal/deploy/docker/operation"
 	goperation "github.com/arm-debug/topo-cli/internal/deploy/operation"
 	checks "github.com/arm-debug/topo-cli/internal/deploy/project_checks"
+	"github.com/arm-debug/topo-cli/internal/output/console"
+	"github.com/arm-debug/topo-cli/internal/output/logger"
+	"github.com/arm-debug/topo-cli/internal/output/term"
 	"github.com/arm-debug/topo-cli/internal/ssh"
 
 	"github.com/spf13/cobra"
@@ -43,10 +46,14 @@ Use --dry-run to see what commands would be executed without actually running th
 	Args: cobra.ExactArgs(0),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
+		c := console.NewLogger(os.Stderr, term.Plain)
 
 		portChanged := cmd.Flags().Changed("port")
 		if portChanged && noRegistry {
-			_, _ = fmt.Fprintln(os.Stderr, "WARN: --port has no effect when --no-registry is set. Define SSH port in your SSH config instead.")
+			c.Log(logger.Entry{
+				Level:   logger.Warning,
+				Message: "--port has no effect when --no-registry is set. Define SSH port in your SSH config instead.",
+			})
 		}
 
 		resolvedTarget, err := resolveTarget(deployTarget)
@@ -83,17 +90,24 @@ Use --dry-run to see what commands would be executed without actually running th
 		deployOpts.UseSSHControlSockets = docker.SupportsSSHControlSockets(goos)
 
 		if !deployOpts.WithRegistry {
-			_, _ = fmt.Fprintln(os.Stderr, "WARN: Registry transfer is not yet supported with this configuration. Falling back to direct transfer.")
+			c.Log(logger.Entry{
+				Level:   logger.Warning,
+				Message: "registry transfer is not yet supported with this configuration. Falling back to direct transfer.",
+			})
 		}
 
 		deployment, cleanup := docker.NewDeployment(composeFile, deployOpts)
-		stop := goperation.SetupExitCleanup(cleanup, os.Stderr, os.Exit)
-		defer stop()
+		stop := goperation.SetupExitCleanup(os.Stderr, cleanup, os.Exit)
+
+		defer func() {
+			entries := stop()
+			c.Log(entries...)
+		}()
 
 		if deployDryRun {
-			return deployment.DryRun(os.Stdout)
+			return deployment.DryRun(os.Stderr)
 		}
-		return deployment.Run(os.Stdout)
+		return deployment.Run(os.Stderr)
 	},
 }
 

--- a/internal/deploy/operation/operation.go
+++ b/internal/deploy/operation/operation.go
@@ -7,6 +7,8 @@ import (
 	"os/signal"
 	"sync"
 	"syscall"
+
+	"github.com/arm-debug/topo-cli/internal/output/logger"
 )
 
 type Operation interface {
@@ -16,20 +18,25 @@ type Operation interface {
 }
 
 // SetupExitCleanup sets up a handler to run an operation once when the program exits due to an interrupt signal.
-func SetupExitCleanup(operation Operation, w io.Writer, exit func(int)) func() {
+func SetupExitCleanup(w io.Writer, operation Operation, exit func(int)) func() []logger.Entry {
 	var once sync.Once
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
-	doCleanupOnce := func() {
+	doCleanupOnce := func() []logger.Entry {
+		entries := []logger.Entry{}
 		once.Do(func() {
 			if operation != nil {
 				if err := operation.Run(w); err != nil {
-					_, _ = fmt.Fprintf(w, "WARN: failed to cleanup on exit: %v\n", err)
+					entries = append(entries, logger.Entry{
+						Level:   logger.Warning,
+						Message: fmt.Sprintf(": failed to cleanup on exit: %v\n", err),
+					})
 				}
 			}
 			signal.Stop(sigChan)
 			close(sigChan)
 		})
+		return entries
 	}
 	go func() {
 		sig, ok := <-sigChan

--- a/internal/deploy/operation/operation_test.go
+++ b/internal/deploy/operation/operation_test.go
@@ -21,7 +21,8 @@ func TestSetupExitCleanup(t *testing.T) {
 		cleanupOp.On("Run", &buf).Return(nil)
 		p, err := os.FindProcess(os.Getpid())
 		require.NoError(t, err)
-		operation.SetupExitCleanup(cleanupOp, &buf, osExit)
+		var stderr bytes.Buffer
+		operation.SetupExitCleanup(&stderr, cleanupOp, osExit)
 
 		err = p.Signal(os.Interrupt)
 		require.NoError(t, err)
@@ -32,9 +33,9 @@ func TestSetupExitCleanup(t *testing.T) {
 
 	t.Run("calls cleanup operation only once when called multiple times", func(t *testing.T) {
 		cleanupOp := new(mockOperation)
-		var buf bytes.Buffer
-		cleanupOp.On("Run", &buf).Return(nil).Once()
-		cleanup := operation.SetupExitCleanup(cleanupOp, &buf, osExit)
+		var stderr bytes.Buffer
+		cleanupOp.On("Run", &stderr).Return(nil).Once()
+		cleanup := operation.SetupExitCleanup(&stderr, cleanupOp, osExit)
 
 		cleanup()
 		cleanup()
@@ -45,8 +46,8 @@ func TestSetupExitCleanup(t *testing.T) {
 
 	t.Run("still handles signal when operation is nil", func(t *testing.T) {
 		testutil.RequireOS(t, "linux")
-		var buf bytes.Buffer
-		operation.SetupExitCleanup(nil, &buf, osExit)
+		var stderr bytes.Buffer
+		operation.SetupExitCleanup(&stderr, nil, osExit)
 		p, err := os.FindProcess(os.Getpid())
 		require.NoError(t, err)
 


### PR DESCRIPTION
## Changes

- Changes warning prints to warning logger entries.
- Returns these entries from `SetupExitCleanup`
- Printing warnings is now done entirely at the cobra/command level

Due to the way `Run` and `DryRun` work at the moment, they've maintained their current output method.
