### PR TITLE
Update command descriptions to reference new Hello World template

### DIFF
--- a/cmd/topo/clone.go
+++ b/cmd/topo/clone.go
@@ -20,7 +20,7 @@ The project-source argument uses scheme prefixes to specify the source type.
 The git: prefix is optional for git@host and https:// URLs.
 
 Template ID (from built-in catalog):
-  topo clone my-demo template:Topo-Welcome
+  topo clone my-demo template:Hello-World
 
 Git repository:
   topo clone my-demo git@github.com:user/repo.git
@@ -37,9 +37,9 @@ Local directory (must contain a Topo template):
 Some projects require build arguments. Supply them on the command line or answer prompts:
 
   # Will prompt for required args
-  topo clone my-demo template:Topo-Welcome
+  topo clone my-demo template:Hello-World
   # Provide args explicitly
-  topo clone my-demo template:Topo-Welcome GREETING="Hello" PORT=8080
+  topo clone my-demo template:Hello-World GREETING_NAME="World"
 `,
 	Args: cobra.MinimumNArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/topo/extend.go
+++ b/cmd/topo/extend.go
@@ -19,7 +19,7 @@ var extendCmd = &cobra.Command{
 The source argument uses scheme prefixes to specify the source type:
 
 Template ID (from built-in templates):
-  topo extend compose.yaml template:Topo-Welcome
+  topo extend compose.yaml template:Hello-World
 
 Git repository (git: prefix is optional for git@host and https:// URLs):
   topo extend compose.yaml git:https://github.com/user/repo.git


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- Update `clone` and `extend` command help text to reference the renamed `Hello-World` template (previously `Topo-Welcome`)
- Update example build argument from `GREETING="Hello" PORT=8080` to `GREETING_NAME="World"` to match the renamed parameter in the template
