### PR TITLE
refactor: make test matrix and reduce over-repeated function names in tests' names

### DIFF
--- a/cmd/topo/deploy.go
+++ b/cmd/topo/deploy.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"runtime"
@@ -14,6 +15,7 @@ import (
 	"github.com/arm/topo/internal/output/console"
 	"github.com/arm/topo/internal/output/logger"
 	"github.com/arm/topo/internal/ssh"
+	"github.com/arm/topo/internal/target"
 
 	"github.com/spf13/cobra"
 )
@@ -104,6 +106,19 @@ Use --dry-run to see what commands would be executed without actually running th
 				Level:   logger.Warning,
 				Message: "registry transfer is not yet supported with this configuration. Falling back to direct transfer.",
 			})
+		}
+
+		logResult := checks.EnsureSSHGatewayPortsAreDisabled(targetHost, target.ConnectionOptions{WithLoginShell: true})
+		if len(logResult) > 0 {
+			for _, entry := range logResult {
+				switch entry.Level {
+				case logger.Err:
+					return errors.New(entry.Message)
+				case logger.Warning:
+					c.Log(entry)
+				}
+			}
+
 		}
 
 		deployment, cleanup := docker.NewDeployment(composeFile, deployOpts)

--- a/cmd/topo/deploy.go
+++ b/cmd/topo/deploy.go
@@ -118,7 +118,6 @@ Use --dry-run to see what commands would be executed without actually running th
 					c.Log(entry)
 				}
 			}
-
 		}
 
 		deployment, cleanup := docker.NewDeployment(composeFile, deployOpts)

--- a/internal/deploy/project_checks/project_checks.go
+++ b/internal/deploy/project_checks/project_checks.go
@@ -6,6 +6,9 @@ import (
 	"strings"
 
 	"github.com/arm/topo/internal/compose"
+	"github.com/arm/topo/internal/output/logger"
+	"github.com/arm/topo/internal/ssh"
+	targetpkg "github.com/arm/topo/internal/target"
 )
 
 const linuxArm64Platform = "linux/arm64"
@@ -47,4 +50,170 @@ func EnsureProjectIsLinuxArm64Ready(composePath string) error {
 	}
 
 	return nil
