### PR TITLE
feat: modify SSH config after SSH key creation

### DIFF
--- a/cmd/topo/setup_keys.go
+++ b/cmd/topo/setup_keys.go
@@ -5,6 +5,8 @@ import (
 	"os"
 
 	"github.com/arm/topo/internal/setupkeys"
+	"github.com/arm/topo/internal/setupkeys/sshconfig"
+	"github.com/arm/topo/internal/ssh"
 	"github.com/spf13/cobra"
 )
 
@@ -30,15 +32,30 @@ Use --dry-run to see what commands would be executed without actually running th
 			return err
 		}
 
+		targetSlug := ssh.Host(resolvedTarget).Slugify()
+		if privateKeyPath == "" {
+			privateKeyPath, err = setupkeys.GetDefaultPrivateKeyPath(targetSlug)
+			if err != nil {
+				return err
+			}
+		}
+
 		seq, err := setupkeys.NewKeySetup(resolvedTarget, privateKeyPath)
 		if err != nil {
 			return err
 		}
 
 		if dryRun {
-			return seq.DryRun(os.Stdout)
+			err = seq.DryRun(os.Stdout)
+		} else {
+			err = seq.Run(os.Stdout)
 		}
-		return seq.Run(os.Stdout)
+
+		if err != nil {
+			return err
+		}
+
+		return sshconfig.ModifySSHConfig(resolvedTarget, privateKeyPath, targetSlug, dryRun, os.Stdout)
 	},
 }
 

--- a/internal/deploy/operation/sequence.go
+++ b/internal/deploy/operation/sequence.go
@@ -1,9 +1,9 @@
 package operation
 
 import (
-	"fmt"
 	"io"
-	"strings"
+
+	"github.com/arm/topo/internal/output/term"
 )
 
 type Sequence []Operation
