### PR TITLE
Used latest gorleaser format

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -29,11 +29,11 @@ builds:
 
 archives:
   - id: archive
-    builds:
+    ids:
       - topo
     format_overrides:
       - goos: windows
-        format: zip
+        formats: zip
     files:
       - README.md
       - CHANGELOG.md


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- Fixes these warnings:

```
  • setting defaults
    • DEPRECATED: archives.format_overrides.format should not be used anymore, check https://goreleaser.com/deprecations#archivesformat_overridesformat for more info
    • DEPRECATED: archives.builds should not be used anymore, check https://goreleaser.com/deprecations#archivesbuilds for more info
```

From https://github.com/arm/topo/actions/runs/22180282587/job/64139497041