### PR TITLE
fix: always drops features prefix from list

### DIFF
--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -38,7 +38,7 @@ func FilterTemplateRepos(flags TemplateFilters, repos []Repo) []Repo {
 	if flags.Target != "" {
 		conn := health.NewConnection(flags.Target, ssh.ExecSSH)
 		targetStatus := conn.Probe()
-		flags.Features = health.ExtractArmFeatures(targetStatus)
+		flags.Features = targetStatus.Hardware.ExtractArmFeatures()
 		targetMode = true
 	}
 

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -6,30 +6,12 @@ import (
 	"github.com/arm-debug/topo-cli/internal/ssh"
 )
 
-var searchFlags = map[string]string{
-	"asimd": "NEON",
-	"sve":   "SVE",
-	"sve2":  "SVE2",
-	"sme":   "SME",
-	"sme2":  "SME2",
-}
-
-func ExtractArmFeatures(targetStatus Status) []string {
-	res := make([]string, 0)
-
-	for _, field := range targetStatus.Hardware.Features {
-		if name, ok := searchFlags[field]; ok {
-			res = append(res, name)
-		}
-	}
-	return res
-}
-
 type HealthCheck struct {
 	Name    string
 	Healthy bool
 	Value   string
 }
+
 type HostReport struct {
 	Dependencies []HealthCheck
 }
@@ -80,7 +62,7 @@ func generateTargetReport(targetStatus Status) TargetReport {
 		Healthy: targetStatus.ConnectionError == nil,
 		Value:   "",
 	}
-	report.Features = ExtractArmFeatures(targetStatus)
+	report.Features = targetStatus.Hardware.ExtractArmFeatures()
 	report.SubsystemDriver = HealthCheck{
 		Name:    "Subsystem Driver (remoteproc)",
 		Healthy: len(targetStatus.Hardware.RemoteCPU) > 0,

--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -9,26 +9,22 @@ import (
 
 func TestExtractArmFeatures(t *testing.T) {
 	t.Run("extracts mapped Arm features and ignores unrecognised", func(t *testing.T) {
-		ts := health.Status{
-			Hardware: health.HardwareProfile{
-				Features: []string{"fp", "asimd", "sve2", "sme"},
-			},
+		ts := health.HardwareProfile{
+			Features: []string{"fp", "asimd", "sve2", "sme"},
 		}
 
-		res := health.ExtractArmFeatures(ts)
+		res := ts.ExtractArmFeatures()
 
 		want := []string{"NEON", "SVE2", "SME"}
 		assert.Equal(t, want, res)
 	})
 
 	t.Run("returns empty slice if no matching features", func(t *testing.T) {
-		ts := health.Status{
-			Hardware: health.HardwareProfile{
-				Features: []string{"fp", "crc32"},
-			},
+		ts := health.HardwareProfile{
+			Features: []string{"fp", "crc32"},
 		}
 
-		res := health.ExtractArmFeatures(ts)
+		res := ts.ExtractArmFeatures()
 
 		assert.Empty(t, res)
 	})

--- a/internal/health/target.go
+++ b/internal/health/target.go
@@ -2,10 +2,19 @@ package health
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/arm-debug/topo-cli/internal/ssh"
 )
+
+var armFeatures = map[string]string{
+	"asimd": "NEON",
+	"sve":   "SVE",
+	"sve2":  "SVE2",
+	"sme":   "SME",
+	"sme2":  "SME2",
+}
 
 type execSSH func(target ssh.Host, command string) (string, error)
 
@@ -20,6 +29,17 @@ func (hw HardwareProfile) Capabilities() map[HardwareCapability]struct{} {
 		capabilities[Remoteproc] = struct{}{}
 	}
 	return capabilities
+}
+
+func (hw HardwareProfile) ExtractArmFeatures() []string {
+	res := make([]string, 0)
+
+	for _, field := range hw.Features {
+		if name, ok := armFeatures[field]; ok {
+			res = append(res, name)
+		}
+	}
+	return res
 }
 
 type Status struct {
@@ -96,11 +116,9 @@ func (c *Connection) collectFeatures() ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	features := strings.Fields(out)
-
-	if len(features) > 0 && features[0] == "Features:" {
-		features = features[1:]
-	}
+	features := slices.DeleteFunc(strings.Fields(out), func(v string) bool {
+		return v == "" || v == "Features:" || v == "Features" || v == ":"
+	})
 	return features, nil
 }
 

--- a/internal/health/target_test.go
+++ b/internal/health/target_test.go
@@ -43,7 +43,7 @@ func TestProbe(t *testing.T) {
 			if command == "" {
 				return "", nil // simulate successful initial connection
 			}
-			return "Features: fpu asimd", nil
+			return "Features        : fpu asimd", nil
 		}
 
 		conn := health.NewConnection("hostname", mockExec)


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- Spotted that `ProbeHardware` was not properly filtering the "Features" prefix from the relevant line in ` /proc/cpuinfo` as it's actually in the format `Features        : fpu asimd` rather than `Features: fpu asimd`. Fixed this and updated the test.
- Also moved `ExtractArmFeatures` to a method on `HardwareProfile` and gave the LUT it uses a clearer name
