### PR TITLE
feat: add Windows Public Key transfer support

### DIFF
--- a/cmd/topo/setup_keys.go
+++ b/cmd/topo/setup_keys.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/arm/topo/internal/setupkeys"
+	"github.com/arm/topo/internal/setup_keys"
 	"github.com/spf13/cobra"
 )
 
@@ -29,12 +29,13 @@ Use --dry-run to see what commands would be executed without actually running th
 		if err != nil {
 			return err
 		}
-		privKeyPath, err := setupkeys.CreateKeyPair(resolvedTarget, setupKeysKeyPath, os.Stdout, dryRun)
+		targetFileName := setup_keys.SanitizeTarget(resolvedTarget)
+		privKeyPath, err := setup_keys.CreateKeyPair(resolvedTarget, targetFileName, setupKeysKeyPath, os.Stdout, dryRun)
 		if err != nil {
 			return err
 		}
 
-		return setupkeys.TransferPubKey(resolvedTarget, privKeyPath, os.Stdout, dryRun)
+		return setup_keys.TransferPubKey(resolvedTarget, privKeyPath, os.Stdout, dryRun)
 	},
 }
 

--- a/cmd/topo/setup_keys.go
+++ b/cmd/topo/setup_keys.go
@@ -29,20 +29,12 @@ Use --dry-run to see what commands would be executed without actually running th
 		if err != nil {
 			return err
 		}
-		keyPairGenCmd, privKeyPath, err := setupkeys.NewKeyPairCreation(resolvedTarget, setupKeysKeyPath)
+		privKeyPath, err := setupkeys.CreateKeyPair(resolvedTarget, setupKeysKeyPath, os.Stdout, dryRun)
 		if err != nil {
-			return err
-		}
-		if err := setupkeys.RunKeyPairCreation(keyPairGenCmd, os.Stdout, dryRun); err != nil {
 			return err
 		}
 
-		pubKeyTransfer, err := setupkeys.NewPubKeyTransfer(resolvedTarget, privKeyPath, dryRun)
-		if err != nil {
-			return err
-		}
-		err = setupkeys.RunPubKeyTransfer(pubKeyTransfer, privKeyPath, os.Stdout, dryRun)
-		return err
+		return setupkeys.TransferPubKey(resolvedTarget, privKeyPath, os.Stdout, dryRun)
 	},
 }
 

--- a/cmd/topo/setup_keys.go
+++ b/cmd/topo/setup_keys.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"runtime"
 
 	"github.com/arm/topo/internal/setupkeys"
 	"github.com/spf13/cobra"
@@ -24,10 +23,6 @@ Use --dry-run to see what commands would be executed without actually running th
 		dryRun, err := cmd.Flags().GetBool("dry-run")
 		if err != nil {
 			panic(fmt.Sprintf("internal error: dry-run flag not registered: %v", err))
-		}
-
-		if runtime.GOOS != "linux" {
-			return fmt.Errorf("topo setup-keys currently supports Linux hosts only")
 		}
 
 		resolvedTarget, err := requireTarget(cmd)

--- a/cmd/topo/setup_keys.go
+++ b/cmd/topo/setup_keys.go
@@ -34,16 +34,20 @@ Use --dry-run to see what commands would be executed without actually running th
 		if err != nil {
 			return err
 		}
-
-		seq, err := setupkeys.NewKeyCreationAndPlacementOnTarget(resolvedTarget, setupKeysKeyPath)
+		keyPairGenCmd, privKeyPath, err := setupkeys.NewKeyPairCreation(resolvedTarget, setupKeysKeyPath)
 		if err != nil {
 			return err
 		}
-
-		if dryRun {
-			return seq.DryRun(os.Stdout)
+		if err := setupkeys.RunKeyPairCreation(keyPairGenCmd, os.Stdout, dryRun); err != nil {
+			return err
 		}
-		return seq.Run(os.Stdout)
+
+		pubKeyTransfer, err := setupkeys.NewPubKeyTransfer(resolvedTarget, privKeyPath, dryRun)
+		if err != nil {
+			return err
+		}
+		err = setupkeys.RunPubKeyTransfer(pubKeyTransfer, privKeyPath, os.Stdout, dryRun)
+		return err
 	},
 }
 

