### PR TITLE
remove url escape in repoURL

### DIFF
--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -134,7 +134,7 @@ func getLatestReleaseTarAddress(repoURL string) (*url.URL, error) {
 
 	base.Path = path.Join(
 		"repos",
-		url.PathEscape(repoURL),
+		repoURL,
 		"releases",
 		"latest",
 	)


### PR DESCRIPTION
## Changes

- It removes a `url.PathEscape` to correctly allow `arm/remoteproc-runtime`
