### PR TITLE
Improved var naming consistency

### DIFF
--- a/internal/describe/describe_test.go
+++ b/internal/describe/describe_test.go
@@ -30,7 +30,7 @@ func TestGenerate(t *testing.T) {
 		expected := target.HardwareProfile{
 			HostProcessor: []target.HostProcessor{
 				{
-					ModelName: "Cortex-A55",
+					Model: "Cortex-A55",
 					Features:  []string{"fp", "asimd"},
 					Cores:     2,
 				},

--- a/internal/describe/describe_test.go
+++ b/internal/describe/describe_test.go
@@ -30,9 +30,9 @@ func TestGenerate(t *testing.T) {
 		expected := target.HardwareProfile{
 			HostProcessor: []target.HostProcessor{
 				{
-					Model: "Cortex-A55",
-					Features:  []string{"fp", "asimd"},
-					Cores:     2,
+					Model:    "Cortex-A55",
+					Features: []string{"fp", "asimd"},
+					Cores:    2,
 				},
 			},
 			RemoteCPU: []target.RemoteprocCPU{

--- a/internal/target/probe.go
+++ b/internal/target/probe.go
@@ -17,9 +17,9 @@ var armCpuFeatures = map[string]string{
 }
 
 type HostProcessor struct {
-	Model     string   `yaml:"model"`
-	Cores     int      `yaml:"cores"`
-	Features  []string `yaml:"features"`
+	Model    string   `yaml:"model"`
+	Cores    int      `yaml:"cores"`
+	Features []string `yaml:"features"`
 }
 
 type RemoteprocCPU struct {
@@ -152,9 +152,9 @@ func newHostProcessor(name string, fields []LscpuOutputField) (HostProcessor, er
 	}
 
 	return HostProcessor{
-		Model: name,
-		Cores:     coresPerUnit * units,
-		Features:  features,
+		Model:    name,
+		Cores:    coresPerUnit * units,
+		Features: features,
 	}, nil
 }
 

--- a/internal/target/probe.go
+++ b/internal/target/probe.go
@@ -17,7 +17,7 @@ var armCpuFeatures = map[string]string{
 }
 
 type HostProcessor struct {
-	ModelName string   `yaml:"model"`
+	Model     string   `yaml:"model"`
 	Cores     int      `yaml:"cores"`
 	Features  []string `yaml:"features"`
 }
@@ -152,7 +152,7 @@ func newHostProcessor(name string, fields []LscpuOutputField) (HostProcessor, er
 	}
 
 	return HostProcessor{
-		ModelName: name,
+		Model: name,
 		Cores:     coresPerUnit * units,
 		Features:  features,
 	}, nil

--- a/internal/target/probe_test.go
+++ b/internal/target/probe_test.go
@@ -103,9 +103,9 @@ func TestCreateCPUProfile(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, got, 1)
 		want := target.HostProcessor{
-			Model: "Cortex-A72",
-			Cores:     8,
-			Features:  []string{"fp", "asimd", "evtstrm"},
+			Model:    "Cortex-A72",
+			Cores:    8,
+			Features: []string{"fp", "asimd", "evtstrm"},
 		}
 		assert.Equal(t, want, got[0])
 	})
@@ -125,9 +125,9 @@ func TestCreateCPUProfile(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, got, 1)
 		want := target.HostProcessor{
-			Model: "Cortex-A55",
-			Cores:     2,
-			Features:  []string{"fp", "asimd"},
+			Model:    "Cortex-A55",
+			Cores:    2,
+			Features: []string{"fp", "asimd"},
 		}
 		assert.Equal(t, want, got[0])
 	})

--- a/internal/target/probe_test.go
+++ b/internal/target/probe_test.go
@@ -53,7 +53,7 @@ func TestProbeHardware(t *testing.T) {
 
 		require.NoError(t, err)
 		require.Len(t, hw.HostProcessor, 1)
-		assert.Equal(t, "Cortex-A55", hw.HostProcessor[0].ModelName)
+		assert.Equal(t, "Cortex-A55", hw.HostProcessor[0].Model)
 		assert.Equal(t, 2, hw.HostProcessor[0].Cores)
 		assert.Equal(t, []string{"fp", "asimd"}, hw.HostProcessor[0].Features)
 	})
@@ -103,7 +103,7 @@ func TestCreateCPUProfile(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, got, 1)
 		want := target.HostProcessor{
-			ModelName: "Cortex-A72",
+			Model: "Cortex-A72",
 			Cores:     8,
 			Features:  []string{"fp", "asimd", "evtstrm"},
 		}
@@ -125,7 +125,7 @@ func TestCreateCPUProfile(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, got, 1)
 		want := target.HostProcessor{
-			ModelName: "Cortex-A55",
+			Model: "Cortex-A55",
 			Cores:     2,
 			Features:  []string{"fp", "asimd"},
 		}
@@ -149,9 +149,9 @@ func TestCreateCPUProfile(t *testing.T) {
 
 		require.NoError(t, err)
 		require.Len(t, got, 2)
-		assert.Equal(t, "Cortex-A55", got[0].ModelName)
+		assert.Equal(t, "Cortex-A55", got[0].Model)
 		assert.Equal(t, 4, got[0].Cores)
-		assert.Equal(t, "Cortex-A78", got[1].ModelName)
+		assert.Equal(t, "Cortex-A78", got[1].Model)
 		assert.Equal(t, 2, got[1].Cores)
 	})
 


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- Use `Model` consistenly instead of `ModelName`
