### PR TITLE
feat: filter compatible templates by target-description file

### DIFF
--- a/cmd/topo/templates.go
+++ b/cmd/topo/templates.go
@@ -8,6 +8,7 @@ import (
 	"github.com/arm/topo/internal/describe"
 	"github.com/arm/topo/internal/output/printable"
 	"github.com/arm/topo/internal/output/templates"
+	"github.com/arm/topo/internal/target"
 	"github.com/spf13/cobra"
 )
 
@@ -44,9 +45,12 @@ var templatesCmd = &cobra.Command{
 			return fmt.Errorf("could not filter templates: %w", err)
 		}
 
-		profile, err := describe.ReadTargetDescriptionFromFile(targetDescriptionPath)
-		if err != nil {
-			return err
+		var profile *target.HardwareProfile
+		if targetDescriptionPath != "" {
+			profile, err = describe.ReadTargetDescriptionFromFile(targetDescriptionPath)
+			if err != nil {
+				return err
+			}
 		}
 
 		reposWithCompatibility := catalog.AnnotateCompatibility(profile, repos)

--- a/cmd/topo/templates.go
+++ b/cmd/topo/templates.go
@@ -5,11 +5,10 @@ import (
 	"os"
 
 	"github.com/arm/topo/internal/catalog"
+	"github.com/arm/topo/internal/describe"
 	"github.com/arm/topo/internal/output/printable"
 	"github.com/arm/topo/internal/output/templates"
-	"github.com/arm/topo/internal/target"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
 )
 
 var (
@@ -45,21 +44,12 @@ var templatesCmd = &cobra.Command{
 			return fmt.Errorf("could not filter templates: %w", err)
 		}
 
-		reposWithCompatibility := catalog.WithCompatibility(repos)
-
-		if targetDescriptionPath != "" {
-			description, err := os.ReadFile(targetDescriptionPath)
-			if err != nil {
-				return fmt.Errorf("failed to read target description file %q: %w", targetDescriptionPath, err)
-			}
-
-			var profile target.HardwareProfile
-			if err := yaml.Unmarshal(description, &profile); err != nil {
-				return fmt.Errorf("failed to parse target description file %q: %w", targetDescriptionPath, err)
-			}
-			reposWithCompatibility = catalog.AnnotateCompatibility(profile, reposWithCompatibility)
+		profile, err := describe.ReadTargetDescriptionFromFile(targetDescriptionPath)
+		if err != nil {
+			return err
 		}
 
+		reposWithCompatibility := catalog.AnnotateCompatibility(profile, repos)
 		return printable.Print(templates.RepoCollection(reposWithCompatibility), os.Stdout, outputFormat)
 	},
 }

--- a/cmd/topo/templates.go
+++ b/cmd/topo/templates.go
@@ -7,10 +7,15 @@ import (
 	"github.com/arm/topo/internal/catalog"
 	"github.com/arm/topo/internal/output/printable"
 	"github.com/arm/topo/internal/output/templates"
+	"github.com/arm/topo/internal/target"
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 )
 
-var templateFilters catalog.TemplateFilters
+var (
+	templateFilters       catalog.TemplateFilters
+	targetDescriptionPath string
+)
 
 var templatesCmd = &cobra.Command{
 	Use:   "templates",
@@ -22,9 +27,12 @@ var templatesCmd = &cobra.Command{
 			return err
 		}
 
-		resolvedTarget, exists := lookupTarget(cmd)
-		if exists {
-			templateFilters.Target = resolvedTarget
+		// even if the target flag was not used, TOPO_TARGET may be set, so we check if the resolved target is non-empty
+		if targetDescriptionPath == "" {
+			resolvedTarget, exists := lookupTarget(cmd)
+			if exists && targetDescriptionPath == "" {
+				templateFilters.Target = resolvedTarget
+			}
 		}
 
 		repos, err := catalog.ParseRepos(catalog.TemplatesJSON)
@@ -36,7 +44,23 @@ var templatesCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("could not filter templates: %w", err)
 		}
-		return printable.Print(templates.RepoCollection(repos), os.Stdout, outputFormat)
+
+		reposWithCompatibility := catalog.WithCompatibility(repos)
+
+		if targetDescriptionPath != "" {
+			description, err := os.ReadFile(targetDescriptionPath)
+			if err != nil {
+				return fmt.Errorf("failed to read target description file %q: %w", targetDescriptionPath, err)
+			}
+
+			var profile target.HardwareProfile
+			if err := yaml.Unmarshal(description, &profile); err != nil {
+				return fmt.Errorf("failed to parse target description file %q: %w", targetDescriptionPath, err)
+			}
+			reposWithCompatibility = catalog.AnnotateCompatibility(profile, reposWithCompatibility)
+		}
+
+		return printable.Print(templates.RepoCollection(reposWithCompatibility), os.Stdout, outputFormat)
 	},
 }
 
@@ -48,6 +72,13 @@ func init() {
 		[]string{},
 		"Only show templates that use the indicated arm feature (NEON, SVE, SME, SVE2, SME2)",
 	)
+	templatesCmd.Flags().StringVar(
+		&targetDescriptionPath,
+		"target-description",
+		"",
+		"Path to the target description file used to show template compatibility",
+	)
 	templatesCmd.MarkFlagsMutuallyExclusive("target", "feature")
+	templatesCmd.MarkFlagsMutuallyExclusive("target", "target-description")
 	rootCmd.AddCommand(templatesCmd)
 }

