### PR TITLE
feat: detection of gatewayport's enablement on dropbear and openssh o…

### DIFF
--- a/cmd/topo/deploy.go
+++ b/cmd/topo/deploy.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"runtime"
@@ -14,6 +15,7 @@ import (
 	"github.com/arm/topo/internal/output/console"
 	"github.com/arm/topo/internal/output/logger"
 	"github.com/arm/topo/internal/ssh"
+	"github.com/arm/topo/internal/target"
 
 	"github.com/spf13/cobra"
 )
@@ -104,6 +106,19 @@ Use --dry-run to see what commands would be executed without actually running th
 				Level:   logger.Warning,
 				Message: "registry transfer is not yet supported with this configuration. Falling back to direct transfer.",
 			})
+		}
+
+		logResult := checks.EnsureSSHGatewayPortsAreDisabled(targetHost, target.ConnectionOptions{WithLoginShell: true})
+		if len(logResult) > 0 {
+			for _, entry := range logResult {
+				switch entry.Level {
+				case logger.Err:
+					return errors.New(entry.Message)
+				case logger.Warning:
+					c.Log(entry)
+				}
+			}
+
 		}
 
 		deployment, cleanup := docker.NewDeployment(composeFile, deployOpts)

--- a/cmd/topo/deploy.go
+++ b/cmd/topo/deploy.go
@@ -118,7 +118,6 @@ Use --dry-run to see what commands would be executed without actually running th
 					c.Log(entry)
 				}
 			}
-
 		}
 
 		deployment, cleanup := docker.NewDeployment(composeFile, deployOpts)

--- a/internal/deploy/project_checks/project_checks.go
+++ b/internal/deploy/project_checks/project_checks.go
@@ -6,6 +6,9 @@ import (
 	"strings"
 
 	"github.com/arm/topo/internal/compose"
+	"github.com/arm/topo/internal/output/logger"
+	"github.com/arm/topo/internal/ssh"
+	targetpkg "github.com/arm/topo/internal/target"
 )
 
 const linuxArm64Platform = "linux/arm64"
@@ -47,4 +50,170 @@ func EnsureProjectIsLinuxArm64Ready(composePath string) error {
 	}
 
 	return nil
