### PR TITLE
fix: acquire known_hosts flock in e2e tests

### DIFF
--- a/internal/testutil/container.go
+++ b/internal/testutil/container.go
@@ -15,6 +15,8 @@ const TargetContainerHost = "root@localhost"
 
 const TargetContainerImage = "topo-e2e-target:latest"
 
+var knownHostsLockPath = filepath.Join(os.TempDir(), "topo-e2e-known_hosts.lock")
+
 type TargetContainer struct {
 	SSHConnectionString string
 	ContainerName       string
@@ -42,7 +44,7 @@ func StartTargetContainer(t *testing.T) *TargetContainer {
 		t.Fatalf("failed to get container port: %v", err)
 	}
 
-	if err := ensureHostKeyKnown("localhost", port); err != nil {
+	if err := ensureHostKeyKnown(t, "localhost", port); err != nil {
 		t.Fatalf("failed to add host key: %v", err)
 	}
 
@@ -104,7 +106,10 @@ func GetContainerPublicPort(containerName string, privatePort string) (string, e
 	return port, nil
 }
 
-func ensureHostKeyKnown(host string, port string) error {
+func ensureHostKeyKnown(t *testing.T, host string, port string) error {
+	releaseLock := AcquireFlock(t, knownHostsLockPath)
+	defer releaseLock()
+
 	_ = exec.Command("ssh-keygen", "-R", fmt.Sprintf("[%s]:%s", host, port)).Run()
 
 	cmd := exec.Command("ssh-keyscan", "-p", port, host)

--- a/internal/testutil/testutil_posix.go
+++ b/internal/testutil/testutil_posix.go
@@ -3,10 +3,30 @@
 package testutil
 
 import (
+	"os"
+	"syscall"
 	"testing"
 )
 
 func IsPrivilegeError(t *testing.T, err error) bool {
 	t.Helper()
 	return false
+}
+
+func AcquireFlock(t *testing.T, path string) func() {
+	t.Helper()
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		t.Fatalf("failed to open lock file: %v", err)
+	}
+
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
+		_ = f.Close()
+		t.Fatalf("failed to acquire lock: %v", err)
+	}
+
+	return func() {
+		_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+		_ = f.Close()
+	}
 }

--- a/internal/testutil/testutil_windows.go
+++ b/internal/testutil/testutil_windows.go
@@ -3,12 +3,45 @@
 package testutil
 
 import (
+	"os"
 	"syscall"
 	"testing"
+
+	"golang.org/x/sys/windows"
 )
 
 func IsPrivilegeError(t *testing.T, err error) bool {
 	t.Helper()
 	sysCallErr, ok := err.(syscall.Errno)
 	return ok && sysCallErr == syscall.ERROR_PRIVILEGE_NOT_HELD
+}
+
+func AcquireFlock(t *testing.T, path string) func() {
+	t.Helper()
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		t.Fatalf("failed to open lock file: %v", err)
+	}
+
+	err = windows.LockFileEx(
+		windows.Handle(f.Fd()),
+		windows.LOCKFILE_EXCLUSIVE_LOCK,
+		0,
+		1, 0,
+		&windows.Overlapped{},
+	)
+	if err != nil {
+		_ = f.Close()
+		t.Fatalf("failed to acquire lock: %v", err)
+	}
+
+	return func() {
+		_ = windows.UnlockFileEx(
+			windows.Handle(f.Fd()),
+			0,
+			1, 0,
+			&windows.Overlapped{},
+		)
+		_ = f.Close()
+	}
 }


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

Noticed e2e tests randomly fail due to simultaneous writes to `.ssh/known_hosts` since we run multiple e2e tests in parallel now - https://github.com/arm/topo/actions/runs/21873888545/job/63136970853.

- Restores flocking utility we previously had in these tests to remedy this but:
  - Makes it cross-platform
  - Scopes it to only when we modify known_hosts to attempt to minimise slow down this would otherwise introduce