--- a/cmd/topo/templates.go
+++ b/cmd/topo/templates.go
@@ -30,7 +30,7 @@ var templatesCmd = &cobra.Command{
 		// even if the target flag was not used, TOPO_TARGET may be set, so we check if the resolved target is non-empty
 		if targetDescriptionPath == "" {
 			resolvedTarget, exists := lookupTarget(cmd)
-			if exists && targetDescriptionPath == "" {
+			if exists {
 				templateFilters.Target = resolvedTarget
 			}
 		}

--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -23,6 +23,7 @@ type Repo struct {
 	Name        string   `json:"name"`
 	Description string   `json:"description"`
 	Features    []string `json:"features"`
+	MinRAMKb    int64    `json:"min_ram_kb,omitempty"`
 	URL         string   `json:"url"`
 	Ref         string   `json:"ref"`
 }

--- a/internal/catalog/compatibility.go
+++ b/internal/catalog/compatibility.go
@@ -61,13 +61,8 @@ func isRepoSupported(profile target.HardwareProfile, supportedFeatures map[strin
 		}
 	}
 
-	if repo.MinRAMKb > 0 {
-		if profile.TotalMemoryKb == 0 {
-			return false
-		}
-		if profile.TotalMemoryKb < repo.MinRAMKb {
-			return false
-		}
+	if repo.MinRAMKb > 0 && profile.TotalMemoryKb < repo.MinRAMKb {
+		return false
 	}
 
 	return true

--- a/internal/catalog/compatibility.go
+++ b/internal/catalog/compatibility.go
@@ -19,14 +19,6 @@ type RepoWithCompatibility struct {
 	Compatibility CompatibilityStatus `json:"compatibility,omitempty"`
 }
 
-func withCompatibility(repos []Repo) []RepoWithCompatibility {
-	withCompatibility := make([]RepoWithCompatibility, len(repos))
-	for i, repo := range repos {
-		withCompatibility[i] = RepoWithCompatibility{Repo: repo}
-	}
-	return withCompatibility
-}
-
 func AnnotateCompatibility(profile *target.HardwareProfile, repos []Repo) []RepoWithCompatibility {
 	annotated := withCompatibility(repos)
 	if profile == nil {
@@ -42,6 +34,14 @@ func AnnotateCompatibility(profile *target.HardwareProfile, repos []Repo) []Repo
 	}
 
 	return annotated
+}
+
+func withCompatibility(repos []Repo) []RepoWithCompatibility {
+	withCompatibility := make([]RepoWithCompatibility, len(repos))
+	for i, repo := range repos {
+		withCompatibility[i] = RepoWithCompatibility{Repo: repo}
+	}
+	return withCompatibility
 }
 
 func compatibilityStatus(profile target.HardwareProfile, supportedFeatures map[string]struct{}, repo Repo) CompatibilityStatus {

--- a/internal/catalog/compatibility.go
+++ b/internal/catalog/compatibility.go
@@ -27,6 +27,19 @@ func AnnotateCompatibility(profile target.HardwareProfile, repos []RepoWithCompa
 	annotated := make([]RepoWithCompatibility, len(repos))
 	copy(annotated, repos)
 
+	supportedFeatures := extractSupportedFeatures(profile)
+
+	for r := range annotated {
+		repo := &annotated[r]
+		repo.Compatibility = &Compatibility{
+			Supported: isRepoSupported(profile, supportedFeatures, repo.Repo),
+		}
+	}
+
+	return annotated
+}
+
+func extractSupportedFeatures(profile target.HardwareProfile) map[string]struct{} {
 	supportedFeatures := map[string]struct{}{}
 	for _, proc := range profile.HostProcessor {
 		for _, feature := range proc.ExtractArmFeatures() {
@@ -37,29 +50,25 @@ func AnnotateCompatibility(profile target.HardwareProfile, repos []RepoWithCompa
 		supportedFeatures["remoteproc"] = struct{}{}
 		supportedFeatures["remoteproc-runtime"] = struct{}{}
 	}
+	return supportedFeatures
+}
 
-	for r := range annotated {
-		repo := &annotated[r]
-		supported := true
-
-		for _, feature := range repo.Features {
-			normalized := strings.ToLower(strings.TrimSpace(feature))
-			if _, ok := supportedFeatures[normalized]; !ok {
-				supported = false
-				break
-			}
+func isRepoSupported(profile target.HardwareProfile, supportedFeatures map[string]struct{}, repo Repo) bool {
+	for _, feature := range repo.Features {
+		normalized := strings.ToLower(strings.TrimSpace(feature))
+		if _, ok := supportedFeatures[normalized]; !ok {
+			return false
 		}
-
-		if repo.MinRAMKb > 0 {
-			if profile.TotalMemoryKb == 0 {
-				supported = false
-			} else if profile.TotalMemoryKb < repo.MinRAMKb {
-				supported = false
-			}
-		}
-
-		repo.Compatibility = &Compatibility{Supported: supported}
 	}
 
-	return annotated
+	if repo.MinRAMKb > 0 {
+		if profile.TotalMemoryKb == 0 {
+			return false
+		}
+		if profile.TotalMemoryKb < repo.MinRAMKb {
+			return false
+		}
+	}
+
+	return true
 }

--- a/internal/catalog/compatibility.go
+++ b/internal/catalog/compatibility.go
@@ -1,0 +1,65 @@
+package catalog
+
+import (
+	"strings"
+
+	"github.com/arm/topo/internal/target"
+)
+
+type Compatibility struct {
+	Supported bool `json:"supported"`
+}
+
+type RepoWithCompatibility struct {
+	Repo
+	Compatibility *Compatibility `json:"compatibility,omitempty"`
+}
+
+func WithCompatibility(repos []Repo) []RepoWithCompatibility {
+	withCompatibility := make([]RepoWithCompatibility, len(repos))
+	for i, repo := range repos {
+		withCompatibility[i] = RepoWithCompatibility{Repo: repo}
+	}
+	return withCompatibility
+}
+
+func AnnotateCompatibility(profile target.HardwareProfile, repos []RepoWithCompatibility) []RepoWithCompatibility {
+	annotated := make([]RepoWithCompatibility, len(repos))
+	copy(annotated, repos)
+
+	supportedFeatures := map[string]struct{}{}
+	for _, proc := range profile.HostProcessor {
+		for _, feature := range proc.ExtractArmFeatures() {
+			supportedFeatures[strings.ToLower(feature)] = struct{}{}
+		}
+	}
+	if len(profile.RemoteCPU) > 0 {
+		supportedFeatures["remoteproc"] = struct{}{}
+		supportedFeatures["remoteproc-runtime"] = struct{}{}
+	}
+
+	for r := range annotated {
+		repo := &annotated[r]
+		supported := true
+
+		for _, feature := range repo.Features {
+			normalized := strings.ToLower(strings.TrimSpace(feature))
+			if _, ok := supportedFeatures[normalized]; !ok {
+				supported = false
+				break
+			}
+		}
+
+		if repo.MinRAMKb > 0 {
+			if profile.TotalMemoryKb == 0 {
+				supported = false
+			} else if profile.TotalMemoryKb < repo.MinRAMKb {
+				supported = false
+			}
+		}
+
+		repo.Compatibility = &Compatibility{Supported: supported}
+	}
+
+	return annotated
+}

--- a/internal/catalog/compatibility.go
+++ b/internal/catalog/compatibility.go
@@ -20,20 +20,20 @@ type RepoWithCompatibility struct {
 }
 
 func AnnotateCompatibility(profile *target.HardwareProfile, repos []Repo) []RepoWithCompatibility {
-	annotated := withCompatibility(repos)
 	if profile == nil {
-		return annotated
+		return withCompatibility(repos)
 	}
 
 	hardwareProfile := *profile
 	supportedFeatures := extractSupportedFeatures(hardwareProfile)
 
-	for r := range annotated {
-		repo := &annotated[r]
-		repo.Compatibility = compatibilityStatus(hardwareProfile, supportedFeatures, repo.Repo)
+	checked := make([]RepoWithCompatibility, len(repos))
+	for i, repo := range repos {
+		checked[i].Repo = repo
+		checked[i].Compatibility = compatibilityStatus(hardwareProfile, supportedFeatures, repo)
 	}
 
-	return annotated
+	return checked
 }
 
 func withCompatibility(repos []Repo) []RepoWithCompatibility {

--- a/internal/catalog/compatibility.go
+++ b/internal/catalog/compatibility.go
@@ -6,13 +6,17 @@ import (
 	"github.com/arm/topo/internal/target"
 )
 
-type Compatibility struct {
-	Supported bool `json:"supported"`
-}
+type CompatibilityStatus string
+
+const (
+	CompatibilityUnknown     CompatibilityStatus = ""
+	CompatibilitySupported   CompatibilityStatus = "supported"
+	CompatibilityUnsupported CompatibilityStatus = "unsupported"
+)
 
 type RepoWithCompatibility struct {
 	Repo
-	Compatibility *Compatibility `json:"compatibility,omitempty"`
+	Compatibility CompatibilityStatus `json:"compatibility,omitempty"`
 }
 
 func WithCompatibility(repos []Repo) []RepoWithCompatibility {
@@ -31,12 +35,17 @@ func AnnotateCompatibility(profile target.HardwareProfile, repos []RepoWithCompa
 
 	for r := range annotated {
 		repo := &annotated[r]
-		repo.Compatibility = &Compatibility{
-			Supported: isRepoSupported(profile, supportedFeatures, repo.Repo),
-		}
+		repo.Compatibility = compatibilityStatus(profile, supportedFeatures, repo.Repo)
 	}
 
 	return annotated
+}
+
+func compatibilityStatus(profile target.HardwareProfile, supportedFeatures map[string]struct{}, repo Repo) CompatibilityStatus {
+	if isRepoSupported(profile, supportedFeatures, repo) {
+		return CompatibilitySupported
+	}
+	return CompatibilityUnsupported
 }
 
 func extractSupportedFeatures(profile target.HardwareProfile) map[string]struct{} {

--- a/internal/catalog/compatibility.go
+++ b/internal/catalog/compatibility.go
@@ -19,7 +19,7 @@ type RepoWithCompatibility struct {
 	Compatibility CompatibilityStatus `json:"compatibility,omitempty"`
 }
 
-func WithCompatibility(repos []Repo) []RepoWithCompatibility {
+func withCompatibility(repos []Repo) []RepoWithCompatibility {
 	withCompatibility := make([]RepoWithCompatibility, len(repos))
 	for i, repo := range repos {
 		withCompatibility[i] = RepoWithCompatibility{Repo: repo}
@@ -27,15 +27,18 @@ func WithCompatibility(repos []Repo) []RepoWithCompatibility {
 	return withCompatibility
 }
 
-func AnnotateCompatibility(profile target.HardwareProfile, repos []RepoWithCompatibility) []RepoWithCompatibility {
-	annotated := make([]RepoWithCompatibility, len(repos))
-	copy(annotated, repos)
+func AnnotateCompatibility(profile *target.HardwareProfile, repos []Repo) []RepoWithCompatibility {
+	annotated := withCompatibility(repos)
+	if profile == nil {
+		return annotated
+	}
 
-	supportedFeatures := extractSupportedFeatures(profile)
+	hardwareProfile := *profile
+	supportedFeatures := extractSupportedFeatures(hardwareProfile)
 
 	for r := range annotated {
 		repo := &annotated[r]
-		repo.Compatibility = compatibilityStatus(profile, supportedFeatures, repo.Repo)
+		repo.Compatibility = compatibilityStatus(hardwareProfile, supportedFeatures, repo.Repo)
 	}
 
 	return annotated

--- a/internal/catalog/compatibility_test.go
+++ b/internal/catalog/compatibility_test.go
@@ -18,7 +18,7 @@ func TestAnnotateCompatibility(t *testing.T) {
 		}
 
 		got := catalog.AnnotateCompatibility(profile, catalog.WithCompatibility(repos))
-		assert.True(t, got[0].Compatibility.Supported)
+		assert.Equal(t, catalog.CompatibilitySupported, got[0].Compatibility)
 	})
 
 	t.Run("marks template unsupported when SVE is missing", func(t *testing.T) {
@@ -30,7 +30,7 @@ func TestAnnotateCompatibility(t *testing.T) {
 		}
 
 		got := catalog.AnnotateCompatibility(profile, catalog.WithCompatibility(repos))
-		assert.False(t, got[0].Compatibility.Supported)
+		assert.Equal(t, catalog.CompatibilityUnsupported, got[0].Compatibility)
 	})
 
 	t.Run("supports template requiring NEON when target has NEON", func(t *testing.T) {
@@ -42,7 +42,7 @@ func TestAnnotateCompatibility(t *testing.T) {
 		}
 
 		got := catalog.AnnotateCompatibility(profile, catalog.WithCompatibility(repos))
-		assert.True(t, got[0].Compatibility.Supported)
+		assert.Equal(t, catalog.CompatibilitySupported, got[0].Compatibility)
 	})
 
 	t.Run("marks template unsupported when NEON is missing", func(t *testing.T) {
@@ -54,7 +54,7 @@ func TestAnnotateCompatibility(t *testing.T) {
 		}
 
 		got := catalog.AnnotateCompatibility(profile, catalog.WithCompatibility(repos))
-		assert.False(t, got[0].Compatibility.Supported)
+		assert.Equal(t, catalog.CompatibilityUnsupported, got[0].Compatibility)
 	})
 
 	t.Run("marks template unsupported when remoteproc is required but absent", func(t *testing.T) {
@@ -62,7 +62,7 @@ func TestAnnotateCompatibility(t *testing.T) {
 		profile := target.HardwareProfile{}
 
 		got := catalog.AnnotateCompatibility(profile, catalog.WithCompatibility(repos))
-		assert.False(t, got[0].Compatibility.Supported)
+		assert.Equal(t, catalog.CompatibilityUnsupported, got[0].Compatibility)
 	})
 
 	t.Run("marks template supported when remoteproc is required and present", func(t *testing.T) {
@@ -74,7 +74,7 @@ func TestAnnotateCompatibility(t *testing.T) {
 		}
 
 		got := catalog.AnnotateCompatibility(profile, catalog.WithCompatibility(repos))
-		assert.True(t, got[0].Compatibility.Supported)
+		assert.Equal(t, catalog.CompatibilitySupported, got[0].Compatibility)
 	})
 
 	t.Run("marks template unsupported when RAM is below requirement", func(t *testing.T) {
@@ -82,7 +82,7 @@ func TestAnnotateCompatibility(t *testing.T) {
 		profile := target.HardwareProfile{TotalMemoryKb: 512}
 
 		got := catalog.AnnotateCompatibility(profile, catalog.WithCompatibility(repos))
-		assert.False(t, got[0].Compatibility.Supported)
+		assert.Equal(t, catalog.CompatibilityUnsupported, got[0].Compatibility)
 	})
 
 	t.Run("supports template with no requirements and does not mutate input", func(t *testing.T) {
@@ -92,8 +92,7 @@ func TestAnnotateCompatibility(t *testing.T) {
 
 		got := catalog.AnnotateCompatibility(target.HardwareProfile{}, catalog.WithCompatibility(repos))
 		assert.Len(t, got, 1)
-		assert.NotNil(t, got[0].Compatibility)
-		assert.True(t, got[0].Compatibility.Supported)
+		assert.Equal(t, catalog.CompatibilitySupported, got[0].Compatibility)
 		assert.Equal(t, "plain", repos[0].Name)
 	})
 }

--- a/internal/catalog/compatibility_test.go
+++ b/internal/catalog/compatibility_test.go
@@ -17,7 +17,7 @@ func TestAnnotateCompatibility(t *testing.T) {
 			},
 		}
 
-		got := catalog.AnnotateCompatibility(profile, catalog.WithCompatibility(repos))
+		got := catalog.AnnotateCompatibility(&profile, repos)
 		assert.Equal(t, catalog.CompatibilitySupported, got[0].Compatibility)
 	})
 
@@ -29,7 +29,7 @@ func TestAnnotateCompatibility(t *testing.T) {
 			},
 		}
 
-		got := catalog.AnnotateCompatibility(profile, catalog.WithCompatibility(repos))
+		got := catalog.AnnotateCompatibility(&profile, repos)
 		assert.Equal(t, catalog.CompatibilityUnsupported, got[0].Compatibility)
 	})
 
@@ -41,7 +41,7 @@ func TestAnnotateCompatibility(t *testing.T) {
 			},
 		}
 
-		got := catalog.AnnotateCompatibility(profile, catalog.WithCompatibility(repos))
+		got := catalog.AnnotateCompatibility(&profile, repos)
 		assert.Equal(t, catalog.CompatibilitySupported, got[0].Compatibility)
 	})
 
@@ -53,7 +53,7 @@ func TestAnnotateCompatibility(t *testing.T) {
 			},
 		}
 
-		got := catalog.AnnotateCompatibility(profile, catalog.WithCompatibility(repos))
+		got := catalog.AnnotateCompatibility(&profile, repos)
 		assert.Equal(t, catalog.CompatibilityUnsupported, got[0].Compatibility)
 	})
 
@@ -61,7 +61,7 @@ func TestAnnotateCompatibility(t *testing.T) {
 		repos := []catalog.Repo{{Name: "rp-template", Features: []string{"remoteproc"}}}
 		profile := target.HardwareProfile{}
 
-		got := catalog.AnnotateCompatibility(profile, catalog.WithCompatibility(repos))
+		got := catalog.AnnotateCompatibility(&profile, repos)
 		assert.Equal(t, catalog.CompatibilityUnsupported, got[0].Compatibility)
 	})
 
@@ -73,7 +73,7 @@ func TestAnnotateCompatibility(t *testing.T) {
 			},
 		}
 
-		got := catalog.AnnotateCompatibility(profile, catalog.WithCompatibility(repos))
+		got := catalog.AnnotateCompatibility(&profile, repos)
 		assert.Equal(t, catalog.CompatibilitySupported, got[0].Compatibility)
 	})
 
@@ -81,7 +81,7 @@ func TestAnnotateCompatibility(t *testing.T) {
 		repos := []catalog.Repo{{Name: "ram-template", MinRAMKb: 1024}}
 		profile := target.HardwareProfile{TotalMemoryKb: 512}
 
-		got := catalog.AnnotateCompatibility(profile, catalog.WithCompatibility(repos))
+		got := catalog.AnnotateCompatibility(&profile, repos)
 		assert.Equal(t, catalog.CompatibilityUnsupported, got[0].Compatibility)
 	})
 
