### PR TITLE
feat: add topo setup-keys command

### DIFF
--- a/cmd/topo/setup_keys.go
+++ b/cmd/topo/setup_keys.go
@@ -50,5 +50,5 @@ func init() {
 	rootCmd.AddCommand(setupKeysCmd)
 	addTargetFlag(setupKeysCmd, &setupKeysTarget)
 	setupKeysCmd.Flags().BoolVar(&setupKeysDryRun, "dry-run", false, "Show what commands would be executed without actually running them")
-	setupKeysCmd.Flags().StringVar(&setupKeysKeyPath, "key-path", "", "Specify the SSH key path where the generated keys will be stored (default is ~/.ssh/id_ed25519_topo_<target>)")
+	setupKeysCmd.Flags().StringVar(&setupKeysKeyPath, "key-path", "", "Specify the SSH path where the generated key pair will be stored. Default directory: ~/.ssh. Default public key file name: id_ed25519_topo_<target>.pub)")
 }

--- a/cmd/topo/setup_keys.go
+++ b/cmd/topo/setup_keys.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+
+	"github.com/arm-debug/topo-cli/internal/setupkeys"
+	"github.com/spf13/cobra"
+)
+
+var (
+	setupKeysTarget  string
+	setupKeysDryRun  bool
+	setupKeysKeyPath string
+)
+
+var setupKeysCmd = &cobra.Command{
+	Use:   "setup-keys",
+	Short: "Generate SSH keys for the target and install the public key on the target host",
+	Long: `Generate SSH keys for the target and install the public key on the target host.
+
+Use --dry-run to see what commands would be executed without actually running them.`,
+	Args: cobra.ExactArgs(0),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+
+		if runtime.GOOS != "linux" {
+			return fmt.Errorf("topo setup-keys currently supports Linux hosts only")
+		}
+
+		resolvedTarget, err := resolveTarget(setupKeysTarget)
+		if err != nil {
+			return err
+		}
+
+		seq, err := setupkeys.NewKeyCreationAndPlacementOnTarget(resolvedTarget, setupKeysKeyPath)
+		if err != nil {
+			return err
+		}
+
+		if setupKeysDryRun {
+			return seq.DryRun(os.Stdout)
+		}
+		return seq.Run(os.Stdout)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(setupKeysCmd)
+	addTargetFlag(setupKeysCmd, &setupKeysTarget)
+	setupKeysCmd.Flags().BoolVar(&setupKeysDryRun, "dry-run", false, "Show what commands would be executed without actually running them")
+	setupKeysCmd.Flags().StringVar(&setupKeysKeyPath, "key-path", "", "Specify the SSH key path where the generated keys will be stored (default is ~/.ssh/id_ed25519_topo_<target>)")
+}

--- a/internal/setupkeys/setupkeys.go
+++ b/internal/setupkeys/setupkeys.go
@@ -1,0 +1,96 @@
+package setupkeys
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"unicode"
+
+	goperation "github.com/arm-debug/topo-cli/internal/deploy/operation"
+)
+
+func NewKeyCreationAndPlacementOnTarget(target string, keyPath string) (goperation.Sequence, error) {
+	if keyPath == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return nil, fmt.Errorf("failed to determine home directory: %w", err)
+		}
+
+		keyName := fmt.Sprintf("id_ed25519_topo_%s", sanitizeTarget(target))
+		keyPath = filepath.Join(home, ".ssh", keyName)
+	}
+
+	if err := ensureSSHDir(keyPath); err != nil {
+		return nil, err
+	}
+
+	ops := []goperation.Operation{
+		newSetupKeysOperation("Generate SSH key pair for target", []string{"ssh-keygen", "-t", "ed25519", "-f", keyPath, "-C", target}),
+		newSetupKeysOperation("Copy SSH public key to target", []string{"ssh-copy-id", "-i", keyPath + ".pub", target}),
+	}
+	return goperation.NewSequence(ops...), nil
+}
+
+func ensureSSHDir(keyPath string) error {
+	dir := filepath.Dir(keyPath)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("failed to create %s: %w", dir, err)
+	}
+	return nil
+}
+
+func sanitizeTarget(target string) string {
+	var b strings.Builder
+	for _, r := range target {
+		switch {
+		case unicode.IsLetter(r) || unicode.IsDigit(r):
+			b.WriteRune(r)
+		case r == '-' || r == '_' || r == '.':
+			b.WriteRune(r)
+		default:
+			b.WriteRune('_')
+		}
+	}
+
+	sanitized := b.String()
+	return sanitized
+}
+
+type setupKeysOperation struct {
+	description string
+	command     []string
+}
+
+func newSetupKeysOperation(description string, command []string) *setupKeysOperation {
+	return &setupKeysOperation{description: description, command: command}
+}
+
+func (c *setupKeysOperation) Description() string {
+	return c.description
+}
+
+func (c *setupKeysOperation) Run(cmdOutput io.Writer) error {
+	if len(c.command) == 0 {
+		return fmt.Errorf("no command configured")
+	}
+	cmd := exec.Command(c.command[0], c.command[1:]...)
+	if cmdOutput != nil {
+		cmd.Stdout = cmdOutput
+		cmd.Stderr = cmdOutput
+	}
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("command %q failed: %w", strings.Join(c.command, " "), err)
+	}
+	return nil
+}
+
+func (c *setupKeysOperation) DryRun(output io.Writer) error {
+	if output == nil {
+		return nil
+	}
+	_, err := fmt.Fprintln(output, strings.Join(c.command, " "))
+	return err
+}

