### PR TITLE
fix: topo health works with unreachable target

### DIFF
--- a/internal/describe/describe.go
+++ b/internal/describe/describe.go
@@ -12,10 +12,6 @@ import (
 const TargetDescriptionFilename = "target-description.yaml"
 
 func GenerateTargetDescription(conn target.Connection) (target.HardwareProfile, error) {
-	if err := conn.ProbeConnection(); err != nil {
-		return target.HardwareProfile{}, err
-	}
-
 	hwProfile, err := conn.ProbeHardware()
 	if err != nil {
 		return target.HardwareProfile{}, err

--- a/internal/describe/describe.go
+++ b/internal/describe/describe.go
@@ -12,7 +12,7 @@ import (
 const TargetDescriptionFilename = "target-description.yaml"
 
 func GenerateTargetDescription(conn target.Connection) (target.HardwareProfile, error) {
-	if err := conn.ProbeConnection(); err != nil {
+	if err := conn.ProbeAuthentication(); err != nil {
 		return target.HardwareProfile{}, err
 	}
 

--- a/internal/describe/describe.go
+++ b/internal/describe/describe.go
@@ -12,7 +12,7 @@ import (
 const TargetDescriptionFilename = "target-description.yaml"
 
 func GenerateTargetDescription(conn target.Connection) (target.HardwareProfile, error) {
-	if err := conn.ProbeAuthentication(); err != nil {
+	if err := conn.ProbeConnection(); err != nil {
 		return target.HardwareProfile{}, err
 	}
 

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -110,11 +110,11 @@ func Check(sshTarget string, acceptNewHostKeys bool) (Report, error) {
 	conn := target.NewConnection(sshTarget, opts)
 	targetStatus := ProbeHealthStatus(conn)
 	report := GenerateReport(dependencyStatuses, targetStatus)
-	if err := targetStatus.AuthError; err != nil {
+	if err := targetStatus.ConnectionError; err != nil {
 		if errors.Is(err, target.ErrPasswordAuthentication) {
 			return report, fmt.Errorf(passwordAuthErrorMessage, sshTarget)
 		}
-		return report, err
+		return report, nil
 	}
 	return report, nil
 }

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -92,16 +92,7 @@ func GenerateReport(hostDependencies []DependencyStatus, targetStatus Status) Re
 
 func Check(sshTarget string, acceptNewHostKeys bool) (Report, error) {
 	dependencyStatuses := CheckInstalled(HostRequiredDependencies, BinaryExistsLocally)
-
-	authProbeEnabled := false
-	for _, s := range dependencyStatuses {
-		if s.Dependency.Name == "ssh" {
-			authProbeEnabled = s.Installed
-			break
-		}
-	}
 	opts := target.ConnectionOptions{
-		AuthProbeEnabled:  authProbeEnabled,
 		AcceptNewHostKeys: acceptNewHostKeys,
 		AuthProbeInput:    os.Stdin,
 		AuthProbeOutput:   os.Stdout,

--- a/internal/health/status.go
+++ b/internal/health/status.go
@@ -20,7 +20,6 @@ func (h HardwareProfile) Capabilities() map[HardwareCapability]struct{} {
 type Status struct {
 	SSHTarget       ssh.Host
 	ConnectionError error
-	AuthError       error
 	Dependencies    []DependencyStatus
 	Hardware        HardwareProfile
 }
@@ -30,11 +29,6 @@ func ProbeHealthStatus(c target.Connection) Status {
 	status.SSHTarget = c.SSHTarget
 
 	if err := c.ProbeAuthentication(); err != nil {
-		status.AuthError = err
-		return status
-	}
-
-	if err := c.ProbeConnection(); err != nil {
 		status.ConnectionError = err
 		return status
 	}

--- a/internal/target/connection.go
+++ b/internal/target/connection.go
@@ -43,7 +43,6 @@ type Connection struct {
 }
 
 type ConnectionOptions struct {
-	AuthProbeEnabled  bool
 	AcceptNewHostKeys bool
 	AuthProbeInput    io.Reader
 	AuthProbeOutput   io.Writer
@@ -110,10 +109,6 @@ func (c *Connection) BinaryExists(bin string) (bool, error) {
 }
 
 func (c *Connection) ProbeAuthentication() error {
-	if !c.opts.AuthProbeEnabled {
-		return nil
-	}
-
 	if !c.opts.AcceptNewHostKeys {
 		err := c.runSSHAuthenticationProbe(knownHostProbeArgs)
 		if err != nil && !errors.Is(err, ErrAuthenticationFailure) {

--- a/internal/target/connection_auth_test.go
+++ b/internal/target/connection_auth_test.go
@@ -63,7 +63,7 @@ func TestProbeAuthentication(t *testing.T) {
 		mockExec := newMockExec(map[string]mockResponse{
 			"public": {stdout: "", err: nil},
 		}, &calls)
-		opts := target.ConnectionOptions{AuthProbeEnabled: true, AcceptNewHostKeys: true, WithMockExec: mockExec}
+		opts := target.ConnectionOptions{AcceptNewHostKeys: true, WithMockExec: mockExec}
 		conn := target.NewConnection("user@host", opts)
 		err := conn.ProbeAuthentication()
 		require.NoError(t, err)
@@ -78,7 +78,7 @@ func TestProbeAuthentication(t *testing.T) {
 		mockExec := newMockExec(map[string]mockResponse{
 			"public": {stdout: "Host key verification failed", err: errSSH},
 		}, &calls)
-		opts := target.ConnectionOptions{AuthProbeEnabled: true, AcceptNewHostKeys: true, WithMockExec: mockExec}
+		opts := target.ConnectionOptions{AcceptNewHostKeys: true, WithMockExec: mockExec}
 		conn := target.NewConnection("user@host", opts)
 		err := conn.ProbeAuthentication()
 		require.ErrorIs(t, err, target.ErrHostKeyVerification)
@@ -91,7 +91,7 @@ func TestProbeAuthentication(t *testing.T) {
 			"public":   {stdout: "Permission denied", err: errSSH},
 			"password": {stdout: "Host key verification failed", err: errSSH},
 		}, &calls)
-		opts := target.ConnectionOptions{AuthProbeEnabled: true, AcceptNewHostKeys: true, WithMockExec: mockExec}
+		opts := target.ConnectionOptions{AcceptNewHostKeys: true, WithMockExec: mockExec}
 		conn := target.NewConnection("user@host", opts)
 		err := conn.ProbeAuthentication()
 		require.ErrorIs(t, err, target.ErrHostKeyVerification)
@@ -105,7 +105,7 @@ func TestProbeAuthentication(t *testing.T) {
 			"public":   {stdout: "Permission denied", err: errSSH},
 			"password": {stdout: "Authentication failed", err: errSSH},
 		}, &calls)
-		opts := target.ConnectionOptions{AuthProbeEnabled: true, AcceptNewHostKeys: true, WithMockExec: mockExec}
+		opts := target.ConnectionOptions{AcceptNewHostKeys: true, WithMockExec: mockExec}
 		conn := target.NewConnection("user@host", opts)
 		err := conn.ProbeAuthentication()
 		require.ErrorIs(t, err, target.ErrPasswordAuthentication)
@@ -117,7 +117,7 @@ func TestProbeAuthentication(t *testing.T) {
 			"public":   {stdout: "Permission denied", err: errSSH},
 			"password": {stdout: "ok", err: nil},
 		}, &calls)
-		opts := target.ConnectionOptions{AuthProbeEnabled: true, AcceptNewHostKeys: true, WithMockExec: mockExec}
+		opts := target.ConnectionOptions{AcceptNewHostKeys: true, WithMockExec: mockExec}
 		conn := target.NewConnection("user@host", opts)
 		err := conn.ProbeAuthentication()
 		require.NoError(t, err)
@@ -131,7 +131,7 @@ func TestProbeAuthentication(t *testing.T) {
 			"public":   {stdout: "Permission denied", err: errSSH},
 			"password": {stdout: "Some other error", err: errSSH},
 		}, &calls)
-		opts := target.ConnectionOptions{AuthProbeEnabled: true, AcceptNewHostKeys: true, WithMockExec: mockExec}
+		opts := target.ConnectionOptions{AcceptNewHostKeys: true, WithMockExec: mockExec}
 		conn := target.NewConnection("user@host", opts)
 		err := conn.ProbeAuthentication()
 		require.Error(t, err)
@@ -144,7 +144,7 @@ func TestProbeAuthentication(t *testing.T) {
 			"knownhost": {stdout: "Permission denied", err: errSSH},
 			"public":    {stdout: "", err: nil},
 		}, &calls)
-		opts := target.ConnectionOptions{AuthProbeEnabled: true, AcceptNewHostKeys: false, WithMockExec: mockExec}
+		opts := target.ConnectionOptions{AcceptNewHostKeys: false, WithMockExec: mockExec}
 		conn := target.NewConnection("user@host", opts)
 		err := conn.ProbeAuthentication()
 		require.NoError(t, err)
@@ -158,7 +158,7 @@ func TestProbeAuthentication(t *testing.T) {
 		mockExec := newMockExec(map[string]mockResponse{
 			"knownhost": {stdout: "HOST KEY VERIFICATION FAILED", err: errSSH},
 		}, &calls)
-		opts := target.ConnectionOptions{AuthProbeEnabled: true, AcceptNewHostKeys: false, WithMockExec: mockExec}
+		opts := target.ConnectionOptions{AcceptNewHostKeys: false, WithMockExec: mockExec}
 		conn := target.NewConnection("user@host", opts)
 		err := conn.ProbeAuthentication()
 		require.ErrorIs(t, err, target.ErrHostKeyVerification)
@@ -170,7 +170,7 @@ func TestProbeAuthentication(t *testing.T) {
 		mockExec := newMockExec(map[string]mockResponse{
 			"knownhost": {stdout: "dial tcp: lookup host: no such host", err: errSSH},
 		}, &calls)
-		opts := target.ConnectionOptions{AuthProbeEnabled: true, AcceptNewHostKeys: false, WithMockExec: mockExec}
+		opts := target.ConnectionOptions{AcceptNewHostKeys: false, WithMockExec: mockExec}
 		conn := target.NewConnection("user@host", opts)
 		err := conn.ProbeAuthentication()
 		require.Error(t, err)

--- a/internal/target/probe.go
+++ b/internal/target/probe.go
@@ -57,11 +57,6 @@ func (proc *HostProcessor) ExtractArmFeatures() []string {
 	return res
 }
 
-func (c *Connection) ProbeConnection() error {
-	_, err := c.Run("true")
-	return err
-}
-
 func (c *Connection) ProbeHardware() (HardwareProfile, error) {
 	var hp HardwareProfile
 


### PR DESCRIPTION
## Problem

<!-- List the changes this PR introduces -->

- Basic problem is we had two probes doing similar things - `ProbeAuthentication` which runs `ssh <target> true` and makes some assertions about error messages and `ProbeConnection` which does the same but just treats any error as a failure
  - Since probing the connection was gated behind probing authentication but only when a specific connection option was set, our unit tests didn't catch this regression


## Solution  

- Turns out, afaict, the `AuthProbeEnabled` option is not necessary - we can run the probe fine and just treat the lack of ssh as a `ConnectionError`. Then, since we are separately checking for SSH on the path, you get exactly the same health report as you did before without the complex logic. This change on its own would mean our unit tests would now catch this bug
- Dropped `ProbeConnection` from health entirely as it's done by virtue of performing the auth check. This lets us avoid separating the errors and go back to treating any non-password-auth-related error as a `ConnectionError` and not crashing out the whole program.

End result is less code + more resilient tests, hence why no new ones are introduced here.