### PR TITLE
Implement some basic e2e health tests

### DIFF
--- a/e2e/health_test.go
+++ b/e2e/health_test.go
@@ -1,0 +1,50 @@
+package e2e
+
+import (
+	"fmt"
+	"os/exec"
+	"testing"
+
+	"github.com/arm/topo/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHealthCheck(t *testing.T) {
+	target := testutil.StartTargetContainer(t)
+	topo := buildBinary(t)
+
+	t.Run("accurately shows host health status", func(t *testing.T) {
+		out, err := runCheckHealth(topo, target)
+		require.NoError(t, err)
+
+		assert.Contains(t, out, "SSH: ✅ (ssh)")
+		assert.Contains(t, out, "Container Engine: ✅")
+	})
+
+	t.Run("shows that it's connected to a valid target", func(t *testing.T) {
+		out, err := runCheckHealth(topo, target)
+		require.NoError(t, err)
+
+		assert.Contains(t, out, "Connected: ✅")
+	})
+
+	t.Run("fails to connect to an invalid target", func(t *testing.T) {
+		fakeContainer := testutil.TargetContainer{
+			SSHConnectionString: "fake@target",
+			ContainerName:       "fake-tgt-container",
+		}
+		out, err := runCheckHealth(topo, &fakeContainer)
+		assert.NoError(t, err)
+		assert.Contains(t, out, "Connected: ❌")
+	})
+}
+
+func runCheckHealth(topo string, target *testutil.TargetContainer) (string, error) {
+	targetURL := fmt.Sprintf("ssh://%s", target.SSHConnectionString)
+	args := []string{"health", "--target", targetURL}
+	healthCmd := exec.Command(topo, args...)
+
+	out, err := healthCmd.CombinedOutput()
+	return string(out), err
+}

--- a/internal/testutil/test-container/Dockerfile
+++ b/internal/testutil/test-container/Dockerfile
@@ -1,6 +1,6 @@
 FROM docker:dind
 
-RUN apk add --no-cache openssh-server
+RUN apk add --no-cache openssh-server util-linux
 
 RUN echo "PasswordAuthentication yes" >> /etc/ssh/sshd_config && \
     echo "PermitEmptyPasswords yes" >> /etc/ssh/sshd_config && \


### PR DESCRIPTION
## Changes

- Adds some basic e2e tests for the health command.
- Validates host information
- Validates target connection
- Ensures proper handling when failing a connection