--- a/internal/setupkeys/setupkeys.go
+++ b/internal/setupkeys/setupkeys.go
@@ -45,14 +45,12 @@ func ensureSSHDir(keyPath string) error {
 func sanitizeTarget(target string) string {
 	var b strings.Builder
 	for _, r := range target {
-		switch {
-		case unicode.IsLetter(r) || unicode.IsDigit(r):
-			b.WriteRune(r)
-		case r == '-' || r == '_' || r == '.':
-			b.WriteRune(r)
-		default:
-			b.WriteRune('_')
+		toWrite := '_'
+		if unicode.IsLetter(r) || unicode.IsDigit(r) || r == '-' || r == '_' || r == '.' {
+			toWrite = r
 		}
+
+		b.WriteRune(toWrite)
 	}
 
 	sanitized := b.String()

--- a/internal/setupkeys/setupkeys.go
+++ b/internal/setupkeys/setupkeys.go
@@ -23,7 +23,7 @@ func NewKeyCreationAndPlacementOnTarget(target string, keyPath string) (goperati
 		keyPath = filepath.Join(home, ".ssh", keyName)
 	}
 
-	if err := ensureSSHDir(keyPath); err != nil {
+	if err := ensureDir(keyPath); err != nil {
 		return nil, err
 	}
 
@@ -34,7 +34,7 @@ func NewKeyCreationAndPlacementOnTarget(target string, keyPath string) (goperati
 	return goperation.NewSequence(ops...), nil
 }
 
-func ensureSSHDir(keyPath string) error {
+func ensureDir(keyPath string) error {
 	dir := filepath.Dir(keyPath)
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return fmt.Errorf("failed to create %s: %w", dir, err)

--- a/internal/setupkeys/setupkeys_test.go
+++ b/internal/setupkeys/setupkeys_test.go
@@ -3,16 +3,14 @@ package setupkeys
 import (
 	"bytes"
 	"path/filepath"
-	"runtime"
 	"testing"
 
+	"github.com/arm-debug/topo-cli/internal/testutil"
 	"github.com/stretchr/testify/require"
 )
 
 func TestNewSequenceDryRunOutputsCommands(t *testing.T) {
-	if runtime.GOOS != "linux" {
-		t.Skip("only runs on linux because it relies on linux-specific paths")
-	}
+	testutil.RequireOS(t, "linux")
 
 	t.Run("default key path", func(t *testing.T) {
 		tmp := t.TempDir()

--- a/internal/setupkeys/setupkeys_test.go
+++ b/internal/setupkeys/setupkeys_test.go
@@ -2,6 +2,8 @@ package setupkeys
 
 import (
 	"bytes"
+	"fmt"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -9,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestNewSequenceDryRunOutputsCommands(t *testing.T) {
+func TestNewKeyCreationAndPlacementOnTarget(t *testing.T) {
 	testutil.RequireOS(t, "linux")
 
 	t.Run("default key path", func(t *testing.T) {
@@ -47,6 +49,34 @@ func TestNewSequenceDryRunOutputsCommands(t *testing.T) {
 	})
 }
 
+func TestKeyCreationAndPlacementOnTarget(t *testing.T) {
+	testutil.RequireOS(t, "linux")
+
+	keyPath := filepath.Join(t.TempDir(), "custom_keys", "id_ed25519_custom_run")
+	fakeBinDir := t.TempDir()
+	logFile := filepath.Join(t.TempDir(), "commands.log")
+
+	writeFakeSSHCommand(t, fakeBinDir, "ssh-keygen", logFile)
+	writeFakeSSHCommand(t, fakeBinDir, "ssh-copy-id", logFile)
+
+	originalPath := os.Getenv("PATH")
+	t.Setenv("PATH", fakeBinDir+string(os.PathListSeparator)+originalPath)
+
+	seq, err := NewKeyCreationAndPlacementOnTarget("user@example.com", keyPath)
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	require.NoError(t, seq.Run(&buf))
+	require.Contains(t, buf.String(), "ssh-keygen invoked", "Run output should include fake ssh-keygen output")
+	require.Contains(t, buf.String(), "ssh-copy-id invoked", "Run output should include fake ssh-copy-id output")
+
+	logData, err := os.ReadFile(logFile)
+	require.NoError(t, err)
+	log := string(logData)
+	require.Contains(t, log, fmt.Sprintf("ssh-keygen -t ed25519 -f %s -C user@example.com", keyPath))
+	require.Contains(t, log, fmt.Sprintf("ssh-copy-id -i %s.pub user@example.com", keyPath))
+}
+
 func TestSanitizeTarget(t *testing.T) {
 	tests := []struct {
 		input string
@@ -64,4 +94,14 @@ func TestSanitizeTarget(t *testing.T) {
 			}
 		})
 	}
+}
+
+func writeFakeSSHCommand(t *testing.T, dir, name, logFile string) {
+	t.Helper()
+	script := fmt.Sprintf(`#!/bin/sh
+echo "%s invoked"
+echo "$0 $@" >> %s
+`, name, logFile)
+	path := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(path, []byte(script), 0o700))
 }

--- a/internal/setupkeys/setupkeys_test.go
+++ b/internal/setupkeys/setupkeys_test.go
@@ -1,0 +1,69 @@
+package setupkeys
+
+import (
+	"bytes"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewSequenceDryRunOutputsCommands(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("only runs on linux because it relies on linux-specific paths")
+	}
+
+	t.Run("default key path", func(t *testing.T) {
+		tmp := t.TempDir()
+		t.Setenv("HOME", tmp)
+
+		seq, err := NewKeyCreationAndPlacementOnTarget("user@example.com", "")
+		require.NoError(t, err)
+
+		var buf bytes.Buffer
+		require.NoError(t, seq.DryRun(&buf))
+
+		keyPath := filepath.Join(tmp, ".ssh", "id_ed25519_topo_user_example.com")
+		wantKeygen := "ssh-keygen -t ed25519 -f " + keyPath + " -C user@example.com"
+		wantCopy := "ssh-copy-id -i " + keyPath + ".pub user@example.com"
+		got := buf.String()
+		require.Contains(t, got, wantKeygen, "DryRun output should include keygen command")
+		require.Contains(t, got, wantCopy, "DryRun output should include ssh-copy-id command")
+	})
+
+	t.Run("custom key path", func(t *testing.T) {
+		keyPath := filepath.Join(t.TempDir(), "custom_keys", "id_ed25519_custom")
+
+		seq, err := NewKeyCreationAndPlacementOnTarget("user@example.com", keyPath)
+		require.NoError(t, err)
+
+		var buf bytes.Buffer
+		require.NoError(t, seq.DryRun(&buf))
+
+		wantKeygen := "ssh-keygen -t ed25519 -f " + keyPath + " -C user@example.com"
+		wantCopy := "ssh-copy-id -i " + keyPath + ".pub user@example.com"
+		got := buf.String()
+		require.Contains(t, got, wantKeygen, "DryRun output should include keygen command")
+		require.Contains(t, got, wantCopy, "DryRun output should include ssh-copy-id command")
+	})
+}
+
+func TestSanitizeTarget(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"user@example.com", "user_example.com"},
+		{"Example-Host", "Example-Host"},
+		{"spaces and/tabs", "spaces_and_tabs"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			if got := sanitizeTarget(tt.input); got != tt.want {
+				t.Fatalf("sanitizeTarget(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
* Add the option to specify the key path or not.
* Add a --dry-run flag

For now, only support:
- Linux
- Creating keys through ssh-keygen
- Sending keys to the target through ssh-copy-id.