+}
+
+func EnsureSSHGatewayPortsAreDisabled(target ssh.Host, connectionOption targetpkg.ConnectionOptions) []logger.Entry {
+	logs := []logger.Entry{}
+
+	if target.IsPlainLocalhost() {
+		return logs
+	}
+
+	conn := targetpkg.NewConnection(string(target), connectionOption)
+	server := detectSSHServer(conn)
+	switch server {
+	case sshServerOpenSSH:
+		logs = gatewayPortsCheckInOpenSSH(conn, target, logs)
+	case sshServerDropbear:
+		logs = gatewayPortsCheckInDropbear(conn, target, logs)
+	default:
+		logs = append(logs, logger.Entry{
+			Level:   logger.Warning,
+			Message: fmt.Sprintf("SSH GatewayPorts check skipped on %s: unable to detect SSH server type", target),
+		})
+	}
+	return logs
+}
+
+func gatewayPortsCheckInDropbear(conn targetpkg.Connection, target ssh.Host, logs []logger.Entry) []logger.Entry {
+	output, err := conn.Run("ps aux | grep dropbear")
+	if err != nil {
+		logs = append(logs, logger.Entry{
+			Level:   logger.Warning,
+			Message: fmt.Sprintf("SSH GatewayPorts check skipped on %s: failed to execute dropbear command: %v", target, err),
+		})
+		return logs
+	}
+
+	if strings.Contains(output, "-a") {
+		logs = append(logs, logger.Entry{
+			Level:   logger.Err,
+			Message: fmt.Sprintf("SSH GatewayPorts must be disabled on %s: Dropbear detected with -a option", target),
+		})
+	}
+	return logs
+}
+
+func gatewayPortsCheckInOpenSSH(conn targetpkg.Connection, target ssh.Host, logs []logger.Entry) []logger.Entry {
+	output, err := conn.Run("sshd -T")
+	if err == nil {
+		gatewayPorts, ok := parseGatewayPortsFromSSHD(output)
+		if !ok {
+			logs = append(logs, logger.Entry{
+				Level:   logger.Err,
+				Message: fmt.Sprintf("SSH GatewayPorts setting not found in sshd -T output on %s; unable to confirm it's disabled. Output may be incomplete or SSH version may not support this check", target),
+			})
+		} else if isGatewayPortsEnabled(gatewayPorts) {
+			logs = append(logs, logger.Entry{
+				Level:   logger.Err,
+				Message: fmt.Sprintf("SSH GatewayPorts must be disabled on %s: expected \"no\", got %q. Update sshd_config and restart sshd", target, gatewayPorts),
+			})
+		}
+
+		return logs
+	} else {
+		output, err = conn.Run("cat /etc/ssh/sshd_config")
+		if err != nil {
+			logs = append(logs, logger.Entry{
+				Level:   logger.Err,
+				Message: fmt.Sprintf("failed to read sshd_config on %s; unable to confirm SSH GatewayPorts is disabled. Error: %v", target, err),
+			})
+			return logs
+		}
+
+		gatewayPorts, uncertain := parseGatewayPortsFromConfig(output)
+		if gatewayPorts == "" {
+			logs = append(logs, logger.Entry{
+				Level:   logger.Warning,
+				Message: fmt.Sprintf("failed to determine SSH GatewayPorts setting on %s: not configured in sshd_config", target),
+			})
+		} else if isGatewayPortsEnabled(gatewayPorts) {
+			logs = append(logs, logger.Entry{
+				Level:   logger.Err,
+				Message: fmt.Sprintf("SSH GatewayPorts must be disabled on %s: expected \"no\", got %q. Update sshd_config and restart sshd", target, gatewayPorts),
+			})
+		} else if uncertain {
+			logs = append(logs, logger.Entry{
+				Level:   logger.Warning,
+				Message: fmt.Sprintf("SSH GatewayPorts setting on %s is uncertain due to Match or Include directives in sshd_config", target),
+			})
+		}
+		return logs
+	}
+}
+
+type sshServerType string
+
+const (
+	sshServerUnknown  sshServerType = "unknown"
+	sshServerOpenSSH  sshServerType = "openssh"
+	sshServerDropbear sshServerType = "dropbear"
+)
+
+func detectSSHServer(conn targetpkg.Connection) sshServerType {
+	output, err := conn.Run("ps -eo comm")
+	if err != nil {
+		return sshServerUnknown
+	}
+
+	lines := strings.Split(output, "\n")
+	hasOpenSSH := false
+	hasDropbear := false
+	for _, line := range lines {
+		switch strings.TrimSpace(line) {
+		case "sshd":
+			hasOpenSSH = true
+		case "dropbear":
+			hasDropbear = true
+		}
+	}
+
+	if hasOpenSSH {
+		return sshServerOpenSSH
+	}
+	if hasDropbear {
+		return sshServerDropbear
+	}
+	return sshServerUnknown
+}
+
+func isGatewayPortsEnabled(value string) bool {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "yes", "clientspecified":
+		return true
+	default:
+		return false
+	}
+}
+
+func parseGatewayPortsFromSSHD(sshdConfig string) (string, bool) {
+	lines := strings.Split(sshdConfig, "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		fields := strings.Fields(lines[i])
+		if len(fields) < 2 {
+			continue
+		}
+		if strings.EqualFold(fields[0], "gatewayports") {
+			return fields[1], true
+		}
+	}
+	return "", false
+}
+
+func parseGatewayPortsFromConfig(sshdConfig string) (value string, uncertain bool) {
+	lines := strings.Split(sshdConfig, "\n")
+	value = ""
+	for _, line := range lines {
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		if strings.EqualFold(fields[0], "match") || strings.EqualFold(fields[0], "include") {
+			uncertain = true
+		}
+		if strings.EqualFold(fields[0], "gatewayports") {
+			value = fields[1]
+		}
+	}
+	return value, uncertain
 }

--- a/internal/deploy/project_checks/project_checks_test.go
+++ b/internal/deploy/project_checks/project_checks_test.go
@@ -2,10 +2,14 @@ package checks_test
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 
 	checks "github.com/arm/topo/internal/deploy/project_checks"