@@ -89,10 +89,21 @@ func TestAnnotateCompatibility(t *testing.T) {
 		repos := []catalog.Repo{
 			{Name: "plain"},
 		}
+		profile := target.HardwareProfile{}
 
-		got := catalog.AnnotateCompatibility(target.HardwareProfile{}, catalog.WithCompatibility(repos))
+		got := catalog.AnnotateCompatibility(&profile, repos)
 		assert.Len(t, got, 1)
 		assert.Equal(t, catalog.CompatibilitySupported, got[0].Compatibility)
 		assert.Equal(t, "plain", repos[0].Name)
+	})
+
+	t.Run("leaves compatibility unknown when profile is nil", func(t *testing.T) {
+		repos := []catalog.Repo{
+			{Name: "plain"},
+		}
+
+		got := catalog.AnnotateCompatibility(nil, repos)
+		assert.Len(t, got, 1)
+		assert.Equal(t, catalog.CompatibilityUnknown, got[0].Compatibility)
 	})
 }

--- a/internal/catalog/compatibility_test.go
+++ b/internal/catalog/compatibility_test.go
@@ -1,0 +1,99 @@
+package catalog_test
+
+import (
+	"testing"
+
+	"github.com/arm/topo/internal/catalog"
+	"github.com/arm/topo/internal/target"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAnnotateCompatibility(t *testing.T) {
+	t.Run("supports template requiring SVE when target has SVE", func(t *testing.T) {
+		repos := []catalog.Repo{{Name: "sve-template", Features: []string{"SVE"}}}
+		profile := target.HardwareProfile{
+			HostProcessor: []target.HostProcessor{
+				{Features: []string{"asimd", "sve"}},
+			},
+		}
+
+		got := catalog.AnnotateCompatibility(profile, catalog.WithCompatibility(repos))
+		assert.True(t, got[0].Compatibility.Supported)
+	})
+
+	t.Run("marks template unsupported when SVE is missing", func(t *testing.T) {
+		repos := []catalog.Repo{{Name: "sve-template", Features: []string{"SVE"}}}
+		profile := target.HardwareProfile{
+			HostProcessor: []target.HostProcessor{
+				{Features: []string{"asimd"}},
+			},
+		}
+
+		got := catalog.AnnotateCompatibility(profile, catalog.WithCompatibility(repos))
+		assert.False(t, got[0].Compatibility.Supported)
+	})
+
+	t.Run("supports template requiring NEON when target has NEON", func(t *testing.T) {
+		repos := []catalog.Repo{{Name: "neon-template", Features: []string{"NEON"}}}
+		profile := target.HardwareProfile{
+			HostProcessor: []target.HostProcessor{
+				{Features: []string{"asimd"}},
+			},
+		}
+
+		got := catalog.AnnotateCompatibility(profile, catalog.WithCompatibility(repos))
+		assert.True(t, got[0].Compatibility.Supported)
+	})
+
+	t.Run("marks template unsupported when NEON is missing", func(t *testing.T) {
+		repos := []catalog.Repo{{Name: "neon-template", Features: []string{"NEON"}}}
+		profile := target.HardwareProfile{
+			HostProcessor: []target.HostProcessor{
+				{Features: []string{"sve"}},
+			},
+		}
+
+		got := catalog.AnnotateCompatibility(profile, catalog.WithCompatibility(repos))
+		assert.False(t, got[0].Compatibility.Supported)
+	})
+
+	t.Run("marks template unsupported when remoteproc is required but absent", func(t *testing.T) {
+		repos := []catalog.Repo{{Name: "rp-template", Features: []string{"remoteproc"}}}
+		profile := target.HardwareProfile{}
+
+		got := catalog.AnnotateCompatibility(profile, catalog.WithCompatibility(repos))
+		assert.False(t, got[0].Compatibility.Supported)
+	})
+
+	t.Run("marks template supported when remoteproc is required and present", func(t *testing.T) {
+		repos := []catalog.Repo{{Name: "rp-template", Features: []string{"remoteproc"}}}
+		profile := target.HardwareProfile{
+			RemoteCPU: []target.RemoteprocCPU{
+				{Name: "m3"},
+			},
+		}
+
+		got := catalog.AnnotateCompatibility(profile, catalog.WithCompatibility(repos))
+		assert.True(t, got[0].Compatibility.Supported)
+	})
+
+	t.Run("marks template unsupported when RAM is below requirement", func(t *testing.T) {
+		repos := []catalog.Repo{{Name: "ram-template", MinRAMKb: 1024}}
+		profile := target.HardwareProfile{TotalMemoryKb: 512}
+
+		got := catalog.AnnotateCompatibility(profile, catalog.WithCompatibility(repos))
+		assert.False(t, got[0].Compatibility.Supported)
+	})
+
+	t.Run("supports template with no requirements and does not mutate input", func(t *testing.T) {
+		repos := []catalog.Repo{
+			{Name: "plain"},
+		}
+
+		got := catalog.AnnotateCompatibility(target.HardwareProfile{}, catalog.WithCompatibility(repos))
+		assert.Len(t, got, 1)
+		assert.NotNil(t, got[0].Compatibility)
+		assert.True(t, got[0].Compatibility.Supported)
+		assert.Equal(t, "plain", repos[0].Name)
+	})
+}

--- a/internal/catalog/compatibility_test.go
+++ b/internal/catalog/compatibility_test.go
@@ -10,7 +10,8 @@ import (
 
 func TestAnnotateCompatibility(t *testing.T) {
 	t.Run("supports template requiring SVE when target has SVE", func(t *testing.T) {
-		repos := []catalog.Repo{{Name: "sve-template", Features: []string{"SVE"}}}
+		repo := catalog.Repo{Name: "sve-template", Features: []string{"SVE"}}
+		repos := []catalog.Repo{repo}
 		profile := target.HardwareProfile{
 			HostProcessor: []target.HostProcessor{
 				{Features: []string{"asimd", "sve"}},
@@ -18,11 +19,15 @@ func TestAnnotateCompatibility(t *testing.T) {
 		}
 
 		got := catalog.AnnotateCompatibility(&profile, repos)
-		assert.Equal(t, catalog.CompatibilitySupported, got[0].Compatibility)
+		want := []catalog.RepoWithCompatibility{
+			{Repo: repo, Compatibility: catalog.CompatibilitySupported},
+		}
+		assert.Equal(t, want, got)
 	})
 
 	t.Run("marks template unsupported when SVE is missing", func(t *testing.T) {
-		repos := []catalog.Repo{{Name: "sve-template", Features: []string{"SVE"}}}
+		repo := catalog.Repo{Name: "sve-template", Features: []string{"SVE"}}
+		repos := []catalog.Repo{repo}
 		profile := target.HardwareProfile{
 			HostProcessor: []target.HostProcessor{
 				{Features: []string{"asimd"}},
@@ -30,11 +35,15 @@ func TestAnnotateCompatibility(t *testing.T) {
 		}
 
 		got := catalog.AnnotateCompatibility(&profile, repos)
-		assert.Equal(t, catalog.CompatibilityUnsupported, got[0].Compatibility)
+		want := []catalog.RepoWithCompatibility{
+			{Repo: repo, Compatibility: catalog.CompatibilityUnsupported},
+		}
+		assert.Equal(t, want, got)
 	})
 
 	t.Run("supports template requiring NEON when target has NEON", func(t *testing.T) {
-		repos := []catalog.Repo{{Name: "neon-template", Features: []string{"NEON"}}}
+		repo := catalog.Repo{Name: "neon-template", Features: []string{"NEON"}}
+		repos := []catalog.Repo{repo}
 		profile := target.HardwareProfile{
 			HostProcessor: []target.HostProcessor{
 				{Features: []string{"asimd"}},
@@ -42,11 +51,15 @@ func TestAnnotateCompatibility(t *testing.T) {
 		}
 
 		got := catalog.AnnotateCompatibility(&profile, repos)
-		assert.Equal(t, catalog.CompatibilitySupported, got[0].Compatibility)
+		want := []catalog.RepoWithCompatibility{
+			{Repo: repo, Compatibility: catalog.CompatibilitySupported},
+		}
+		assert.Equal(t, want, got)
 	})
 
 	t.Run("marks template unsupported when NEON is missing", func(t *testing.T) {
-		repos := []catalog.Repo{{Name: "neon-template", Features: []string{"NEON"}}}
+		repo := catalog.Repo{Name: "neon-template", Features: []string{"NEON"}}
+		repos := []catalog.Repo{repo}
 		profile := target.HardwareProfile{
 			HostProcessor: []target.HostProcessor{
 				{Features: []string{"sve"}},
@@ -54,19 +67,27 @@ func TestAnnotateCompatibility(t *testing.T) {
 		}
 
 		got := catalog.AnnotateCompatibility(&profile, repos)
-		assert.Equal(t, catalog.CompatibilityUnsupported, got[0].Compatibility)
+		want := []catalog.RepoWithCompatibility{
+			{Repo: repo, Compatibility: catalog.CompatibilityUnsupported},
+		}
+		assert.Equal(t, want, got)
 	})
 
 	t.Run("marks template unsupported when remoteproc is required but absent", func(t *testing.T) {
-		repos := []catalog.Repo{{Name: "rp-template", Features: []string{"remoteproc"}}}
+		repo := catalog.Repo{Name: "rp-template", Features: []string{"remoteproc"}}
+		repos := []catalog.Repo{repo}
 		profile := target.HardwareProfile{}
 
 		got := catalog.AnnotateCompatibility(&profile, repos)
-		assert.Equal(t, catalog.CompatibilityUnsupported, got[0].Compatibility)
+		want := []catalog.RepoWithCompatibility{
+			{Repo: repo, Compatibility: catalog.CompatibilityUnsupported},
+		}
+		assert.Equal(t, want, got)
 	})
 
 	t.Run("marks template supported when remoteproc is required and present", func(t *testing.T) {
-		repos := []catalog.Repo{{Name: "rp-template", Features: []string{"remoteproc"}}}
+		repo := catalog.Repo{Name: "rp-template", Features: []string{"remoteproc"}}
+		repos := []catalog.Repo{repo}
 		profile := target.HardwareProfile{
 			RemoteCPU: []target.RemoteprocCPU{
 				{Name: "m3"},
@@ -74,36 +95,44 @@ func TestAnnotateCompatibility(t *testing.T) {
 		}
 
 		got := catalog.AnnotateCompatibility(&profile, repos)
-		assert.Equal(t, catalog.CompatibilitySupported, got[0].Compatibility)
+		want := []catalog.RepoWithCompatibility{
+			{Repo: repo, Compatibility: catalog.CompatibilitySupported},
+		}
+		assert.Equal(t, want, got)
 	})
 
 	t.Run("marks template unsupported when RAM is below requirement", func(t *testing.T) {
-		repos := []catalog.Repo{{Name: "ram-template", MinRAMKb: 1024}}
+		repo := catalog.Repo{Name: "ram-template", MinRAMKb: 1024}
+		repos := []catalog.Repo{repo}
 		profile := target.HardwareProfile{TotalMemoryKb: 512}
 
 		got := catalog.AnnotateCompatibility(&profile, repos)
-		assert.Equal(t, catalog.CompatibilityUnsupported, got[0].Compatibility)
+		want := []catalog.RepoWithCompatibility{
+			{Repo: repo, Compatibility: catalog.CompatibilityUnsupported},
+		}
+		assert.Equal(t, want, got)
 	})
 
 	t.Run("supports template with no requirements and does not mutate input", func(t *testing.T) {
-		repos := []catalog.Repo{
-			{Name: "plain"},
-		}
+		repo := catalog.Repo{Name: "plain"}
+		repos := []catalog.Repo{repo}
 		profile := target.HardwareProfile{}
 
 		got := catalog.AnnotateCompatibility(&profile, repos)
-		assert.Len(t, got, 1)
-		assert.Equal(t, catalog.CompatibilitySupported, got[0].Compatibility)
-		assert.Equal(t, "plain", repos[0].Name)
+		want := []catalog.RepoWithCompatibility{
+			{Repo: repo, Compatibility: catalog.CompatibilitySupported},
+		}
+		assert.Equal(t, want, got)
 	})
 
 	t.Run("leaves compatibility unknown when profile is nil", func(t *testing.T) {
-		repos := []catalog.Repo{
-			{Name: "plain"},
-		}
+		repo := catalog.Repo{Name: "plain"}
+		repos := []catalog.Repo{repo}
 
 		got := catalog.AnnotateCompatibility(nil, repos)
-		assert.Len(t, got, 1)
-		assert.Equal(t, catalog.CompatibilityUnknown, got[0].Compatibility)
+		want := []catalog.RepoWithCompatibility{
+			{Repo: repo, Compatibility: catalog.CompatibilityUnknown},
+		}
+		assert.Equal(t, want, got)
 	})
 }

--- a/internal/describe/describe.go
+++ b/internal/describe/describe.go
@@ -41,9 +41,9 @@ func ReadTargetDescriptionFromFile(filePath string) (*target.HardwareProfile, er
 		return nil, fmt.Errorf("failed to read target description file %q: %w", filePath, err)
 	}
 
-	var profile *target.HardwareProfile
-	if err := yaml.Unmarshal(description, profile); err != nil {
+	var profile target.HardwareProfile
+	if err := yaml.Unmarshal(description, &profile); err != nil {
 		return nil, fmt.Errorf("failed to parse target description file %q: %w", filePath, err)
 	}
-	return profile, nil
+	return &profile, nil
 }

--- a/internal/describe/describe.go
+++ b/internal/describe/describe.go
@@ -36,10 +36,6 @@ func WriteTargetDescriptionToFile(dir string, report target.HardwareProfile) (st
 }
 
 func ReadTargetDescriptionFromFile(filePath string) (*target.HardwareProfile, error) {
-	if filePath == "" {
-		return nil, nil
-	}
-
 	description, err := os.ReadFile(filePath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read target description file %q: %w", filePath, err)

--- a/internal/describe/describe.go
+++ b/internal/describe/describe.go
@@ -2,6 +2,7 @@ package describe
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -32,4 +33,21 @@ func WriteTargetDescriptionToFile(dir string, report target.HardwareProfile) (st
 		return "", errors.Join(err, closeErr)
 	}
 	return outputFile, f.Close()
+}
+
+func ReadTargetDescriptionFromFile(filePath string) (*target.HardwareProfile, error) {
+	if filePath == "" {
+		return nil, nil
+	}
+
+	description, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read target description file %q: %w", filePath, err)
+	}
+
+	var profile target.HardwareProfile
+	if err := yaml.Unmarshal(description, &profile); err != nil {
+		return nil, fmt.Errorf("failed to parse target description file %q: %w", filePath, err)
+	}
+	return &profile, nil
 }

--- a/internal/describe/describe.go
+++ b/internal/describe/describe.go
@@ -41,9 +41,9 @@ func ReadTargetDescriptionFromFile(filePath string) (*target.HardwareProfile, er
 		return nil, fmt.Errorf("failed to read target description file %q: %w", filePath, err)
 	}
 
-	var profile target.HardwareProfile
-	if err := yaml.Unmarshal(description, &profile); err != nil {
+	var profile *target.HardwareProfile
+	if err := yaml.Unmarshal(description, profile); err != nil {
 		return nil, fmt.Errorf("failed to parse target description file %q: %w", filePath, err)
 	}
-	return &profile, nil
+	return profile, nil
 }

--- a/internal/describe/describe_test.go
+++ b/internal/describe/describe_test.go
@@ -116,12 +116,6 @@ func TestWriteTargetDescriptionFile(t *testing.T) {
 }
 
 func TestReadTargetDescriptionFromFile(t *testing.T) {
-	t.Run("returns nil profile when path is empty", func(t *testing.T) {
-		profile, err := describe.ReadTargetDescriptionFromFile("")
-		require.NoError(t, err)
-		assert.Nil(t, profile)
-	})
-
 	t.Run("Correctly reads and parses target description from yaml file", func(t *testing.T) {
 		dir := t.TempDir()
 		filePath := dir + "/target-description.yaml"
@@ -136,11 +130,9 @@ remoteprocs:
 totalmemory_kb: 16384
 `
 		require.NoError(t, os.WriteFile(filePath, []byte(content), 0o644))
-
 		profile, err := describe.ReadTargetDescriptionFromFile(filePath)
-		require.NoError(t, err)
-		require.NotNil(t, profile)
 
+		require.NoError(t, err)
 		assert.Equal(t, target.HardwareProfile{
 			HostProcessor: []target.HostProcessor{
 				{
@@ -155,9 +147,9 @@ totalmemory_kb: 16384
 	})
 
 	t.Run("returns error when target description file does not exist", func(t *testing.T) {
-		profile, err := describe.ReadTargetDescriptionFromFile("/no/such/file.yaml")
+		_, err := describe.ReadTargetDescriptionFromFile("/no/such/file.yaml")
+
 		require.Error(t, err)
-		assert.Nil(t, profile)
 		assert.ErrorContains(t, err, "failed to read target description file")
 	})
 

--- a/internal/describe/describe_test.go
+++ b/internal/describe/describe_test.go
@@ -167,8 +167,6 @@ totalmemory_kb: 16384
 		require.NoError(t, os.WriteFile(filePath, []byte("host_processor: ["), 0o644))
 
 		profile, err := describe.ReadTargetDescriptionFromFile(filePath)
-		require.Error(t, err)
-		assert.Nil(t, profile)
 		assert.ErrorContains(t, err, "failed to parse target description file")
 	})
 }

--- a/internal/describe/describe_test.go
+++ b/internal/describe/describe_test.go
@@ -114,3 +114,61 @@ func TestWriteTargetDescriptionFile(t *testing.T) {
 		assert.NotContains(t, string(content), "feature2")
 	})
 }
+
+func TestReadTargetDescriptionFromFile(t *testing.T) {
+	t.Run("returns nil profile when path is empty", func(t *testing.T) {
+		profile, err := describe.ReadTargetDescriptionFromFile("")
+		require.NoError(t, err)
+		assert.Nil(t, profile)
+	})
+
+	t.Run("Correctly reads and parses target description from yaml file", func(t *testing.T) {
+		dir := t.TempDir()
+		filePath := dir + "/target-description.yaml"
+		content := `host:
+  - model: Cortex-A55
+    features:
+      - asimd
+      - sve
+    cores: 2
+remoteprocs:
+  - name: remoteproc0
+totalmemory_kb: 16384
+`
+		require.NoError(t, os.WriteFile(filePath, []byte(content), 0o644))
+
+		profile, err := describe.ReadTargetDescriptionFromFile(filePath)
+		require.NoError(t, err)
+		require.NotNil(t, profile)
+
+		assert.Equal(t, target.HardwareProfile{
+			HostProcessor: []target.HostProcessor{
+				{
+					Model:    "Cortex-A55",
+					Features: []string{"asimd", "sve"},
+					Cores:    2,
+				},
+			},
+			RemoteCPU:     []target.RemoteprocCPU{{Name: "remoteproc0"}},
+			TotalMemoryKb: 16384,
+		}, *profile)
+	})
+
+	t.Run("returns error when target description file does not exist", func(t *testing.T) {
+		profile, err := describe.ReadTargetDescriptionFromFile("/no/such/file.yaml")
+		require.Error(t, err)
+		assert.Nil(t, profile)
+		assert.ErrorContains(t, err, "failed to read target description file")
+	})
+
+	t.Run("returns error when target description yaml is invalid", func(t *testing.T) {
+		dir := t.TempDir()
+		filePath := dir + "/invalid.yaml"
+		require.NoError(t, os.WriteFile(filePath, []byte("host_processor: ["), 0o644))
+
+		profile, err := describe.ReadTargetDescriptionFromFile(filePath)
+		require.Error(t, err)
+		assert.Nil(t, profile)
+		assert.ErrorContains(t, err, "failed to parse target description file")
+	})
+}

--- a/internal/describe/describe_test.go
+++ b/internal/describe/describe_test.go
@@ -166,7 +166,7 @@ totalmemory_kb: 16384
 		filePath := dir + "/invalid.yaml"
 		require.NoError(t, os.WriteFile(filePath, []byte("host_processor: ["), 0o644))
 
-		profile, err := describe.ReadTargetDescriptionFromFile(filePath)
+		_, err := describe.ReadTargetDescriptionFromFile(filePath)
 		assert.ErrorContains(t, err, "failed to parse target description file")
 	})
 }

--- a/internal/describe/describe_test.go
+++ b/internal/describe/describe_test.go
@@ -159,6 +159,7 @@ totalmemory_kb: 16384
 		require.NoError(t, os.WriteFile(filePath, []byte("host_processor: ["), 0o644))
 
 		_, err := describe.ReadTargetDescriptionFromFile(filePath)
+
 		assert.ErrorContains(t, err, "failed to parse target description file")
 	})
 }

--- a/internal/output/templates/templates.go
+++ b/internal/output/templates/templates.go
@@ -27,12 +27,12 @@ func getFuncMap(isTTY bool) template.FuncMap {
 	return f
 }
 
-func plainCompatibilityMark(c *catalog.Compatibility) string {
-	if c == nil {
-		return ""
-	}
-	if c.Supported {
+func plainCompatibilityMark(c catalog.CompatibilityStatus) string {
+	if c == catalog.CompatibilitySupported {
 		return "✅"
 	}
-	return "❌"
+	if c == catalog.CompatibilityUnsupported {
+		return "❌"
+	}
+	return ""
 }

--- a/internal/output/templates/templates.go
+++ b/internal/output/templates/templates.go
@@ -4,16 +4,18 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/arm/topo/internal/catalog"
 	"github.com/arm/topo/internal/output/term"
 )
 
 func getFuncMap(isTTY bool) template.FuncMap {
 	f := template.FuncMap{
-		"join":   strings.Join,
-		"wrap":   func(s string) string { return term.WrapText(s, 80, 2) },
-		"cyan":   func(s string) string { return s },
-		"blue":   func(s string) string { return s },
-		"yellow": func(s string) string { return s },
+		"join":              strings.Join,
+		"wrap":              func(s string) string { return term.WrapText(s, 80, 2) },
+		"cyan":              func(s string) string { return s },
+		"blue":              func(s string) string { return s },
+		"yellow":            func(s string) string { return s },
+		"compatibilityMark": plainCompatibilityMark,
 	}
 
 	if isTTY {
@@ -23,4 +25,14 @@ func getFuncMap(isTTY bool) template.FuncMap {
 	}
 
 	return f
+}
+
+func plainCompatibilityMark(c *catalog.Compatibility) string {
+	if c == nil {
+		return ""
+	}
+	if c.Supported {
+		return "✅"
+	}
+	return "❌"
 }

--- a/internal/output/templates/templates_list.go
+++ b/internal/output/templates/templates_list.go
@@ -8,7 +8,7 @@ import (
 	"github.com/arm/topo/internal/catalog"
 )
 
-type RepoCollection []catalog.Repo
+type RepoCollection []catalog.RepoWithCompatibility
 
 const repoTemplate = `
 {{- define "featuresRow" -}}
@@ -24,7 +24,7 @@ const repoTemplate = `
 {{- end }}
 
 {{- define "repoRow" }}
-{{- cyan .Name }} | {{ blue .URL }} | {{ yellow .Ref }}
+{{- if .Compatibility }}{{ compatibilityMark .Compatibility }} {{ end }}{{ cyan .Name }} | {{ blue .URL }} | {{ yellow .Ref }}
 {{- template "featuresRow" . }}
 {{- template "descriptionRow" . }}
 {{- end }}

--- a/internal/output/templates/templates_list_test.go
+++ b/internal/output/templates/templates_list_test.go
@@ -220,9 +220,7 @@ name-of-other-project | url.git | main
 					URL:  "url.git",
 					Ref:  "main",
 				},
-				Compatibility: &catalog.Compatibility{
-					Supported: true,
-				},
+				Compatibility: catalog.CompatibilitySupported,
 			},
 		}
 
@@ -236,11 +234,11 @@ name-of-other-project | url.git | main
 	t.Run("prints compatibility marker if project is compatible and vice versa", func(t *testing.T) {
 		compatibleRepo := catalog.RepoWithCompatibility{
 			Repo:          catalog.Repo{Name: "lasagne"},
-			Compatibility: &catalog.Compatibility{Supported: true},
+			Compatibility: catalog.CompatibilitySupported,
 		}
 		incompatibleRepo := catalog.RepoWithCompatibility{
 			Repo:          catalog.Repo{Name: "spaghetti"},
-			Compatibility: &catalog.Compatibility{Supported: false},
+			Compatibility: catalog.CompatibilityUnsupported,
 		}
 		repos := []catalog.RepoWithCompatibility{compatibleRepo, incompatibleRepo}
 
@@ -260,7 +258,7 @@ name-of-other-project | url.git | main
 					URL:  "url.git",
 					Ref:  "main",
 				},
-				Compatibility: &catalog.Compatibility{Supported: true},
+				Compatibility: catalog.CompatibilitySupported,
 			},
 			{
 				Repo: catalog.Repo{
@@ -268,7 +266,7 @@ name-of-other-project | url.git | main
 					URL:  "url.git",
 					Ref:  "main",
 				},
-				Compatibility: &catalog.Compatibility{Supported: false},
+				Compatibility: catalog.CompatibilityUnsupported,
 			},
 		}
 
@@ -281,24 +279,20 @@ name-of-other-project | url.git | main
 
 		want := []any{
 			map[string]any{
-				"name":        "lasagne",
-				"description": "",
-				"features":    nil,
-				"url":         "url.git",
-				"ref":         "main",
-				"compatibility": map[string]any{
-					"supported": true,
-				},
+				"name":          "lasagne",
+				"description":   "",
+				"features":      nil,
+				"url":           "url.git",
+				"ref":           "main",
+				"compatibility": "supported",
 			},
 			map[string]any{
-				"name":        "spaghetti",
-				"description": "",
-				"features":    nil,
-				"url":         "url.git",
-				"ref":         "main",
-				"compatibility": map[string]any{
-					"supported": false,
-				},
+				"name":          "spaghetti",
+				"description":   "",
+				"features":      nil,
+				"url":           "url.git",
+				"ref":           "main",
+				"compatibility": "unsupported",
 			},
 		}
 

--- a/internal/output/templates/templates_list_test.go
+++ b/internal/output/templates/templates_list_test.go
@@ -15,18 +15,22 @@ import (
 
 func TestPrintTemplateRepos(t *testing.T) {
 	t.Run("prints multiple items correctly", func(t *testing.T) {
-		repos := []catalog.Repo{
+		repos := []catalog.RepoWithCompatibility{
 			{
-				Name:        "name-of-project",
-				Description: "blah blah blah",
-				URL:         "url.git",
-				Ref:         "main",
+				Repo: catalog.Repo{
+					Name:        "name-of-project",
+					Description: "blah blah blah",
+					URL:         "url.git",
+					Ref:         "main",
+				},
 			},
 			{
-				Name:        "name-of-other-project",
-				Description: "blah blah blah",
-				URL:         "url.git",
-				Ref:         "main",
+				Repo: catalog.Repo{
+					Name:        "name-of-other-project",
+					Description: "blah blah blah",
+					URL:         "url.git",
+					Ref:         "main",
+				},
 			},
 		}
 
@@ -50,12 +54,14 @@ name-of-other-project | url.git | main
 	})
 
 	t.Run("ignores features when none present", func(t *testing.T) {
-		repos := []catalog.Repo{
+		repos := []catalog.RepoWithCompatibility{
 			{
-				Name:        "name-of-project",
-				Description: "blah blah blah",
-				URL:         "url.git",
-				Ref:         "main",
+				Repo: catalog.Repo{
+					Name:        "name-of-project",
+					Description: "blah blah blah",
+					URL:         "url.git",
+					Ref:         "main",
+				},
 			},
 		}
 
@@ -76,13 +82,15 @@ name-of-other-project | url.git | main
 	})
 
 	t.Run("includes features when present", func(t *testing.T) {
-		repos := []catalog.Repo{
+		repos := []catalog.RepoWithCompatibility{
 			{
-				Name:        "name-of-project",
-				Description: "blah blah blah",
-				Features:    []string{"walnut", "almond"},
-				URL:         "url.git",
-				Ref:         "main",
+				Repo: catalog.Repo{
+					Name:        "name-of-project",
+					Description: "blah blah blah",
+					Features:    []string{"walnut", "almond"},
+					URL:         "url.git",
+					Ref:         "main",
+				},
 			},
 		}
 
@@ -104,13 +112,15 @@ name-of-other-project | url.git | main
 	})
 
 	t.Run("correctly wraps long descriptions", func(t *testing.T) {
-		repos := []catalog.Repo{
+		repos := []catalog.RepoWithCompatibility{
 			{
-				Name:        "name-of-project",
-				Description: "This sentence exists purely to verify that text wrapping behaves correctly when the content is long enough to span multiple lines.",
-				Features:    []string{"walnut", "almond"},
-				URL:         "url.git",
-				Ref:         "main",
+				Repo: catalog.Repo{
+					Name:        "name-of-project",
+					Description: "This sentence exists purely to verify that text wrapping behaves correctly when the content is long enough to span multiple lines.",
+					Features:    []string{"walnut", "almond"},
+					URL:         "url.git",
+					Ref:         "main",
+				},
 			},
 		}
 
@@ -133,13 +143,15 @@ name-of-other-project | url.git | main
 	})
 
 	t.Run("correctly splits paragraphs in the description", func(t *testing.T) {
-		repos := []catalog.Repo{
+		repos := []catalog.RepoWithCompatibility{
 			{
-				Name:        "name-of-project",
-				Description: "blah blah blah\n\nblah blah blah",
-				Features:    []string{"walnut", "almond"},
-				URL:         "url.git",
-				Ref:         "main",
+				Repo: catalog.Repo{
+					Name:        "name-of-project",
+					Description: "blah blah blah\n\nblah blah blah",
+					Features:    []string{"walnut", "almond"},
+					URL:         "url.git",
+					Ref:         "main",
+				},
 			},
 		}
 
@@ -163,13 +175,15 @@ name-of-other-project | url.git | main
 	})
 
 	t.Run("correctly prints json", func(t *testing.T) {
-		repos := []catalog.Repo{
+		repos := []catalog.RepoWithCompatibility{
 			{
-				Name:        "name-of-project",
-				Description: "blah blah blah\n\nblah blah blah",
-				Features:    []string{"walnut", "almond"},
-				URL:         "url.git",
-				Ref:         "main",
+				Repo: catalog.Repo{
+					Name:        "name-of-project",
+					Description: "blah blah blah\n\nblah blah blah",
+					Features:    []string{"walnut", "almond"},
+					URL:         "url.git",
+					Ref:         "main",
+				},
 			},
 		}
 
@@ -190,6 +204,130 @@ name-of-other-project | url.git | main
 				"name":        "name-of-project",
 				"description": "blah blah blah\n\nblah blah blah",
 				"features":    []any{"walnut", "almond"},
+				"url":         "url.git",
+				"ref":         "main",
+			},
+		}
+
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("prints compatibility marker when supported = true", func(t *testing.T) {
+		repos := []catalog.RepoWithCompatibility{
+			{
+				Repo: catalog.Repo{
+					Name: "name-of-project",
+					URL:  "url.git",
+					Ref:  "main",
+				},
+				Compatibility: &catalog.Compatibility{
+					Supported: true,
+				},
+			},
+		}
+
+		var outBuf bytes.Buffer
+		err := printable.Print(templates.RepoCollection(repos), &outBuf, term.Plain)
+		require.NoError(t, err)
+
+		assert.Equal(t, "✅ name-of-project | url.git | main\n\n", outBuf.String())
+	})
+
+	t.Run("prints compatibility marker if project is compatible and vice versa", func(t *testing.T) {
+		compatibleRepo := catalog.RepoWithCompatibility{
+			Repo:          catalog.Repo{Name: "lasagne"},
+			Compatibility: &catalog.Compatibility{Supported: true},
+		}
+		incompatibleRepo := catalog.RepoWithCompatibility{
+			Repo:          catalog.Repo{Name: "spaghetti"},
+			Compatibility: &catalog.Compatibility{Supported: false},
+		}
+		repos := []catalog.RepoWithCompatibility{compatibleRepo, incompatibleRepo}
+
+		var outBuf bytes.Buffer
+		err := printable.Print(templates.RepoCollection(repos), &outBuf, term.Plain)
+		require.NoError(t, err)
+
+		assert.Contains(t, outBuf.String(), "✅ lasagne")
+		assert.Contains(t, outBuf.String(), "❌ spaghetti")
+	})
+
+	t.Run("json includes compatibility marker if project is compatible and vice versa", func(t *testing.T) {
+		repos := []catalog.RepoWithCompatibility{
+			{
+				Repo: catalog.Repo{
+					Name: "lasagne",
+					URL:  "url.git",
+					Ref:  "main",
+				},
+				Compatibility: &catalog.Compatibility{Supported: true},
+			},
+			{
+				Repo: catalog.Repo{
+					Name: "spaghetti",
+					URL:  "url.git",
+					Ref:  "main",
+				},
+				Compatibility: &catalog.Compatibility{Supported: false},
+			},
+		}
+
+		var outBuf bytes.Buffer
+		err := printable.Print(templates.RepoCollection(repos), &outBuf, term.JSON)
+		require.NoError(t, err)
+
+		var got any
+		require.NoError(t, json.Unmarshal(outBuf.Bytes(), &got))
+
+		want := []any{
+			map[string]any{
+				"name":        "lasagne",
+				"description": "",
+				"features":    nil,
+				"url":         "url.git",
+				"ref":         "main",
+				"compatibility": map[string]any{
+					"supported": true,
+				},
+			},
+			map[string]any{
+				"name":        "spaghetti",
+				"description": "",
+				"features":    nil,
+				"url":         "url.git",
+				"ref":         "main",
+				"compatibility": map[string]any{
+					"supported": false,
+				},
+			},
+		}
+
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("json omits compatibility when not present", func(t *testing.T) {
+		repos := []catalog.RepoWithCompatibility{
+			{
+				Repo: catalog.Repo{
+					Name: "name-of-project",
+					URL:  "url.git",
+					Ref:  "main",
+				},
+			},
+		}
+
+		var outBuf bytes.Buffer
+		err := printable.Print(templates.RepoCollection(repos), &outBuf, term.JSON)
+		require.NoError(t, err)
+
+		var got any
+		require.NoError(t, json.Unmarshal(outBuf.Bytes(), &got))
+
+		want := []any{
+			map[string]any{
+				"name":        "name-of-project",
+				"description": "",
+				"features":    nil,
 				"url":         "url.git",
 				"ref":         "main",
 			},


### PR DESCRIPTION
 * Use the target-description file to show whether or not a template is compatible with the given target.

This helps users choose templates with confidence before cloning or deploying, using the same hardware understanding produced by topo describe.

## Changes

- Added `--target-description` flag to `topo templates` to load a local target profile file and annotate compatibility.
- Extended catalog repo model with Compatibility metadata and optional min_ram_kb
- Checks for SVE, NEON and remoteproc
