### PR TITLE
chore: allow for an injectable ssh hook without modifying API

### DIFF
--- a/cmd/topo/describe.go
+++ b/cmd/topo/describe.go
@@ -8,7 +8,6 @@ import (
 	"github.com/arm/topo/internal/output/console"
 	"github.com/arm/topo/internal/output/logger"
 	"github.com/arm/topo/internal/output/term"
-	"github.com/arm/topo/internal/ssh"
 	"github.com/arm/topo/internal/target"
 	"github.com/spf13/cobra"
 )
@@ -25,7 +24,7 @@ var describeCmd = &cobra.Command{
 			return err
 		}
 
-		conn := target.NewConnection(sshTarget, ssh.ExecCmd, target.ConnectionOptions{Multiplex: true})
+		conn := target.NewConnection(sshTarget, target.ConnectionOptions{Multiplex: true})
 		report, err := describe.GenerateTargetDescription(conn)
 		if err != nil {
 			return err

--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -8,7 +8,6 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/arm/topo/internal/ssh"
 	"github.com/arm/topo/internal/target"
 )
 
@@ -36,7 +35,7 @@ func FilterTemplateRepos(flags TemplateFilters, repos []Repo) ([]Repo, error) {
 	targetMode := false
 
 	if flags.Target != "" {
-		conn := target.NewConnection(flags.Target, ssh.ExecCmd, target.ConnectionOptions{Multiplex: true})
+		conn := target.NewConnection(flags.Target, target.ConnectionOptions{Multiplex: true})
 		hw, err := conn.ProbeHardware()
 		if err != nil {
 			return nil, err

--- a/internal/describe/describe_test.go
+++ b/internal/describe/describe_test.go
@@ -41,7 +41,7 @@ func TestGenerate(t *testing.T) {
 			},
 		}
 
-		conn := target.NewConnection("test", mockExecSSH, target.ConnectionOptions{})
+		conn := target.NewConnection("test", target.ConnectionOptions{WithMockExec: mockExecSSH})
 		report, err := describe.GenerateTargetDescription(conn)
 
 		require.NoError(t, err)
@@ -53,7 +53,7 @@ func TestGenerate(t *testing.T) {
 			return testutil.CmdWithOutput(assert.AnError.Error(), 1)
 		}
 
-		conn := target.NewConnection("test", mockExecSSH, target.ConnectionOptions{})
+		conn := target.NewConnection("test", target.ConnectionOptions{WithMockExec: mockExecSSH})
 		_, err := describe.GenerateTargetDescription(conn)
 
 		assert.Error(t, err)

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/arm/topo/internal/ssh"
 	"github.com/arm/topo/internal/target"
 )
 
@@ -106,7 +105,7 @@ func Check(sshTarget string, acceptNewHostKeys bool) (Report, error) {
 		AuthProbeOutput:   os.Stdout,
 		Multiplex:         true,
 	}
-	conn := target.NewConnection(sshTarget, ssh.ExecCmd, opts)
+	conn := target.NewConnection(sshTarget, opts)
 	targetStatus := ProbeHealthStatus(conn)
 	report := GenerateReport(dependencyStatuses, targetStatus)
 	if err := targetStatus.AuthError; err != nil {

--- a/internal/health/status_test.go
+++ b/internal/health/status_test.go
@@ -18,7 +18,7 @@ func TestProbeHealthStatus(t *testing.T) {
 			return testutil.CmdWithOutput("connection refused", 1)
 		}
 
-		conn := target.NewConnection("hostname", mockExec, target.ConnectionOptions{})
+		conn := target.NewConnection("hostname", target.ConnectionOptions{WithMockExec: mockExec})
 		ts := health.ProbeHealthStatus(conn)
 
 		assert.Error(t, ts.ConnectionError)
@@ -39,7 +39,7 @@ func TestProbeHealthStatus(t *testing.T) {
 			}
 		}
 
-		conn := target.NewConnection("hostname", mockExec, target.ConnectionOptions{})
+		conn := target.NewConnection("hostname", target.ConnectionOptions{WithMockExec: mockExec})
 		ts := health.ProbeHealthStatus(conn)
 
 		want := health.HardwareProfile{RemoteCPU: []target.RemoteprocCPU{{Name: "foo"}, {Name: "bar"}}}
@@ -57,7 +57,7 @@ func TestProbeHealthStatus(t *testing.T) {
 			}
 		}
 