--- a/internal/setup_keys/setup_keys.go
+++ b/internal/setup_keys/setup_keys.go
@@ -1,4 +1,4 @@
-package setupkeys
+package setup_keys
 
 import (
 	"fmt"
@@ -15,19 +15,22 @@ import (
 
 const remoteAuthorizedKeysCommand = "mkdir -p ~/.ssh && chmod 700 ~/.ssh && cat >> ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys"
 
+// Exported only so blackbox tests can inject fakes.
+type ExecCommandFunc func(string, ...string) *exec.Cmd
+
 var (
-	execCommand = exec.Command
-	sshExec     = ssh.Exec
+	ExecCommand ExecCommandFunc = exec.Command
+	SSHExec                     = ssh.Exec
 )
 
-func CreateKeyPair(targetHost string, privKeyPath string, cmdOutput io.Writer, dryRun bool) (string, error) {
+func CreateKeyPair(targetHost string, targetFileName string, privKeyPath string, cmdOutput io.Writer, dryRun bool) (string, error) {
 	if privKeyPath == "" {
 		home, err := os.UserHomeDir()
 		if err != nil {
 			return "", fmt.Errorf("failed to determine home directory: %w", err)
 		}
 
-		keyName := fmt.Sprintf("id_ed25519_topo_%s", sanitizeTarget(targetHost))
+		keyName := fmt.Sprintf("id_ed25519_topo_%s", targetFileName)
 		privKeyPath = filepath.Join(home, ".ssh", keyName)
 	}
 
@@ -35,7 +38,7 @@ func CreateKeyPair(targetHost string, privKeyPath string, cmdOutput io.Writer, d
 		return "", err
 	}
 
-	keyPairCreationCmd := execCommand("ssh-keygen", "-t", "ed25519", "-f", privKeyPath, "-C", targetHost)
+	keyPairCreationCmd := ExecCommand("ssh-keygen", "-t", "ed25519", "-f", privKeyPath, "-C", targetHost)
 
 	if dryRun && cmdOutput != nil {
 		_, err := fmt.Fprintln(cmdOutput, keyPairCreationCmd.String())
@@ -69,7 +72,7 @@ func TransferPubKey(targetHost string, privKeyPath string, output io.Writer, dry
 	}
 
 	opts := target.ConnectionOptions{WithLoginShell: true, WithStdin: pubKey}
-	pubKeyTransfer := target.NewConnection(targetHost, sshExec, opts)
+	pubKeyTransfer := target.NewConnection(targetHost, SSHExec, opts)
 	if _, err := pubKeyTransfer.Run(remoteAuthorizedKeysCommand); err != nil {
 		return err
 	}
@@ -85,7 +88,7 @@ func ensureDir(keyPath string) error {
 	return nil
 }
 
-func sanitizeTarget(target string) string {
+func SanitizeTarget(target string) string {
 	var b strings.Builder
 	for _, r := range target {
 		toWrite := '_'

--- a/internal/setup_keys/setup_keys.go
+++ b/internal/setup_keys/setup_keys.go
@@ -15,14 +15,6 @@ import (
 
 const remoteAuthorizedKeysCommand = "mkdir -p ~/.ssh && chmod 700 ~/.ssh && cat >> ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys"
 
-// Exported only so blackbox tests can inject fakes.
-type ExecCommandFunc func(string, ...string) *exec.Cmd
-
-var (
-	ExecCommand ExecCommandFunc = exec.Command
-	SSHExec                     = ssh.Exec
-)
-
 func CreateKeyPair(targetHost string, targetFileName string, privKeyPath string, cmdOutput io.Writer, dryRun bool) (string, error) {
 	if privKeyPath == "" {
 		home, err := os.UserHomeDir()
@@ -38,7 +30,7 @@ func CreateKeyPair(targetHost string, targetFileName string, privKeyPath string,
 		return "", err
 	}
 
-	keyPairCreationCmd := ExecCommand("ssh-keygen", "-t", "ed25519", "-f", privKeyPath, "-C", targetHost)
+	keyPairCreationCmd := exec.Command("ssh-keygen", "-t", "ed25519", "-f", privKeyPath, "-C", targetHost)
 
 	if dryRun && cmdOutput != nil {
 		_, err := fmt.Fprintln(cmdOutput, keyPairCreationCmd.String())
@@ -72,7 +64,7 @@ func TransferPubKey(targetHost string, privKeyPath string, output io.Writer, dry
 	}
 
 	opts := target.ConnectionOptions{WithLoginShell: true, WithStdin: pubKey}
-	pubKeyTransfer := target.NewConnection(targetHost, SSHExec, opts)
+	pubKeyTransfer := target.NewConnection(targetHost, ssh.Exec, opts)
 	if _, err := pubKeyTransfer.Run(remoteAuthorizedKeysCommand); err != nil {
 		return err
 	}

--- a/internal/setup_keys/setup_keys_test.go
+++ b/internal/setup_keys/setup_keys_test.go
@@ -1,4 +1,4 @@
-package setupkeys
+package setup_keys_test
 
 import (
 	"bytes"
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/arm/topo/internal/setup_keys"
 	"github.com/arm/topo/internal/ssh"
 	"github.com/stretchr/testify/require"
 )
@@ -51,7 +52,8 @@ func TestNewKeyCreationAndPlacementOnTargetDryRun(t *testing.T) {
 			}
 
 			var buf bytes.Buffer
-			keyPath, err := CreateKeyPair("user@example.com", inputKeyPath, &buf, true)
+			targetFileName := setup_keys.SanitizeTarget("user@example.com")
+			keyPath, err := setup_keys.CreateKeyPair("user@example.com", targetFileName, inputKeyPath, &buf, true)
 			require.NoError(t, err)
 
 			wantKeyPath := filepath.Join(tmp, tt.wantKeyPath)
@@ -62,7 +64,7 @@ func TestNewKeyCreationAndPlacementOnTargetDryRun(t *testing.T) {
 			require.Contains(t, got, "ssh-keygen", "DryRun output should include keygen command")
 			require.Contains(t, got, wantKeygen, "DryRun output should include keygen arguments")
 
-			transferErr := TransferPubKey("user@example.com", keyPath, &buf, true)
+			transferErr := setup_keys.TransferPubKey("user@example.com", keyPath, &buf, true)
 			require.NoError(t, transferErr)
 			got = buf.String()
 			require.Contains(t, got, "ssh user@example.com", "DryRun output should include ssh command")
@@ -76,14 +78,15 @@ func TestKeyCreationAndPlacementOnTarget(t *testing.T) {
 	logFile := filepath.Join(t.TempDir(), "commands.log")
 
 	testLogFile := logFile
-	origExec := execCommand
-	execCommand = func(command string, args ...string) *exec.Cmd {
+	origExec := setup_keys.ExecCommand
+	setup_keys.ExecCommand = func(command string, args ...string) *exec.Cmd {
 		return mockExecCommand(testLogFile, command, args...)
 	}
-	t.Cleanup(func() { execCommand = origExec })
+	t.Cleanup(func() { setup_keys.ExecCommand = origExec })
 
 	var buf bytes.Buffer
-	keyPath, keyPairErr := CreateKeyPair("user@example.com", keyPath, &buf, false)
+	targetFileName := setup_keys.SanitizeTarget("user@example.com")
+	keyPath, keyPairErr := setup_keys.CreateKeyPair("user@example.com", targetFileName, keyPath, &buf, false)
 	require.NoError(t, keyPairErr)
 	require.Contains(t, buf.String(), "ssh-keygen invoked", "Run output should include fake ssh-keygen output")
 
@@ -92,21 +95,22 @@ func TestKeyCreationAndPlacementOnTarget(t *testing.T) {
 	log := string(logData)
 	require.Contains(t, log, fmt.Sprintf("ssh-keygen -t ed25519 -f %s -C user@example.com", keyPath))
 
-	origSSHExec := sshExec
+	origSSHExec := setup_keys.SSHExec
 	var gotCommand string
 	var gotStdin []byte
-	sshExec = func(_ ssh.Host, command string, stdin []byte, _ ...string) (string, error) {
+	setup_keys.SSHExec = func(_ ssh.Host, command string, stdin []byte, _ ...string) (string, error) {
 		gotCommand = command
 		gotStdin = stdin
 		return "", nil
 	}
-	t.Cleanup(func() { sshExec = origSSHExec })
+	t.Cleanup(func() { setup_keys.SSHExec = origSSHExec })
 
-	transferErr := TransferPubKey("user@example.com", keyPath, &buf, false)
+	transferErr := setup_keys.TransferPubKey("user@example.com", keyPath, &buf, false)
 	require.NoError(t, transferErr)
 	pubKey, err := os.ReadFile(keyPath + ".pub")
 	require.NoError(t, err)
-	require.Equal(t, ssh.ShellCommand(remoteAuthorizedKeysCommand), gotCommand)
+	wantCommand := ssh.ShellCommand("mkdir -p ~/.ssh && chmod 700 ~/.ssh && cat >> ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys")
+	require.Equal(t, wantCommand, gotCommand)
 	require.Equal(t, pubKey, gotStdin)
 }
 
@@ -122,7 +126,7 @@ func TestSanitizeTarget(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
-			if got := sanitizeTarget(tt.input); got != tt.want {
+			if got := setup_keys.SanitizeTarget(tt.input); got != tt.want {
 				t.Fatalf("sanitizeTarget(%q) = %q, want %q", tt.input, got, tt.want)
 			}
 		})

--- a/internal/setup_keys/setup_keys_test.go
+++ b/internal/setup_keys/setup_keys_test.go
@@ -2,21 +2,16 @@ package setup_keys_test
 
 import (
 	"bytes"
-	"fmt"
-	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime"
-	"slices"
 	"strings"
 	"testing"
 
 	"github.com/arm/topo/internal/setup_keys"
-	"github.com/arm/topo/internal/ssh"
 	"github.com/stretchr/testify/require"
 )
 
-func TestNewKeyCreationAndPlacementOnTargetDryRun(t *testing.T) {
+func TestKeyPairCreationAndPlacementOnTargetDryRun(t *testing.T) {
 	tests := []struct {
 		name         string
 		inputKeyPath string
@@ -73,47 +68,6 @@ func TestNewKeyCreationAndPlacementOnTargetDryRun(t *testing.T) {
 	}
 }
 
-func TestKeyCreationAndPlacementOnTarget(t *testing.T) {
-	keyPath := filepath.Join(t.TempDir(), "custom_keys", "id_ed25519_custom_run")
-	logFile := filepath.Join(t.TempDir(), "commands.log")
-
-	testLogFile := logFile
-	origExec := setup_keys.ExecCommand
-	setup_keys.ExecCommand = func(command string, args ...string) *exec.Cmd {
-		return mockExecCommand(testLogFile, command, args...)
-	}
-	t.Cleanup(func() { setup_keys.ExecCommand = origExec })
-
-	var buf bytes.Buffer
-	targetFileName := setup_keys.SanitizeTarget("user@example.com")
-	keyPath, keyPairErr := setup_keys.CreateKeyPair("user@example.com", targetFileName, keyPath, &buf, false)
-	require.NoError(t, keyPairErr)
-	require.Contains(t, buf.String(), "ssh-keygen invoked", "Run output should include fake ssh-keygen output")
-
-	logData, err := os.ReadFile(logFile)
-	require.NoError(t, err)
-	log := string(logData)
-	require.Contains(t, log, fmt.Sprintf("ssh-keygen -t ed25519 -f %s -C user@example.com", keyPath))
-
-	origSSHExec := setup_keys.SSHExec
-	var gotCommand string
-	var gotStdin []byte
-	setup_keys.SSHExec = func(_ ssh.Host, command string, stdin []byte, _ ...string) (string, error) {
-		gotCommand = command
-		gotStdin = stdin
-		return "", nil
-	}
-	t.Cleanup(func() { setup_keys.SSHExec = origSSHExec })
-
-	transferErr := setup_keys.TransferPubKey("user@example.com", keyPath, &buf, false)
-	require.NoError(t, transferErr)
-	pubKey, err := os.ReadFile(keyPath + ".pub")
-	require.NoError(t, err)
-	wantCommand := ssh.ShellCommand("mkdir -p ~/.ssh && chmod 700 ~/.ssh && cat >> ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys")
-	require.Equal(t, wantCommand, gotCommand)
-	require.Equal(t, pubKey, gotStdin)
-}
-
 func TestSanitizeTarget(t *testing.T) {
 	tests := []struct {
 		input string
@@ -131,66 +85,4 @@ func TestSanitizeTarget(t *testing.T) {
 			}
 		})
 	}
-}
-
-func mockExecCommand(logFile, command string, args ...string) *exec.Cmd {
-	cs := slices.Concat([]string{"-test.run=TestHelperProcess", "--", command}, args)
-	cmd := exec.Command(os.Args[0], cs...)
-	cmd.Env = append(os.Environ(),
-		"GO_WANT_HELPER_PROCESS=1",
-		"TOPO_TEST_LOG="+logFile,
-	)
-	return cmd
-}
-
-func TestHelperProcess(t *testing.T) {
-	// Only run if invoked as a from another test. This is not a standalone test, so exit otherwise!
-	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
-		return
-	}
-
-	args := os.Args
-	sep := slices.Index(args, "--")
-	if sep == -1 || sep+1 >= len(args) {
-		os.Exit(2)
-	}
-
-	command := args[sep+1]
-	cmdArgs := args[sep+2:]
-	fmt.Printf("%s invoked\n", command)
-
-	logFile := os.Getenv("TOPO_TEST_LOG")
-	if logFile == "" || appendLine(logFile, strings.Join(append([]string{command}, cmdArgs...), " ")) != nil {
-		os.Exit(2)
-	}
-
-	if command == "ssh-keygen" {
-		key := ""
-		for i := 0; i < len(cmdArgs); i++ {
-			if cmdArgs[i] == "-f" && i+1 < len(cmdArgs) {
-				key = cmdArgs[i+1]
-				break
-			}
-		}
-		if key != "" {
-			if err := os.WriteFile(key, []byte("FAKEKEY"), 0o600); err != nil {
-				os.Exit(2)
-			}
-			if err := os.WriteFile(key+".pub", []byte("FAKEPUB"), 0o600); err != nil {
-				os.Exit(2)
-			}
-		}
-	}
-
-	os.Exit(0)
-}
-
-func appendLine(path, line string) error {
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = f.Close() }()
-	_, err = fmt.Fprintln(f, line)
-	return err
 }

--- a/internal/setupkeys/setupkeys.go
+++ b/internal/setupkeys/setupkeys.go
@@ -15,13 +15,16 @@ import (
 
 const remoteAuthorizedKeysCommand = "mkdir -p ~/.ssh && chmod 700 ~/.ssh && cat >> ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys"
 
-var execCommand = exec.Command
+var (
+	execCommand = exec.Command
+	sshExec     = ssh.Exec
+)
 
-func NewKeyPairCreation(targetHost string, privKeyPath string) (*exec.Cmd, string, error) {
+func CreateKeyPair(targetHost string, privKeyPath string, cmdOutput io.Writer, dryRun bool) (string, error) {
 	if privKeyPath == "" {
 		home, err := os.UserHomeDir()
 		if err != nil {
-			return nil, "", fmt.Errorf("failed to determine home directory: %w", err)
+			return "", fmt.Errorf("failed to determine home directory: %w", err)
 		}
 
 		keyName := fmt.Sprintf("id_ed25519_topo_%s", sanitizeTarget(targetHost))
@@ -29,17 +32,15 @@ func NewKeyPairCreation(targetHost string, privKeyPath string) (*exec.Cmd, strin
 	}
 
 	if err := ensureDir(privKeyPath); err != nil {
-		return nil, "", err
+		return "", err
 	}
 
-	return execCommand("ssh-keygen", "-t", "ed25519", "-f", privKeyPath, "-C", targetHost), privKeyPath, nil
-}
+	keyPairCreationCmd := execCommand("ssh-keygen", "-t", "ed25519", "-f", privKeyPath, "-C", targetHost)
 
-func RunKeyPairCreation(keyPairCreationCmd *exec.Cmd, cmdOutput io.Writer, dryRun bool) error {
 	if dryRun && cmdOutput != nil {
 		_, err := fmt.Fprintln(cmdOutput, keyPairCreationCmd.String())
 		if err != nil {
-			return err
+			return "", err
 		}
 	} else if !dryRun {
 		if cmdOutput != nil {
@@ -48,37 +49,31 @@ func RunKeyPairCreation(keyPairCreationCmd *exec.Cmd, cmdOutput io.Writer, dryRu
 		}
 
 		if err := keyPairCreationCmd.Run(); err != nil {
-			return fmt.Errorf("command %q failed: %w", keyPairCreationCmd.String(), err)
+			return "", fmt.Errorf("command %q failed: %w", keyPairCreationCmd.String(), err)
 		}
 	}
-
-	return nil
+	return privKeyPath, nil
 }
 
-func NewPubKeyTransfer(targetHost string, privKeyPath string, dryRun bool) (*target.Connection, error) {
+func TransferPubKey(targetHost string, privKeyPath string, output io.Writer, dryRun bool) error {
 	pubKeyPath := privKeyPath + ".pub"
-	opts := target.ConnectionOptions{WithLoginShell: true}
-	if !dryRun {
-		pubKey, err := os.ReadFile(pubKeyPath)
-		if err != nil {
-			return nil, fmt.Errorf("failed to read public key %s: %w", pubKeyPath, err)
-		}
-		opts.WithStdin = pubKey
-	}
 
-	pubKeyTransfer := target.NewConnection(targetHost, ssh.Exec, opts)
-	return &pubKeyTransfer, nil
-}
-
-func RunPubKeyTransfer(pubKeyTransfer *target.Connection, privKeyPath string, output io.Writer, dryRun bool) error {
 	if dryRun {
-		_, err := fmt.Fprintf(output, "ssh %s %q < %s.pub\n", pubKeyTransfer.SSHTarget, remoteAuthorizedKeysCommand, privKeyPath)
+		_, err := fmt.Fprintf(output, "ssh %s %q < %s.pub\n", targetHost, remoteAuthorizedKeysCommand, privKeyPath)
 		return err
-	} else {
-		if _, err := pubKeyTransfer.Run(remoteAuthorizedKeysCommand); err != nil {
-			return err
-		}
 	}
+
+	pubKey, err := os.ReadFile(pubKeyPath)
+	if err != nil {
+		return fmt.Errorf("failed to read public key %s: %w", pubKeyPath, err)
+	}
+
+	opts := target.ConnectionOptions{WithLoginShell: true, WithStdin: pubKey}
+	pubKeyTransfer := target.NewConnection(targetHost, sshExec, opts)
+	if _, err := pubKeyTransfer.Run(remoteAuthorizedKeysCommand); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/internal/setupkeys/setupkeys.go
+++ b/internal/setupkeys/setupkeys.go
@@ -9,29 +9,77 @@ import (
 	"strings"
 	"unicode"
 
-	goperation "github.com/arm/topo/internal/deploy/operation"
+	"github.com/arm/topo/internal/ssh"
+	"github.com/arm/topo/internal/target"
 )
 
-func NewKeyCreationAndPlacementOnTarget(target string, keyPath string) (goperation.Sequence, error) {
-	if keyPath == "" {
+const remoteAuthorizedKeysCommand = "mkdir -p ~/.ssh && chmod 700 ~/.ssh && cat >> ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys"
+
+var execCommand = exec.Command
+
+func NewKeyPairCreation(targetHost string, privKeyPath string) (*exec.Cmd, string, error) {
+	if privKeyPath == "" {
 		home, err := os.UserHomeDir()
 		if err != nil {
-			return nil, fmt.Errorf("failed to determine home directory: %w", err)
+			return nil, "", fmt.Errorf("failed to determine home directory: %w", err)
 		}
 
-		keyName := fmt.Sprintf("id_ed25519_topo_%s", sanitizeTarget(target))
-		keyPath = filepath.Join(home, ".ssh", keyName)
+		keyName := fmt.Sprintf("id_ed25519_topo_%s", sanitizeTarget(targetHost))
+		privKeyPath = filepath.Join(home, ".ssh", keyName)
 	}
 
-	if err := ensureDir(keyPath); err != nil {
-		return nil, err
+	if err := ensureDir(privKeyPath); err != nil {
+		return nil, "", err
 	}
 
-	ops := []goperation.Operation{
-		newSetupKeysOperation("Generate SSH key pair for target", []string{"ssh-keygen", "-t", "ed25519", "-f", keyPath, "-C", target}),
-		newSetupKeysOperation("Copy SSH public key to target", []string{"ssh-copy-id", "-i", keyPath + ".pub", target}),
+	return execCommand("ssh-keygen", "-t", "ed25519", "-f", privKeyPath, "-C", targetHost), privKeyPath, nil
+}
+
+func RunKeyPairCreation(keyPairCreationCmd *exec.Cmd, cmdOutput io.Writer, dryRun bool) error {
+	if dryRun && cmdOutput != nil {
+		_, err := fmt.Fprintln(cmdOutput, keyPairCreationCmd.String())
+		if err != nil {
+			return err
+		}
+	} else if !dryRun {
+		if cmdOutput != nil {
+			keyPairCreationCmd.Stdout = cmdOutput
+			keyPairCreationCmd.Stderr = cmdOutput
+		}
+
+		if err := keyPairCreationCmd.Run(); err != nil {
+			return fmt.Errorf("command %q failed: %w", keyPairCreationCmd.String(), err)
+		}
 	}
-	return goperation.NewSequence(ops...), nil
+
+	return nil
+}
+
+func NewPubKeyTransfer(targetHost string, privKeyPath string, dryRun bool) (*target.Connection, error) {
+	pubKeyPath := privKeyPath + ".pub"
+	opts := target.ConnectionOptions{WithLoginShell: true}
+	if !dryRun {
+		pubKey, err := os.ReadFile(pubKeyPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read public key %s: %w", pubKeyPath, err)
+		}
+		opts.WithStdin = pubKey
+	}
+
+	pubKeyTransfer := target.NewConnection(targetHost, ssh.Exec, opts)
+	return &pubKeyTransfer, nil
+}
+
+func RunPubKeyTransfer(pubKeyTransfer *target.Connection, privKeyPath string, output io.Writer, dryRun bool) error {
+	if dryRun {
+		_, err := fmt.Fprintf(output, "ssh %s %q < %s.pub\n", pubKeyTransfer.SSHTarget, remoteAuthorizedKeysCommand, privKeyPath)
+		return err
+	} else {
+		if _, err := pubKeyTransfer.Run(remoteAuthorizedKeysCommand); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func ensureDir(keyPath string) error {
@@ -55,40 +103,4 @@ func sanitizeTarget(target string) string {
 
 	sanitized := b.String()
 	return sanitized
-}
-
-type setupKeysOperation struct {
-	description string
-	command     []string
-}
-
-func newSetupKeysOperation(description string, command []string) *setupKeysOperation {
-	return &setupKeysOperation{description: description, command: command}
-}
-
-func (c *setupKeysOperation) Description() string {
-	return c.description
-}
-
-func (c *setupKeysOperation) Run(cmdOutput io.Writer) error {
-	if len(c.command) == 0 {
-		return fmt.Errorf("no command configured")
-	}
-	cmd := exec.Command(c.command[0], c.command[1:]...)
-	if cmdOutput != nil {
-		cmd.Stdout = cmdOutput
-		cmd.Stderr = cmdOutput
-	}
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("command %q failed: %w", strings.Join(c.command, " "), err)
-	}
-	return nil
-}
-
-func (c *setupKeysOperation) DryRun(output io.Writer) error {
-	if output == nil {
-		return nil
-	}
-	_, err := fmt.Fprintln(output, strings.Join(c.command, " "))
-	return err
 }

--- a/internal/setupkeys/setupkeys_test.go
+++ b/internal/setupkeys/setupkeys_test.go
@@ -4,77 +4,119 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
+	"slices"
+	"strings"
 	"testing"
 
-	"github.com/arm/topo/internal/testutil"
+	"github.com/arm/topo/internal/ssh"
+	"github.com/arm/topo/internal/target"
 	"github.com/stretchr/testify/require"
 )
 
-func TestNewKeyCreationAndPlacementOnTarget(t *testing.T) {
-	testutil.RequireOS(t, "linux")
+func TestNewKeyCreationAndPlacementOnTargetDryRun(t *testing.T) {
+	tests := []struct {
+		name         string
+		inputKeyPath string
+		wantKeyPath  string
+	}{
+		{
+			name:         "default key path",
+			inputKeyPath: "",
+			wantKeyPath:  filepath.Join(".ssh", "id_ed25519_topo_user_example.com"),
+		},
+		{
+			name:         "custom key path",
+			inputKeyPath: filepath.Join("custom_keys", "id_ed25519_custom"),
+			wantKeyPath:  filepath.Join("custom_keys", "id_ed25519_custom"),
+		},
+	}
 
-	t.Run("default key path", func(t *testing.T) {
-		tmp := t.TempDir()
-		t.Setenv("HOME", tmp)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmp := t.TempDir()
+			t.Setenv("HOME", tmp)
+			if runtime.GOOS == "windows" {
+				t.Setenv("USERPROFILE", tmp)
+				if vol := filepath.VolumeName(tmp); vol != "" {
+					t.Setenv("HOMEDRIVE", vol)
+					t.Setenv("HOMEPATH", strings.TrimPrefix(tmp, vol))
+				}
+			}
 
-		seq, err := NewKeyCreationAndPlacementOnTarget("user@example.com", "")
-		require.NoError(t, err)
+			inputKeyPath := tt.inputKeyPath
+			if inputKeyPath != "" {
+				inputKeyPath = filepath.Join(tmp, inputKeyPath)
+			}
 
-		var buf bytes.Buffer
-		require.NoError(t, seq.DryRun(&buf))
+			keygenCmd, keyPath, err := NewKeyPairCreation("user@example.com", inputKeyPath)
+			require.NoError(t, err)
 
-		keyPath := filepath.Join(tmp, ".ssh", "id_ed25519_topo_user_example.com")
-		wantKeygen := "ssh-keygen -t ed25519 -f " + keyPath + " -C user@example.com"
-		wantCopy := "ssh-copy-id -i " + keyPath + ".pub user@example.com"
-		got := buf.String()
-		require.Contains(t, got, wantKeygen, "DryRun output should include keygen command")
-		require.Contains(t, got, wantCopy, "DryRun output should include ssh-copy-id command")
-	})
+			wantKeyPath := filepath.Join(tmp, tt.wantKeyPath)
+			require.Equal(t, wantKeyPath, keyPath, "NewKeyPairCreation should return expected key path")
 
-	t.Run("custom key path", func(t *testing.T) {
-		keyPath := filepath.Join(t.TempDir(), "custom_keys", "id_ed25519_custom")
+			var buf bytes.Buffer
+			require.NoError(t, RunKeyPairCreation(keygenCmd, &buf, true))
 
-		seq, err := NewKeyCreationAndPlacementOnTarget("user@example.com", keyPath)
-		require.NoError(t, err)
+			wantKeygen := "-t ed25519 -f " + keyPath + " -C user@example.com"
+			got := buf.String()
+			require.Contains(t, got, "ssh-keygen", "DryRun output should include keygen command")
+			require.Contains(t, got, wantKeygen, "DryRun output should include keygen arguments")
 
-		var buf bytes.Buffer
-		require.NoError(t, seq.DryRun(&buf))
-
-		wantKeygen := "ssh-keygen -t ed25519 -f " + keyPath + " -C user@example.com"
-		wantCopy := "ssh-copy-id -i " + keyPath + ".pub user@example.com"
-		got := buf.String()
-		require.Contains(t, got, wantKeygen, "DryRun output should include keygen command")
-		require.Contains(t, got, wantCopy, "DryRun output should include ssh-copy-id command")
-	})
+			conn, err := NewPubKeyTransfer("user@example.com", keyPath, true)
+			require.NoError(t, err)
+			require.NoError(t, RunPubKeyTransfer(conn, keyPath, &buf, true))
+			got = buf.String()
+			require.Contains(t, got, "ssh user@example.com", "DryRun output should include ssh command")
+			require.Contains(t, got, keyPath+".pub", "DryRun output should include public key path")
+		})
+	}
 }
 
 func TestKeyCreationAndPlacementOnTarget(t *testing.T) {
-	testutil.RequireOS(t, "linux")
-
 	keyPath := filepath.Join(t.TempDir(), "custom_keys", "id_ed25519_custom_run")
-	fakeBinDir := t.TempDir()
 	logFile := filepath.Join(t.TempDir(), "commands.log")
 
-	writeFakeSSHCommand(t, fakeBinDir, "ssh-keygen", logFile)
-	writeFakeSSHCommand(t, fakeBinDir, "ssh-copy-id", logFile)
+	testLogFile := logFile
+	origExec := execCommand
+	execCommand = func(command string, args ...string) *exec.Cmd {
+		return fakeExecCommand(testLogFile, command, args...)
+	}
+	t.Cleanup(func() { execCommand = origExec })
 
-	originalPath := os.Getenv("PATH")
-	t.Setenv("PATH", fakeBinDir+string(os.PathListSeparator)+originalPath)
-
-	seq, err := NewKeyCreationAndPlacementOnTarget("user@example.com", keyPath)
+	keygenCmd, keyPath, err := NewKeyPairCreation("user@example.com", keyPath)
 	require.NoError(t, err)
 
 	var buf bytes.Buffer
-	require.NoError(t, seq.Run(&buf))
+	require.NoError(t, RunKeyPairCreation(keygenCmd, &buf, false))
 	require.Contains(t, buf.String(), "ssh-keygen invoked", "Run output should include fake ssh-keygen output")
-	require.Contains(t, buf.String(), "ssh-copy-id invoked", "Run output should include fake ssh-copy-id output")
 
 	logData, err := os.ReadFile(logFile)
 	require.NoError(t, err)
 	log := string(logData)
 	require.Contains(t, log, fmt.Sprintf("ssh-keygen -t ed25519 -f %s -C user@example.com", keyPath))
-	require.Contains(t, log, fmt.Sprintf("ssh-copy-id -i %s.pub user@example.com", keyPath))
+
+	_, err = NewPubKeyTransfer("user@example.com", keyPath, false)
+	require.NoError(t, err)
+
+	var gotCommand string
+	var gotStdin []byte
+	fakeExec := func(_ ssh.Host, command string, stdin []byte, _ ...string) (string, error) {
+		gotCommand = command
+		gotStdin = stdin
+		return "", nil
+	}
+	pubKey, err := os.ReadFile(keyPath + ".pub")
+	require.NoError(t, err)
+	fakeConn := target.NewConnection("user@example.com", fakeExec, target.ConnectionOptions{
+		WithLoginShell: true,
+		WithStdin:      pubKey,
+	})
+	require.NoError(t, RunPubKeyTransfer(&fakeConn, keyPath, &buf, false))
+	require.Equal(t, ssh.ShellCommand(remoteAuthorizedKeysCommand), gotCommand)
+	require.Equal(t, pubKey, gotStdin)
 }
 
 func TestSanitizeTarget(t *testing.T) {
@@ -96,12 +138,64 @@ func TestSanitizeTarget(t *testing.T) {
 	}
 }
 
-func writeFakeSSHCommand(t *testing.T, dir, name, logFile string) {
-	t.Helper()
-	script := fmt.Sprintf(`#!/bin/sh
-echo "%s invoked"
-echo "$0 $@" >> %s
-`, name, logFile)
-	path := filepath.Join(dir, name)
-	require.NoError(t, os.WriteFile(path, []byte(script), 0o700))
+func fakeExecCommand(logFile, command string, args ...string) *exec.Cmd {
+	cs := slices.Concat([]string{"-test.run=TestHelperProcess", "--", command}, args)
+	cmd := exec.Command(os.Args[0], cs...)
+	cmd.Env = append(os.Environ(),
+		"GO_WANT_HELPER_PROCESS=1",
+		"TOPO_TEST_LOG="+logFile,
+	)
+	return cmd
+}
+
+func TestHelperProcess(t *testing.T) {
+	// Only run if invoked as a from another test. This is not a standalone test, so exit otherwise!
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+
+	args := os.Args
+	sep := slices.Index(args, "--")
+	if sep == -1 || sep+1 >= len(args) {
+		os.Exit(2)
+	}
+
+	command := args[sep+1]
+	cmdArgs := args[sep+2:]
+	fmt.Printf("%s invoked\n", command)
+
+	logFile := os.Getenv("TOPO_TEST_LOG")
+	if logFile == "" || appendLine(logFile, strings.Join(append([]string{command}, cmdArgs...), " ")) != nil {
+		os.Exit(2)
+	}
+
+	if command == "ssh-keygen" {
+		key := ""
+		for i := 0; i < len(cmdArgs); i++ {
+			if cmdArgs[i] == "-f" && i+1 < len(cmdArgs) {
+				key = cmdArgs[i+1]
+				break
+			}
+		}
+		if key != "" {
+			if err := os.WriteFile(key, []byte("FAKEKEY"), 0o600); err != nil {
+				os.Exit(2)
+			}
+			if err := os.WriteFile(key+".pub", []byte("FAKEPUB"), 0o600); err != nil {
+				os.Exit(2)
+			}
+		}
+	}
+
+	os.Exit(0)
+}
+
+func appendLine(path, line string) error {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+	_, err = fmt.Fprintln(f, line)
+	return err
 }

--- a/internal/setupkeys/setupkeys_test.go
+++ b/internal/setupkeys/setupkeys_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 
 	"github.com/arm/topo/internal/ssh"
-	"github.com/arm/topo/internal/target"
 	"github.com/stretchr/testify/require"
 )
 
@@ -51,23 +50,20 @@ func TestNewKeyCreationAndPlacementOnTargetDryRun(t *testing.T) {
 				inputKeyPath = filepath.Join(tmp, inputKeyPath)
 			}
 
-			keygenCmd, keyPath, err := NewKeyPairCreation("user@example.com", inputKeyPath)
+			var buf bytes.Buffer
+			keyPath, err := CreateKeyPair("user@example.com", inputKeyPath, &buf, true)
 			require.NoError(t, err)
 
 			wantKeyPath := filepath.Join(tmp, tt.wantKeyPath)
 			require.Equal(t, wantKeyPath, keyPath, "NewKeyPairCreation should return expected key path")
-
-			var buf bytes.Buffer
-			require.NoError(t, RunKeyPairCreation(keygenCmd, &buf, true))
 
 			wantKeygen := "-t ed25519 -f " + keyPath + " -C user@example.com"
 			got := buf.String()
 			require.Contains(t, got, "ssh-keygen", "DryRun output should include keygen command")
 			require.Contains(t, got, wantKeygen, "DryRun output should include keygen arguments")
 
-			conn, err := NewPubKeyTransfer("user@example.com", keyPath, true)
-			require.NoError(t, err)
-			require.NoError(t, RunPubKeyTransfer(conn, keyPath, &buf, true))
+			transferErr := TransferPubKey("user@example.com", keyPath, &buf, true)
+			require.NoError(t, transferErr)
 			got = buf.String()
 			require.Contains(t, got, "ssh user@example.com", "DryRun output should include ssh command")
 			require.Contains(t, got, keyPath+".pub", "DryRun output should include public key path")
@@ -82,15 +78,13 @@ func TestKeyCreationAndPlacementOnTarget(t *testing.T) {
 	testLogFile := logFile
 	origExec := execCommand
 	execCommand = func(command string, args ...string) *exec.Cmd {
-		return fakeExecCommand(testLogFile, command, args...)
+		return mockExecCommand(testLogFile, command, args...)
 	}
 	t.Cleanup(func() { execCommand = origExec })
 
-	keygenCmd, keyPath, err := NewKeyPairCreation("user@example.com", keyPath)
-	require.NoError(t, err)
-
 	var buf bytes.Buffer
-	require.NoError(t, RunKeyPairCreation(keygenCmd, &buf, false))
+	keyPath, keyPairErr := CreateKeyPair("user@example.com", keyPath, &buf, false)
+	require.NoError(t, keyPairErr)
 	require.Contains(t, buf.String(), "ssh-keygen invoked", "Run output should include fake ssh-keygen output")
 
 	logData, err := os.ReadFile(logFile)
@@ -98,23 +92,20 @@ func TestKeyCreationAndPlacementOnTarget(t *testing.T) {
 	log := string(logData)
 	require.Contains(t, log, fmt.Sprintf("ssh-keygen -t ed25519 -f %s -C user@example.com", keyPath))
 
-	_, err = NewPubKeyTransfer("user@example.com", keyPath, false)
-	require.NoError(t, err)
-
+	origSSHExec := sshExec
 	var gotCommand string
 	var gotStdin []byte
-	fakeExec := func(_ ssh.Host, command string, stdin []byte, _ ...string) (string, error) {
+	sshExec = func(_ ssh.Host, command string, stdin []byte, _ ...string) (string, error) {
 		gotCommand = command
 		gotStdin = stdin
 		return "", nil
 	}
+	t.Cleanup(func() { sshExec = origSSHExec })
+
+	transferErr := TransferPubKey("user@example.com", keyPath, &buf, false)
+	require.NoError(t, transferErr)
 	pubKey, err := os.ReadFile(keyPath + ".pub")
 	require.NoError(t, err)
-	fakeConn := target.NewConnection("user@example.com", fakeExec, target.ConnectionOptions{
-		WithLoginShell: true,
-		WithStdin:      pubKey,
-	})
-	require.NoError(t, RunPubKeyTransfer(&fakeConn, keyPath, &buf, false))
 	require.Equal(t, ssh.ShellCommand(remoteAuthorizedKeysCommand), gotCommand)
 	require.Equal(t, pubKey, gotStdin)
 }
@@ -138,7 +129,7 @@ func TestSanitizeTarget(t *testing.T) {
 	}
 }
 
-func fakeExecCommand(logFile, command string, args ...string) *exec.Cmd {
+func mockExecCommand(logFile, command string, args ...string) *exec.Cmd {
 	cs := slices.Concat([]string{"-test.run=TestHelperProcess", "--", command}, args)
 	cmd := exec.Command(os.Args[0], cs...)
 	cmd.Env = append(os.Environ(),


### PR DESCRIPTION
On Windows, the ssh-copy-id tool is not available.

 * use ssh commands (through the Connection interface) to perform the transfer to the target instead.
 * remove Linux requirements for the related tests.
 * add a new way to mock tests.