+}
+
+func EnsureSSHGatewayPortsAreDisabled(target ssh.Host, connectionOption targetpkg.ConnectionOptions) []logger.Entry {
+	logs := []logger.Entry{}
+
+	if target.IsPlainLocalhost() {
+		return logs
+	}
+
+	conn := targetpkg.NewConnection(string(target), connectionOption)
+	server := detectSSHServer(conn)
+	switch server {
+	case sshServerOpenSSH:
+		logs = gatewayPortsCheckInOpenSSH(conn, target, logs)
+	case sshServerDropbear:
+		logs = gatewayPortsCheckInDropbear(conn, target, logs)
+	default:
+		logs = append(logs, logger.Entry{
+			Level:   logger.Warning,
+			Message: fmt.Sprintf("SSH GatewayPorts check skipped on %s: unable to detect SSH server type", target),
+		})
+	}
+	return logs
+}
+
+func gatewayPortsCheckInDropbear(conn targetpkg.Connection, target ssh.Host, logs []logger.Entry) []logger.Entry {
+	output, err := conn.Run("ps aux | grep dropbear")
+	if err != nil {
+		logs = append(logs, logger.Entry{
+			Level:   logger.Warning,
+			Message: fmt.Sprintf("SSH GatewayPorts check skipped on %s: failed to execute dropbear command: %v", target, err),
+		})
+		return logs
+	}
+
+	if strings.Contains(output, "-a") {
+		logs = append(logs, logger.Entry{
+			Level:   logger.Err,
+			Message: fmt.Sprintf("SSH GatewayPorts must be disabled on %s: Dropbear detected with -a option", target),
+		})
+	}
+	return logs
+}
+
+func gatewayPortsCheckInOpenSSH(conn targetpkg.Connection, target ssh.Host, logs []logger.Entry) []logger.Entry {
+	output, err := conn.Run("sshd -T")
+	if err == nil {
+		gatewayPorts, ok := parseGatewayPortsFromSSHD(output)
+		if !ok {
+			logs = append(logs, logger.Entry{
+				Level:   logger.Err,
+				Message: fmt.Sprintf("SSH GatewayPorts setting not found in sshd -T output on %s; unable to confirm it's disabled. Output may be incomplete or SSH version may not support this check", target),
+			})
+		} else if isGatewayPortsEnabled(gatewayPorts) {
+			logs = append(logs, logger.Entry{
+				Level:   logger.Err,
+				Message: fmt.Sprintf("SSH GatewayPorts must be disabled on %s: expected \"no\", got %q. Update sshd_config and restart sshd", target, gatewayPorts),
+			})
+		}
+
+		return logs
+	} else {
+		output, err = conn.Run("cat /etc/ssh/sshd_config")
+		if err != nil {
+			logs = append(logs, logger.Entry{
+				Level:   logger.Err,
+				Message: fmt.Sprintf("failed to read sshd_config on %s; unable to confirm SSH GatewayPorts is disabled. Error: %v", target, err),
+			})
+			return logs
+		}
+
+		gatewayPorts, uncertain := parseGatewayPortsFromConfig(output)
+		if gatewayPorts == "" {
+			logs = append(logs, logger.Entry{
+				Level:   logger.Warning,
+				Message: fmt.Sprintf("failed to determine SSH GatewayPorts setting on %s: not configured in sshd_config", target),
+			})
+		} else if isGatewayPortsEnabled(gatewayPorts) {
+			logs = append(logs, logger.Entry{
+				Level:   logger.Err,
+				Message: fmt.Sprintf("SSH GatewayPorts must be disabled on %s: expected \"no\", got %q. Update sshd_config and restart sshd", target, gatewayPorts),
+			})
+		} else if uncertain {
+			logs = append(logs, logger.Entry{
+				Level:   logger.Warning,
+				Message: fmt.Sprintf("SSH GatewayPorts setting on %s is uncertain due to Match or Include directives in sshd_config", target),
+			})
+		}
+		return logs
+	}
+}
+
+type sshServerType string
+
+const (
+	sshServerUnknown  sshServerType = "unknown"
+	sshServerOpenSSH  sshServerType = "openssh"
+	sshServerDropbear sshServerType = "dropbear"
+)
+
+func detectSSHServer(conn targetpkg.Connection) sshServerType {
+	output, err := conn.Run("ps -eo comm")
+	if err != nil {
+		return sshServerUnknown
+	}
+
+	lines := strings.Split(output, "\n")
+	hasOpenSSH := false
+	hasDropbear := false
+	for _, line := range lines {
+		switch strings.TrimSpace(line) {
+		case "sshd":
+			hasOpenSSH = true
+		case "dropbear":
+			hasDropbear = true
+		}
+	}
+
+	if hasOpenSSH {
+		return sshServerOpenSSH
+	}
+	if hasDropbear {
+		return sshServerDropbear
+	}
+	return sshServerUnknown
+}
+
+func isGatewayPortsEnabled(value string) bool {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "yes", "clientspecified":
+		return true
+	default:
+		return false
+	}
+}
+
+func parseGatewayPortsFromSSHD(sshdConfig string) (string, bool) {
+	lines := strings.Split(sshdConfig, "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		fields := strings.Fields(lines[i])
+		if len(fields) < 2 {
+			continue
+		}
+		if strings.EqualFold(fields[0], "gatewayports") {
+			return fields[1], true
+		}
+	}
+	return "", false
+}
+
+func parseGatewayPortsFromConfig(sshdConfig string) (value string, uncertain bool) {
+	lines := strings.Split(sshdConfig, "\n")
+	value = ""
+	for _, line := range lines {
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		if strings.EqualFold(fields[0], "match") || strings.EqualFold(fields[0], "include") {
+			uncertain = true
+		}
+		if strings.EqualFold(fields[0], "gatewayports") {
+			value = fields[1]
+		}
+	}
+	return value, uncertain
 }

