### PR TITLE
Bump go to 1.26

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
-          version: v2.7.2
+          version: v2.10.1
 
   build-and-test:
     strategy:

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The full format specification is at [arm/topo-template-format](https://github.co
 
 Download the latest binary for your platform from [GitHub Releases](https://github.com/arm/topo/releases/latest), extract it, and place it on your `PATH`.
 
-To build from source instead (requires Go 1.25+):
+To build from source instead (requires Go 1.26+):
 
 ```sh
 go build ./cmd/topo

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/arm/topo
 
-go 1.25.7
+go 1.26.0
 
 require (
 	github.com/compose-spec/compose-go/v2 v2.10.1

--- a/internal/arguments/strict_provider_chain.go
+++ b/internal/arguments/strict_provider_chain.go
@@ -1,5 +1,7 @@
 package arguments
 
+import "strings"
+
 import "fmt"
 
 // StrictProviderChain chains multiple providers and ensures all required arguments are resolved.
@@ -58,15 +60,16 @@ func (p *StrictProviderChain) Provide(args []Arg) ([]ResolvedArg, error) {
 type MissingArgsError []Arg
 
 func (e MissingArgsError) Error() string {
-	msg := "missing required build arguments:\n"
+	var msg strings.Builder
+	msg.WriteString("missing required build arguments:\n")
 	for _, arg := range e {
-		msg += fmt.Sprintf("  %s:\n", arg.Name)
-		msg += fmt.Sprintf("    description: %s\n", arg.Description)
+		msg.WriteString(fmt.Sprintf("  %s:\n", arg.Name))
+		msg.WriteString(fmt.Sprintf("    description: %s\n", arg.Description))
 		if arg.Example != "" {
-			msg += fmt.Sprintf("    example: %s\n", arg.Example)
+			msg.WriteString(fmt.Sprintf("    example: %s\n", arg.Example))
 		}
 	}
-	return msg
+	return msg.String()
 }
 
 func filterProvided(args []Arg, provided map[string]string) []Arg {

--- a/internal/arguments/strict_provider_chain.go
+++ b/internal/arguments/strict_provider_chain.go
@@ -63,10 +63,10 @@ func (e MissingArgsError) Error() string {
 	var msg strings.Builder
 	msg.WriteString("missing required build arguments:\n")
 	for _, arg := range e {
-		msg.WriteString(fmt.Sprintf("  %s:\n", arg.Name))
-		msg.WriteString(fmt.Sprintf("    description: %s\n", arg.Description))
+		fmt.Fprintf(&msg, "  %s:\n", arg.Name)
+		fmt.Fprintf(&msg, "    description: %s\n", arg.Description)
 		if arg.Example != "" {
-			msg.WriteString(fmt.Sprintf("    example: %s\n", arg.Example))
+			fmt.Fprintf(&msg, "    example: %s\n", arg.Example)
 		}
 	}
 	return msg.String()

--- a/internal/deploy/docker/operation/docker_compose_transfer.go
+++ b/internal/deploy/docker/operation/docker_compose_transfer.go
@@ -73,8 +73,8 @@ func (t *DockerComposePipeTransfer) getImagesFromCompose(cmdOutput io.Writer) ([
 		return nil, fmt.Errorf("failed to get image names from compose file: %w", err)
 	}
 	var imageNames []string
-	lines := strings.Split(strings.TrimSpace(string(output)), "\n")
-	for _, line := range lines {
+	lines := strings.SplitSeq(strings.TrimSpace(string(output)), "\n")
+	for line := range lines {
 		line = strings.TrimSpace(line)
 		if line != "" {
 			imageNames = append(imageNames, line)

--- a/internal/deploy/docker/testutil/testutil.go
+++ b/internal/deploy/docker/testutil/testutil.go
@@ -105,9 +105,9 @@ type jsonObject map[string]any
 
 func unmarshalNDJSON(ndJSON []byte) ([]jsonObject, error) {
 	objects := []jsonObject{}
-	lines := bytes.Split(bytes.TrimSpace(ndJSON), []byte("\n"))
+	lines := bytes.SplitSeq(bytes.TrimSpace(ndJSON), []byte("\n"))
 
-	for _, line := range lines {
+	for line := range lines {
 		line = bytes.TrimSpace(line)
 		if len(line) == 0 {
 			continue

--- a/internal/deploy/project_checks/project_checks.go
+++ b/internal/deploy/project_checks/project_checks.go
@@ -36,9 +36,9 @@ func EnsureProjectIsLinuxArm64Ready(composePath string) error {
 		}
 
 		if isPlatformMissing(svc.Platform) {
-			builder.WriteString(fmt.Sprintf("- service %q is missing platform declaration (set platform: %s or configure remoteproc)\n", svcName, linuxArm64Platform))
+			fmt.Fprintf(&builder, "- service %q is missing platform declaration (set platform: %s or configure remoteproc)\n", svcName, linuxArm64Platform)
 		} else if isPlatformMismatch(svc.Platform) {
-			builder.WriteString(fmt.Sprintf("- service %q declares platform %q (expected %s)\n", svcName, svc.Platform, linuxArm64Platform))
+			fmt.Fprintf(&builder, "- service %q declares platform %q (expected %s)\n", svcName, svc.Platform, linuxArm64Platform)
 		}
 	}
 

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -16,8 +16,7 @@ import (
 
 func Clone(path string, src template.Source, argProvider arguments.Provider) ([]logger.Entry, error) {
 	if err := src.CopyTo(path); err != nil {
-		var errDestDirExists template.DestDirExistsError
-		if errors.As(err, &errDestDirExists) {
+		if errDestDirExists, ok := errors.AsType[template.DestDirExistsError](err); ok {
 			return nil, fmt.Errorf("%w: please choose a different project directory or remove the existing directory", errDestDirExists)
 		}
 		return nil, fmt.Errorf("failed to copy Service Template: %w", err)


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- Bump golang to 1.26
- Leverage newly added [`errors.AsType`](https://pkg.go.dev/errors#AsType)
- Run `go fix` (resulted in changes to string building and `SplitSeq` usage - possibly unrelated to `1.26` bump)
- ℹ️ Bumping golang meant we also have to bump `golangci-lint`
