### PR TITLE
chore: Rename `--port` to `--registry-port`

### DIFF
--- a/cmd/topo/deploy.go
+++ b/cmd/topo/deploy.go
@@ -20,7 +20,7 @@ import (
 
 var (
 	noRegistry        bool
-	port              string
+	registryPort      string
 	skipProjectChecks bool
 )
 
@@ -58,11 +58,11 @@ Use --dry-run to see what commands would be executed without actually running th
 			return err
 		}
 
-		portChanged := cmd.Flags().Changed("port")
+		portChanged := cmd.Flags().Changed("registry-port")
 		if portChanged && noRegistry {
 			c.Log(logger.Entry{
 				Level:   logger.Warning,
-				Message: "--port has no effect when --no-registry is set. Define SSH port in your SSH config instead.",
+				Message: "--registry-port has no effect when --no-registry is set. Define SSH port in your SSH config instead.",
 			})
 		}
 
@@ -76,7 +76,7 @@ Use --dry-run to see what commands would be executed without actually running th
 			return err
 		}
 
-		resolvedPort, err := resolvePort(cmd, port)
+		resolvedPort, err := resolvePort(cmd, registryPort)
 		if err != nil {
 			return err
 		}
@@ -87,7 +87,7 @@ Use --dry-run to see what commands would be executed without actually running th
 
 		targetHost := ssh.Host(resolvedTarget)
 		deployOpts.TargetHost = targetHost
-		deployOpts.Port = resolvedPort
+		deployOpts.RegistryPort = resolvedPort
 
 		if !skipProjectChecks {
 			if err := checks.EnsureProjectIsLinuxArm64Ready(composeFile); err != nil {
@@ -145,7 +145,7 @@ func validatePort(port string) error {
 func resolvePort(cmd *cobra.Command, flagValue string) (string, error) {
 	const portEnvVar = "TOPO_PORT"
 
-	if cmd.Flags().Changed("port") {
+	if cmd.Flags().Changed("registry-port") {
 		return flagValue, nil
 	}
 	if env := strings.TrimSpace(os.Getenv(portEnvVar)); env != "" {
@@ -157,7 +157,7 @@ func resolvePort(cmd *cobra.Command, flagValue string) (string, error) {
 func init() {
 	addTargetFlag(deployCmd)
 	addDryRunFlag(deployCmd)
-	deployCmd.Flags().StringVarP(&port, "port", "p", operation.DefaultRegistryPort, "Registry and SSH tunnel port (can also be set via TOPO_PORT env var)")
+	deployCmd.Flags().StringVarP(&registryPort, "registry-port", "p", operation.DefaultRegistryPort, "Registry and SSH tunnel port (can also be set via TOPO_PORT env var)")
 	deployCmd.Flags().BoolVar(&noRegistry, "no-registry", false, "Disable private registry flow; use direct save/load transfer")
 	deployCmd.Flags().BoolVar(&deployOpts.ForceRecreate, "force-recreate", false, "Force recreation of containers even if their configuration and image haven't changed")
 	deployCmd.Flags().BoolVar(&deployOpts.NoRecreate, "no-recreate", false, "Prevent recreation of containers even if their configuration and image have changed")

--- a/internal/deploy/docker/deploy.go
+++ b/internal/deploy/docker/deploy.go
@@ -11,7 +11,7 @@ type DeployOptions struct {
 	WithRegistry         bool
 	TargetHost           ssh.Host
 	NoRecreate           bool
-	Port                 string
+	RegistryPort         string
 	UseSSHControlSockets bool
 }
 
@@ -40,11 +40,11 @@ func NewDeployment(composeFile string, opts DeployOptions) (goperation.Sequence,
 	var cleanup goperation.Operation
 	if !opts.TargetHost.IsPlainLocalhost() {
 		if opts.WithRegistry {
-			start, stop := ssh.NewSSHTunnel(opts.TargetHost, opts.Port, opts.UseSSHControlSockets)
+			start, stop := ssh.NewSSHTunnel(opts.TargetHost, opts.RegistryPort, opts.UseSSHControlSockets)
 			cleanup = stop
-			ops = append(ops, operation.NewRunRegistry(opts.Port)...)
+			ops = append(ops, operation.NewRunRegistry(opts.RegistryPort)...)
 			ops = append(ops, start)
-			ops = append(ops, operation.NewRegistryTransfer(composeFile, sourceHost, opts.TargetHost, opts.Port))
+			ops = append(ops, operation.NewRegistryTransfer(composeFile, sourceHost, opts.TargetHost, opts.RegistryPort))
 			ops = append(ops, stop)
 		} else {
 			ops = append(ops, operation.NewDockerComposePipeTransfer(composeFile, sourceHost, opts.TargetHost))

--- a/internal/deploy/docker/deploy_test.go
+++ b/internal/deploy/docker/deploy_test.go
@@ -36,7 +36,7 @@ func TestNewDeployment(t *testing.T) {
 	t.Run("includes registry operations for remote host when enabled", func(t *testing.T) {
 		remoteHost := ssh.Host("user@remote")
 		port := operation.DefaultRegistryPort
-		opts := docker.DeployOptions{TargetHost: remoteHost, WithRegistry: true, ForceRecreate: false, Port: port, UseSSHControlSockets: true}
+		opts := docker.DeployOptions{TargetHost: remoteHost, WithRegistry: true, ForceRecreate: false, RegistryPort: port, UseSSHControlSockets: true}
 		upArgs := operation.DockerComposeUpArgs{
 			ForceRecreate: opts.ForceRecreate,
 		}
@@ -124,13 +124,13 @@ func TestNewDeployment(t *testing.T) {
 	t.Run("does not use SSH control sockets when disabled", func(t *testing.T) {
 		remoteHost := ssh.Host("user@remote")
 		port := operation.DefaultRegistryPort
-		opts := docker.DeployOptions{TargetHost: remoteHost, WithRegistry: true, ForceRecreate: false, Port: port, UseSSHControlSockets: false}
+		opts := docker.DeployOptions{TargetHost: remoteHost, WithRegistry: true, ForceRecreate: false, RegistryPort: port, UseSSHControlSockets: false}
 		upArgs := operation.DockerComposeUpArgs{
 			ForceRecreate: opts.ForceRecreate,
 		}
 		got, _ := docker.NewDeployment(composeFile, opts)
 
-		wantTunnelStart, wantTunnelEnd := ssh.NewSSHTunnel(remoteHost, opts.Port, opts.UseSSHControlSockets)
+		wantTunnelStart, wantTunnelEnd := ssh.NewSSHTunnel(remoteHost, opts.RegistryPort, opts.UseSSHControlSockets)
 		want := goperation.Sequence{
 			operation.NewDockerComposeBuild(composeFile, ssh.PlainLocalhost),
 			operation.NewDockerComposePull(composeFile, ssh.PlainLocalhost),


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- Makes it more obvious what port we're talking about, `--port` could be mistaken with target/connection port