+	"github.com/arm/topo/internal/ssh"
+	"github.com/arm/topo/internal/target"
+	"github.com/arm/topo/internal/testutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -90,4 +94,118 @@ func writeComposeFile(t *testing.T, contents string) string {
 		t.Fatalf("failed to write compose file: %v", err)
 	}
 	return path
+}
+
+func TestEnsureSSHGatewayPortsAreDisabled_SkipsLocalhost(t *testing.T) {
+	logResult := checks.EnsureSSHGatewayPortsAreDisabled(ssh.PlainLocalhost, target.ConnectionOptions{WithLoginShell: true})
+	require.Empty(t, logResult)
+}
+
+func TestEnsureSSHGatewayPortsAreDisabled_AllowsNoinOpenSSH(t *testing.T) {
+	mockExec := mockExecByCommand(t, map[string]mockedCommand{
+		"ps -eo comm": {output: "sshd\n", exitCode: 0},
+		"sshd -T":     {output: "gatewayports no\n", exitCode: 0},
+	})
+
+	logResult := checks.EnsureSSHGatewayPortsAreDisabled(ssh.Host("pumpkin@halloweenRemote"), target.ConnectionOptions{WithMockExec: mockExec})
+	require.Empty(t, logResult)
+}
+
+func TestEnsureSSHGatewayPortsAreDisabled_FailsWhenEnabledinOpenSSH(t *testing.T) {
+	mockExec := mockExecByCommand(t, map[string]mockedCommand{
+		"ps -eo comm": {output: "sshd\n", exitCode: 0},
+		"sshd -T":     {output: "gatewayports yes\nInclude /etc/ssh/sshd_config.d/*.conf", exitCode: 0},
+	})
+
+	logResult := checks.EnsureSSHGatewayPortsAreDisabled(ssh.Host("turkey@xmasRemote"), target.ConnectionOptions{WithMockExec: mockExec})
+	require.NotEmpty(t, logResult)
+	require.Equal(t, string(logResult[0].Level), "ERROR")
+	require.Contains(t, logResult[0].Message, "SSH GatewayPorts must be disabled on turkey@xmasRemote")
+}
+
+func TestEnsureSSHGatewayPortsAreDisabled_FailsWhenClientSpecifiedinOpenSSH(t *testing.T) {
+	mockExec := mockExecByCommand(t, map[string]mockedCommand{
+		"ps -eo comm": {output: "sshd\n", exitCode: 0},
+		"sshd -T":     {output: "gatewayports clientspecified\nInclude /etc/ssh/sshd_config.d/*.conf", exitCode: 0},
+	})
+
+	logResult := checks.EnsureSSHGatewayPortsAreDisabled(ssh.Host("sunday@brunchRemote"), target.ConnectionOptions{WithMockExec: mockExec})
+	require.NotEmpty(t, logResult)
+	require.Equal(t, string(logResult[0].Level), "ERROR")
+	require.Contains(t, logResult[0].Message, "SSH GatewayPorts must be disabled on sunday@brunchRemote")
+}
+
+func TestEnsureSSHGatewayPortsAreDisabled_FallsBackToConfigFileinOpenSSH(t *testing.T) {
+	mockExec := mockExecByCommand(t, map[string]mockedCommand{
+		"ps -eo comm":              {output: "sshd\n", exitCode: 0},
+		"sshd -T":                  {output: "", exitCode: 1},
+		"cat /etc/ssh/sshd_config": {output: "gatewayports no\n", exitCode: 0},
+	})
+
+	logResult := checks.EnsureSSHGatewayPortsAreDisabled(ssh.Host("pancake@shroveRemote"), target.ConnectionOptions{WithMockExec: mockExec})
+	require.Empty(t, logResult)
+}
+
+func TestEnsureSSHGatewayPortsAreDisabled_WarnsWhenConfigIsAmbiguousinOpenSSH(t *testing.T) {
+	mockExec := mockExecByCommand(t, map[string]mockedCommand{
+		"ps -eo comm":              {output: "sshd\n", exitCode: 0},
+		"sshd -T":                  {output: "", exitCode: 1},
+		"cat /etc/ssh/sshd_config": {output: "Include /etc/ssh/sshd_config.d/*.conf\ngatewayports no", exitCode: 0},
+	})
+
+	logResult := checks.EnsureSSHGatewayPortsAreDisabled(ssh.Host("mardi@grasRemote"), target.ConnectionOptions{WithMockExec: mockExec})
+	require.NotEmpty(t, logResult)
+	require.Equal(t, string(logResult[0].Level), "WARN")
+	require.Contains(t, logResult[0].Message, "SSH GatewayPorts setting on mardi@grasRemote is uncertain due to Match or Include directives in sshd_config")
+}
+
+func TestEnsureSSHGatewayPortsAreDisabled_PropagatesReadErrorinOpenSSH(t *testing.T) {
+	mockExec := mockExecByCommand(t, map[string]mockedCommand{
+		"ps -eo comm":              {output: "sshd\n", exitCode: 0},
+		"sshd -T":                  {output: "", exitCode: 1},
+		"cat /etc/ssh/sshd_config": {output: "", exitCode: 1},
+	})
+
+	logResult := checks.EnsureSSHGatewayPortsAreDisabled(ssh.Host("pancake@shroveRemote"), target.ConnectionOptions{WithMockExec: mockExec})
+	require.NotEmpty(t, logResult)
+	require.Equal(t, string(logResult[0].Level), "ERROR")
+	require.Contains(t, logResult[0].Message, "failed to read sshd_config on pancake@shroveRemote; unable to confirm SSH GatewayPorts is disabled. Error:")
+}
+
+func TestEnsureSSHGatewayPortsAreDisabled_dashADetectionErrorDropbear(t *testing.T) {
+	mockExec := mockExecByCommand(t, map[string]mockedCommand{
+		"ps -eo comm":            {output: "dropbear\n", exitCode: 0},
+		"ps aux | grep dropbear": {output: "/usr/sbin/dropbear -R -E -a\n", exitCode: 0},
+	})
+
+	logResult := checks.EnsureSSHGatewayPortsAreDisabled(ssh.Host("teddy@DropbearRemote"), target.ConnectionOptions{WithMockExec: mockExec})
+	require.NotEmpty(t, logResult)
+	require.Equal(t, string(logResult[0].Level), "ERROR")
+	require.Contains(t, logResult[0].Message, "SSH GatewayPorts must be disabled on teddy@DropbearRemote: Dropbear detected with -a option")
+}
+
+func TestEnsureSSHGatewayPortsAreDisabled_AllowswithoutDashADropbear(t *testing.T) {
+	mockExec := mockExecByCommand(t, map[string]mockedCommand{
+		"ps -eo comm":            {output: "dropbear\n", exitCode: 0},
+		"ps aux | grep dropbear": {output: "/usr/sbin/dropbear -R -E\n", exitCode: 0},
+	})
+
+	logResult := checks.EnsureSSHGatewayPortsAreDisabled(ssh.Host("teddy@DropbearRemote"), target.ConnectionOptions{WithMockExec: mockExec})
+	require.Empty(t, logResult)
+}
+
+type mockedCommand struct {
+	output   string
+	exitCode int
+}
+
+func mockExecByCommand(t *testing.T, responses map[string]mockedCommand) func(ssh.Host, string, []byte, ...string) *exec.Cmd {
+	t.Helper()
+	return func(_ ssh.Host, command string, _ []byte, _ ...string) *exec.Cmd {
+		response, ok := responses[command]
+		if !ok {
+			t.Fatalf("unexpected command: %s", command)
+		}
+		return testutil.CmdWithOutput(response.output, response.exitCode)
+	}
 }


### PR DESCRIPTION
Changes suggested while addressing this ticket - [DEML-1319](https://jira.arm.com/browse/DEML-1319)

## Changes

<!-- List the changes this PR introduces -->

- Implement logic to detect the target's ssh server program: Currently detects for OpenSSH and dropbear
- Implement logic to detect if the gatewayport is open
- Warn if we cannot be sure that gatewayport is disabled
- Error if we can be sure if gatewayport is enabled
