### PR TITLE
chore: Rename `install remoteproc` to `install remoteproc-runtime`

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,12 +138,12 @@ topo stop --target my-board
 
 The Getting Started walkthrough above covers the core flow. These additional commands are available:
 
-| Command              | When to use it                                                                                              |
-| -------------------- | ----------------------------------------------------------------------------------------------------------- |
-| `init`               | Scaffold a new empty project instead of cloning a template                                                  |
-| `extend`             | Add services from a template into an existing project                                                       |
-| `service remove`     | Remove a service from your compose file                                                                     |
-| `setup-keys`         | Set up SSH key authentication if your target currently uses password-based SSH, which Topo does not support |
-| `install remoteproc` | Install the remoteproc runtime on your target                                                               |
+| Command                      | When to use it                                                                                              |
+| ---------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `init`                       | Scaffold a new empty project instead of cloning a template                                                  |
+| `extend`                     | Add services from a template into an existing project                                                       |
+| `service remove`             | Remove a service from your compose file                                                                     |
+| `setup-keys`                 | Set up SSH key authentication if your target currently uses password-based SSH, which Topo does not support |
+| `install remoteproc-runtime` | Install the remoteproc runtime on your target                                                               |
 
 Run `topo <command> --help` for full usage details.

--- a/cmd/topo/install.go
+++ b/cmd/topo/install.go
@@ -1,63 +1,14 @@
 package main
 
 import (
-	"os"
-
-	"github.com/arm/topo/internal/install"
-	"github.com/arm/topo/internal/output/printable"
-	"github.com/arm/topo/internal/output/templates"
-	"github.com/arm/topo/internal/ssh"
 	"github.com/spf13/cobra"
 )
-
-const remoteprocRepoURL = "arm/remoteproc-runtime"
 
 var installCmd = &cobra.Command{
 	Use:   "install",
 	Short: "Install components to target",
 }
 
-var installRemoteprocRuntimeCmd = &cobra.Command{
-	Use:   "remoteproc-runtime",
-	Short: "Install remoteproc-runtime and shim to a location on the target's PATH",
-	Long: `Install remoteproc-runtime and shim to a location on the target's PATH.
-
-Fetches binaries from https://github.com/` + remoteprocRepoURL + `
-Set GITHUB_TOKEN to authenticate with the GitHub API and avoid rate limits.
-
-Attempts to replace existing installations if found.
-Falls back to ~/bin if no suitable locations are automatically found.
-`,
-	Args: cobra.ExactArgs(0),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		cmd.SilenceUsage = true
-		sshTarget, err := requireTarget(cmd)
-		if err != nil {
-			return err
-		}
-
-		outputFormat, err := resolveOutput(cmd)
-		if err != nil {
-			return err
-		}
-		p, err := installRemoteprocRuntime(ssh.Host(sshTarget))
-		if err != nil {
-			return err
-		}
-		return printable.Print(p, os.Stdout, outputFormat)
-	},
-}
-
 func init() {
 	rootCmd.AddCommand(installCmd)
-	installCmd.AddCommand(installRemoteprocRuntimeCmd)
-	addTargetFlag(installRemoteprocRuntimeCmd)
-}
-
-func installRemoteprocRuntime(targetHost ssh.Host) (printable.Printable, error) {
-	results, err := install.InstallBinariesFromGithubRelease(targetHost, remoteprocRepoURL, []string{"remoteproc-runtime", "containerd-shim-remoteproc-v1"})
-	if err != nil {
-		return nil, err
-	}
-	return templates.InstallResults(results), nil
 }

--- a/cmd/topo/install.go
+++ b/cmd/topo/install.go
@@ -17,8 +17,8 @@ var installCmd = &cobra.Command{
 	Short: "Install components to target",
 }
 
