### PR TITLE
fix:Organize signing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -101,8 +101,8 @@ jobs:
         with:
           name: topo-v${{ steps.version.outputs.version }}-macos-unsigned
           path: |
-            dist/topo_darwin_amd64_*
-            dist/topo_darwin_arm64_*
+            dist/topo_darwin_amd64
+            dist/topo_darwin_arm64
           if-no-files-found: error
 
       - name: Upload unsigned Windows artifacts
@@ -110,8 +110,8 @@ jobs:
         with:
           name: topo-v${{ steps.version.outputs.version }}-windows-unsigned
           path: |
-            dist/topo_windows_amd64_*
-            dist/topo_windows_arm64_*
+            dist/topo_windows_amd64
+            dist/topo_windows_arm64
           if-no-files-found: error
 
       - name: Create GitHub App token for signer
@@ -169,7 +169,8 @@ jobs:
         with:
           name: topo-v${{ steps.version.outputs.version }}-linux
           path: |
-            dist/topo_linux_*
+            dist/topo_linux_amd64
+            dist/topo_linux_arm64
           if-no-files-found: error
 
       - name: Trigger archive and upload to artifactory workflow for linux artifacts

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -120,7 +120,7 @@ jobs:
           OWNER: Arm-debug
           REPO: signer
           WORKFLOW_FILE: upload_archives_to_artifactory.yml
-          REF: pythonize
+          REF: port-to-python
           UPSTREAM_RUN_ID: ${{ github.run_id }}
         run: |
           gh workflow run "$WORKFLOW_FILE" \
@@ -138,7 +138,7 @@ jobs:
           OWNER: Arm-debug
           REPO: signer
           WORKFLOW_FILE: sign-and-post-macos.yml
-          REF: pythonize
+          REF: port-to-python
           UPSTREAM_RUN_ID: ${{ github.run_id }}
         run: |
           gh workflow run "$WORKFLOW_FILE" \
@@ -157,7 +157,7 @@ jobs:
           OWNER: Arm-debug
           REPO: signer
           WORKFLOW_FILE: sign-and-post-windows.yml
-          REF: pythonize
+          REF: port-to-python
           UPSTREAM_RUN_ID: ${{ github.run_id }}
         run: |
           gh workflow run "$WORKFLOW_FILE" \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -128,6 +128,7 @@ jobs:
             -f "repo-name=topo" \
             -f "org-name=arm" \
             -f "binary-name=topo" \
+            -f "artifactory-uploadables=topo_darwin_*"
 
       - name: Trigger Windows signer workflow
         env:
@@ -148,6 +149,7 @@ jobs:
             -f "org-name=arm" \
             -f "binary-name=topo.exe" \
             -f "signing-artifactory-repo=edge-ai-tooling.topo-cli-signing" \
+            -f "artifactory-uploadables=topo_windows_*"
 
       - name: Upload linux artifacts
         uses: actions/upload-artifact@v6
@@ -175,3 +177,4 @@ jobs:
             -f "artifactory-path=linux" \
             -f "repo-name=topo" \
             -f "org-name=arm" \
+            -f "artifactory-uploadables=topo_linux_*"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -144,6 +144,14 @@ jobs:
             -f "binary-name=topo.exe" \
             -f "signing-artifactory-repo=edge-ai-tooling.topo-cli-signing" \
 
+      - name: Upload linux artifacts
+        uses: actions/upload-artifact@v6
+        with:
+          name: topo-v${{ steps.version.outputs.version }}-linux
+          path: |
+            dist/topo_linux_*/topo
+          if-no-files-found: error
+
       - name: Trigger upload archives to artifactory workflow for linux artifacts
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -129,7 +129,7 @@ jobs:
           OWNER: Arm-debug
           REPO: signer
           WORKFLOW_FILE: sign-and-post-macos.yml
-          REF: separate-inputs-action
+          REF: main
           UPSTREAM_RUN_ID: ${{ github.run_id }}
         run: |
           gh workflow run "$WORKFLOW_FILE" \
@@ -149,7 +149,7 @@ jobs:
           OWNER: Arm-debug
           REPO: signer
           WORKFLOW_FILE: sign-and-post-windows.yml
-          REF: separate-inputs-action
+          REF: main
           UPSTREAM_RUN_ID: ${{ github.run_id }}
         run: |
           gh workflow run "$WORKFLOW_FILE" \
@@ -179,7 +179,7 @@ jobs:
           OWNER: Arm-debug
           REPO: signer
           WORKFLOW_FILE: archive-and-upload-to-artifactory.yml
-          REF: separate-inputs-action
+          REF: main
           UPSTREAM_RUN_ID: ${{ github.run_id }}
         run: |
           gh workflow run "$WORKFLOW_FILE" \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -78,10 +78,22 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_CURRENT_TAG: v${{ steps.version.outputs.version }}
 
