### PR TITLE
feat: include target name in password-auth error

### DIFF
--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -2,6 +2,7 @@ package health
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"strings"
 
@@ -10,7 +11,7 @@ import (
 
 const passwordAuthErrorMessage = `note: Topo does not support SSH password-based authentication. To connect, either:
 - create your own SSH keys for the target, or
-- run 'topo setup-keys --target <target>' to let Topo generate keys and configure passwordless authentication`
+- run 'topo setup-keys --target %s' to let Topo generate keys and configure passwordless authentication`
 
 type HealthCheck struct {
 	Name    string
@@ -110,7 +111,7 @@ func Check(sshTarget string, acceptNewHostKeys bool) (Report, error) {
 	report := GenerateReport(dependencyStatuses, targetStatus)
 	if err := targetStatus.AuthError; err != nil {
 		if errors.Is(err, target.ErrPasswordAuthentication) {
-			return report, errors.New(passwordAuthErrorMessage)
+			return report, fmt.Errorf(passwordAuthErrorMessage, sshTarget)
 		}
 		return report, err
 	}


### PR DESCRIPTION
## Changes

- Format the setup-keys hint with the actual sshTarget so the guidance is actionable for the failing target.