--- a/internal/deploy/project_checks/project_checks_test.go
+++ b/internal/deploy/project_checks/project_checks_test.go
@@ -13,76 +13,88 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestEnsureProjectIsLinuxArm64Ready_SucceedsWithValidRemoteProc(t *testing.T) {
-	composeFile := writeComposeFile(t, `
+func TestEnsureProjectIsLinuxArm64Ready(t *testing.T) {
+	cases := []struct {
+		name        string
+		compose     string
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name: "allows remoteproc runtime",
+			compose: `
 services:
   rtos-firmware:
     build:
       context: .
     runtime: io.containerd.remoteproc.v1
-`)
-
-	require.NoError(t, checks.EnsureProjectIsLinuxArm64Ready(composeFile))
-}
-
-func TestEnsureProjectIsLinuxArm64Ready_SucceedsWithValidPlatforms(t *testing.T) {
-	t.Run("without variant", func(t *testing.T) {
-		composeFile := writeComposeFile(t, `
+`,
+		},
+		{
+			name: "allows linux arm64 without variant",
+			compose: `
 services:
   app:
     image: alpine
     platform: linux/arm64
-`)
-
-		require.NoError(t, checks.EnsureProjectIsLinuxArm64Ready(composeFile))
-	})
-
-	t.Run("with variant", func(t *testing.T) {
-		composeFile := writeComposeFile(t, `
+`,
+		},
+		{
+			name: "allows linux arm64 with variant",
+			compose: `
 services:
   app:
     image: alpine
     platform: linux/arm64/v8
-`)
-
-		require.NoError(t, checks.EnsureProjectIsLinuxArm64Ready(composeFile))
-	})
-}
-
-func TestEnsureProjectIsLinuxArm64Ready_FailsWhenPlatformMissing(t *testing.T) {
-	composeFile := writeComposeFile(t, `
+`,
+		},
+		{
+			name: "fails when platform missing",
+			compose: `
 services:
   api:
     image: busybox
-`)
-
-	err := checks.EnsureProjectIsLinuxArm64Ready(composeFile)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "missing platform declaration")
-}
-
-func TestEnsureProjectIsLinuxArm64Ready_FailsWhenPlatformMismatch(t *testing.T) {
-	composeFile := writeComposeFile(t, `
+`,
+			wantErr:     true,
+			errContains: "missing platform declaration",
+		},
+		{
+			name: "fails when platform mismatch",
+			compose: `
 services:
   api:
     image: busybox
     platform: linux/amd64
-`)
-
-	err := checks.EnsureProjectIsLinuxArm64Ready(composeFile)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "linux/amd64")
-}
-
-func TestEnsureProjectIsLinuxArm64Ready_SkipsRemoteprocRuntime(t *testing.T) {
-	composeFile := writeComposeFile(t, `
+`,
+			wantErr:     true,
+			errContains: "linux/amd64",
+		},
+		{
+			name: "skips remoteproc runtime",
+			compose: `
 services:
   firmware:
     image: zephyr
     runtime: io.containerd.remoteproc.v1
-`)
+`,
+		},
+	}
 
