### PR TITLE
feat: Implement --output flag in log

### DIFF
--- a/cmd/topo/clone.go
+++ b/cmd/topo/clone.go
@@ -4,7 +4,6 @@ import (
 	"os"
 
 	"github.com/arm-debug/topo-cli/internal/arguments"
-	"github.com/arm-debug/topo-cli/internal/output/console"
 	"github.com/arm-debug/topo-cli/internal/output/term"
 	"github.com/arm-debug/topo-cli/internal/project"
 	"github.com/arm-debug/topo-cli/internal/template"
@@ -43,6 +42,10 @@ Some projects require build arguments. Supply them on the command line or answer
 `,
 	Args: cobra.MinimumNArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		c, err := GetLogger(cmd)
+		if err != nil {
+			return err
+		}
 		cmd.SilenceUsage = true
 		path := args[0]
 		src := args[1]
@@ -72,7 +75,6 @@ Some projects require build arguments. Supply them on the command line or answer
 
 		logs, err := project.Clone(path, projectSource, argProvider)
 
-		c := console.NewLogger(os.Stderr, term.Plain)
 		c.Log(logs...)
 		return err
 	},

--- a/cmd/topo/clone.go
+++ b/cmd/topo/clone.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	"github.com/arm-debug/topo-cli/internal/arguments"
+	"github.com/arm-debug/topo-cli/internal/output/console"
 	"github.com/arm-debug/topo-cli/internal/output/term"
 	"github.com/arm-debug/topo-cli/internal/project"
 	"github.com/arm-debug/topo-cli/internal/template"
@@ -42,10 +43,11 @@ Some projects require build arguments. Supply them on the command line or answer
 `,
 	Args: cobra.MinimumNArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		c, err := GetLogger(cmd)
+		outputFormat, err := resolveOutput(cmd)
 		if err != nil {
 			return err
 		}
+		c := console.NewLogger(os.Stderr, outputFormat)
 		cmd.SilenceUsage = true
 		path := args[0]
 		src := args[1]

--- a/cmd/topo/deploy.go
+++ b/cmd/topo/deploy.go
@@ -46,7 +46,10 @@ Use --dry-run to see what commands would be executed without actually running th
 	Args: cobra.ExactArgs(0),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		c := console.NewLogger(os.Stderr, term.Plain)
+		c, err := GetLogger(cmd)
+		if err != nil {
+			return err
+		}
 
 		portChanged := cmd.Flags().Changed("port")
 		if portChanged && noRegistry {

--- a/cmd/topo/deploy.go
+++ b/cmd/topo/deploy.go
@@ -11,9 +11,7 @@ import (
 	"github.com/arm-debug/topo-cli/internal/deploy/docker/operation"
 	goperation "github.com/arm-debug/topo-cli/internal/deploy/operation"
 	checks "github.com/arm-debug/topo-cli/internal/deploy/project_checks"
-	"github.com/arm-debug/topo-cli/internal/output/console"
 	"github.com/arm-debug/topo-cli/internal/output/logger"
-	"github.com/arm-debug/topo-cli/internal/output/term"
 	"github.com/arm-debug/topo-cli/internal/ssh"
 
 	"github.com/spf13/cobra"

--- a/cmd/topo/deploy.go
+++ b/cmd/topo/deploy.go
@@ -11,6 +11,7 @@ import (
 	"github.com/arm-debug/topo-cli/internal/deploy/docker/operation"
 	goperation "github.com/arm-debug/topo-cli/internal/deploy/operation"
 	checks "github.com/arm-debug/topo-cli/internal/deploy/project_checks"
+	"github.com/arm-debug/topo-cli/internal/output/console"
 	"github.com/arm-debug/topo-cli/internal/output/logger"
 	"github.com/arm-debug/topo-cli/internal/ssh"
 
@@ -44,7 +45,11 @@ Use --dry-run to see what commands would be executed without actually running th
 	Args: cobra.ExactArgs(0),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		c, err := GetLogger(cmd)
+		outputFormat, err := resolveOutput(cmd)
+		if err != nil {
+			return err
+		}
+		c := console.NewLogger(os.Stderr, outputFormat)
 		if err != nil {
 			return err
 		}

--- a/cmd/topo/extend.go
+++ b/cmd/topo/extend.go
@@ -49,6 +49,8 @@ or interactively when prompted:
 		composeFilePath := args[0]
 		sourceArg := args[1]
 
+		c, err := GetLogger(cmd)
+
 		src, err := template.NewSource(sourceArg)
 		if err != nil {
 			return err
@@ -74,7 +76,6 @@ or interactively when prompted:
 
 		logs, err := project.Extend(composeFilePath, src, argProvider)
 
-		c := console.NewLogger(os.Stderr, term.Plain)
 		c.Log(logs...)
 		return err
 	},

--- a/cmd/topo/extend.go
+++ b/cmd/topo/extend.go
@@ -4,7 +4,6 @@ import (
 	"os"
 
 	"github.com/arm-debug/topo-cli/internal/arguments"
-	"github.com/arm-debug/topo-cli/internal/output/console"
 	"github.com/arm-debug/topo-cli/internal/output/term"
 	"github.com/arm-debug/topo-cli/internal/project"
 	"github.com/arm-debug/topo-cli/internal/template"
@@ -50,6 +49,9 @@ or interactively when prompted:
 		sourceArg := args[1]
 
 		c, err := GetLogger(cmd)
+		if err != nil {
+			return err
+		}
 
 		src, err := template.NewSource(sourceArg)
 		if err != nil {

--- a/cmd/topo/extend.go
+++ b/cmd/topo/extend.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	"github.com/arm-debug/topo-cli/internal/arguments"
+	"github.com/arm-debug/topo-cli/internal/output/console"
 	"github.com/arm-debug/topo-cli/internal/output/term"
 	"github.com/arm-debug/topo-cli/internal/project"
 	"github.com/arm-debug/topo-cli/internal/template"
@@ -48,7 +49,12 @@ or interactively when prompted:
 		composeFilePath := args[0]
 		sourceArg := args[1]
 
-		c, err := GetLogger(cmd)
+		outputFormat, err := resolveOutput(cmd)
+		if err != nil {
+			return err
+		}
+		c := console.NewLogger(os.Stderr, outputFormat)
+
 		if err != nil {
 			return err
 		}

--- a/cmd/topo/health.go
+++ b/cmd/topo/health.go
@@ -1,18 +1,17 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/arm-debug/topo-cli/internal/health"
+	"github.com/arm-debug/topo-cli/internal/output/logger"
 	"github.com/arm-debug/topo-cli/internal/output/printable"
 	"github.com/arm-debug/topo-cli/internal/output/templates"
 	"github.com/spf13/cobra"
 )
 
-var (
-	healthTarget string
-	healthOutput string
-)
+var healthTarget string
 
 var healthCmd = &cobra.Command{
 	Use:   "health",
@@ -20,11 +19,17 @@ var healthCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(0),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
+		c, err := GetLogger(cmd)
+		c.Log(logger.Entry{
+			Level:   logger.Info,
+			Message: "woop",
+		})
+		return fmt.Errorf("noooo")
 		sshTarget, err := resolveTarget(healthTarget)
 		if err != nil {
 			return err
 		}
-		outputFormat, err := resolveOutput(healthOutput)
+		outputFormat, err := resolveOutput(output)
 		if err != nil {
 			return err
 		}
@@ -38,6 +43,5 @@ var healthCmd = &cobra.Command{
 
 func init() {
 	addTargetFlag(healthCmd, &healthTarget)
-	addOutputFlag(healthCmd, &healthOutput)
 	rootCmd.AddCommand(healthCmd)
 }

--- a/cmd/topo/health.go
+++ b/cmd/topo/health.go
@@ -21,7 +21,7 @@ var healthCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		outputFormat, err := resolveOutput(output)
+		outputFormat, err := resolveOutput(cmd)
 		if err != nil {
 			return err
 		}

--- a/cmd/topo/health.go
+++ b/cmd/topo/health.go
@@ -1,11 +1,9 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/arm-debug/topo-cli/internal/health"
-	"github.com/arm-debug/topo-cli/internal/output/logger"
 	"github.com/arm-debug/topo-cli/internal/output/printable"
 	"github.com/arm-debug/topo-cli/internal/output/templates"
 	"github.com/spf13/cobra"
@@ -19,11 +17,6 @@ var healthCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(0),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		c, err := GetLogger(cmd)
-		c.Log(logger.Entry{
-			Level:   logger.Info,
-			Message: "woop",
-		})
 		sshTarget, err := resolveTarget(healthTarget)
 		if err != nil {
 			return err

--- a/cmd/topo/health.go
+++ b/cmd/topo/health.go
@@ -24,7 +24,6 @@ var healthCmd = &cobra.Command{
 			Level:   logger.Info,
 			Message: "woop",
 		})
-		return fmt.Errorf("noooo")
 		sshTarget, err := resolveTarget(healthTarget)
 		if err != nil {
 			return err

--- a/cmd/topo/install.go
+++ b/cmd/topo/install.go
@@ -12,9 +12,7 @@ import (
 
 const remoteprocRepoURL = "arm/remoteproc-runtime"
 
-var (
-	installRemoteprocTarget string
-)
+var installRemoteprocTarget string
 
 var installCmd = &cobra.Command{
 	Use:   "install",

--- a/cmd/topo/install.go
+++ b/cmd/topo/install.go
@@ -40,7 +40,7 @@ Falls back to ~/bin if no suitable locations are automatically found.
 			return err
 		}
 
-		outputFormat, err := resolveOutput(output)
+		outputFormat, err := resolveOutput(cmd)
 		if err != nil {
 			return err
 		}

--- a/cmd/topo/install.go
+++ b/cmd/topo/install.go
@@ -14,7 +14,6 @@ const remoteprocRepoURL = "arm/remoteproc-runtime"
 
 var (
 	installRemoteprocTarget string
-	installRemoteprocOutput string
 )
 
 var installCmd = &cobra.Command{
@@ -41,7 +40,7 @@ Falls back to ~/bin if no suitable locations are automatically found.
 			return err
 		}
 
-		outputFormat, err := resolveOutput(installRemoteprocOutput)
+		outputFormat, err := resolveOutput(output)
 		if err != nil {
 			return err
 		}

--- a/cmd/topo/install.go
+++ b/cmd/topo/install.go
@@ -57,7 +57,6 @@ func init() {
 	rootCmd.AddCommand(installCmd)
 	installCmd.AddCommand(installRemoteprocCmd)
 	addTargetFlag(installRemoteprocCmd, &installRemoteprocTarget)
-	addOutputFlag(installRemoteprocCmd, &installRemoteprocOutput)
 }
 
 func installRemoteprocRuntime(targetHost ssh.Host) (printable.Printable, error) {

--- a/cmd/topo/main.go
+++ b/cmd/topo/main.go
@@ -10,14 +10,11 @@ import (
 
 func main() {
 	if err := rootCmd.Execute(); err != nil {
-		output, _ := rootCmd.Flags().GetString("output")
-
-		format, err := resolveOutput(output)
+		outputFormat, err := resolveOutput(rootCmd)
 		if err != nil {
-			format = term.Plain
+			outputFormat = term.Plain
 		}
-
-		c := console.NewLogger(os.Stderr, format)
+		c := console.NewLogger(os.Stderr, outputFormat)
 		c.Log(logger.Entry{
 			Level:   logger.Err,
 			Message: err.Error(),

--- a/cmd/topo/main.go
+++ b/cmd/topo/main.go
@@ -5,12 +5,17 @@ import (
 
 	"github.com/arm-debug/topo-cli/internal/output/console"
 	"github.com/arm-debug/topo-cli/internal/output/logger"
+	"github.com/arm-debug/topo-cli/internal/output/term"
 )
 
 func main() {
 	if err := rootCmd.Execute(); err != nil {
 		output, _ := rootCmd.Flags().GetString("output")
-		format, _ := resolveOutput(output)
+
+		format, err := resolveOutput(output)
+		if err != nil {
+			format = term.Plain
+		}
 
 		c := console.NewLogger(os.Stderr, format)
 		c.Log(logger.Entry{

--- a/cmd/topo/main.go
+++ b/cmd/topo/main.go
@@ -10,8 +10,8 @@ import (
 
 func main() {
 	if err := rootCmd.Execute(); err != nil {
-		outputFormat, err := resolveOutput(rootCmd)
-		if err != nil {
+		outputFormat, e := resolveOutput(rootCmd)
+		if e != nil {
 			outputFormat = term.Plain
 		}
 		c := console.NewLogger(os.Stderr, outputFormat)

--- a/cmd/topo/main.go
+++ b/cmd/topo/main.go
@@ -5,13 +5,19 @@ import (
 
 	"github.com/arm-debug/topo-cli/internal/output/console"
 	"github.com/arm-debug/topo-cli/internal/output/logger"
-	"github.com/arm-debug/topo-cli/internal/output/term"
 )
 
 func main() {
 	if err := rootCmd.Execute(); err != nil {
-		c := console.NewLogger(os.Stderr, term.Plain)
-		c.Log(logger.Entry{Level: logger.Err, Message: err.Error()})
+		output, _ := rootCmd.Flags().GetString("output")
+		format, _ := resolveOutput(output)
+
+		c := console.NewLogger(os.Stderr, format)
+		c.Log(logger.Entry{
+			Level:   logger.Err,
+			Message: err.Error(),
+		})
+
 		os.Exit(1)
 	}
 }

--- a/cmd/topo/main.go
+++ b/cmd/topo/main.go
@@ -10,8 +10,8 @@ import (
 
 func main() {
 	if err := rootCmd.Execute(); err != nil {
-		outputFormat, e := resolveOutput(rootCmd)
-		if e != nil {
+		outputFormat, outputFormatError := resolveOutput(rootCmd)
+		if outputFormatError != nil {
 			outputFormat = term.Plain
 		}
 		c := console.NewLogger(os.Stderr, outputFormat)

--- a/cmd/topo/root.go
+++ b/cmd/topo/root.go
@@ -46,7 +46,7 @@ func resolveTarget(flagValue string) (string, error) {
 func resolveOutput(cmd *cobra.Command) (term.Format, error) {
 	flagValue, err := cmd.Flags().GetString("output")
 	if err != nil {
-		return term.Plain, err
+		return term.Plain, nil
 	}
 
 	v := strings.TrimSpace(strings.ToLower(flagValue))

--- a/cmd/topo/root.go
+++ b/cmd/topo/root.go
@@ -11,8 +11,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var output string
-
 var rootCmd = &cobra.Command{
 	Use:           "topo",
 	Short:         "Topo CLI",
@@ -22,8 +20,7 @@ var rootCmd = &cobra.Command{
 }
 
 func init() {
-	rootCmd.PersistentFlags().StringVarP(
-		&output,
+	rootCmd.PersistentFlags().StringP(
 		"output",
 		"o",
 		"plain",

--- a/cmd/topo/root.go
+++ b/cmd/topo/root.go
@@ -46,7 +46,7 @@ func resolveTarget(flagValue string) (string, error) {
 func resolveOutput(cmd *cobra.Command) (term.Format, error) {
 	flagValue, err := cmd.Flags().GetString("output")
 	if err != nil {
-		return term.Plain, nil
+		panic(fmt.Sprintf("bug: output flag not registered: %v", err))
 	}
 
 	v := strings.TrimSpace(strings.ToLower(flagValue))

--- a/cmd/topo/root.go
+++ b/cmd/topo/root.go
@@ -11,10 +11,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-type ctxKey string
-
-const loggerKey ctxKey = "logger"
-
 var output string
 
 var rootCmd = &cobra.Command{

--- a/cmd/topo/root.go
+++ b/cmd/topo/root.go
@@ -77,9 +77,5 @@ func GetLogger(cmd *cobra.Command) (*console.Logger, error) {
 	}
 
 	log := console.NewLogger(os.Stderr, format)
-
-	ctx := context.WithValue(cmd.Context(), loggerKey, log)
-	cmd.SetContext(ctx)
-
 	return log, nil
 }

--- a/cmd/topo/root.go
+++ b/cmd/topo/root.go
@@ -1,14 +1,22 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
 
+	"github.com/arm-debug/topo-cli/internal/output/console"
 	"github.com/arm-debug/topo-cli/internal/output/term"
 	"github.com/arm-debug/topo-cli/internal/version"
 	"github.com/spf13/cobra"
 )
+
+type ctxKey string
+
+const loggerKey ctxKey = "logger"
+
+var output string
 
 var rootCmd = &cobra.Command{
 	Use:           "topo",
@@ -18,12 +26,18 @@ var rootCmd = &cobra.Command{
 	SilenceUsage:  true,
 }
 
-func addTargetFlag(cmd *cobra.Command, target *string) {
-	cmd.Flags().StringVar(target, "target", "", "The SSH destination.")
+func init() {
+	rootCmd.PersistentFlags().StringVarP(
+		&output,
+		"output",
+		"o",
+		"plain",
+		"Output format: plain or json",
+	)
 }
 
-func addOutputFlag(cmd *cobra.Command, output *string) {
-	cmd.Flags().StringVarP(output, "output", "o", "plain", "Output format: plain or json")
+func addTargetFlag(cmd *cobra.Command, target *string) {
+	cmd.Flags().StringVar(target, "target", "", "The SSH destination.")
 }
 
 func resolveTarget(flagValue string) (string, error) {
@@ -49,4 +63,23 @@ func resolveOutput(flagValue string) (term.Format, error) {
 		err := fmt.Errorf("invalid output value %q: must be 'plain' or 'json'", flagValue)
 		return term.Plain, err
 	}
+}
+
+func GetLogger(cmd *cobra.Command) (*console.Logger, error) {
+	flagValue, err := cmd.Flags().GetString("output")
+	if err != nil {
+		return nil, err
+	}
+
+	format, err := resolveOutput(flagValue)
+	if err != nil {
+		return nil, err
+	}
+
+	log := console.NewLogger(os.Stderr, format)
+
+	ctx := context.WithValue(cmd.Context(), loggerKey, log)
+	cmd.SetContext(ctx)
+
+	return log, nil
 }

--- a/cmd/topo/root.go
+++ b/cmd/topo/root.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/arm-debug/topo-cli/internal/output/console"
 	"github.com/arm-debug/topo-cli/internal/output/term"
 	"github.com/arm-debug/topo-cli/internal/version"
 	"github.com/spf13/cobra"
@@ -44,7 +43,12 @@ func resolveTarget(flagValue string) (string, error) {
 	return "", fmt.Errorf("target not specified: provide --target or set TOPO_TARGET env var")
 }
 
-func resolveOutput(flagValue string) (term.Format, error) {
+func resolveOutput(cmd *cobra.Command) (term.Format, error) {
+	flagValue, err := cmd.Flags().GetString("output")
+	if err != nil {
+		return term.Plain, err
+	}
+
 	v := strings.TrimSpace(strings.ToLower(flagValue))
 	switch v {
 	case "plain":
@@ -55,19 +59,4 @@ func resolveOutput(flagValue string) (term.Format, error) {
 		err := fmt.Errorf("invalid output value %q: must be 'plain' or 'json'", flagValue)
 		return term.Plain, err
 	}
-}
-
-func GetLogger(cmd *cobra.Command) (*console.Logger, error) {
-	flagValue, err := cmd.Flags().GetString("output")
-	if err != nil {
-		return nil, err
-	}
-
-	format, err := resolveOutput(flagValue)
-	if err != nil {
-		return nil, err
-	}
-
-	log := console.NewLogger(os.Stderr, format)
-	return log, nil
 }

--- a/cmd/topo/root.go
+++ b/cmd/topo/root.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"strings"

--- a/cmd/topo/templates.go
+++ b/cmd/topo/templates.go
@@ -11,7 +11,6 @@ import (
 
 var (
 	templateFilters catalog.TemplateFilters
-	templatesOutput string
 )
 
 var templatesCmd = &cobra.Command{
@@ -19,7 +18,7 @@ var templatesCmd = &cobra.Command{
 	Short: "List available Service Templates",
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		cmd.SilenceUsage = true
-		outputFormat, err := resolveOutput(templatesOutput)
+		outputFormat, err := resolveOutput(output)
 		if err != nil {
 			return err
 		}
@@ -44,7 +43,6 @@ var templatesCmd = &cobra.Command{
 
 func init() {
 	addTargetFlag(templatesCmd, &templateFilters.Target)
-	addOutputFlag(templatesCmd, &templatesOutput)
 	templatesCmd.Flags().StringSliceVar(
 		&templateFilters.Features,
 		"feature",

--- a/cmd/topo/templates.go
+++ b/cmd/topo/templates.go
@@ -16,7 +16,7 @@ var templatesCmd = &cobra.Command{
 	Short: "List available Service Templates",
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		cmd.SilenceUsage = true
-		outputFormat, err := resolveOutput(output)
+		outputFormat, err := resolveOutput(cmd)
 		if err != nil {
 			return err
 		}

--- a/cmd/topo/templates.go
+++ b/cmd/topo/templates.go
@@ -9,9 +9,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-	templateFilters catalog.TemplateFilters
-)
+var templateFilters catalog.TemplateFilters
 
 var templatesCmd = &cobra.Command{
 	Use:   "templates",


### PR DESCRIPTION
## Changes

- Moves the output to be var-less. Is now accessed through a consolidated resolve function
- This replaces defaulting to plain for functions without the output flag