-      - name: Place README.md in every architecture binary folder
+      - name: delete the build folders now the archives are there
+        run: find dist -maxdepth 1 -type d -name 'topo_*_*_v*' -exec rm -rf {} +
+
+      - name: decompress the archives for signing
         run: |
-          for dir in dist/*/; do
-            cp README.md "$dir"
+          for archive in dist/*.tar.gz; do
+            base="${archive##*/}"
+            dir="dist/${base%.tar.gz}"
+            mkdir -p "$dir"
+            tar -xzf "$archive" -C "$dir"
+          done
+          for archive in dist/*.zip; do
+            base="${archive##*/}"
+            dir="dist/${base%.zip}"
+            mkdir -p "$dir"
+            unzip -o "$archive" -d "$dir"
           done
 
       - name: Upload unsigned macOS artifact

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -83,8 +83,13 @@ jobs:
         with:
           name: topo-v${{ steps.version.outputs.version }}-macos-unsigned
           path: |
+<<<<<<< HEAD
             dist/topo_darwin_amd64_*/topo
             dist/topo_darwin_arm64_*/topo
+=======
+            dist/topo_darwin_amd64_*
+            dist/topo_darwin_arm64_*
+>>>>>>> 2e47013 (fix: publish all artifacts including readmes for signing and uploading)
           if-no-files-found: error
 
       - name: Upload unsigned Windows artifacts
@@ -92,8 +97,8 @@ jobs:
         with:
           name: topo-v${{ steps.version.outputs.version }}-windows-unsigned
           path: |
-            dist/topo_windows_amd64_*/topo.exe
-            dist/topo_windows_arm64_*/topo.exe
+            dist/topo_windows_amd64_*
+            dist/topo_windows_arm64_*
           if-no-files-found: error
 
       - name: Create GitHub App token for signer
@@ -149,7 +154,7 @@ jobs:
         with:
           name: topo-v${{ steps.version.outputs.version }}-linux
           path: |
-            dist/topo_linux_*/topo
+            dist/topo_linux_*
           if-no-files-found: error
 
       - name: Trigger upload archives to artifactory workflow for linux artifacts
@@ -166,7 +171,7 @@ jobs:
             --ref "$REF" \
             -f "run-id=$UPSTREAM_RUN_ID" \
             -f "release-version=${{ steps.version.outputs.version }}" \
-            -f "archive-name=topo-${{ steps.version.outputs.version }}-linux" \
+            -f "archive-name=topo-v${{ steps.version.outputs.version }}-linux" \
             -f "artifactory-path=linux" \
             -f "repo-name=topo" \
             -f "org-name=arm" \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -113,24 +113,6 @@ jobs:
           private-key: ${{ secrets.ML_REPO_ACCESS_PRIVATE_KEY }}
           owner: Arm-debug
           repositories: signer
-      
-      - name: Trigger upload archives to artifactory workflow
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          OWNER: Arm-debug
-          REPO: signer
-          WORKFLOW_FILE: upload_archives_to_artifactory.yml
-          REF: port-to-python
-          UPSTREAM_RUN_ID: ${{ github.run_id }}
-        run: |
-          gh workflow run "$WORKFLOW_FILE" \
-            --repo "$OWNER/$REPO" \
-            --ref "$REF" \
-            -f "run-id=$UPSTREAM_RUN_ID" \
-            -f "release-version=${{ steps.version.outputs.version }}" \
-            -f "archive-name=topo-v${{ steps.version.outputs.version }}-archives" \
-            -f "repo-name=topo" \
-            -f "org-name=arm" \
 
       - name: Trigger macOS signer workflow
         env:
@@ -138,7 +120,7 @@ jobs:
           OWNER: Arm-debug
           REPO: signer
           WORKFLOW_FILE: sign-and-post-macos.yml
-          REF: port-to-python
+          REF: organize-upload-path
           UPSTREAM_RUN_ID: ${{ github.run_id }}
         run: |
           gh workflow run "$WORKFLOW_FILE" \
@@ -157,7 +139,7 @@ jobs:
           OWNER: Arm-debug
           REPO: signer
           WORKFLOW_FILE: sign-and-post-windows.yml
-          REF: port-to-python
+          REF: organize-upload-path
           UPSTREAM_RUN_ID: ${{ github.run_id }}
         run: |
           gh workflow run "$WORKFLOW_FILE" \
@@ -170,3 +152,21 @@ jobs:
             -f "org-name=arm" \
             -f "binary-name=topo.exe" \
             -f "signing-artifactory-repo=edge-ai-tooling.topo-cli-signing" \