-	require.NoError(t, checks.EnsureProjectIsLinuxArm64Ready(composeFile))
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			composeFile := writeComposeFile(t, tc.compose)
+			err := checks.EnsureProjectIsLinuxArm64Ready(composeFile)
+			if tc.wantErr {
+				require.Error(t, err)
+				if tc.errContains != "" {
+					require.Contains(t, err.Error(), tc.errContains)
+				}
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
 }
 
 func writeComposeFile(t *testing.T, contents string) string {
@@ -96,102 +108,120 @@ func writeComposeFile(t *testing.T, contents string) string {
 	return path
 }
 
-func TestEnsureSSHGatewayPortsAreDisabled_SkipsLocalhost(t *testing.T) {
-	logResult := checks.EnsureSSHGatewayPortsAreDisabled(ssh.PlainLocalhost, target.ConnectionOptions{WithLoginShell: true})
-	require.Empty(t, logResult)
-}
-
-func TestEnsureSSHGatewayPortsAreDisabled_AllowsNoinOpenSSH(t *testing.T) {
-	mockExec := mockExecByCommand(t, map[string]mockedCommand{
-		"ps -eo comm": {output: "sshd\n", exitCode: 0},
-		"sshd -T":     {output: "gatewayports no\n", exitCode: 0},
+func TestEnsureSSHGatewayPortsAreDisabled(t *testing.T) {
+	t.Run("skips localhost", func(t *testing.T) {
+		logResult := checks.EnsureSSHGatewayPortsAreDisabled(ssh.PlainLocalhost, target.ConnectionOptions{WithLoginShell: true})
+		require.Empty(t, logResult)
 	})
 
-	logResult := checks.EnsureSSHGatewayPortsAreDisabled(ssh.Host("pumpkin@halloweenRemote"), target.ConnectionOptions{WithMockExec: mockExec})
-	require.Empty(t, logResult)
-}
+	cases := []struct {
+		name        string
+		target      ssh.Host
+		responses   map[string]mockedCommand
+		wantEmpty   bool
+		wantLevel   string
+		wantMessage string
+	}{
+		{
+			name:   "openssh allows when gateway ports disabled",
+			target: ssh.Host("halloween@opensshRemote"),
+			responses: map[string]mockedCommand{
+				"ps -eo comm": {output: "sshd\n", exitCode: 0},
+				"sshd -T":     {output: "gatewayports no\n", exitCode: 0},
+			},
+			wantEmpty: true,
+		},
+		{
+			name:   "openssh fails when gateway ports enabled",
+			target: ssh.Host("christmas@opensshRemote"),
+			responses: map[string]mockedCommand{
+				"ps -eo comm": {output: "sshd\n", exitCode: 0},
+				"sshd -T":     {output: "gatewayports yes\nInclude /etc/ssh/sshd_config.d/*.conf", exitCode: 0},
+			},
+			wantLevel:   "ERROR",
+			wantMessage: "SSH GatewayPorts must be disabled on christmas@opensshRemote",
+		},
+		{
+			name:   "openssh fails when gateway ports are clientspecified",
+			target: ssh.Host("easter@opensshRemote"),
+			responses: map[string]mockedCommand{
+				"ps -eo comm": {output: "sshd\n", exitCode: 0},
+				"sshd -T":     {output: "gatewayports clientspecified\nInclude /etc/ssh/sshd_config.d/*.conf", exitCode: 0},
+			},
+			wantLevel:   "ERROR",
+			wantMessage: "SSH GatewayPorts must be disabled on easter@opensshRemote",
+		},
+		{
+			name:   "openssh falls back to config file",
+			target: ssh.Host("boxingday@opensshRemote"),
+			responses: map[string]mockedCommand{
+				"ps -eo comm":              {output: "sshd\n", exitCode: 0},
+				"sshd -T":                  {output: "", exitCode: 1},
+				"cat /etc/ssh/sshd_config": {output: "gatewayports no\n", exitCode: 0},
+			},
+			wantEmpty: true,
+		},
+		{
+			name:   "openssh warns when config is ambiguous",
+			target: ssh.Host("mayday@opensshRemote"),
+			responses: map[string]mockedCommand{
+				"ps -eo comm":              {output: "sshd\n", exitCode: 0},
+				"sshd -T":                  {output: "", exitCode: 1},
+				"cat /etc/ssh/sshd_config": {output: "Include /etc/ssh/sshd_config.d/*.conf\ngatewayports no", exitCode: 0},
+			},
+			wantLevel:   "WARN",
+			wantMessage: "SSH GatewayPorts setting on mayday@opensshRemote is uncertain due to Match or Include directives in sshd_config",
+		},
+		{
+			name:   "openssh propagates read error",
+			target: ssh.Host("bonfire@opensshRemote"),
+			responses: map[string]mockedCommand{
+				"ps -eo comm":              {output: "sshd\n", exitCode: 0},
+				"sshd -T":                  {output: "", exitCode: 1},
+				"cat /etc/ssh/sshd_config": {output: "", exitCode: 1},
+			},
+			wantLevel:   "ERROR",
+			wantMessage: "failed to read sshd_config on bonfire@opensshRemote; unable to confirm SSH GatewayPorts is disabled. Error:",
+		},
+		{
+			name:   "fails when dropbear uses -a",
+			target: ssh.Host("teddy@DropbearRemote"),
+			responses: map[string]mockedCommand{
+				"ps -eo comm":            {output: "dropbear\n", exitCode: 0},
+				"ps aux | grep dropbear": {output: "/usr/sbin/dropbear -R -E -a\n", exitCode: 0},
+			},
+			wantLevel:   "ERROR",
+			wantMessage: "SSH GatewayPorts must be disabled on teddy@DropbearRemote: Dropbear detected with -a option",
+		},
+		{
+			name:   "allows dropbear without -a",
+			target: ssh.Host("fluffy@DropbearRemote"),
+			responses: map[string]mockedCommand{
+				"ps -eo comm":            {output: "dropbear\n", exitCode: 0},
+				"ps aux | grep dropbear": {output: "/usr/sbin/dropbear -R -E\n", exitCode: 0},
+			},
+			wantEmpty: true,
+		},
+	}
 
-func TestEnsureSSHGatewayPortsAreDisabled_FailsWhenEnabledinOpenSSH(t *testing.T) {
-	mockExec := mockExecByCommand(t, map[string]mockedCommand{
-		"ps -eo comm": {output: "sshd\n", exitCode: 0},
-		"sshd -T":     {output: "gatewayports yes\nInclude /etc/ssh/sshd_config.d/*.conf", exitCode: 0},
-	})
-
-	logResult := checks.EnsureSSHGatewayPortsAreDisabled(ssh.Host("turkey@xmasRemote"), target.ConnectionOptions{WithMockExec: mockExec})
-	require.NotEmpty(t, logResult)
-	require.Equal(t, string(logResult[0].Level), "ERROR")
-	require.Contains(t, logResult[0].Message, "SSH GatewayPorts must be disabled on turkey@xmasRemote")
-}
-
-func TestEnsureSSHGatewayPortsAreDisabled_FailsWhenClientSpecifiedinOpenSSH(t *testing.T) {
-	mockExec := mockExecByCommand(t, map[string]mockedCommand{
-		"ps -eo comm": {output: "sshd\n", exitCode: 0},
-		"sshd -T":     {output: "gatewayports clientspecified\nInclude /etc/ssh/sshd_config.d/*.conf", exitCode: 0},
-	})
-
-	logResult := checks.EnsureSSHGatewayPortsAreDisabled(ssh.Host("sunday@brunchRemote"), target.ConnectionOptions{WithMockExec: mockExec})
-	require.NotEmpty(t, logResult)
-	require.Equal(t, string(logResult[0].Level), "ERROR")
-	require.Contains(t, logResult[0].Message, "SSH GatewayPorts must be disabled on sunday@brunchRemote")
-}
-
-func TestEnsureSSHGatewayPortsAreDisabled_FallsBackToConfigFileinOpenSSH(t *testing.T) {
-	mockExec := mockExecByCommand(t, map[string]mockedCommand{
-		"ps -eo comm":              {output: "sshd\n", exitCode: 0},
-		"sshd -T":                  {output: "", exitCode: 1},
-		"cat /etc/ssh/sshd_config": {output: "gatewayports no\n", exitCode: 0},
-	})
-
-	logResult := checks.EnsureSSHGatewayPortsAreDisabled(ssh.Host("pancake@shroveRemote"), target.ConnectionOptions{WithMockExec: mockExec})
-	require.Empty(t, logResult)
-}
-
-func TestEnsureSSHGatewayPortsAreDisabled_WarnsWhenConfigIsAmbiguousinOpenSSH(t *testing.T) {
-	mockExec := mockExecByCommand(t, map[string]mockedCommand{
-		"ps -eo comm":              {output: "sshd\n", exitCode: 0},
-		"sshd -T":                  {output: "", exitCode: 1},
-		"cat /etc/ssh/sshd_config": {output: "Include /etc/ssh/sshd_config.d/*.conf\ngatewayports no", exitCode: 0},
-	})
-
-	logResult := checks.EnsureSSHGatewayPortsAreDisabled(ssh.Host("mardi@grasRemote"), target.ConnectionOptions{WithMockExec: mockExec})
-	require.NotEmpty(t, logResult)
-	require.Equal(t, string(logResult[0].Level), "WARN")
-	require.Contains(t, logResult[0].Message, "SSH GatewayPorts setting on mardi@grasRemote is uncertain due to Match or Include directives in sshd_config")
-}
-
-func TestEnsureSSHGatewayPortsAreDisabled_PropagatesReadErrorinOpenSSH(t *testing.T) {
-	mockExec := mockExecByCommand(t, map[string]mockedCommand{
-		"ps -eo comm":              {output: "sshd\n", exitCode: 0},
-		"sshd -T":                  {output: "", exitCode: 1},
-		"cat /etc/ssh/sshd_config": {output: "", exitCode: 1},
-	})
-
-	logResult := checks.EnsureSSHGatewayPortsAreDisabled(ssh.Host("pancake@shroveRemote"), target.ConnectionOptions{WithMockExec: mockExec})
-	require.NotEmpty(t, logResult)
-	require.Equal(t, string(logResult[0].Level), "ERROR")
-	require.Contains(t, logResult[0].Message, "failed to read sshd_config on pancake@shroveRemote; unable to confirm SSH GatewayPorts is disabled. Error:")
-}
-
-func TestEnsureSSHGatewayPortsAreDisabled_dashADetectionErrorDropbear(t *testing.T) {
-	mockExec := mockExecByCommand(t, map[string]mockedCommand{
-		"ps -eo comm":            {output: "dropbear\n", exitCode: 0},
-		"ps aux | grep dropbear": {output: "/usr/sbin/dropbear -R -E -a\n", exitCode: 0},
-	})
-
-	logResult := checks.EnsureSSHGatewayPortsAreDisabled(ssh.Host("teddy@DropbearRemote"), target.ConnectionOptions{WithMockExec: mockExec})
-	require.NotEmpty(t, logResult)
-	require.Equal(t, string(logResult[0].Level), "ERROR")
-	require.Contains(t, logResult[0].Message, "SSH GatewayPorts must be disabled on teddy@DropbearRemote: Dropbear detected with -a option")
-}
-
-func TestEnsureSSHGatewayPortsAreDisabled_AllowswithoutDashADropbear(t *testing.T) {
-	mockExec := mockExecByCommand(t, map[string]mockedCommand{
-		"ps -eo comm":            {output: "dropbear\n", exitCode: 0},
-		"ps aux | grep dropbear": {output: "/usr/sbin/dropbear -R -E\n", exitCode: 0},
-	})
-
-	logResult := checks.EnsureSSHGatewayPortsAreDisabled(ssh.Host("teddy@DropbearRemote"), target.ConnectionOptions{WithMockExec: mockExec})
-	require.Empty(t, logResult)
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			mockExec := mockExecByCommand(t, tc.responses)
+			logResult := checks.EnsureSSHGatewayPortsAreDisabled(tc.target, target.ConnectionOptions{WithMockExec: mockExec})
+			if tc.wantEmpty {
+				require.Empty(t, logResult)
+				return
+			}
+			require.NotEmpty(t, logResult)
+			if tc.wantLevel != "" {
+				require.Equal(t, tc.wantLevel, string(logResult[0].Level))
+			}
+			if tc.wantMessage != "" {
+				require.Contains(t, logResult[0].Message, tc.wantMessage)
+			}
+		})
+	}
 }
 
 type mockedCommand struct {

--- a/internal/deploy/project_checks/project_checks_test.go
+++ b/internal/deploy/project_checks/project_checks_test.go
@@ -2,10 +2,14 @@ package checks_test
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 
 	checks "github.com/arm/topo/internal/deploy/project_checks"
+	"github.com/arm/topo/internal/ssh"
+	"github.com/arm/topo/internal/target"
+	"github.com/arm/topo/internal/testutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -90,4 +94,118 @@ func writeComposeFile(t *testing.T, contents string) string {
 		t.Fatalf("failed to write compose file: %v", err)
 	}
 	return path
+}
+
+func TestEnsureSSHGatewayPortsAreDisabled_SkipsLocalhost(t *testing.T) {
+	logResult := checks.EnsureSSHGatewayPortsAreDisabled(ssh.PlainLocalhost, target.ConnectionOptions{WithLoginShell: true})
+	require.Empty(t, logResult)
+}
+
+func TestEnsureSSHGatewayPortsAreDisabled_AllowsNoinOpenSSH(t *testing.T) {
+	mockExec := mockExecByCommand(t, map[string]mockedCommand{
+		"ps -eo comm": {output: "sshd\n", exitCode: 0},
+		"sshd -T":     {output: "gatewayports no\n", exitCode: 0},
+	})
+
+	logResult := checks.EnsureSSHGatewayPortsAreDisabled(ssh.Host("pumpkin@halloweenRemote"), target.ConnectionOptions{WithMockExec: mockExec})
+	require.Empty(t, logResult)
+}
+
+func TestEnsureSSHGatewayPortsAreDisabled_FailsWhenEnabledinOpenSSH(t *testing.T) {
+	mockExec := mockExecByCommand(t, map[string]mockedCommand{
+		"ps -eo comm": {output: "sshd\n", exitCode: 0},
+		"sshd -T":     {output: "gatewayports yes\nInclude /etc/ssh/sshd_config.d/*.conf", exitCode: 0},
+	})
+
+	logResult := checks.EnsureSSHGatewayPortsAreDisabled(ssh.Host("turkey@xmasRemote"), target.ConnectionOptions{WithMockExec: mockExec})
+	require.NotEmpty(t, logResult)
+	require.Equal(t, string(logResult[0].Level), "ERROR")
+	require.Contains(t, logResult[0].Message, "SSH GatewayPorts must be disabled on turkey@xmasRemote")
+}
+
+func TestEnsureSSHGatewayPortsAreDisabled_FailsWhenClientSpecifiedinOpenSSH(t *testing.T) {
+	mockExec := mockExecByCommand(t, map[string]mockedCommand{
+		"ps -eo comm": {output: "sshd\n", exitCode: 0},
+		"sshd -T":     {output: "gatewayports clientspecified\nInclude /etc/ssh/sshd_config.d/*.conf", exitCode: 0},
+	})
+
+	logResult := checks.EnsureSSHGatewayPortsAreDisabled(ssh.Host("sunday@brunchRemote"), target.ConnectionOptions{WithMockExec: mockExec})
+	require.NotEmpty(t, logResult)
+	require.Equal(t, string(logResult[0].Level), "ERROR")
+	require.Contains(t, logResult[0].Message, "SSH GatewayPorts must be disabled on sunday@brunchRemote")
+}
+
+func TestEnsureSSHGatewayPortsAreDisabled_FallsBackToConfigFileinOpenSSH(t *testing.T) {
+	mockExec := mockExecByCommand(t, map[string]mockedCommand{
+		"ps -eo comm":              {output: "sshd\n", exitCode: 0},
+		"sshd -T":                  {output: "", exitCode: 1},
+		"cat /etc/ssh/sshd_config": {output: "gatewayports no\n", exitCode: 0},
+	})
+
+	logResult := checks.EnsureSSHGatewayPortsAreDisabled(ssh.Host("pancake@shroveRemote"), target.ConnectionOptions{WithMockExec: mockExec})
+	require.Empty(t, logResult)
+}
+
+func TestEnsureSSHGatewayPortsAreDisabled_WarnsWhenConfigIsAmbiguousinOpenSSH(t *testing.T) {
+	mockExec := mockExecByCommand(t, map[string]mockedCommand{
+		"ps -eo comm":              {output: "sshd\n", exitCode: 0},
+		"sshd -T":                  {output: "", exitCode: 1},
+		"cat /etc/ssh/sshd_config": {output: "Include /etc/ssh/sshd_config.d/*.conf\ngatewayports no", exitCode: 0},
+	})
+
+	logResult := checks.EnsureSSHGatewayPortsAreDisabled(ssh.Host("mardi@grasRemote"), target.ConnectionOptions{WithMockExec: mockExec})
+	require.NotEmpty(t, logResult)
+	require.Equal(t, string(logResult[0].Level), "WARN")
+	require.Contains(t, logResult[0].Message, "SSH GatewayPorts setting on mardi@grasRemote is uncertain due to Match or Include directives in sshd_config")
+}
+
+func TestEnsureSSHGatewayPortsAreDisabled_PropagatesReadErrorinOpenSSH(t *testing.T) {
+	mockExec := mockExecByCommand(t, map[string]mockedCommand{
+		"ps -eo comm":              {output: "sshd\n", exitCode: 0},
+		"sshd -T":                  {output: "", exitCode: 1},
+		"cat /etc/ssh/sshd_config": {output: "", exitCode: 1},
+	})
+
+	logResult := checks.EnsureSSHGatewayPortsAreDisabled(ssh.Host("pancake@shroveRemote"), target.ConnectionOptions{WithMockExec: mockExec})
+	require.NotEmpty(t, logResult)
+	require.Equal(t, string(logResult[0].Level), "ERROR")
+	require.Contains(t, logResult[0].Message, "failed to read sshd_config on pancake@shroveRemote; unable to confirm SSH GatewayPorts is disabled. Error:")
+}
+
+func TestEnsureSSHGatewayPortsAreDisabled_dashADetectionErrorDropbear(t *testing.T) {
+	mockExec := mockExecByCommand(t, map[string]mockedCommand{
+		"ps -eo comm":            {output: "dropbear\n", exitCode: 0},
+		"ps aux | grep dropbear": {output: "/usr/sbin/dropbear -R -E -a\n", exitCode: 0},
+	})
+
+	logResult := checks.EnsureSSHGatewayPortsAreDisabled(ssh.Host("teddy@DropbearRemote"), target.ConnectionOptions{WithMockExec: mockExec})
+	require.NotEmpty(t, logResult)
+	require.Equal(t, string(logResult[0].Level), "ERROR")
+	require.Contains(t, logResult[0].Message, "SSH GatewayPorts must be disabled on teddy@DropbearRemote: Dropbear detected with -a option")
+}
+
+func TestEnsureSSHGatewayPortsAreDisabled_AllowswithoutDashADropbear(t *testing.T) {
+	mockExec := mockExecByCommand(t, map[string]mockedCommand{
+		"ps -eo comm":            {output: "dropbear\n", exitCode: 0},
+		"ps aux | grep dropbear": {output: "/usr/sbin/dropbear -R -E\n", exitCode: 0},
+	})
+
+	logResult := checks.EnsureSSHGatewayPortsAreDisabled(ssh.Host("teddy@DropbearRemote"), target.ConnectionOptions{WithMockExec: mockExec})
+	require.Empty(t, logResult)
+}
+
+type mockedCommand struct {
+	output   string
+	exitCode int
+}
+
+func mockExecByCommand(t *testing.T, responses map[string]mockedCommand) func(ssh.Host, string, []byte, ...string) *exec.Cmd {
+	t.Helper()
+	return func(_ ssh.Host, command string, _ []byte, _ ...string) *exec.Cmd {
+		response, ok := responses[command]
+		if !ok {
+			t.Fatalf("unexpected command: %s", command)
+		}
+		return testutil.CmdWithOutput(response.output, response.exitCode)
+	}
 }


### PR DESCRIPTION
tests in `project_checks.go` were sore in the eyes because the names of the tests were trying to say everything what they were doing in camel cases. These descriptions also came after the statement of the function name the test is testing combined with _. Made the test matrix, and preserved the test description in more readable way