@@ -15,7 +15,7 @@ func NewSequence(operations ...Operation) Sequence {
 func (s Sequence) Run(cmdOutput io.Writer) error {
 	for _, op := range s {
 		if cmdOutput != nil {
-			err := printHeader(cmdOutput, op.Description())
+			err := term.PrintHeader(cmdOutput, op.Description())
 			if err != nil {
 				return err
 			}
@@ -29,7 +29,7 @@ func (s Sequence) Run(cmdOutput io.Writer) error {
 
 func (s Sequence) DryRun(output io.Writer) error {
 	for _, op := range s {
-		err := printHeader(output, op.Description())
+		err := term.PrintHeader(output, op.Description())
 		if err != nil {
 			return err
 		}
@@ -38,21 +38,4 @@ func (s Sequence) DryRun(output io.Writer) error {
 		}
 	}
 	return nil
-}
-
-func printHeader(w io.Writer, description string) error {
-	if description == "" {
-		return nil
-	}
-
-	const totalWidth = 60
-	prefix := "┌─ "
-	suffix := " "
-
-	descriptionWidth := len(description)
-	barWidth := max(totalWidth-len(prefix)-descriptionWidth-len(suffix), 0)
-
-	header := prefix + description + suffix + strings.Repeat("─", barWidth)
-	_, err := fmt.Fprintf(w, "\n%s\n", header)
-	return err
 }

--- a/internal/output/term/header.go
+++ b/internal/output/term/header.go
@@ -1,0 +1,24 @@
+package term
+
+import (
+	"fmt"
+	"io"
+	"strings"
+)
+
+func PrintHeader(w io.Writer, description string) error {
+	if description == "" {
+		return nil
+	}
+
+	const totalWidth = 60
+	prefix := "┌─ "
+	suffix := " "
+
+	descriptionWidth := len(description)
+	barWidth := max(totalWidth-len(prefix)-descriptionWidth-len(suffix), 0)
+
+	header := prefix + description + suffix + strings.Repeat("─", barWidth)
+	_, err := fmt.Fprintf(w, "\n%s\n", header)
+	return err
+}

--- a/internal/output/term/term_test.go
+++ b/internal/output/term/term_test.go
@@ -1,7 +1,9 @@
 package term_test
 
 import (
+	"bytes"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/arm/topo/internal/output/term"
@@ -73,5 +75,31 @@ func TestWrapText(t *testing.T) {
 		out := term.WrapText(in, 10, 0)
 
 		assert.Equal(t, "hello\nworld here", out)
+	})
+}
+
+func TestPrintHeader(t *testing.T) {
+	t.Run("renders header with padding", func(t *testing.T) {
+		var buf bytes.Buffer
+
+		require.NoError(t, term.PrintHeader(&buf, "Hello"))
+
+		const totalWidth = 60
+		prefix := "┌─ "
+		suffix := " "
+		barWidth := totalWidth - len(prefix) - len("Hello") - len(suffix)
+		expected := "\n" + prefix + "Hello" + suffix + strings.Repeat("─", barWidth) + "\n"
+
+		assert.Equal(t, expected, buf.String())
+	})
+
+	t.Run("renders without padding when description is too long", func(t *testing.T) {
+		var buf bytes.Buffer
+		description := strings.Repeat("x", 80)
+
+		require.NoError(t, term.PrintHeader(&buf, description))
+
+		expected := "\n┌─ " + description + " \n"
+		assert.Equal(t, expected, buf.String())
 	})
 }

--- a/internal/setupkeys/setup_keys.go
+++ b/internal/setupkeys/setup_keys.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
-	"unicode"
 
 	goperation "github.com/arm/topo/internal/deploy/operation"
 	"github.com/arm/topo/internal/setupkeys/pubkeytransfer"
@@ -13,16 +11,6 @@ import (
 )
 
 func NewKeySetup(target string, privKeyPath string) (goperation.Sequence, error) {
-	if privKeyPath == "" {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return nil, fmt.Errorf("failed to determine default key path: %w", err)
-		}
-
-		keyName := fmt.Sprintf("id_ed25519_topo_%s", slugifyTarget(target))
-		privKeyPath = filepath.Join(home, ".ssh", keyName)
-	}
-
 	ops := []goperation.Operation{
 		sshkeygen.NewSSHKeyGen("Generate SSH key pair for target", target, "ed25519", privKeyPath, sshkeygen.SSHKeyGenOptions{}),
 		pubkeytransfer.NewPubKeyTransfer("Transfer public key to target and set it as an authorized key", target, privKeyPath, pubkeytransfer.PubKeyTransferOptions{}),
@@ -30,16 +18,12 @@ func NewKeySetup(target string, privKeyPath string) (goperation.Sequence, error)
 	return goperation.NewSequence(ops...), nil
 }
 
-func slugifyTarget(target string) string {
-	var b strings.Builder
-	for _, r := range target {
-		toWrite := '_'
-		if unicode.IsLetter(r) || unicode.IsDigit(r) || r == '-' || r == '_' || r == '.' {
-			toWrite = r
-		}
-
-		b.WriteRune(toWrite)
+func GetDefaultPrivateKeyPath(targetSlug string) (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to determine default key path: %w", err)
 	}
-
-	return b.String()
+	keyName := fmt.Sprintf("id_ed25519_topo_%s", targetSlug)
+	privKeyPath := filepath.Join(home, ".ssh", keyName)
+	return privKeyPath, nil
 }

--- a/internal/setupkeys/setup_keys_test.go
+++ b/internal/setupkeys/setup_keys_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/arm/topo/internal/setupkeys"
 	"github.com/arm/topo/internal/setupkeys/pubkeytransfer"
 	"github.com/arm/topo/internal/setupkeys/sshkeygen"
+	"github.com/arm/topo/internal/ssh"
 	"github.com/arm/topo/internal/testutil"
 	"github.com/stretchr/testify/require"
 )
@@ -41,7 +42,14 @@ func TestNewKeySetupDryRun(t *testing.T) {
 			if tt.inputKeyPath == "" {
 				wantKeyPath = filepath.Join(tmp, tt.wantKeyPath)
 			}
-			got, err := setupkeys.NewKeySetup(tt.wantTarget, tt.inputKeyPath)
+			targetSlug := ssh.Host(tt.wantTarget).Slugify()
+			inputKeyPath := tt.inputKeyPath
+			if inputKeyPath == "" {
+				var err error
+				inputKeyPath, err = setupkeys.GetDefaultPrivateKeyPath(targetSlug)
+				require.NoError(t, err)
+			}
+			got, err := setupkeys.NewKeySetup(tt.wantTarget, inputKeyPath)
 			require.NoError(t, err)
 			require.Len(t, got, 2)
 			require.IsType(t, &sshkeygen.SSHKeyGen{}, got[0])

--- a/internal/setupkeys/sshconfig/ssh_config.go
+++ b/internal/setupkeys/sshconfig/ssh_config.go
@@ -1,0 +1,125 @@
+package sshconfig
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/arm/topo/internal/output/term"
+	"github.com/arm/topo/internal/ssh"
+)
+
+func ModifySSHConfig(targetHost string, privKeyPath string, targetSlug string, dryRun bool, output io.Writer) error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("failed to determine home directory for SSH config: %w", err)
+	}
+
+	sshTopoConfigDir := filepath.Join(home, ".ssh", "topo_config")
+	sshTopoConfigPath := filepath.Join(sshTopoConfigDir, fmt.Sprintf("topo_%s.conf", targetSlug))
+
+	mainConfigPath := filepath.Join(home, ".ssh", "config")
+
+	// ssh config parsing expects forward slashes (even on Windows)
+	includeLine := fmt.Sprintf("Include %s", filepath.ToSlash(sshTopoConfigDir+"/*.conf"))
+
+	if dryRun {
+		if output == nil {
+			return errors.New("dry run requested but no output writer provided for SSH config changes")
+		}
+
+		if err := term.PrintHeader(output, "Update local SSH config for key-based authentication"); err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintf(output, "Will update %s to include:\n- %s\n", mainConfigPath, includeLine); err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintf(output, "Will create %s and place the target SSH config there pointing at the key that was just created.\n", sshTopoConfigPath); err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	if err := os.MkdirAll(sshTopoConfigDir, 0o700); err != nil {
+		return fmt.Errorf("failed to create %s: %w", sshTopoConfigDir, err)
+	}
+
+	existingTopoContent, errTopo := getFileContents(sshTopoConfigPath)
+	if errTopo != nil {
+		return errTopo
+	}
+
+	existingMainContent, errMain := getFileContents(mainConfigPath)
+	if errMain != nil {
+		return errMain
+	}
+
+	configBody := buildSSHConfigFragment(targetHost, privKeyPath)
+
+	if string(existingTopoContent) != configBody {
+		if err := os.WriteFile(sshTopoConfigPath, []byte(configBody), 0o600); err != nil {
+			return fmt.Errorf("failed to write %s: %w", sshTopoConfigPath, err)
+		}
+	}
+
+	if !hasIncludeLine(existingMainContent, includeLine) {
+		updated := slices.Concat([]byte(includeLine+"\n\n"), existingMainContent)
+		return os.WriteFile(mainConfigPath, updated, 0o600)
+	}
+
+	return nil
+}
+
+func getFileContents(filePath string) ([]byte, error) {
+	existingContent, err := os.ReadFile(filePath)
+	if err != nil && !os.IsNotExist(err) {
+		return nil, fmt.Errorf("failed to read %s: %w", filePath, err)
+	} else if os.IsNotExist(err) {
+		existingContent = []byte{}
+	}
+
+	return existingContent, nil
+}
+
+func hasIncludeLine(data []byte, includeLine string) bool {
+	for line := range strings.SplitSeq(string(data), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		if strings.EqualFold(trimmed, includeLine) {
+			return true
+		}
+	}
+	return false
+}
+
+func buildSSHConfigFragment(targetHost string, privKeyPath string) string {
+	user, host, port := ssh.SplitUserHostPort(targetHost)
+	hostAlias := host
+	if hostAlias == "" {
+		hostAlias = targetHost
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "Host %s\n", hostAlias)
+	if host != "" && (strings.Contains(targetHost, "@") || strings.Contains(targetHost, ":")) {
+		fmt.Fprintf(&b, "  HostName %s\n", host)
+	}
+	if user != "" {
+		fmt.Fprintf(&b, "  User %s\n", user)
+	}
+	if port != "" {
+		fmt.Fprintf(&b, "  Port %s\n", port)
+	}
+
+	// needs to be this way even on Windows to work with ssh config parsing, which generally accepts forward slashes
+	fmt.Fprintf(&b, "  IdentityFile %s\n", filepath.ToSlash(privKeyPath))
+	b.WriteString("  IdentitiesOnly yes\n")
+	return b.String()
+}

--- a/internal/setupkeys/sshconfig/ssh_config_test.go
+++ b/internal/setupkeys/sshconfig/ssh_config_test.go
@@ -1,0 +1,52 @@
+package sshconfig_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/arm/topo/internal/setupkeys/sshconfig"
+	"github.com/stretchr/testify/require"
+)
+
+func TestModifySSHConfigWritesIncludeAndFragment(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	if runtime.GOOS == "windows" {
+		t.Setenv("USERPROFILE", tmp)
+		if vol := filepath.VolumeName(tmp); vol != "" {
+			t.Setenv("HOMEDRIVE", vol)
+			t.Setenv("HOMEPATH", strings.TrimPrefix(tmp, vol))
+		}
+	}
+
+	targetHost := "user@example.com:2222"
+	targetFileName := "user_example_com_2222"
+	privKeyPath := filepath.Join(tmp, ".ssh", fmt.Sprintf("id_ed25519_topo_%s", targetFileName))
+
+	err := sshconfig.ModifySSHConfig(targetHost, privKeyPath, targetFileName, false, nil)
+	require.NoError(t, err)
+
+	mainConfigPath := filepath.Join(tmp, ".ssh", "config")
+	mainConfig, err := os.ReadFile(mainConfigPath)
+	require.NoError(t, err)
+	mainConfigText := string(mainConfig)
+	require.Contains(t, mainConfigText, "Include ")
+	require.Contains(t, mainConfigText, filepath.ToSlash(filepath.Join(tmp, ".ssh", "topo_config", "*.conf")))
+
+	fragmentPath := filepath.Join(tmp, ".ssh", "topo_config", fmt.Sprintf("topo_%s.conf", targetFileName))
+	fragment, err := os.ReadFile(fragmentPath)
+	require.NoError(t, err)
+
+	expected := "" +
+		"Host example.com\n" +
+		"  HostName example.com\n" +
+		"  User user\n" +
+		"  Port 2222\n" +
+		fmt.Sprintf("  IdentityFile %s\n", filepath.ToSlash(privKeyPath)) +
+		"  IdentitiesOnly yes\n"
+	require.Equal(t, expected, string(fragment))
+}

--- a/internal/ssh/host.go
+++ b/internal/ssh/host.go
@@ -2,7 +2,9 @@ package ssh
 
 import (
 	"fmt"
+	"net"
 	"strings"
+	"unicode"
 )
 
 type Host string
@@ -15,4 +17,34 @@ func (h Host) IsPlainLocalhost() bool {
 
 func (h Host) AsURI() string {
 	return fmt.Sprintf("ssh://%s", h)
+}
+
+func (h Host) Slugify() string {
+	var b strings.Builder
+	for _, r := range h {
+		toWrite := '_'
+		if unicode.IsLetter(r) || unicode.IsDigit(r) || r == '-' || r == '_' || r == '.' {
+			toWrite = r
+		}
+		b.WriteRune(toWrite)
+	}
+	return b.String()
+}
+
+func SplitUserHostPort(raw string) (user, host, port string) {
+	hostPart := raw
+	if at := strings.LastIndex(raw, "@"); at != -1 {
+		user = raw[:at]
+		hostPart = raw[at+1:]
+	}
+
+	if strings.HasPrefix(hostPart, "[") && strings.HasSuffix(hostPart, "]") {
+		host = strings.TrimSuffix(strings.TrimPrefix(hostPart, "["), "]")
+		return user, host, port
+	}
+
+	if h, p, err := net.SplitHostPort(hostPart); err == nil {
+		return user, h, p
+	}
+	return user, hostPart, port
 }

--- a/internal/ssh/host_test.go
+++ b/internal/ssh/host_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/arm/topo/internal/ssh"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestHost(t *testing.T) {
@@ -66,5 +67,47 @@ func TestHost(t *testing.T) {
 
 			assert.Equal(t, "ssh://user@host", h.AsURI())
 		})
+	})
+	t.Run("Slugify", func(t *testing.T) {
+		tests := []struct {
+			input string
+			want  string
+		}{
+			{"user@example.com", "user_example.com"},
+			{"Example-Host", "Example-Host"},
+			{"spaces and/tabs", "spaces_and_tabs"},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.input, func(t *testing.T) {
+				require.Equal(t, tt.want, ssh.Host(tt.input).Slugify(), "Slugify should replace special characters with underscores and keep allowed characters")
+			})
+		}
+	})
+
+	t.Run("SplitUserHostPort", func(t *testing.T) {
+		cases := []struct {
+			raw      string
+			wantUser string
+			wantHost string
+			wantPort string
+		}{
+			{raw: "user@example.com:2222", wantUser: "user", wantHost: "example.com", wantPort: "2222"},
+			{raw: "example.com:2222", wantUser: "", wantHost: "example.com", wantPort: "2222"},
+			{raw: "example.com", wantUser: "", wantHost: "example.com", wantPort: ""},
+			{raw: "user@example.com", wantUser: "user", wantHost: "example.com", wantPort: ""},
+			{raw: "[2001:db8::1]", wantUser: "", wantHost: "2001:db8::1", wantPort: ""},
+			{raw: "user@[2001:db8::1]:2222", wantUser: "user", wantHost: "2001:db8::1", wantPort: "2222"},
+			{raw: "[2001:db8::1]:2222", wantUser: "", wantHost: "2001:db8::1", wantPort: "2222"},
+		}
+
+		for _, tc := range cases {
+			t.Run(tc.raw, func(t *testing.T) {
+				user, host, port := ssh.SplitUserHostPort(tc.raw)
+				require.Equal(t, tc.wantUser, user, "user for %q", tc.raw)
+				require.Equal(t, tc.wantHost, host, "host for %q", tc.raw)
+				require.Equal(t, tc.wantPort, port, "port for %q", tc.raw)
+			})
+		}
 	})
 }