-var installRemoteprocCmd = &cobra.Command{
-	Use:   "remoteproc",
+var installRemoteprocRuntimeCmd = &cobra.Command{
+	Use:   "remoteproc-runtime",
 	Short: "Install remoteproc-runtime and shim to a location on the target's PATH",
 	Long: `Install remoteproc-runtime and shim to a location on the target's PATH.
 
@@ -50,8 +50,8 @@ Falls back to ~/bin if no suitable locations are automatically found.
 
 func init() {
 	rootCmd.AddCommand(installCmd)
-	installCmd.AddCommand(installRemoteprocCmd)
-	addTargetFlag(installRemoteprocCmd)
+	installCmd.AddCommand(installRemoteprocRuntimeCmd)
+	addTargetFlag(installRemoteprocRuntimeCmd)
 }
 
 func installRemoteprocRuntime(targetHost ssh.Host) (printable.Printable, error) {

--- a/cmd/topo/install_remoteproc_runtime.go
+++ b/cmd/topo/install_remoteproc_runtime.go
@@ -10,14 +10,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const remoteprocRepoURL = "arm/remoteproc-runtime"
+const remoteprocRuntimeRepoURL = "arm/remoteproc-runtime"
 
 var installRemoteprocRuntimeCmd = &cobra.Command{
 	Use:   "remoteproc-runtime",
 	Short: "Install remoteproc-runtime and shim to a location on the target's PATH",
 	Long: `Install remoteproc-runtime and shim to a location on the target's PATH.
 
-Fetches binaries from https://github.com/` + remoteprocRepoURL + `
+Fetches binaries from https://github.com/` + remoteprocRuntimeRepoURL + `
 Set GITHUB_TOKEN to authenticate with the GitHub API and avoid rate limits.
 
 Attempts to replace existing installations if found.
@@ -44,7 +44,7 @@ Falls back to ~/bin if no suitable locations are automatically found.
 }
 
 func installRemoteprocRuntime(targetHost ssh.Host) (printable.Printable, error) {
-	results, err := install.InstallBinariesFromGithubRelease(targetHost, remoteprocRepoURL, []string{"remoteproc-runtime", "containerd-shim-remoteproc-v1"})
+	results, err := install.InstallBinariesFromGithubRelease(targetHost, remoteprocRuntimeRepoURL, []string{"remoteproc-runtime", "containerd-shim-remoteproc-v1"})
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/topo/install_remoteproc_runtime.go
+++ b/cmd/topo/install_remoteproc_runtime.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"os"
+
+	"github.com/arm/topo/internal/install"
+	"github.com/arm/topo/internal/output/printable"
+	"github.com/arm/topo/internal/output/templates"
+	"github.com/arm/topo/internal/ssh"
+	"github.com/spf13/cobra"
+)
+
+const remoteprocRepoURL = "arm/remoteproc-runtime"
+
+var installRemoteprocRuntimeCmd = &cobra.Command{
+	Use:   "remoteproc-runtime",
+	Short: "Install remoteproc-runtime and shim to a location on the target's PATH",
+	Long: `Install remoteproc-runtime and shim to a location on the target's PATH.
+
+Fetches binaries from https://github.com/` + remoteprocRepoURL + `
+Set GITHUB_TOKEN to authenticate with the GitHub API and avoid rate limits.
+
+Attempts to replace existing installations if found.
+Falls back to ~/bin if no suitable locations are automatically found.
+`,
+	Args: cobra.ExactArgs(0),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+		sshTarget, err := requireTarget(cmd)
+		if err != nil {
+			return err
+		}
+
+		outputFormat, err := resolveOutput(cmd)
+		if err != nil {
+			return err
+		}
+		p, err := installRemoteprocRuntime(ssh.Host(sshTarget))
+		if err != nil {
+			return err
+		}
+		return printable.Print(p, os.Stdout, outputFormat)
+	},
+}
+
+func installRemoteprocRuntime(targetHost ssh.Host) (printable.Printable, error) {
+	results, err := install.InstallBinariesFromGithubRelease(targetHost, remoteprocRepoURL, []string{"remoteproc-runtime", "containerd-shim-remoteproc-v1"})
+	if err != nil {
+		return nil, err
+	}
+	return templates.InstallResults(results), nil
+}
+
+func init() {
+	installCmd.AddCommand(installRemoteprocRuntimeCmd)
+	addTargetFlag(installRemoteprocRuntimeCmd)
+}


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- Makes `install` command less confusing - we're not installing remoteproc, but installing the runtime.
- Moves the `remotproc-runtime` subcommand logic to a separate file, which is consistent with other sub-commands (`service remove` lives in `service_remove.go`)
