### PR TITLE
Use login shell for checking binaries

### DIFF
--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -105,6 +105,7 @@ func Check(sshTarget string, acceptNewHostKeys bool) (Report, error) {
 		AuthProbeInput:    os.Stdin,
 		AuthProbeOutput:   os.Stdout,
 		Multiplex:         true,
+		WithLoginShell:    true,
 	}
 	conn := target.NewConnection(sshTarget, opts)
 	targetStatus := ProbeHealthStatus(conn)


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- Fixes bug in connection resulting in binary not checking