--- a/internal/ssh/ssh_tunnel.go
+++ b/internal/ssh/ssh_tunnel.go
@@ -4,7 +4,6 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io"
-	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -22,22 +21,18 @@ func ControlSocketPath(targetHost string) string {
 	return filepath.Join(os.TempDir(), fmt.Sprintf("topo-tunnel-%s", hostHash))
 }
 
-func splitHostPort(raw string) (host, port string) {
-	userPart := ""
-	hostPart := raw
-	if at := strings.LastIndex(raw, "@"); at != -1 {
-		userPart = raw[:at+1]
-		hostPart = raw[at+1:]
+func formatSSHHost(raw string, user string, host string) string {
+	if host == "" {
+		return raw
 	}
-
-	host, port, err := net.SplitHostPort(hostPart)
-	if err == nil {
-		if strings.HasPrefix(hostPart, "[") {
-			host = "[" + host + "]"
-		}
-		return userPart + host, port
+	hostPart := host
+	if strings.Contains(hostPart, ":") {
+		hostPart = "[" + hostPart + "]"
 	}
-	return raw, ""
+	if user == "" {
+		return hostPart
+	}
+	return user + "@" + hostPart
 }
 
 func NewSSHTunnel(targetHost Host, port string, useControlSockets bool) (operation.Operation, operation.Operation) {
@@ -68,7 +63,9 @@ func NewSSHTunnelStart(targetHost Host, port string, useControlSockets bool) *SS
 }
 
 func (s *SSHTunnelStart) Command() *exec.Cmd {
-	host, port := splitHostPort(string(s.TargetHost))
+	rawHost := string(s.TargetHost)
+	user, host, port := SplitUserHostPort(rawHost)
+	hostArg := formatSSHHost(rawHost, user, host)
 	args := []string{"ssh", "-N", "-o", "ExitOnForwardFailure=yes"}
 	if port != "" {
 		args = append(args, "-p", port)
@@ -80,7 +77,7 @@ func (s *SSHTunnelStart) Command() *exec.Cmd {
 	}
 	args = append(args,
 		"-R", fmt.Sprintf("%s:127.0.0.1:%s", s.Port, s.Port),
-		host,
+		hostArg,
 	)
 	return exec.Command(args[0], args[1:]...)
 }
@@ -121,7 +118,9 @@ func NewSSHTunnelStop(targetHost Host) *SSHTunnelStop {
 }
 
 func (s *SSHTunnelStop) Command() *exec.Cmd {
-	host, port := splitHostPort(string(s.TargetHost))
+	rawHost := string(s.TargetHost)
+	user, host, port := SplitUserHostPort(rawHost)
+	hostArg := formatSSHHost(rawHost, user, host)
 	args := []string{"ssh"}
 	if port != "" {
 		args = append(args, "-p", port)
@@ -129,7 +128,7 @@ func (s *SSHTunnelStop) Command() *exec.Cmd {
 	args = append(args,
 		"-S", ControlSocketPath(string(s.TargetHost)),
 		"-O", "exit",
-		host,
+		hostArg,
 	)
 	return exec.Command(args[0], args[1:]...)
 }


### PR DESCRIPTION
## Changes

- Create a topo SSH configuration file to cover hosts and their associated keys for the keys created via the `topo setup-keys` command
- Add a line on the user's SSH config file to include that directory.
