### PR TITLE
Protect against ssh flag-injection

### DIFF
--- a/internal/ssh/exec.go
+++ b/internal/ssh/exec.go
@@ -42,7 +42,7 @@ func Exec(target Host, command string, stdin []byte, sshArgs ...string) (string,
 	if target.IsPlainLocalhost() {
 		cmd = exec.Command("/bin/sh", "-c", command)
 	} else {
-		args := slices.Concat(sshArgs, []string{string(target), command})
+		args := slices.Concat(sshArgs, []string{"--", string(target), command})
 		cmd = exec.Command("ssh", args...)
 	}
 


### PR DESCRIPTION
## Changes

- SSH already contains the right functionality to protect against command injection.
- With the use of `--` injected options are rejected.