-		conn := target.NewConnection("hostname", mockExec, target.ConnectionOptions{})
+		conn := target.NewConnection("hostname", target.ConnectionOptions{WithMockExec: mockExec})
 		ts := health.ProbeHealthStatus(conn)
 
 		assert.NoError(t, ts.ConnectionError)

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -37,7 +37,7 @@ type PathCandidate struct {
 }
 
 func getPathDirs(targetHost ssh.Host) ([]string, error) {
-	conn := target.NewConnection(string(targetHost), ssh.ExecCmd, target.ConnectionOptions{WithLoginShell: true})
+	conn := target.NewConnection(string(targetHost), target.ConnectionOptions{WithLoginShell: true})
 	output, err := conn.Run("echo $PATH")
 	if err != nil {
 		return nil, err
@@ -50,7 +50,7 @@ func getPathDirs(targetHost ssh.Host) ([]string, error) {
 }
 
 func getHomeDir(targetHost ssh.Host) (string, error) {
-	conn := target.NewConnection(string(targetHost), ssh.ExecCmd, target.ConnectionOptions{WithLoginShell: true})
+	conn := target.NewConnection(string(targetHost), target.ConnectionOptions{WithLoginShell: true})
 	output, err := conn.Run("echo $HOME")
 	if err != nil {
 		return "", err
@@ -59,7 +59,7 @@ func getHomeDir(targetHost ssh.Host) (string, error) {
 }
 
 func getExistingBinaryDir(targetHost ssh.Host, binaryName string) (string, error) {
-	conn := target.NewConnection(string(targetHost), ssh.ExecCmd, target.ConnectionOptions{WithLoginShell: true})
+	conn := target.NewConnection(string(targetHost), target.ConnectionOptions{WithLoginShell: true})
 	output, err := conn.Run(fmt.Sprintf("command -v %s", binaryName))
 	if err != nil {
 		return "", nil
@@ -267,7 +267,7 @@ func install(installPath string, targetHost ssh.Host, binaries map[string][]byte
 		}
 
 		installCmd := fmt.Sprintf("install -D -m %s /dev/stdin %s/%s", mode, installPath, binaryName)
-		conn := target.NewConnection(string(targetHost), ssh.ExecCmd, target.ConnectionOptions{WithLoginShell: true, WithStdin: binaryData})
+		conn := target.NewConnection(string(targetHost), target.ConnectionOptions{WithLoginShell: true, WithStdin: binaryData})
 		stderr, err := conn.Run(installCmd)
 		if err != nil {
 			stderrStr := strings.ToLower(stderr)

--- a/internal/target/connection.go
+++ b/internal/target/connection.go
@@ -50,14 +50,19 @@ type ConnectionOptions struct {
 	WithLoginShell    bool
 	WithStdin         []byte
 	Multiplex         bool
+	WithMockExec      execSSH
 }
 
 var ErrPasswordAuthentication = errors.New("only password authentication is configured; key-based ssh is required")
 
-func NewConnection(sshTarget string, exec execSSH, opts ConnectionOptions) Connection {
+func NewConnection(sshTarget string, opts ConnectionOptions) Connection {
+	execFn := ssh.ExecCmd
+	if opts.WithMockExec != nil {
+		execFn = opts.WithMockExec
+	}
 	return Connection{
 		SSHTarget: ssh.Host(sshTarget),
-		exec:      exec,
+		exec:      execFn,
 		opts:      opts,
 	}
 }

--- a/internal/target/connection_auth_test.go
+++ b/internal/target/connection_auth_test.go
@@ -63,8 +63,8 @@ func TestProbeAuthentication(t *testing.T) {
 		mockExec := newMockExec(map[string]mockResponse{
 			"public": {stdout: "", err: nil},
 		}, &calls)
-		opts := target.ConnectionOptions{AuthProbeEnabled: true, AcceptNewHostKeys: true}
-		conn := target.NewConnection("user@host", mockExec, opts)
+		opts := target.ConnectionOptions{AuthProbeEnabled: true, AcceptNewHostKeys: true, WithMockExec: mockExec}
+		conn := target.NewConnection("user@host", opts)
 		err := conn.ProbeAuthentication()
 		require.NoError(t, err)
 
@@ -78,8 +78,8 @@ func TestProbeAuthentication(t *testing.T) {
 		mockExec := newMockExec(map[string]mockResponse{
 			"public": {stdout: "Host key verification failed", err: errSSH},
 		}, &calls)
-		opts := target.ConnectionOptions{AuthProbeEnabled: true, AcceptNewHostKeys: true}
-		conn := target.NewConnection("user@host", mockExec, opts)
+		opts := target.ConnectionOptions{AuthProbeEnabled: true, AcceptNewHostKeys: true, WithMockExec: mockExec}
+		conn := target.NewConnection("user@host", opts)
 		err := conn.ProbeAuthentication()
 		require.ErrorIs(t, err, target.ErrHostKeyVerification)
 		require.Len(t, calls, 1)
@@ -91,8 +91,8 @@ func TestProbeAuthentication(t *testing.T) {
 			"public":   {stdout: "Permission denied", err: errSSH},
 			"password": {stdout: "Host key verification failed", err: errSSH},
 		}, &calls)
-		opts := target.ConnectionOptions{AuthProbeEnabled: true, AcceptNewHostKeys: true}
-		conn := target.NewConnection("user@host", mockExec, opts)
+		opts := target.ConnectionOptions{AuthProbeEnabled: true, AcceptNewHostKeys: true, WithMockExec: mockExec}
+		conn := target.NewConnection("user@host", opts)
 		err := conn.ProbeAuthentication()
 		require.ErrorIs(t, err, target.ErrHostKeyVerification)
 		require.Len(t, calls, 2)
@@ -105,8 +105,8 @@ func TestProbeAuthentication(t *testing.T) {
 			"public":   {stdout: "Permission denied", err: errSSH},
 			"password": {stdout: "Authentication failed", err: errSSH},
 		}, &calls)
-		opts := target.ConnectionOptions{AuthProbeEnabled: true, AcceptNewHostKeys: true}
-		conn := target.NewConnection("user@host", mockExec, opts)
+		opts := target.ConnectionOptions{AuthProbeEnabled: true, AcceptNewHostKeys: true, WithMockExec: mockExec}
+		conn := target.NewConnection("user@host", opts)
 		err := conn.ProbeAuthentication()
 		require.ErrorIs(t, err, target.ErrPasswordAuthentication)
 	})
@@ -117,8 +117,8 @@ func TestProbeAuthentication(t *testing.T) {
 			"public":   {stdout: "Permission denied", err: errSSH},
 			"password": {stdout: "ok", err: nil},
 		}, &calls)
-		opts := target.ConnectionOptions{AuthProbeEnabled: true, AcceptNewHostKeys: true}
-		conn := target.NewConnection("user@host", mockExec, opts)
+		opts := target.ConnectionOptions{AuthProbeEnabled: true, AcceptNewHostKeys: true, WithMockExec: mockExec}
+		conn := target.NewConnection("user@host", opts)
 		err := conn.ProbeAuthentication()
 		require.NoError(t, err)
 		require.Len(t, calls, 2)
@@ -131,8 +131,8 @@ func TestProbeAuthentication(t *testing.T) {
 			"public":   {stdout: "Permission denied", err: errSSH},
 			"password": {stdout: "Some other error", err: errSSH},
 		}, &calls)
-		opts := target.ConnectionOptions{AuthProbeEnabled: true, AcceptNewHostKeys: true}
-		conn := target.NewConnection("user@host", mockExec, opts)
+		opts := target.ConnectionOptions{AuthProbeEnabled: true, AcceptNewHostKeys: true, WithMockExec: mockExec}
+		conn := target.NewConnection("user@host", opts)
 		err := conn.ProbeAuthentication()
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "ssh probe failed")
@@ -144,8 +144,8 @@ func TestProbeAuthentication(t *testing.T) {
 			"knownhost": {stdout: "Permission denied", err: errSSH},
 			"public":    {stdout: "", err: nil},
 		}, &calls)
-		opts := target.ConnectionOptions{AuthProbeEnabled: true, AcceptNewHostKeys: false}
-		conn := target.NewConnection("user@host", mockExec, opts)
+		opts := target.ConnectionOptions{AuthProbeEnabled: true, AcceptNewHostKeys: false, WithMockExec: mockExec}
+		conn := target.NewConnection("user@host", opts)
 		err := conn.ProbeAuthentication()
 		require.NoError(t, err)
 
@@ -158,8 +158,8 @@ func TestProbeAuthentication(t *testing.T) {
 		mockExec := newMockExec(map[string]mockResponse{
 			"knownhost": {stdout: "HOST KEY VERIFICATION FAILED", err: errSSH},
 		}, &calls)
-		opts := target.ConnectionOptions{AuthProbeEnabled: true, AcceptNewHostKeys: false}
-		conn := target.NewConnection("user@host", mockExec, opts)
+		opts := target.ConnectionOptions{AuthProbeEnabled: true, AcceptNewHostKeys: false, WithMockExec: mockExec}
+		conn := target.NewConnection("user@host", opts)
 		err := conn.ProbeAuthentication()
 		require.ErrorIs(t, err, target.ErrHostKeyVerification)
 		require.Len(t, calls, 1)
@@ -170,8 +170,8 @@ func TestProbeAuthentication(t *testing.T) {
 		mockExec := newMockExec(map[string]mockResponse{
 			"knownhost": {stdout: "dial tcp: lookup host: no such host", err: errSSH},
 		}, &calls)
-		opts := target.ConnectionOptions{AuthProbeEnabled: true, AcceptNewHostKeys: false}
-		conn := target.NewConnection("user@host", mockExec, opts)
+		opts := target.ConnectionOptions{AuthProbeEnabled: true, AcceptNewHostKeys: false, WithMockExec: mockExec}
+		conn := target.NewConnection("user@host", opts)
 		err := conn.ProbeAuthentication()
 		require.Error(t, err)
 		require.Len(t, calls, 1)

--- a/internal/target/connection_test.go
+++ b/internal/target/connection_test.go
@@ -16,7 +16,7 @@ func TestRun(t *testing.T) {
 		mockExec := func(_ ssh.Host, _ string, _ []byte, _ ...string) *exec.Cmd {
 			return testutil.CmdWithOutput("success", 0)
 		}
-		conn := target.NewConnection("hostname", mockExec, target.ConnectionOptions{})
+		conn := target.NewConnection("hostname", target.ConnectionOptions{WithMockExec: mockExec})
 
 		out, err := conn.Run("ls")
 
@@ -28,7 +28,7 @@ func TestRun(t *testing.T) {
 		mockExec := func(_ ssh.Host, _ string, _ []byte, _ ...string) *exec.Cmd {
 			return testutil.CmdWithOutput("", 1)
 		}
-		conn := target.NewConnection("hostname", mockExec, target.ConnectionOptions{})
+		conn := target.NewConnection("hostname", target.ConnectionOptions{WithMockExec: mockExec})
 
 		out, err := conn.Run("ls")
 
@@ -43,7 +43,7 @@ func TestRun(t *testing.T) {
 			capturedArgs = strings.Join(sshArgs, " ")
 			return testutil.CmdWithOutput("success", 0)
 		}
-		conn := target.NewConnection("hostname", mockExec, target.ConnectionOptions{Multiplex: true})
+		conn := target.NewConnection("hostname", target.ConnectionOptions{Multiplex: true, WithMockExec: mockExec})
 
 		_, err := conn.Run("ls")
 
@@ -60,7 +60,7 @@ func TestRun(t *testing.T) {
 			capturedArgs = strings.Join(sshArgs, " ")
 			return testutil.CmdWithOutput("success", 0)
 		}
-		conn := target.NewConnection("hostname", mockExec, target.ConnectionOptions{Multiplex: true})
+		conn := target.NewConnection("hostname", target.ConnectionOptions{Multiplex: true, WithMockExec: mockExec})
 
 		_, err := conn.Run("ls")
 
@@ -76,7 +76,7 @@ func TestBinaryExists(t *testing.T) {
 		mockExec := func(_ ssh.Host, _ string, _ []byte, _ ...string) *exec.Cmd {
 			return testutil.CmdWithOutput("/foo/bar", 0)
 		}
-		conn := target.NewConnection("hostname", mockExec, target.ConnectionOptions{})
+		conn := target.NewConnection("hostname", target.ConnectionOptions{WithMockExec: mockExec})
 
 		got, err := conn.BinaryExists("bar")
 
@@ -88,7 +88,7 @@ func TestBinaryExists(t *testing.T) {
 		mockExec := func(_ ssh.Host, _ string, _ []byte, _ ...string) *exec.Cmd {
 			return testutil.CmdWithOutput("/foo/bar", 0)
 		}
-		conn := target.NewConnection("hostname", mockExec, target.ConnectionOptions{})
+		conn := target.NewConnection("hostname", target.ConnectionOptions{WithMockExec: mockExec})
 
 		got, err := conn.BinaryExists("b a r")
 

--- a/internal/target/probe_test.go
+++ b/internal/target/probe_test.go
@@ -48,7 +48,7 @@ func TestProbeHardware(t *testing.T) {
 			}
 		}
 
-		conn := target.NewConnection("hostname", mockExec, target.ConnectionOptions{})
+		conn := target.NewConnection("hostname", target.ConnectionOptions{WithMockExec: mockExec})
 		hw, err := conn.ProbeHardware()
 
 		require.NoError(t, err)
@@ -63,7 +63,7 @@ func TestProbeHardware(t *testing.T) {
 			return testutil.CmdWithOutput("not found", 1)
 		}
 
-		conn := target.NewConnection("hostname", mockExec, target.ConnectionOptions{})
+		conn := target.NewConnection("hostname", target.ConnectionOptions{WithMockExec: mockExec})
 		_, err := conn.ProbeHardware()
 
 		assert.ErrorContains(t, err, "lscpu not found")
@@ -81,7 +81,7 @@ func TestProbeHardware(t *testing.T) {
 			}
 		}
 
-		conn := target.NewConnection("hostname", mockExec, target.ConnectionOptions{})
+		conn := target.NewConnection("hostname", target.ConnectionOptions{WithMockExec: mockExec})
 		_, err := conn.ProbeHardware()
 
 		assert.ErrorContains(t, err, "collecting CPU info")


### PR DESCRIPTION
Keep production behavior untouched while enabling SSH mocking in tests.
This avoids runtime risk (e.g., accidental test code paths in prod, API drift, or hidden side effects).

## Changes

- add an `WithMockExec` option to `ConnectionOptions` to explicitly mock the SSH function in Connection.
- Remove the execSSH function parameter in `NewConnection`, as this should default to the normal execSSH function.
    
    