+
+      - name: Trigger upload archives to artifactory workflow for linux artifacts
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          OWNER: Arm-debug
+          REPO: signer
+          WORKFLOW_FILE: upload_archives_to_artifactory.yml
+          REF: organize-upload-path
+          UPSTREAM_RUN_ID: ${{ github.run_id }}
+        run: |
+          gh workflow run "$WORKFLOW_FILE" \
+            --repo "$OWNER/$REPO" \
+            --ref "$REF" \
+            -f "run-id=$UPSTREAM_RUN_ID" \
+            -f "release-version=${{ steps.version.outputs.version }}" \
+            -f "archive-name=topo-v${{ steps.version.outputs.version }}-archives" \
+            -f "repo-name=topo" \
+            -f "org-name=arm" \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -78,15 +78,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_CURRENT_TAG: v${{ steps.version.outputs.version }}
 
-      - name: Upload all archive artifacts
-        uses: actions/upload-artifact@v7
-        with:
-          name: topo-v${{ steps.version.outputs.version }}-archives
-          path: |
-            dist/*.tar.gz
-            dist/*.zip
-            dist/checksums.txt
-
       - name: Upload unsigned macOS artifact
         uses: actions/upload-artifact@v7
         with:
@@ -167,6 +158,7 @@ jobs:
             --ref "$REF" \
             -f "run-id=$UPSTREAM_RUN_ID" \
             -f "release-version=${{ steps.version.outputs.version }}" \
-            -f "archive-name=topo-v${{ steps.version.outputs.version }}-archives" \
+            -f "archive-name=topo-${{ steps.version.outputs.version }}-linux" \
+            -f "artifactory-path=linux" \
             -f "repo-name=topo" \
             -f "org-name=arm" \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -78,6 +78,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_CURRENT_TAG: v${{ steps.version.outputs.version }}
 
+      - name: Place README.md in every architecture binary folder
+        run: |
+          for dir in dist/*/; do
+            cp README.md "$dir"
+          done
+
       - name: Upload unsigned macOS artifact
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -129,7 +129,7 @@ jobs:
           OWNER: Arm-debug
           REPO: signer
           WORKFLOW_FILE: sign-and-post-macos.yml
-          REF: organize-upload-path
+          REF: separate-inputs-action
           UPSTREAM_RUN_ID: ${{ github.run_id }}
         run: |
           gh workflow run "$WORKFLOW_FILE" \
@@ -149,7 +149,7 @@ jobs:
           OWNER: Arm-debug
           REPO: signer
           WORKFLOW_FILE: sign-and-post-windows.yml
-          REF: organize-upload-path
+          REF: separate-inputs-action
           UPSTREAM_RUN_ID: ${{ github.run_id }}
         run: |
           gh workflow run "$WORKFLOW_FILE" \
@@ -179,7 +179,7 @@ jobs:
           OWNER: Arm-debug
           REPO: signer
           WORKFLOW_FILE: archive-and-upload-to-artifactory.yml
-          REF: organize-upload-path
+          REF: separate-inputs-action
           UPSTREAM_RUN_ID: ${{ github.run_id }}
         run: |
           gh workflow run "$WORKFLOW_FILE" \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -83,13 +83,8 @@ jobs:
         with:
           name: topo-v${{ steps.version.outputs.version }}-macos-unsigned
           path: |
-<<<<<<< HEAD
-            dist/topo_darwin_amd64_*/topo
-            dist/topo_darwin_arm64_*/topo
-=======
             dist/topo_darwin_amd64_*
             dist/topo_darwin_arm64_*
->>>>>>> 2e47013 (fix: publish all artifacts including readmes for signing and uploading)
           if-no-files-found: error
 
       - name: Upload unsigned Windows artifacts

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -120,7 +120,7 @@ jobs:
           OWNER: Arm-debug
           REPO: signer
           WORKFLOW_FILE: upload_archives_to_artifactory.yml
-          REF: main
+          REF: pythonize
           UPSTREAM_RUN_ID: ${{ github.run_id }}
         run: |
           gh workflow run "$WORKFLOW_FILE" \
@@ -138,7 +138,7 @@ jobs:
           OWNER: Arm-debug
           REPO: signer
           WORKFLOW_FILE: sign-and-post-macos.yml
-          REF: main
+          REF: pythonize
           UPSTREAM_RUN_ID: ${{ github.run_id }}
         run: |
           gh workflow run "$WORKFLOW_FILE" \
@@ -157,7 +157,7 @@ jobs:
           OWNER: Arm-debug
           REPO: signer
           WORKFLOW_FILE: sign-and-post-windows.yml
