### PR TITLE
Check /proc/meminfo for total memory.

### DIFF
--- a/internal/describe/describe_test.go
+++ b/internal/describe/describe_test.go
@@ -25,6 +25,9 @@ func TestGenerate(t *testing.T) {
 			if strings.Contains(command, "remoteproc") {
 				return testutil.CmdWithOutput("remoteproc1 remoteproc2", 0)
 			}
+			if strings.Contains(command, "meminfo") {
+				return testutil.CmdWithOutput("MemTotal:       16384000 kB", 0)
+			}
 			return testutil.CmdWithOutput("", 0)
 		}
 		expected := target.HardwareProfile{
@@ -39,6 +42,7 @@ func TestGenerate(t *testing.T) {
 				{Name: "remoteproc1"},
 				{Name: "remoteproc2"},
 			},
+			TotalMemoryKb: 16384000,
 		}
 
 		conn := target.NewConnection("test", target.ConnectionOptions{WithMockExec: mockExecSSH})

--- a/internal/target/probe.go
+++ b/internal/target/probe.go
@@ -1,6 +1,7 @@
 package target
 
 import (
+	"bufio"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -29,6 +30,7 @@ type RemoteprocCPU struct {
 type HardwareProfile struct {
 	HostProcessor []HostProcessor `yaml:"host"`
 	RemoteCPU     []RemoteprocCPU `yaml:"remoteprocs"`
+	TotalMemory   int64
 }
 
 type LscpuOutputField struct {
@@ -75,6 +77,12 @@ func (c *Connection) ProbeHardware() (HardwareProfile, error) {
 	}
 	hp.RemoteCPU = cpus
 
+	memTotal, err := c.collectMemInfo()
+	if err != nil {
+		return hp, fmt.Errorf("collecting memory info: %w", err)
+	}
+	hp.TotalMemory = memTotal
+
 	return hp, nil
 }
 
@@ -118,6 +126,33 @@ func (c *Connection) collectCPUInfo() ([]HostProcessor, error) {
 	}
 
 	return CreateCPUProfile(lscpuOutput.Lscpu)
+}
+
+func FindKeyValueInString(key string, text string) (int64, error) {
+	scanner := bufio.NewScanner(strings.NewReader(text))
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) >= 2 && fields[0] == key+":" {
+			return strconv.ParseInt(fields[1], 10, 64)
+		}
+	}
+	return 0, fmt.Errorf("field %s not found", key)
+}
+
+func (c *Connection) collectMemInfo() (int64, error) {
+	key := "MemTotal"
+	path := "/proc/meminfo"
+
+	out, err := c.Run(fmt.Sprintf("cat %s", path))
+	if err != nil {
+		return 0, err
+	}
+
+	value, err := FindKeyValueInString(key, out)
+	if err != nil {
+		return 0, fmt.Errorf("in checking %s", path)
+	}
+	return value, nil
 }
 
 func newHostProcessor(name string, fields []LscpuOutputField) (HostProcessor, error) {

--- a/internal/target/probe.go
+++ b/internal/target/probe.go
@@ -30,7 +30,7 @@ type RemoteprocCPU struct {
 type HardwareProfile struct {
 	HostProcessor []HostProcessor `yaml:"host"`
 	RemoteCPU     []RemoteprocCPU `yaml:"remoteprocs"`
-	TotalMemory   int64
+	TotalMemoryKb int64           `yaml:"totalmemory_kb"`
 }
 
 type LscpuOutputField struct {
@@ -81,7 +81,7 @@ func (c *Connection) ProbeHardware() (HardwareProfile, error) {
 	if err != nil {
 		return hp, fmt.Errorf("collecting memory info: %w", err)
 	}
-	hp.TotalMemory = memTotal
+	hp.TotalMemoryKb = memTotal
 
 	return hp, nil
 }

--- a/internal/target/probe_test.go
+++ b/internal/target/probe_test.go
@@ -43,6 +43,8 @@ func TestProbeHardware(t *testing.T) {
 				return testutil.CmdWithOutput("/usr/bin/lscpu", 0)
 			case command == "lscpu --json":
 				return testutil.CmdWithOutput(testutil.LsCpuOutputRaw, 0)
+			case strings.Contains(command, "meminfo"):
+				return testutil.CmdWithOutput("MemTotal:       16384000 kB", 0)
 			default:
 				return testutil.CmdWithOutput("not found", 1)
 			}
@@ -56,6 +58,7 @@ func TestProbeHardware(t *testing.T) {
 		assert.Equal(t, "Cortex-A55", hw.HostProcessor[0].ModelName)
 		assert.Equal(t, 2, hw.HostProcessor[0].Cores)
 		assert.Equal(t, []string{"fp", "asimd"}, hw.HostProcessor[0].Features)
+		assert.Equal(t, int64(16384000), hw.TotalMemoryKb)
 	})
 
 	t.Run("returns error when lscpu not found", func(t *testing.T) {
@@ -76,6 +79,8 @@ func TestProbeHardware(t *testing.T) {
 				return testutil.CmdWithOutput("/usr/bin/lscpu", 0)
 			case command == "lscpu --json":
 				return testutil.CmdWithOutput("not json", 0)
+			case strings.Contains(command, "meminfo"):
+				return testutil.CmdWithOutput("MemTotal:       16384000 kB", 0)
 			default:
 				return testutil.CmdWithOutput("not found", 1)
 			}

--- a/internal/target/probe_test.go
+++ b/internal/target/probe_test.go
@@ -88,6 +88,35 @@ func TestProbeHardware(t *testing.T) {
 	})
 }
 
+func TestFindKeyValueInString(t *testing.T) {
+	t.Run("finds key and parses value", func(t *testing.T) {
+		text := `MemTotal:       16384000 kB
+MemFree:        8192000 kB`
+
+		got, err := target.FindKeyValueInString("MemTotal", text)
+
+		require.NoError(t, err)
+		assert.Equal(t, int64(16384000), got)
+	})
+
+	t.Run("returns error when key not found", func(t *testing.T) {
+		text := `MemTotal:       16384000 kB`
+
+		got, err := target.FindKeyValueInString("MissingKey", text)
+
+		assert.Error(t, err)
+		assert.Equal(t, int64(0), got)
+	})
+
+	t.Run("returns error when value is invalid", func(t *testing.T) {
+		text := `MemTotal:       notanumber`
+
+		_, err := target.FindKeyValueInString("MemTotal", text)
+
+		assert.Error(t, err)
+	})
+}
+
 func TestCreateCPUProfile(t *testing.T) {
 	t.Run("parses lscpu with sockets", func(t *testing.T) {
 		input := []target.LscpuOutputField{


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- Adds a `totalmemory` field in the target-info.
We fetch this info from /proc/meminfo, as lsmem lists the exact same information.
