### PR TITLE
feat: detect SSH password-based authentication

### DIFF
--- a/cmd/topo/describe.go
+++ b/cmd/topo/describe.go
@@ -27,7 +27,7 @@ var describeCmd = &cobra.Command{
 			return err
 		}
 
-		conn := target.NewConnection(sshTarget, ssh.ExecSSH)
+		conn := target.NewConnection(sshTarget, ssh.ExecSSH, target.ConnectionOptions{})
 		report, err := describe.GenerateTargetDescription(conn)
 		if err != nil {
 			return err

--- a/cmd/topo/health.go
+++ b/cmd/topo/health.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/arm-debug/topo-cli/internal/health"
@@ -9,10 +10,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-	healthTarget           string
-	healthAcceptNewHostKey bool
-)
+var healthTarget string
+
+const acceptNewHostFlag = "accept-new-host-keys"
 
 var healthCmd = &cobra.Command{
 	Use:   "health",
@@ -28,7 +28,13 @@ var healthCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		report, err := health.Check(sshTarget, healthAcceptNewHostKey)
+
+		acceptNewHostKeys, err := cmd.Flags().GetBool(acceptNewHostFlag)
+		if err != nil {
+			panic(fmt.Sprintf("internal error: %s flag not registered: %v", acceptNewHostFlag, err))
+		}
+
+		report, err := health.Check(sshTarget, acceptNewHostKeys)
 		if err != nil {
 			return err
 		}
@@ -38,6 +44,6 @@ var healthCmd = &cobra.Command{
 
 func init() {
 	addTargetFlag(healthCmd, &healthTarget)
-	healthCmd.Flags().BoolVar(&healthAcceptNewHostKey, "accept-new-host-keys", false, "Automatically trust and add new SSH host keys for the target")
+	healthCmd.Flags().Bool(acceptNewHostFlag, false, "Automatically trust and add new SSH host keys for the target")
 	rootCmd.AddCommand(healthCmd)
 }

--- a/cmd/topo/health.go
+++ b/cmd/topo/health.go
@@ -9,7 +9,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var healthTarget string
+var (
+	healthTarget           string
+	healthAcceptNewHostKey bool
+)
 
 var healthCmd = &cobra.Command{
 	Use:   "health",
@@ -25,7 +28,7 @@ var healthCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		report, err := health.Check(sshTarget)
+		report, err := health.Check(sshTarget, healthAcceptNewHostKey)
 		if err != nil {
 			return err
 		}
@@ -35,5 +38,6 @@ var healthCmd = &cobra.Command{
 
 func init() {
 	addTargetFlag(healthCmd, &healthTarget)
+	healthCmd.Flags().BoolVar(&healthAcceptNewHostKey, "accept-new-host-keys", false, "Automatically trust and add new SSH host keys for the target")
 	rootCmd.AddCommand(healthCmd)
 }

--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -36,7 +36,7 @@ func FilterTemplateRepos(flags TemplateFilters, repos []Repo) []Repo {
 	targetMode := false
 
 	if flags.Target != "" {
-		conn := target.NewConnection(flags.Target, ssh.ExecSSH)
+		conn := target.NewConnection(flags.Target, ssh.ExecSSH, target.ConnectionOptions{})
 		hw, err := conn.ProbeHardware()
 		if err == nil && len(hw.HostProcessor) > 0 {
 			flags.Features = hw.HostProcessor[0].ExtractArmFeatures()

--- a/internal/describe/describe_test.go
+++ b/internal/describe/describe_test.go
@@ -40,7 +40,7 @@ func TestGenerate(t *testing.T) {
 			},
 		}
 
-		conn := target.NewConnection("test", mockExecSSH)
+		conn := target.NewConnection("test", mockExecSSH, target.ConnectionOptions{})
 		report, err := describe.GenerateTargetDescription(conn)
 
 		require.NoError(t, err)
@@ -52,7 +52,7 @@ func TestGenerate(t *testing.T) {
 			return "", assert.AnError
 		}
 
-		conn := target.NewConnection("test", mockExecSSH)
+		conn := target.NewConnection("test", mockExecSSH, target.ConnectionOptions{})
 		_, err := describe.GenerateTargetDescription(conn)
 
 		assert.Error(t, err)

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -90,12 +90,13 @@ func GenerateReport(hostDependencies []DependencyStatus, targetStatus Status) Re
 func Check(sshTarget string, acceptNewHostKeys bool) (Report, error) {
 	dependencyStatuses := CheckInstalled(HostRequiredDependencies, BinaryExistsLocally)
 
-	sshExists, err := BinaryExistsLocally("ssh")
-	if err != nil {
-		return GenerateReport(dependencyStatuses, Status{}), err
+	authProbeEnabled := false
+	for _, s := range dependencyStatuses {
+		if s.Dependency.Name == "ssh" {
+			authProbeEnabled = s.Installed
+			break
+		}
 	}
-
-	authProbeEnabled := sshExists
 	opts := target.ConnectionOptions{
 		AuthProbeEnabled:  authProbeEnabled,
 		AcceptNewHostKeys: acceptNewHostKeys,

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -9,7 +9,7 @@ import (
 	"github.com/arm-debug/topo-cli/internal/target"
 )
 
-const passwordAuthErrorMessage = `Topo does not support SSH password-based authentication. To connect, either:
+const passwordAuthErrorMessage = `note: Topo does not support SSH password-based authentication. To connect, either:
 - create your own SSH keys for the target, or
 - run 'topo setup-keys --target <target>' to let Topo generate keys and configure passwordless authentication`
 

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -1,11 +1,15 @@
 package health
 
 import (
+	"errors"
+	"os"
 	"strings"
 
 	"github.com/arm-debug/topo-cli/internal/ssh"
 	"github.com/arm-debug/topo-cli/internal/target"
 )
+
+var passwordAuthErrorMessage = "SSH password-based authentication is not supported by topo. Please either:\n- create your own SSH keys for the target or\n- run `topo setup-keys --target <target>` to have topo generate keys for you and set up passwordless authentication"
 
 type HealthCheck struct {
 	Name    string
@@ -83,11 +87,29 @@ func GenerateReport(hostDependencies []DependencyStatus, targetStatus Status) Re
 	return report
 }
 
-func Check(sshTarget string) (Report, error) {
+func Check(sshTarget string, acceptNewHostKeys bool) (Report, error) {
 	dependencyStatuses := CheckInstalled(HostRequiredDependencies, BinaryExistsLocally)
 
-	conn := target.NewConnection(sshTarget, ssh.ExecSSH)
+	sshExists, err := BinaryExistsLocally("ssh")
+	if err != nil {
+		return GenerateReport(dependencyStatuses, Status{}), err
+	}
+
+	authProbeEnabled := sshExists
+	opts := target.ConnectionOptions{
+		AuthProbeEnabled:  authProbeEnabled,
+		AcceptNewHostKeys: acceptNewHostKeys,
+		AuthProbeInput:    os.Stdin,
+		AuthProbeOutput:   os.Stdout,
+	}
+	conn := target.NewConnection(sshTarget, ssh.ExecSSH, opts)
 	targetStatus := ProbeHealthStatus(conn)
 	report := GenerateReport(dependencyStatuses, targetStatus)
+	if err := targetStatus.AuthError; err != nil {
+		if errors.Is(err, target.ErrPasswordAuthenticationRequired) {
+			return report, errors.New(passwordAuthErrorMessage)
+		}
+		return report, err
+	}
 	return report, nil
 }

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -9,7 +9,9 @@ import (
 	"github.com/arm-debug/topo-cli/internal/target"
 )
 
-var passwordAuthErrorMessage = "SSH password-based authentication is not supported by topo. Please either:\n- create your own SSH keys for the target or\n- run `topo setup-keys --target <target>` to have topo generate keys for you and set up passwordless authentication"
+const passwordAuthErrorMessage = `Topo does not support SSH password-based authentication. To connect, either:
+- create your own SSH keys for the target, or
+- run 'topo setup-keys --target <target>' to let Topo generate keys and configure passwordless authentication`
 
 type HealthCheck struct {
 	Name    string

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -109,7 +109,7 @@ func Check(sshTarget string, acceptNewHostKeys bool) (Report, error) {
 	targetStatus := ProbeHealthStatus(conn)
 	report := GenerateReport(dependencyStatuses, targetStatus)
 	if err := targetStatus.AuthError; err != nil {
-		if errors.Is(err, target.ErrPasswordAuthenticationRequired) {
+		if errors.Is(err, target.ErrPasswordAuthentication) {
 			return report, errors.New(passwordAuthErrorMessage)
 		}
 		return report, err

--- a/internal/health/status.go
+++ b/internal/health/status.go
@@ -20,6 +20,7 @@ func (h HardwareProfile) Capabilities() map[HardwareCapability]struct{} {
 type Status struct {
 	SSHTarget       ssh.Host
 	ConnectionError error
+	AuthError       error
 	Dependencies    []DependencyStatus
 	Hardware        HardwareProfile
 }
@@ -27,6 +28,12 @@ type Status struct {
 func ProbeHealthStatus(c target.Connection) Status {
 	var status Status
 	status.SSHTarget = c.SSHTarget
+
+	if err := c.ProbeAuthentication(); err != nil {
+		status.AuthError = err
+		status.ConnectionError = err
+		return status
+	}
 
 	if err := c.ProbeConnection(); err != nil {
 		status.ConnectionError = err

--- a/internal/health/status.go
+++ b/internal/health/status.go
@@ -31,7 +31,6 @@ func ProbeHealthStatus(c target.Connection) Status {
 
 	if err := c.ProbeAuthentication(); err != nil {
 		status.AuthError = err
-		status.ConnectionError = err
 		return status
 	}
 

--- a/internal/health/status_test.go
+++ b/internal/health/status_test.go
@@ -18,7 +18,7 @@ func TestProbeHealthStatus(t *testing.T) {
 			return "", fmt.Errorf("connection refused")
 		}
 
-		conn := target.NewConnection("hostname", mockExec)
+		conn := target.NewConnection("hostname", mockExec, target.ConnectionOptions{})
 		ts := health.ProbeHealthStatus(conn)
 
 		assert.Error(t, ts.ConnectionError)
@@ -39,7 +39,7 @@ func TestProbeHealthStatus(t *testing.T) {
 			}
 		}
 
-		conn := target.NewConnection("hostname", mockExec)
+		conn := target.NewConnection("hostname", mockExec, target.ConnectionOptions{})
 		ts := health.ProbeHealthStatus(conn)
 
 		want := health.HardwareProfile{RemoteCPU: []target.RemoteprocCPU{{Name: "foo"}, {Name: "bar"}}}
@@ -57,7 +57,7 @@ func TestProbeHealthStatus(t *testing.T) {
 			}
 		}
 
-		conn := target.NewConnection("hostname", mockExec)
+		conn := target.NewConnection("hostname", mockExec, target.ConnectionOptions{})
 		ts := health.ProbeHealthStatus(conn)
 
 		assert.NoError(t, ts.ConnectionError)

--- a/internal/ssh/exec.go
+++ b/internal/ssh/exec.go
@@ -53,12 +53,14 @@ func ExecSSHWithShell(target Host, command string) (string, error) {
 
 // Exec runs a command on the target host. If the target is localhost, it runs locally.
 // Pass stdin data as optional parameter, or nil for no stdin.
-func Exec(target Host, command string, stdin []byte) (stdout, stderr string, err error) {
+func Exec(target Host, command string, stdin []byte, sshArgs ...string) (stdout, stderr string, err error) {
 	var cmd *exec.Cmd
 	if target.IsPlainLocalhost() {
 		cmd = exec.Command("/bin/sh", "-c", command)
 	} else {
-		cmd = exec.Command("ssh", string(target), command)
+		args := append([]string{}, sshArgs...)
+		args = append(args, string(target), command)
+		cmd = exec.Command("ssh", args...)
 	}
 
 	if stdin != nil {

--- a/internal/target/connection.go
+++ b/internal/target/connection.go
@@ -1,11 +1,9 @@
 package target
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"io"
-	"os/exec"
 	"slices"
 	"strings"
 
@@ -75,7 +73,7 @@ func (c *Connection) ProbeAuthentication() error {
 	}
 
 	if !c.opts.AcceptNewHostKeys {
-		if err := c.ensureKnownHost(c.opts.AuthProbeInput, c.opts.AuthProbeOutput); err != nil {
+		if err := c.ensureKnownHost(); err != nil {
 			return err
 		}
 	}
@@ -91,56 +89,40 @@ func (c *Connection) ProbeAuthentication() error {
 }
 
 var ErrHostKeyVerification = errors.New("ssh host key verification failed")
+var ErrAuthenticationFailure = errors.New("ssh authentication failed")
 
 func (c *Connection) isPasswordAuthenticated() (bool, error) {
+	// If public key auth succeeds, the target doesn't require password auth.
 	publicArgs := slices.Clone(publicKeyProbeArgs)
 	if c.opts.AcceptNewHostKeys {
 		publicArgs = slices.Concat(publicArgs, acceptNewHostKeyArgs)
 	}
-	publicOut, publicErr := c.runSSHProbe(publicArgs)
-	if publicErr == nil {
+	if err := c.runSSHProbe(publicArgs); err == nil {
 		return false, nil
-	}
-	if isHostKeyVerificationFailure(publicOut) {
-		return false, ErrHostKeyVerification
+	} else if !errors.Is(err, ErrAuthenticationFailure) {
+		return false, err
 	}
 
+	// Public key was rejected. Check if the target accepts password auth.
 	passwordArgs := slices.Clone(passwordProbeArgs)
 	if c.opts.AcceptNewHostKeys {
 		passwordArgs = slices.Concat(passwordArgs, acceptNewHostKeyArgs)
 	}
-	passwordOut, passwordErr := c.runSSHProbe(passwordArgs)
-	if passwordErr == nil {
+	if err := c.runSSHProbe(passwordArgs); err == nil {
 		return false, nil
-	}
-	if isHostKeyVerificationFailure(passwordOut) {
-		return false, ErrHostKeyVerification
-	}
-
-	if isAuthenticationFailure(passwordOut) {
+	} else if errors.Is(err, ErrAuthenticationFailure) {
 		return true, nil
+	} else {
+		return false, err
 	}
-
-	return false, fmt.Errorf("ssh probe failed: %w", passwordErr)
 }
 
-func (c *Connection) ensureKnownHost(in io.Reader, out io.Writer) error {
-	args := slices.Concat(knownHostProbeArgs, []string{string(c.SSHTarget), "true"})
-	cmd := exec.Command("ssh", args...)
-	cmd.Stdin = in
-	var buf bytes.Buffer
-	writer := io.Writer(&buf)
-	if out != nil {
-		writer = io.MultiWriter(out, &buf)
-	}
-	cmd.Stdout = writer
-	cmd.Stderr = writer
-	if err := cmd.Run(); err != nil {
-		output := buf.String()
+func (c *Connection) ensureKnownHost() error {
+	if err := c.runSSHProbe(knownHostProbeArgs); err != nil {
 		switch {
-		case isHostKeyVerificationFailure(output):
+		case errors.Is(err, ErrHostKeyVerification):
 			return ErrHostKeyVerification
-		case isAuthenticationFailure(output):
+		case errors.Is(err, ErrAuthenticationFailure):
 			return nil
 		default:
 			return err
@@ -149,9 +131,19 @@ func (c *Connection) ensureKnownHost(in io.Reader, out io.Writer) error {
 	return nil
 }
 
-func (c *Connection) runSSHProbe(sshArgs []string) (string, error) {
+func (c *Connection) runSSHProbe(sshArgs []string) error {
 	stdout, stderr, err := ssh.Exec(c.SSHTarget, "true", nil, sshArgs...)
-	return stdout + stderr, err
+	if err == nil {
+		return nil
+	}
+	output := stdout + stderr
+	if isHostKeyVerificationFailure(output) {
+		return ErrHostKeyVerification
+	}
+	if isAuthenticationFailure(output) {
+		return ErrAuthenticationFailure
+	}
+	return fmt.Errorf("ssh probe failed: %w", err)
 }
 
 func isHostKeyVerificationFailure(output string) bool {

--- a/internal/target/connection.go
+++ b/internal/target/connection.go
@@ -88,8 +88,10 @@ func (c *Connection) ProbeAuthentication() error {
 	return nil
 }
 
-var ErrHostKeyVerification = errors.New("ssh host key verification failed")
-var ErrAuthenticationFailure = errors.New("ssh authentication failed")
+var (
+	ErrHostKeyVerification   = errors.New("ssh host key verification failed")
+	ErrAuthenticationFailure = errors.New("ssh authentication failed")
+)
 
 func (c *Connection) isPasswordAuthenticated() (bool, error) {
 	// If public key auth succeeds, the target doesn't require password auth.

--- a/internal/target/connection.go
+++ b/internal/target/connection.go
@@ -125,21 +125,12 @@ func (c *Connection) runSSHProbe(sshArgs []string) error {
 		return nil
 	}
 	output := stdout + stderr
-	if isHostKeyVerificationFailure(output) {
+	output = strings.ToLower(output)
+	if strings.Contains(output, "host key verification failed") {
 		return ErrHostKeyVerification
 	}
-	if isAuthenticationFailure(output) {
+	if strings.Contains(output, "permission denied") || strings.Contains(output, "authentication failed") || strings.Contains(output, "password") {
 		return ErrAuthenticationFailure
 	}
 	return fmt.Errorf("ssh probe failed: %w", err)
-}
-
-func isHostKeyVerificationFailure(output string) bool {
-	lower := strings.ToLower(output)
-	return strings.Contains(lower, "host key verification failed")
-}
-
-func isAuthenticationFailure(output string) bool {
-	lower := strings.ToLower(output)
-	return strings.Contains(lower, "permission denied") || strings.Contains(lower, "authentication failed") || strings.Contains(lower, "password")
 }

--- a/internal/target/connection.go
+++ b/internal/target/connection.go
@@ -46,7 +46,7 @@ type ConnectionOptions struct {
 	AuthProbeOutput   io.Writer
 }
 
-var ErrPasswordAuthenticationRequired = errors.New("password authentication required")
+var ErrPasswordAuthentication = errors.New("password authentication required")
 
 func NewConnection(sshTarget string, exec execSSH, opts ConnectionOptions) Connection {
 	return Connection{
@@ -84,7 +84,7 @@ func (c *Connection) ProbeAuthentication() error {
 		return err
 	}
 	if needsSetup {
-		return ErrPasswordAuthenticationRequired
+		return ErrPasswordAuthentication
 	}
 	return nil
 }

--- a/internal/target/connection.go
+++ b/internal/target/connection.go
@@ -1,9 +1,34 @@
 package target
 
 import (
+	"bytes"
+	"errors"
 	"fmt"
+	"io"
+	"os/exec"
+	"strings"
 
 	"github.com/arm-debug/topo-cli/internal/ssh"
+)
+
+var (
+	publicKeyProbeArgs = []string{
+		"-o", "BatchMode=yes",
+		"-o", "PreferredAuthentications=publickey",
+	}
+	passwordProbeArgs = []string{
+		"-o", "BatchMode=yes",
+		"-o", "PreferredAuthentications=password",
+		"-o", "NumberOfPasswordPrompts=0",
+	}
+	knownHostProbeArgs = []string{
+		"-o", "PreferredAuthentications=publickey",
+		"-o", "PasswordAuthentication=no",
+		"-o", "NumberOfPasswordPrompts=0",
+	}
+	acceptNewHostKeyArgs = []string{
+		"-o", "StrictHostKeyChecking=accept-new",
+	}
 )
 
 type execSSH func(target ssh.Host, command string) (string, error)
@@ -11,12 +36,23 @@ type execSSH func(target ssh.Host, command string) (string, error)
 type Connection struct {
 	SSHTarget ssh.Host
 	exec      execSSH
+	opts      ConnectionOptions
 }
 
-func NewConnection(sshTarget string, exec execSSH) Connection {
+type ConnectionOptions struct {
+	AuthProbeEnabled  bool
+	AcceptNewHostKeys bool
+	AuthProbeInput    io.Reader
+	AuthProbeOutput   io.Writer
+}
+
+var ErrPasswordAuthenticationRequired = errors.New("password authentication required")
+
+func NewConnection(sshTarget string, exec execSSH, opts ConnectionOptions) Connection {
 	return Connection{
 		SSHTarget: ssh.Host(sshTarget),
 		exec:      exec,
+		opts:      opts,
 	}
 }
 
@@ -30,4 +66,103 @@ func (c *Connection) BinaryExists(bin string) (bool, error) {
 	}
 	_, err := c.exec(c.SSHTarget, ssh.ShellCommand(fmt.Sprintf("command -v %s", bin)))
 	return err == nil, nil
+}
+
+func (c *Connection) ProbeAuthentication() error {
+	if !c.opts.AuthProbeEnabled {
+		return nil
+	}
+
+	needsSetup, err := c.IsPasswordAuthenticated()
+	if err != nil {
+		return err
+	}
+	if needsSetup {
+		return ErrPasswordAuthenticationRequired
+	}
+	return nil
+}
+
+var ErrHostKeyVerification = errors.New("ssh host key verification failed")
+
+func (c *Connection) IsPasswordAuthenticated() (bool, error) {
+	args := []string{}
+	if !c.opts.AcceptNewHostKeys {
+		if err := c.ensureKnownHost(c.opts.AuthProbeInput, c.opts.AuthProbeOutput); err != nil {
+			return false, err
+		}
+	} else {
+		args = append(args, acceptNewHostKeyArgs...)
+	}
+
+	return c.detectPasswordAuthentication(args)
+}
+
+func (c *Connection) detectPasswordAuthentication(extraArgs []string) (bool, error) {
+	publicArgs := append([]string{}, publicKeyProbeArgs...)
+	publicArgs = append(publicArgs, extraArgs...)
+	publicOut, publicErr := c.runSSHProbe(publicArgs)
+	if publicErr == nil {
+		return false, nil
+	}
+	if isHostKeyVerificationFailure(publicOut) {
+		return false, ErrHostKeyVerification
+	}
+
+	passwordArgs := append([]string{}, passwordProbeArgs...)
+	passwordArgs = append(passwordArgs, extraArgs...)
+	passwordOut, passwordErr := c.runSSHProbe(passwordArgs)
+	if passwordErr == nil {
+		return false, nil
+	}
+	if isHostKeyVerificationFailure(passwordOut) {
+		return false, ErrHostKeyVerification
+	}
+
+	if isAuthenticationFailure(passwordOut) {
+		return true, nil
+	}
+
+	return false, fmt.Errorf("ssh probe failed: %w", passwordErr)
+}
+
+func (c *Connection) ensureKnownHost(in io.Reader, out io.Writer) error {
+	args := append([]string{}, knownHostProbeArgs...)
+	args = append(args, string(c.SSHTarget), "true")
+	cmd := exec.Command("ssh", args...)
+	cmd.Stdin = in
+	var buf bytes.Buffer
+	writer := io.Writer(&buf)
+	if out != nil {
+		writer = io.MultiWriter(out, &buf)
+	}
+	cmd.Stdout = writer
+	cmd.Stderr = writer
+	if err := cmd.Run(); err != nil {
+		output := buf.String()
+		switch {
+		case isHostKeyVerificationFailure(output):
+			return ErrHostKeyVerification
+		case isAuthenticationFailure(output):
+			return nil
+		default:
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *Connection) runSSHProbe(sshArgs []string) (string, error) {
+	stdout, stderr, err := ssh.Exec(c.SSHTarget, "true", nil, sshArgs...)
+	return stdout + stderr, err
+}
+
+func isHostKeyVerificationFailure(output string) bool {
+	lower := strings.ToLower(output)
+	return strings.Contains(lower, "host key verification failed")
+}
+
+func isAuthenticationFailure(output string) bool {
+	lower := strings.ToLower(output)
+	return strings.Contains(lower, "permission denied") || strings.Contains(lower, "authentication failed") || strings.Contains(lower, "password")
 }

--- a/internal/target/connection.go
+++ b/internal/target/connection.go
@@ -45,7 +45,7 @@ type ConnectionOptions struct {
 	AuthProbeOutput   io.Writer
 }
 
-var ErrPasswordAuthentication = errors.New("password authentication required")
+var ErrPasswordAuthentication = errors.New("only password authentication is configured; key-based ssh is required")
 
 func NewConnection(sshTarget string, exec execSSH, opts ConnectionOptions) Connection {
 	return Connection{
@@ -79,11 +79,11 @@ func (c *Connection) ProbeAuthentication() error {
 		}
 	}
 
-	needsSetup, err := c.isPasswordAuthenticated()
+	isPwdAuth, err := c.isPasswordAuthenticated()
 	if err != nil {
 		return err
 	}
-	if needsSetup {
+	if isPwdAuth {
 		return ErrPasswordAuthentication
 	}
 	return nil

--- a/internal/target/connection.go
+++ b/internal/target/connection.go
@@ -94,12 +94,15 @@ var (
 )
 
 func (c *Connection) isPasswordAuthenticated() (bool, error) {
+
+	var extraArgs []string
+	if c.opts.AcceptNewHostKeys {
+		extraArgs = acceptNewHostKeyArgs
+	}
+
 	// If public key auth succeeds, the target doesn't require password auth.
 	publicArgs := slices.Clone(publicKeyProbeArgs)
-	if c.opts.AcceptNewHostKeys {
-		publicArgs = slices.Concat(publicArgs, acceptNewHostKeyArgs)
-	}
-	if err := c.runSSHProbe(publicArgs); err == nil {
+	if err := c.runSSHProbe(slices.Concat(publicArgs, extraArgs)); err == nil {
 		return false, nil
 	} else if !errors.Is(err, ErrAuthenticationFailure) {
 		return false, err
@@ -107,10 +110,7 @@ func (c *Connection) isPasswordAuthenticated() (bool, error) {
 
 	// Public key was rejected. Check if the target accepts password auth.
 	passwordArgs := slices.Clone(passwordProbeArgs)
-	if c.opts.AcceptNewHostKeys {
-		passwordArgs = slices.Concat(passwordArgs, acceptNewHostKeyArgs)
-	}
-	if err := c.runSSHProbe(passwordArgs); err == nil {
+	if err := c.runSSHProbe(slices.Concat(passwordArgs, extraArgs)); err == nil {
 		return false, nil
 	} else if errors.Is(err, ErrAuthenticationFailure) {
 		return true, nil

--- a/internal/target/connection.go
+++ b/internal/target/connection.go
@@ -73,7 +73,8 @@ func (c *Connection) ProbeAuthentication() error {
 	}
 
 	if !c.opts.AcceptNewHostKeys {
-		if err := c.ensureKnownHost(); err != nil {
+		err := c.runSSHProbe(knownHostProbeArgs)
+		if err != nil && !errors.Is(err, ErrAuthenticationFailure) {
 			return err
 		}
 	}
@@ -94,7 +95,6 @@ var (
 )
 
 func (c *Connection) isPasswordAuthenticated() (bool, error) {
-
 	var extraArgs []string
 	if c.opts.AcceptNewHostKeys {
 		extraArgs = acceptNewHostKeyArgs
@@ -117,20 +117,6 @@ func (c *Connection) isPasswordAuthenticated() (bool, error) {
 	} else {
 		return false, err
 	}
-}
-
-func (c *Connection) ensureKnownHost() error {
-	if err := c.runSSHProbe(knownHostProbeArgs); err != nil {
-		switch {
-		case errors.Is(err, ErrHostKeyVerification):
-			return ErrHostKeyVerification
-		case errors.Is(err, ErrAuthenticationFailure):
-			return nil
-		default:
-			return err
-		}
-	}
-	return nil
 }
 
 func (c *Connection) runSSHProbe(sshArgs []string) error {

--- a/internal/target/connection.go
+++ b/internal/target/connection.go
@@ -73,7 +73,13 @@ func (c *Connection) ProbeAuthentication() error {
 		return nil
 	}
 
-	needsSetup, err := c.IsPasswordAuthenticated()
+	if !c.opts.AcceptNewHostKeys {
+		if err := c.ensureKnownHost(c.opts.AuthProbeInput, c.opts.AuthProbeOutput); err != nil {
+			return err
+		}
+	}
+
+	needsSetup, err := c.isPasswordAuthenticated()
 	if err != nil {
 		return err
 	}
@@ -85,22 +91,11 @@ func (c *Connection) ProbeAuthentication() error {
 
 var ErrHostKeyVerification = errors.New("ssh host key verification failed")
 
-func (c *Connection) IsPasswordAuthenticated() (bool, error) {
-	args := []string{}
-	if !c.opts.AcceptNewHostKeys {
-		if err := c.ensureKnownHost(c.opts.AuthProbeInput, c.opts.AuthProbeOutput); err != nil {
-			return false, err
-		}
-	} else {
-		args = append(args, acceptNewHostKeyArgs...)
-	}
-
-	return c.detectPasswordAuthentication(args)
-}
-
-func (c *Connection) detectPasswordAuthentication(extraArgs []string) (bool, error) {
+func (c *Connection) isPasswordAuthenticated() (bool, error) {
 	publicArgs := append([]string{}, publicKeyProbeArgs...)
-	publicArgs = append(publicArgs, extraArgs...)
+	if c.opts.AcceptNewHostKeys {
+		publicArgs = append(publicArgs, acceptNewHostKeyArgs...)
+	}
 	publicOut, publicErr := c.runSSHProbe(publicArgs)
 	if publicErr == nil {
 		return false, nil
@@ -110,7 +105,9 @@ func (c *Connection) detectPasswordAuthentication(extraArgs []string) (bool, err
 	}
 
 	passwordArgs := append([]string{}, passwordProbeArgs...)
-	passwordArgs = append(passwordArgs, extraArgs...)
+	if c.opts.AcceptNewHostKeys {
+		passwordArgs = append(passwordArgs, acceptNewHostKeyArgs...)
+	}
 	passwordOut, passwordErr := c.runSSHProbe(passwordArgs)
 	if passwordErr == nil {
 		return false, nil

--- a/internal/target/connection.go
+++ b/internal/target/connection.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os/exec"
+	"slices"
 	"strings"
 
 	"github.com/arm-debug/topo-cli/internal/ssh"
@@ -92,9 +93,9 @@ func (c *Connection) ProbeAuthentication() error {
 var ErrHostKeyVerification = errors.New("ssh host key verification failed")
 
 func (c *Connection) isPasswordAuthenticated() (bool, error) {
-	publicArgs := append([]string{}, publicKeyProbeArgs...)
+	publicArgs := slices.Clone(publicKeyProbeArgs)
 	if c.opts.AcceptNewHostKeys {
-		publicArgs = append(publicArgs, acceptNewHostKeyArgs...)
+		publicArgs = slices.Concat(publicArgs, acceptNewHostKeyArgs)
 	}
 	publicOut, publicErr := c.runSSHProbe(publicArgs)
 	if publicErr == nil {
@@ -104,9 +105,9 @@ func (c *Connection) isPasswordAuthenticated() (bool, error) {
 		return false, ErrHostKeyVerification
 	}
 
-	passwordArgs := append([]string{}, passwordProbeArgs...)
+	passwordArgs := slices.Clone(passwordProbeArgs)
 	if c.opts.AcceptNewHostKeys {
-		passwordArgs = append(passwordArgs, acceptNewHostKeyArgs...)
+		passwordArgs = slices.Concat(passwordArgs, acceptNewHostKeyArgs)
 	}
 	passwordOut, passwordErr := c.runSSHProbe(passwordArgs)
 	if passwordErr == nil {
@@ -124,8 +125,7 @@ func (c *Connection) isPasswordAuthenticated() (bool, error) {
 }
 
 func (c *Connection) ensureKnownHost(in io.Reader, out io.Writer) error {
-	args := append([]string{}, knownHostProbeArgs...)
-	args = append(args, string(c.SSHTarget), "true")
+	args := slices.Concat(knownHostProbeArgs, []string{string(c.SSHTarget), "true"})
 	cmd := exec.Command("ssh", args...)
 	cmd.Stdin = in
 	var buf bytes.Buffer

--- a/internal/target/connection_auth_test.go
+++ b/internal/target/connection_auth_test.go
@@ -73,7 +73,7 @@ func TestProbeAuthentication(t *testing.T) {
 		}, func(argsFile string) {
 			conn := newConnectionWithOpts(target.ConnectionOptions{AuthProbeEnabled: true, AcceptNewHostKeys: true})
 			err := conn.ProbeAuthentication()
-			require.ErrorIs(t, err, target.ErrPasswordAuthenticationRequired)
+			require.ErrorIs(t, err, target.ErrPasswordAuthentication)
 		})
 	})
 

--- a/internal/target/connection_auth_test.go
+++ b/internal/target/connection_auth_test.go
@@ -1,0 +1,152 @@
+package target_test
+
+import (
+	"testing"
+
+	"github.com/arm-debug/topo-cli/internal/ssh"
+	"github.com/arm-debug/topo-cli/internal/target"
+	"github.com/arm-debug/topo-cli/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newConnectionWithOpts(opts target.ConnectionOptions) target.Connection {
+	mockExec := func(_ ssh.Host, _ string) (string, error) {
+		return "", nil
+	}
+	return target.NewConnection("user@host", mockExec, opts)
+}
+
+func TestIsPasswordAuthenticated(t *testing.T) {
+	testutil.RequireOS(t, "linux")
+
+	t.Run("returns false when public key succeeds", func(t *testing.T) {
+		testutil.WithFakeSSH(t, map[string]string{
+			"SSH_TEST_PUBLIC_EXIT": "0",
+		}, func(argsFile string) {
+			conn := newConnectionWithOpts(target.ConnectionOptions{AcceptNewHostKeys: true})
+			got, err := conn.IsPasswordAuthenticated()
+			require.NoError(t, err)
+			assert.False(t, got)
+
+			lines := testutil.ReadArgsLines(t, argsFile)
+			require.Len(t, lines, 1)
+			assert.Contains(t, lines[0], "PreferredAuthentications=publickey")
+			assert.Contains(t, lines[0], "StrictHostKeyChecking=accept-new")
+		})
+	})
+
+	t.Run("returns host key verification error for public key probe", func(t *testing.T) {
+		testutil.WithFakeSSH(t, map[string]string{
+			"SSH_TEST_PUBLIC_STDERR": "Host key verification failed",
+			"SSH_TEST_PUBLIC_EXIT":   "1",
+		}, func(argsFile string) {
+			conn := newConnectionWithOpts(target.ConnectionOptions{AcceptNewHostKeys: true})
+			_, err := conn.IsPasswordAuthenticated()
+			require.ErrorIs(t, err, target.ErrHostKeyVerification)
+			lines := testutil.ReadArgsLines(t, argsFile)
+			require.Len(t, lines, 1)
+		})
+	})
+
+	t.Run("returns host key verification error for password probe", func(t *testing.T) {
+		testutil.WithFakeSSH(t, map[string]string{
+			"SSH_TEST_PUBLIC_STDERR":   "Permission denied",
+			"SSH_TEST_PUBLIC_EXIT":     "1",
+			"SSH_TEST_PASSWORD_STDERR": "Host key verification failed",
+			"SSH_TEST_PASSWORD_EXIT":   "1",
+		}, func(argsFile string) {
+			conn := newConnectionWithOpts(target.ConnectionOptions{AcceptNewHostKeys: true})
+			_, err := conn.IsPasswordAuthenticated()
+			require.ErrorIs(t, err, target.ErrHostKeyVerification)
+			lines := testutil.ReadArgsLines(t, argsFile)
+			require.Len(t, lines, 2)
+			assert.Contains(t, lines[1], "PreferredAuthentications=password")
+		})
+	})
+
+	t.Run("detects password-based authentication", func(t *testing.T) {
+		testutil.WithFakeSSH(t, map[string]string{
+			"SSH_TEST_PUBLIC_STDERR":   "Permission denied",
+			"SSH_TEST_PUBLIC_EXIT":     "1",
+			"SSH_TEST_PASSWORD_STDERR": "Authentication failed",
+			"SSH_TEST_PASSWORD_EXIT":   "1",
+		}, func(argsFile string) {
+			conn := newConnectionWithOpts(target.ConnectionOptions{AcceptNewHostKeys: true})
+			got, err := conn.IsPasswordAuthenticated()
+			require.NoError(t, err)
+			assert.True(t, got)
+		})
+	})
+
+	t.Run("returns false when password probe succeeds", func(t *testing.T) {
+		testutil.WithFakeSSH(t, map[string]string{
+			"SSH_TEST_PUBLIC_STDERR":   "Permission denied",
+			"SSH_TEST_PUBLIC_EXIT":     "1",
+			"SSH_TEST_PASSWORD_STDOUT": "ok",
+			"SSH_TEST_PASSWORD_EXIT":   "0",
+		}, func(argsFile string) {
+			conn := newConnectionWithOpts(target.ConnectionOptions{AcceptNewHostKeys: true})
+			got, err := conn.IsPasswordAuthenticated()
+			require.NoError(t, err)
+			assert.False(t, got)
+		})
+	})
+
+	t.Run("returns error on non-auth failure for password probe", func(t *testing.T) {
+		testutil.WithFakeSSH(t, map[string]string{
+			"SSH_TEST_PUBLIC_STDERR":   "Permission denied",
+			"SSH_TEST_PUBLIC_EXIT":     "1",
+			"SSH_TEST_PASSWORD_STDERR": "Some other error",
+			"SSH_TEST_PASSWORD_EXIT":   "1",
+		}, func(argsFile string) {
+			conn := newConnectionWithOpts(target.ConnectionOptions{AcceptNewHostKeys: true})
+			_, err := conn.IsPasswordAuthenticated()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "ssh probe failed")
+		})
+	})
+
+	t.Run("ensures known host when not accepting new host keys", func(t *testing.T) {
+		testutil.WithFakeSSH(t, map[string]string{
+			"SSH_TEST_KNOWNHOST_STDERR": "Permission denied",
+			"SSH_TEST_KNOWNHOST_EXIT":   "1",
+			"SSH_TEST_PUBLIC_EXIT":      "0",
+		}, func(argsFile string) {
+			conn := newConnectionWithOpts(target.ConnectionOptions{AcceptNewHostKeys: false})
+			got, err := conn.IsPasswordAuthenticated()
+			require.NoError(t, err)
+			assert.False(t, got)
+
+			lines := testutil.ReadArgsLines(t, argsFile)
+			require.Len(t, lines, 2)
+			assert.Contains(t, lines[0], "PasswordAuthentication=no")
+		})
+	})
+
+	t.Run("returns host key verification error when known host fails", func(t *testing.T) {
+		testutil.WithFakeSSH(t, map[string]string{
+			"SSH_TEST_KNOWNHOST_STDERR": "HOST KEY VERIFICATION FAILED",
+			"SSH_TEST_KNOWNHOST_EXIT":   "1",
+		}, func(argsFile string) {
+			conn := newConnectionWithOpts(target.ConnectionOptions{AcceptNewHostKeys: false})
+			_, err := conn.IsPasswordAuthenticated()
+			require.ErrorIs(t, err, target.ErrHostKeyVerification)
+			lines := testutil.ReadArgsLines(t, argsFile)
+			require.Len(t, lines, 1)
+		})
+	})
+
+	t.Run("returns error when known host fails with other error", func(t *testing.T) {
+		testutil.WithFakeSSH(t, map[string]string{
+			"SSH_TEST_KNOWNHOST_STDERR": "dial tcp: lookup host: no such host",
+			"SSH_TEST_KNOWNHOST_EXIT":   "1",
+		}, func(argsFile string) {
+			conn := newConnectionWithOpts(target.ConnectionOptions{AcceptNewHostKeys: false})
+			_, err := conn.IsPasswordAuthenticated()
+			require.Error(t, err)
+			lines := testutil.ReadArgsLines(t, argsFile)
+			require.Len(t, lines, 1)
+		})
+	})
+}

--- a/internal/target/connection_auth_test.go
+++ b/internal/target/connection_auth_test.go
@@ -64,7 +64,7 @@ func TestProbeAuthentication(t *testing.T) {
 		})
 	})
 
-	t.Run("returns password authentication required when password auth fails", func(t *testing.T) {
+	t.Run("returns password-only auth error when auth fails", func(t *testing.T) {
 		testutil.WithFakeSSH(t, map[string]string{
 			"SSH_TEST_PUBLIC_STDERR":   "Permission denied",
 			"SSH_TEST_PUBLIC_EXIT":     "1",

--- a/internal/target/connection_auth_test.go
+++ b/internal/target/connection_auth_test.go
@@ -17,17 +17,16 @@ func newConnectionWithOpts(opts target.ConnectionOptions) target.Connection {
 	return target.NewConnection("user@host", mockExec, opts)
 }
 
-func TestIsPasswordAuthenticated(t *testing.T) {
+func TestProbeAuthentication(t *testing.T) {
 	testutil.RequireOS(t, "linux")
 
-	t.Run("returns false when public key succeeds", func(t *testing.T) {
+	t.Run("does not require password when public key succeeds", func(t *testing.T) {
 		testutil.WithFakeSSH(t, map[string]string{
 			"SSH_TEST_PUBLIC_EXIT": "0",
 		}, func(argsFile string) {
-			conn := newConnectionWithOpts(target.ConnectionOptions{AcceptNewHostKeys: true})
-			got, err := conn.IsPasswordAuthenticated()
+			conn := newConnectionWithOpts(target.ConnectionOptions{AuthProbeEnabled: true, AcceptNewHostKeys: true})
+			err := conn.ProbeAuthentication()
 			require.NoError(t, err)
-			assert.False(t, got)
 
 			lines := testutil.ReadArgsLines(t, argsFile)
 			require.Len(t, lines, 1)
@@ -41,8 +40,8 @@ func TestIsPasswordAuthenticated(t *testing.T) {
 			"SSH_TEST_PUBLIC_STDERR": "Host key verification failed",
 			"SSH_TEST_PUBLIC_EXIT":   "1",
 		}, func(argsFile string) {
-			conn := newConnectionWithOpts(target.ConnectionOptions{AcceptNewHostKeys: true})
-			_, err := conn.IsPasswordAuthenticated()
+			conn := newConnectionWithOpts(target.ConnectionOptions{AuthProbeEnabled: true, AcceptNewHostKeys: true})
+			err := conn.ProbeAuthentication()
 			require.ErrorIs(t, err, target.ErrHostKeyVerification)
 			lines := testutil.ReadArgsLines(t, argsFile)
 			require.Len(t, lines, 1)
@@ -56,8 +55,8 @@ func TestIsPasswordAuthenticated(t *testing.T) {
 			"SSH_TEST_PASSWORD_STDERR": "Host key verification failed",
 			"SSH_TEST_PASSWORD_EXIT":   "1",
 		}, func(argsFile string) {
-			conn := newConnectionWithOpts(target.ConnectionOptions{AcceptNewHostKeys: true})
-			_, err := conn.IsPasswordAuthenticated()
+			conn := newConnectionWithOpts(target.ConnectionOptions{AuthProbeEnabled: true, AcceptNewHostKeys: true})
+			err := conn.ProbeAuthentication()
 			require.ErrorIs(t, err, target.ErrHostKeyVerification)
 			lines := testutil.ReadArgsLines(t, argsFile)
 			require.Len(t, lines, 2)
@@ -65,31 +64,32 @@ func TestIsPasswordAuthenticated(t *testing.T) {
 		})
 	})
 
-	t.Run("detects password-based authentication", func(t *testing.T) {
+	t.Run("returns password authentication required when password auth fails", func(t *testing.T) {
 		testutil.WithFakeSSH(t, map[string]string{
 			"SSH_TEST_PUBLIC_STDERR":   "Permission denied",
 			"SSH_TEST_PUBLIC_EXIT":     "1",
 			"SSH_TEST_PASSWORD_STDERR": "Authentication failed",
 			"SSH_TEST_PASSWORD_EXIT":   "1",
 		}, func(argsFile string) {
-			conn := newConnectionWithOpts(target.ConnectionOptions{AcceptNewHostKeys: true})
-			got, err := conn.IsPasswordAuthenticated()
-			require.NoError(t, err)
-			assert.True(t, got)
+			conn := newConnectionWithOpts(target.ConnectionOptions{AuthProbeEnabled: true, AcceptNewHostKeys: true})
+			err := conn.ProbeAuthentication()
+			require.ErrorIs(t, err, target.ErrPasswordAuthenticationRequired)
 		})
 	})
 
-	t.Run("returns false when password probe succeeds", func(t *testing.T) {
+	t.Run("does not require password when password probe succeeds", func(t *testing.T) {
 		testutil.WithFakeSSH(t, map[string]string{
 			"SSH_TEST_PUBLIC_STDERR":   "Permission denied",
 			"SSH_TEST_PUBLIC_EXIT":     "1",
 			"SSH_TEST_PASSWORD_STDOUT": "ok",
 			"SSH_TEST_PASSWORD_EXIT":   "0",
 		}, func(argsFile string) {
-			conn := newConnectionWithOpts(target.ConnectionOptions{AcceptNewHostKeys: true})
-			got, err := conn.IsPasswordAuthenticated()
+			conn := newConnectionWithOpts(target.ConnectionOptions{AuthProbeEnabled: true, AcceptNewHostKeys: true})
+			err := conn.ProbeAuthentication()
 			require.NoError(t, err)
-			assert.False(t, got)
+			lines := testutil.ReadArgsLines(t, argsFile)
+			require.Len(t, lines, 2)
+			assert.Contains(t, lines[1], "PreferredAuthentications=password")
 		})
 	})
 
@@ -100,8 +100,8 @@ func TestIsPasswordAuthenticated(t *testing.T) {
 			"SSH_TEST_PASSWORD_STDERR": "Some other error",
 			"SSH_TEST_PASSWORD_EXIT":   "1",
 		}, func(argsFile string) {
-			conn := newConnectionWithOpts(target.ConnectionOptions{AcceptNewHostKeys: true})
-			_, err := conn.IsPasswordAuthenticated()
+			conn := newConnectionWithOpts(target.ConnectionOptions{AuthProbeEnabled: true, AcceptNewHostKeys: true})
+			err := conn.ProbeAuthentication()
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), "ssh probe failed")
 		})
@@ -113,10 +113,9 @@ func TestIsPasswordAuthenticated(t *testing.T) {
 			"SSH_TEST_KNOWNHOST_EXIT":   "1",
 			"SSH_TEST_PUBLIC_EXIT":      "0",
 		}, func(argsFile string) {
-			conn := newConnectionWithOpts(target.ConnectionOptions{AcceptNewHostKeys: false})
-			got, err := conn.IsPasswordAuthenticated()
+			conn := newConnectionWithOpts(target.ConnectionOptions{AuthProbeEnabled: true, AcceptNewHostKeys: false})
+			err := conn.ProbeAuthentication()
 			require.NoError(t, err)
-			assert.False(t, got)
 
 			lines := testutil.ReadArgsLines(t, argsFile)
 			require.Len(t, lines, 2)
@@ -129,8 +128,8 @@ func TestIsPasswordAuthenticated(t *testing.T) {
 			"SSH_TEST_KNOWNHOST_STDERR": "HOST KEY VERIFICATION FAILED",
 			"SSH_TEST_KNOWNHOST_EXIT":   "1",
 		}, func(argsFile string) {
-			conn := newConnectionWithOpts(target.ConnectionOptions{AcceptNewHostKeys: false})
-			_, err := conn.IsPasswordAuthenticated()
+			conn := newConnectionWithOpts(target.ConnectionOptions{AuthProbeEnabled: true, AcceptNewHostKeys: false})
+			err := conn.ProbeAuthentication()
 			require.ErrorIs(t, err, target.ErrHostKeyVerification)
 			lines := testutil.ReadArgsLines(t, argsFile)
 			require.Len(t, lines, 1)
@@ -142,8 +141,8 @@ func TestIsPasswordAuthenticated(t *testing.T) {
 			"SSH_TEST_KNOWNHOST_STDERR": "dial tcp: lookup host: no such host",
 			"SSH_TEST_KNOWNHOST_EXIT":   "1",
 		}, func(argsFile string) {
-			conn := newConnectionWithOpts(target.ConnectionOptions{AcceptNewHostKeys: false})
-			_, err := conn.IsPasswordAuthenticated()
+			conn := newConnectionWithOpts(target.ConnectionOptions{AuthProbeEnabled: true, AcceptNewHostKeys: false})
+			err := conn.ProbeAuthentication()
 			require.Error(t, err)
 			lines := testutil.ReadArgsLines(t, argsFile)
 			require.Len(t, lines, 1)

--- a/internal/target/connection_test.go
+++ b/internal/target/connection_test.go
@@ -14,7 +14,7 @@ func TestRun(t *testing.T) {
 		mockExec := func(_ ssh.Host, _ string) (string, error) {
 			return "success", nil
 		}
-		conn := target.NewConnection("hostname", mockExec)
+		conn := target.NewConnection("hostname", mockExec, target.ConnectionOptions{})
 
 		out, err := conn.Run("ls")
 
@@ -26,7 +26,7 @@ func TestRun(t *testing.T) {
 		mockExec := func(_ ssh.Host, _ string) (string, error) {
 			return "", errors.New("ssh failed")
 		}
-		conn := target.NewConnection("hostname", mockExec)
+		conn := target.NewConnection("hostname", mockExec, target.ConnectionOptions{})
 
 		out, err := conn.Run("ls")
 
@@ -40,7 +40,7 @@ func TestBinaryExists(t *testing.T) {
 		mockExec := func(_ ssh.Host, _ string) (string, error) {
 			return "/foo/bar", nil
 		}
-		conn := target.NewConnection("hostname", mockExec)
+		conn := target.NewConnection("hostname", mockExec, target.ConnectionOptions{})
 
 		got, err := conn.BinaryExists("bar")
 
@@ -52,7 +52,7 @@ func TestBinaryExists(t *testing.T) {
 		mockExec := func(_ ssh.Host, _ string) (string, error) {
 			return "/foo/bar", nil
 		}
-		conn := target.NewConnection("hostname", mockExec)
+		conn := target.NewConnection("hostname", mockExec, target.ConnectionOptions{})
 
 		got, err := conn.BinaryExists("b a r")
 

--- a/internal/target/probe_test.go
+++ b/internal/target/probe_test.go
@@ -48,7 +48,7 @@ func TestProbeHardware(t *testing.T) {
 			}
 		}
 
-		conn := target.NewConnection("hostname", mockExec)
+		conn := target.NewConnection("hostname", mockExec, target.ConnectionOptions{})
 		hw, err := conn.ProbeHardware()
 
 		require.NoError(t, err)
@@ -63,7 +63,7 @@ func TestProbeHardware(t *testing.T) {
 			return "", errors.New("not found")
 		}
 
-		conn := target.NewConnection("hostname", mockExec)
+		conn := target.NewConnection("hostname", mockExec, target.ConnectionOptions{})
 		_, err := conn.ProbeHardware()
 
 		assert.ErrorContains(t, err, "lscpu not found")
@@ -81,7 +81,7 @@ func TestProbeHardware(t *testing.T) {
 			}
 		}
 
-		conn := target.NewConnection("hostname", mockExec)
+		conn := target.NewConnection("hostname", mockExec, target.ConnectionOptions{})
 		_, err := conn.ProbeHardware()
 
 		assert.ErrorContains(t, err, "collecting CPU info")

--- a/internal/testutil/testdata/fake_ssh.sh
+++ b/internal/testutil/testdata/fake_ssh.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+set -eu
+
+if [ -n "${SSH_TEST_ARGS_FILE:-}" ]; then
+  printf '%s\n' "$*" >> "$SSH_TEST_ARGS_FILE"
+fi
+
+mode="default"
+for arg in "$@"; do
+  case "$arg" in
+    PreferredAuthentications=publickey) mode="public" ;;
+    PreferredAuthentications=password) mode="password" ;;
+    PasswordAuthentication=no) mode="knownhost" ;;
+  esac
+done
+
+stdout_var=""
+stderr_var=""
+exit_var=""
+case "$mode" in
+  public)
+    stdout_var="SSH_TEST_PUBLIC_STDOUT"
+    stderr_var="SSH_TEST_PUBLIC_STDERR"
+    exit_var="SSH_TEST_PUBLIC_EXIT"
+    ;;
+  password)
+    stdout_var="SSH_TEST_PASSWORD_STDOUT"
+    stderr_var="SSH_TEST_PASSWORD_STDERR"
+    exit_var="SSH_TEST_PASSWORD_EXIT"
+    ;;
+  knownhost)
+    stdout_var="SSH_TEST_KNOWNHOST_STDOUT"
+    stderr_var="SSH_TEST_KNOWNHOST_STDERR"
+    exit_var="SSH_TEST_KNOWNHOST_EXIT"
+    ;;
+  *)
+    stdout_var="SSH_TEST_DEFAULT_STDOUT"
+    stderr_var="SSH_TEST_DEFAULT_STDERR"
+    exit_var="SSH_TEST_DEFAULT_EXIT"
+    ;;
+esac
+
+eval "stdout=\${$stdout_var-}"
+eval "stderr=\${$stderr_var-}"
+eval "exit_code=\${$exit_var-1}"
+
+if [ -n "${stdout-}" ]; then
+  printf '%s' "$stdout"
+fi
+if [ -n "${stderr-}" ]; then
+  printf '%s' "$stderr" >&2
+fi
+
+exit "$exit_code"

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -56,6 +56,44 @@ func RequireWriteFile(t testing.TB, path, content string) {
 	require.NoError(t, err)
 }
 
+func WithFakeSSH(t testing.TB, env map[string]string, fn func(argsFile string)) {
+	t.Helper()
+
+	dir := t.TempDir()
+	_, file, _, ok := runtime.Caller(0)
+	require.True(t, ok, "resolve testutil path")
+	scriptPath := filepath.Join(filepath.Dir(file), "testdata", "fake_ssh.sh")
+	script, err := os.ReadFile(scriptPath)
+	require.NoError(t, err, "read fake ssh script")
+	sshPath := filepath.Join(dir, "ssh")
+	require.NoError(t, os.WriteFile(sshPath, script, 0o755), "write fake ssh")
+
+	argsFile := filepath.Join(dir, "args.txt")
+	t.Setenv("SSH_TEST_ARGS_FILE", argsFile)
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	for k, v := range env {
+		t.Setenv(k, v)
+	}
+
+	fn(argsFile)
+}
+
+func ReadArgsLines(t testing.TB, argsFile string) []string {
+	t.Helper()
+	data, err := os.ReadFile(argsFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		require.NoError(t, err, "read args")
+	}
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if len(lines) == 1 && lines[0] == "" {
+		return nil
+	}
+	return lines
+}
+
 func SanitiseTestName(t testing.TB) string {
 	name := strings.ToLower(t.Name())
 	name = strings.ReplaceAll(name, "/", "-")


### PR DESCRIPTION
topo does not support password-based authentication (and does not intend to, as key-based authentication is stronger).

Currently, the first command in topo's flow is:
- `topo health --target <target>`.

`topo health` is therefore the command in which we check what type of authentication is being used in the SSH.

 * Add a check in `topo health` that fails early if SSH password-based authentication is the only authentication that is set up.

This approach means that if `topo health` is skipped, the user won't get this early failure and will probably face issues on the rest of the commands.