-          REF: main
+          REF: pythonize
           UPSTREAM_RUN_ID: ${{ github.run_id }}
         run: |
           gh workflow run "$WORKFLOW_FILE" \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -173,3 +173,29 @@ jobs:
             -f "repo-name=topo" \
             -f "org-name=arm" \
             -f "artifactory-uploadables=topo_linux_*"
+
+      - name: Upload README.md as an artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: README.md
+          path: README.md
+          if-no-files-found: error
+
+      - name: Trigger upload archives to artifactory workflow for README.md
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          OWNER: Arm-debug
+          REPO: signer
+          WORKFLOW_FILE: upload_archives_to_artifactory.yml
+          REF: organize-upload-path
+          UPSTREAM_RUN_ID: ${{ github.run_id }}
+        run: |
+          gh workflow run "$WORKFLOW_FILE" \
+            --repo "$OWNER/$REPO" \
+            --ref "$REF" \
+            -f "run-id=$UPSTREAM_RUN_ID" \
+            -f "release-version=${{ steps.version.outputs.version }}" \
+            -f "archive-name=README.md" \
+            -f "repo-name=topo" \
+            -f "org-name=arm" \
+            -f "artifactory-uploadables=README.md"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -157,7 +157,7 @@ jobs:
         with:
           name: topo-v${{ steps.version.outputs.version }}-linux
           path: |
-            dist/topo_*_linux_*
+            dist/topo_linux_*
           if-no-files-found: error
 
       - name: Trigger archive and upload to artifactory workflow for linux artifacts

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,7 +46,7 @@ jobs:
             Major) new="$((major+1)).0.0";;
             Minor) new="$major.$((minor+1)).0";;
             Patch) new="$major.$minor.$((patch+1))";;
-            Pre-release) new="$base-$(date +%Y%m%d%H%M%S)";;
+            Pre-release) new="$base-$(date +%Y-%m-%d-%H-%M-%S)";;
             *) echo "invalid release type"; exit 1;;
           esac
           echo "version=$new" >> $GITHUB_OUTPUT
@@ -157,7 +157,7 @@ jobs:
         with:
           name: topo-v${{ steps.version.outputs.version }}-linux
           path: |
-            dist/topo_linux_*
+            dist/topo_*_linux_*
           if-no-files-found: error
 
       - name: Trigger archive and upload to artifactory workflow for linux artifacts

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -160,12 +160,12 @@ jobs:
             dist/topo_linux_*
           if-no-files-found: error
 
-      - name: Trigger upload archives to artifactory workflow for linux artifacts
+      - name: Trigger archive and upload to artifactory workflow for linux artifacts
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           OWNER: Arm-debug
           REPO: signer
-          WORKFLOW_FILE: upload_archives_to_artifactory.yml
+          WORKFLOW_FILE: archive-and-upload-to-artifactory.yml
           REF: organize-upload-path
           UPSTREAM_RUN_ID: ${{ github.run_id }}
         run: |
@@ -178,30 +178,6 @@ jobs:
             -f "artifactory-path=linux" \
             -f "repo-name=topo" \
             -f "org-name=arm" \
-            -f "artifactory-uploadables=topo_linux_*"
-
-      - name: Upload README.md as an artifact
-        uses: actions/upload-artifact@v6
-        with:
-          name: README.md
-          path: README.md
-          if-no-files-found: error
-
-      - name: Trigger upload archives to artifactory workflow for README.md
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          OWNER: Arm-debug
-          REPO: signer
-          WORKFLOW_FILE: upload_archives_to_artifactory.yml
-          REF: organize-upload-path
-          UPSTREAM_RUN_ID: ${{ github.run_id }}
-        run: |
-          gh workflow run "$WORKFLOW_FILE" \
-            --repo "$OWNER/$REPO" \
-            --ref "$REF" \
-            -f "run-id=$UPSTREAM_RUN_ID" \
-            -f "release-version=${{ steps.version.outputs.version }}" \
-            -f "archive-name=README.md" \
-            -f "repo-name=topo" \
-            -f "org-name=arm" \
-            -f "artifactory-uploadables=README.md"
+            -f "artifactory-uploadables=topo_linux_*" \
+            -f "archive-format=tar.gz" \
+            -f "executables=*/topo"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -26,6 +26,7 @@ builds:
 
 archives:
   - id: archive
+    name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
     ids:
       - topo
     format_overrides:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/arm/topo
 
-go 1.26.0
+go 1.26.1
 
 require (
 	github.com/compose-spec/compose-go/v2 v2.10.1


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- Fix the tag name for pre-releases so that it's obvious it's tagged by the date
- delete the build folders after the archives are made
- decompress the final archives before sending them off to be signed
- use the decompressed archives to sign not the build folder
- use the updated workflow file names in the signer
- Update the archive name format in goreleaser
- Update the go version so that the CI wouldn't fail on govulncheck
