### PR TITLE
Use same variable for the github token

### DIFF
--- a/scripts/update_templates/main.go
+++ b/scripts/update_templates/main.go
@@ -24,9 +24,9 @@ type Template struct {
 }
 
 func main() {
-	token := os.Getenv("GH_PAT")
+	token := os.Getenv("GITHUB_TOKEN")
 	if token == "" {
-		fmt.Fprintln(os.Stderr, "GH_PAT is not set: create a personal access token and set the envvar")
+		fmt.Fprintln(os.Stderr, "GITHUB_TOKEN is not set: create a personal access token and set the envvar")
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- I noticed we use `GH_PATH` for the update script but in our codebases (including this one) we normally use `GITHUB_TOKEN`. This PR makes things more consistent.
