### PR TITLE
chore: Gosec cleanup

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -22,6 +22,7 @@ func DockerCompose(h ssh.Host, composeFile string, args ...string) *exec.Cmd {
 
 func SSHKeyGen(keyType string, keyPath string, targetHost string) *exec.Cmd {
 	sshKeyGenArgs := []string{"-t", keyType, "-f", keyPath, "-C", targetHost}
+	// #nosec G204 -- Args are controlled by topo
 	return exec.Command("ssh-keygen", sshKeyGenArgs...)
 }
 

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -9,20 +9,17 @@ import (
 
 func Docker(h ssh.Host, args ...string) *exec.Cmd {
 	cmdArgs := append(hostToArgs(h), args...)
-	// #nosec G204 -- Callers validate the command args
 	return exec.Command("docker", cmdArgs...)
 }
 
 func DockerCompose(h ssh.Host, composeFile string, args ...string) *exec.Cmd {
 	composeArgs := append([]string{"compose", "-f", composeFile}, args...)
 	cmdArgs := append(hostToArgs(h), composeArgs...)
-	// #nosec G204 -- Callers validate the command args
 	return exec.Command("docker", cmdArgs...)
 }
 
 func SSHKeyGen(keyType string, keyPath string, targetHost string) *exec.Cmd {
 	sshKeyGenArgs := []string{"-t", keyType, "-f", keyPath, "-C", targetHost}
-	// #nosec G204 -- Args are controlled by topo
 	return exec.Command("ssh-keygen", sshKeyGenArgs...)
 }
 

--- a/internal/template/source.go
+++ b/internal/template/source.go
@@ -234,7 +234,8 @@ func copyFile(src, dst string) error {
 		return err
 	}
 
-	dstFile, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, srcInfo.Mode()) // #nosec G703 -- dst is a user-specified destination directory; writing there is intentional
+	// #nosec G703 -- dst is a user-specified destination directory; writing there is intentional
+	dstFile, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, srcInfo.Mode())
 	if err != nil {
 		return err
 	}

--- a/internal/template/source.go
+++ b/internal/template/source.go
@@ -234,8 +234,7 @@ func copyFile(src, dst string) error {
 		return err
 	}
 
-	// #nosec G703 -- dst has been validated prior to this function
-	dstFile, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, srcInfo.Mode())
+	dstFile, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, srcInfo.Mode()) // #nosec G703 -- dst is a user-specified destination directory; writing there is intentional
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- Removes a bunch of `G204` ignores, which we exclude by `severity: high` entry in `.golangci.yaml`
- Maybe improves `#nosec G703` explanation
