### PR TITLE
Filter templates now handles errors

### DIFF
--- a/cmd/topo/templates.go
+++ b/cmd/topo/templates.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/arm-debug/topo-cli/internal/catalog"
@@ -31,7 +32,10 @@ var templatesCmd = &cobra.Command{
 			return err
 		}
 
-		repos = catalog.FilterTemplateRepos(templateFilters, repos)
+		repos, err = catalog.FilterTemplateRepos(templateFilters, repos)
+		if err != nil {
+			return fmt.Errorf("could not filter templates: %w", err)
+		}
 		return printable.Print(templates.RepoCollection(repos), os.Stdout, outputFormat)
 	},
 }

--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -32,13 +32,16 @@ func GetTemplateRepo(id string) (*Repo, error) {
 	return GetRepo(id, TemplatesJSON)
 }
 
-func FilterTemplateRepos(flags TemplateFilters, repos []Repo) []Repo {
+func FilterTemplateRepos(flags TemplateFilters, repos []Repo) ([]Repo, error) {
 	targetMode := false
 
 	if flags.Target != "" {
 		conn := target.NewConnection(flags.Target, ssh.ExecSSH, target.ConnectionOptions{})
 		hw, err := conn.ProbeHardware()
-		if err == nil && len(hw.HostProcessor) > 0 {
+		if err != nil {
+			return nil, err
+		}
+		if len(hw.HostProcessor) > 0 {
 			flags.Features = hw.HostProcessor[0].ExtractArmFeatures()
 		}
 		targetMode = true
@@ -50,7 +53,7 @@ func FilterTemplateRepos(flags TemplateFilters, repos []Repo) []Repo {
 			filtered = append(filtered, repo)
 		}
 	}
-	return filtered
+	return filtered, nil
 }
 
 func supportsFeatures(features []string, repo Repo, targetMode bool) bool {

--- a/internal/catalog/catalog_test.go
+++ b/internal/catalog/catalog_test.go
@@ -53,7 +53,8 @@ func TestFilterTemplateRepos(t *testing.T) {
 			},
 		}
 
-		got := catalog.FilterTemplateRepos(flags, collection)
+		got, err := catalog.FilterTemplateRepos(flags, collection)
+		require.NoError(t, err)
 
 		want := []catalog.Repo{
 			{
@@ -90,7 +91,8 @@ func TestFilterTemplateRepos(t *testing.T) {
 			},
 		}
 
-		got := catalog.FilterTemplateRepos(flags, collection)
+		got, err := catalog.FilterTemplateRepos(flags, collection)
+		require.NoError(t, err)
 
 		want := []catalog.Repo{
 			{


### PR DESCRIPTION
## Changes

- I noticed that the template filtering on target failed silently if you could not connect to the target
- Now fails when a target is unavailable.
