### PR TITLE
chore: camelCase keys in topo health json output

### DIFF
--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -15,24 +15,24 @@ const passwordAuthErrorMessage = `note: Topo does not support SSH password-based
 - run 'topo setup-keys --target %s' to let Topo generate keys and configure passwordless authentication`
 
 type HealthCheck struct {
-	Name    string
-	Healthy bool
-	Value   string
+	Name    string `json:"name"`
+	Healthy bool   `json:"healthy"`
+	Value   string `json:"value"`
 }
 type HostReport struct {
-	Dependencies []HealthCheck
+	Dependencies []HealthCheck `json:"dependencies"`
 }
 
 type TargetReport struct {
-	IsLocalhost     bool
-	Connectivity    HealthCheck
-	Dependencies    []HealthCheck
-	SubsystemDriver HealthCheck
+	IsLocalhost     bool          `json:"is_localhost"`
+	Connectivity    HealthCheck   `json:"connectivity"`
+	Dependencies    []HealthCheck `json:"dependencies"`
+	SubsystemDriver HealthCheck   `json:"subsystem_driver"`
 }
 
 type Report struct {
-	Host   HostReport
-	Target TargetReport
+	Host   HostReport   `json:"host"`
+	Target TargetReport `json:"target"`
 }
 
 func generateDependencyReport(statuses []DependencyStatus) []HealthCheck {

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -24,10 +24,10 @@ type HostReport struct {
 }
 
 type TargetReport struct {
-	IsLocalhost     bool          `json:"is_localhost"`
+	IsLocalhost     bool          `json:"isLocalhost"`
 	Connectivity    HealthCheck   `json:"connectivity"`
 	Dependencies    []HealthCheck `json:"dependencies"`
-	SubsystemDriver HealthCheck   `json:"subsystem_driver"`
+	SubsystemDriver HealthCheck   `json:"subsystemDriver"`
 }
 
 type Report struct {

--- a/internal/output/templates/health_test.go
+++ b/internal/output/templates/health_test.go
@@ -114,16 +114,16 @@ func TestPrintHealthReport(t *testing.T) {
 			require.NoError(t, err)
 
 			want := `{
-				"Host": {
-					"Dependencies": [
-						{"Name":"Flux Capacitor","Healthy":true,"Value":""}
+				"host": {
+					"dependencies": [
+						{"name":"Flux Capacitor","healthy":true,"value":""}
 					]
 				},
-				"Target": {
-					"IsLocalhost": false,
-					"Connectivity": {"Name":"Connected","Healthy":true,"Value":""},
-					"Dependencies": [],
-					"SubsystemDriver": {"Name":"","Healthy":false,"Value":""}
+				"target": {
+					"is_localhost": false,
+					"connectivity": {"name":"Connected","healthy":true,"value":""},
+					"dependencies": [],
+					"subsystem_driver": {"name":"","healthy":false,"value":""}
 				}
 			}`
 

--- a/internal/output/templates/health_test.go
+++ b/internal/output/templates/health_test.go
@@ -120,10 +120,10 @@ func TestPrintHealthReport(t *testing.T) {
 					]
 				},
 				"target": {
-					"is_localhost": false,
+					"isLocalhost": false,
 					"connectivity": {"name":"Connected","healthy":true,"value":""},
 					"dependencies": [],
-					"subsystem_driver": {"name":"","healthy":false,"value":""}
+					"subsystemDriver": {"name":"","healthy":false,"value":""}
 				}
 			}`
 


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- Does what it says on the tin. Allows us to have more standard-looking JS objects in the vscode extension + rename props on these structs without breaking the extension in the future

Why is the branch called snake-case but the PR is in camelCase? I changed my mind after pushing the branch
