### PR TITLE
fix: Allow using `ssh://` scheme for deployment targets

### DIFF
--- a/e2e/deploy_test.go
+++ b/e2e/deploy_test.go
@@ -22,7 +22,7 @@ func TestDeploy(t *testing.T) {
 		projectDir := t.TempDir()
 		composeFile := filepath.Join(projectDir, "compose.yaml")
 		t.Cleanup(func() {
-			composeDown(t, composeFile, target.SSHConnectionString)
+			composeDown(t, composeFile, target.SSHDestination)
 		})
 
 		requireInit(t, topo, projectDir)
@@ -32,7 +32,7 @@ func TestDeploy(t *testing.T) {
 
 		requireExtend(t, topo, projectDir, composeFile, nameArgValue)
 
-		requireDeploy(t, topo, projectDir, target.SSHConnectionString)
+		requireDeploy(t, topo, projectDir, target.SSHDestination)
 		port, err := testutil.GetContainerPublicPort(target.ContainerName, "8080")
 		require.NoError(t, err)
 		assertResponseBody(t, fmt.Sprintf("http://localhost:%s/", port), expectedResponse)
@@ -43,12 +43,12 @@ func TestDeploy(t *testing.T) {
 		cloneDir := filepath.Join(baseDir, "project")
 		composeFile := filepath.Join(cloneDir, "compose.yaml")
 		t.Cleanup(func() {
-			composeDown(t, composeFile, target.SSHConnectionString)
+			composeDown(t, composeFile, target.SSHDestination)
 		})
 
 		nameArgValue := "Topo"
 		requireClone(t, topo, baseDir, cloneDir, "testdata/services/hello-server", fmt.Sprintf("NAME=%s", nameArgValue))
-		requireDeploy(t, topo, cloneDir, target.SSHConnectionString)
+		requireDeploy(t, topo, cloneDir, target.SSHDestination)
 		expectedResponse := fmt.Sprintf("Hello %s\n", nameArgValue)
 		port, err := testutil.GetContainerPublicPort(target.ContainerName, "8080")
 		require.NoError(t, err)
@@ -93,8 +93,8 @@ func requireExtend(t *testing.T, topo, projectDir, composeFile, customName strin
 	require.NoErrorf(t, err, "extend failed: %s", out)
 }
 
-func requireDeploy(t *testing.T, topo, projectDir, sshTarget string, extraArgs ...string) {
-	args := []string{"deploy", "--target", sshTarget, "--skip-project-checks"}
+func requireDeploy(t *testing.T, topo, projectDir, sshDestination string, extraArgs ...string) {
+	args := []string{"deploy", "--target", sshDestination, "--skip-project-checks"}
 	args = append(args, extraArgs...)
 
 	deployCmd := exec.Command(topo, args...)
@@ -125,9 +125,9 @@ func assertResponseBody(t *testing.T, url, wantBody string) {
 	assert.Equal(t, wantBody, string(body))
 }
 
-func composeDown(t *testing.T, composeFile, sshTarget string) {
+func composeDown(t *testing.T, composeFile, sshDestination string) {
 	t.Helper()
-	cmd := exec.Command("docker", "-H", "ssh://"+sshTarget, "compose", "-f", composeFile, "down", "-v")
+	cmd := exec.Command("docker", "-H", sshDestination, "compose", "-f", composeFile, "down", "-v")
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Logf("compose down failed: %v, output: %s", err, out)
 	}

--- a/e2e/health_test.go
+++ b/e2e/health_test.go
@@ -1,7 +1,6 @@
 package e2e
 
 import (
-	"fmt"
 	"os/exec"
 	"testing"
 
@@ -31,8 +30,8 @@ func TestHealthCheck(t *testing.T) {
 
 	t.Run("fails to connect to an invalid target", func(t *testing.T) {
 		fakeContainer := testutil.TargetContainer{
-			SSHConnectionString: "fake@target",
-			ContainerName:       "fake-tgt-container",
+			SSHDestination: "fake@target",
+			ContainerName:  "fake-tgt-container",
 		}
 		out, err := runCheckHealth(topo, &fakeContainer)
 		assert.NoError(t, err)
@@ -41,8 +40,7 @@ func TestHealthCheck(t *testing.T) {
 }
 
 func runCheckHealth(topo string, target *testutil.TargetContainer) (string, error) {
-	targetURL := fmt.Sprintf("ssh://%s", target.SSHConnectionString)
-	args := []string{"health", "--target", targetURL}
+	args := []string{"health", "--target", target.SSHDestination}
 	healthCmd := exec.Command(topo, args...)
 
 	out, err := healthCmd.CombinedOutput()

--- a/e2e/install_test.go
+++ b/e2e/install_test.go
@@ -1,7 +1,6 @@
 package e2e
 
 import (
-	"fmt"
 	"os/exec"
 	"testing"
 
@@ -14,12 +13,10 @@ func TestInstall(t *testing.T) {
 	topo := buildBinary(t)
 
 	t.Run("installs the binary", func(t *testing.T) {
-		targetURL := fmt.Sprintf("ssh://%s", target.SSHConnectionString)
-
-		out, err := installRemoteprocRuntime(topo, targetURL)
+		out, err := installRemoteprocRuntime(topo, target.SSHDestination)
 
 		require.NoError(t, err, out)
-		requireInstalled(t, "remoteproc-runtime", targetURL)
+		requireInstalled(t, "remoteproc-runtime", target.SSHDestination)
 	})
 }
 

--- a/internal/deploy/docker/deploy_test.go
+++ b/internal/deploy/docker/deploy_test.go
@@ -154,7 +154,7 @@ func TestDeployment(t *testing.T) {
 		target := testutil.StartTargetContainer(t)
 
 		t.Run("builds images, transfers them, and starts services", func(t *testing.T) {
-			remoteDockerHost := ssh.Host(target.SSHConnectionString)
+			remoteDockerHost := ssh.Host(target.SSHDestination)
 			tmpDir := t.TempDir()
 			dockerFilePath := filepath.Join(tmpDir, "Dockerfile")
 			dockerFileContent := `

--- a/internal/deploy/docker/stop_test.go
+++ b/internal/deploy/docker/stop_test.go
@@ -47,7 +47,7 @@ func TestDeploymentStop(t *testing.T) {
 		target := testutil.StartTargetContainer(t)
 
 		t.Run("deploys services then confirms stop shuts down containers", func(t *testing.T) {
-			remoteDockerHost := ssh.Host(target.SSHConnectionString)
+			remoteDockerHost := ssh.Host(target.SSHDestination)
 			tmpDir := t.TempDir()
 			dockerFilePath := filepath.Join(tmpDir, "Dockerfile")
 			dockerFileContent := `

--- a/internal/ssh/host.go
+++ b/internal/ssh/host.go
@@ -16,7 +16,9 @@ func (h Host) IsPlainLocalhost() bool {
 }
 
 func (h Host) AsURI() string {
-	return fmt.Sprintf("ssh://%s", h)
+	const scheme = "ssh://"
+	withoutScheme := strings.TrimLeft(string(h), scheme)
+	return fmt.Sprintf("ssh://%s", withoutScheme)
 }
 
 func (h Host) Slugify() string {

--- a/internal/ssh/host.go
+++ b/internal/ssh/host.go
@@ -17,7 +17,7 @@ func (h Host) IsPlainLocalhost() bool {
 
 func (h Host) AsURI() string {
 	const scheme = "ssh://"
-	withoutScheme := strings.TrimLeft(string(h), scheme)
+	withoutScheme := strings.TrimPrefix(string(h), scheme)
 	return fmt.Sprintf("ssh://%s", withoutScheme)
 }
 

--- a/internal/ssh/host_test.go
+++ b/internal/ssh/host_test.go
@@ -67,7 +67,14 @@ func TestHost(t *testing.T) {
 
 			assert.Equal(t, "ssh://user@host", h.AsURI())
 		})
+
+		t.Run("doesn't duplicate ssh:// scheme", func(t *testing.T) {
+			h := ssh.Host("ssh://user@host:123")
+
+			assert.Equal(t, "ssh://user@host:123", h.AsURI())
+		})
 	})
+
 	t.Run("Slugify", func(t *testing.T) {
 		tests := []struct {
 			input string

--- a/internal/testutil/container.go
+++ b/internal/testutil/container.go
@@ -15,8 +15,8 @@ const TargetContainerHost = "root@localhost"
 const TargetContainerImage = "topo-e2e-target:latest"
 
 type TargetContainer struct {
-	SSHConnectionString string
-	ContainerName       string
+	SSHDestination string
+	ContainerName  string
 }
 
 func StartTargetContainer(t *testing.T) *TargetContainer {
@@ -44,7 +44,10 @@ func StartTargetContainer(t *testing.T) *TargetContainer {
 	waitForDockerReady(t, TargetContainerHost, port)
 
 	// #nosec G204 -- ignore as its a test helper
-	return &TargetContainer{SSHConnectionString: fmt.Sprintf("%s:%s", TargetContainerHost, port), ContainerName: containerName}
+	return &TargetContainer{
+		SSHDestination: fmt.Sprintf("ssh://%s:%s", TargetContainerHost, port),
+		ContainerName:  containerName,
+	}
 }
 
 func generateTargetContainerName(t *testing.T) string {


### PR DESCRIPTION
## Preamble
- In `topo`, the value of `--target` is either passed to `ssh` or used as value of `docker -H` argument
- When used with `ssh` the `--target` becomes what `ssh` accepts as the _destination_ argument (`man ssh`).
- In `ssh`, the only legit way to specify a port in the _destination_ is to use `ssh://` scheme:
   - `ssh ssh://localhost:1337` is valid
   -  `ssh localhost:1337` is not valid (it treats `:1337` as part of the hostname)
- When used with `docker`, target becomes the value of `-H` argument. Here, the only legit way to specify docker engine over ssh is always using `ssh://` scheme prefix (even if you don't specify the port!)

## Changes

<!-- List the changes this PR introduces -->
- Rename `SSHConnectionString` to `SSHDestination` - it's more accurate and we also now ensure it holds a valid `ssh` destination - the version with a port needs `ssh://` scheme prefix
- Ensure that `topo deploy ssh://somehost:1337` doesn't explode by trying to talk to `ssh://ssh://somehost:1337`

ℹ️ Frankly, there's more issues across the codebase wrt us not distinguishing between host and destination, perhaps can be solved by naming or introducing separate types to represent docker host and ssh destination. Something for another PR.
