### PR TITLE
feat: setup-keys - support selecting SSH key type

### DIFF
--- a/cmd/topo/setup_keys.go
+++ b/cmd/topo/setup_keys.go
@@ -66,6 +66,6 @@ func init() {
 	addTargetFlag(setupKeysCmd)
 	addDryRunFlag(setupKeysCmd)
 	setupKeysCmd.Flags().StringVar(&privateKeyPath, "key-path", "", "Specify the SSH path where the generated key pair will be stored. Default directory: ~/.ssh. Default public key file name: id_ed25519_topo_<target>.pub)")
-	setupKeysCmd.Flags().StringVar(&keyType, "key-type", "ed25519", "Specify the type of SSH key to generate. Supported types: ed25519, rsa. Default: ed25519")
+	setupKeysCmd.Flags().StringVar(&keyType, "key-type", "ed25519", fmt.Sprintf("Specify the type of SSH key to generate. Supported types: %s, %s. Default: %s", setupkeys.KeyTypeED25519, setupkeys.KeyTypeRSA, setupkeys.KeyTypeED25519))
 	rootCmd.AddCommand(setupKeysCmd)
 }

--- a/cmd/topo/setup_keys.go
+++ b/cmd/topo/setup_keys.go
@@ -43,7 +43,12 @@ Use --dry-run to see what commands would be executed without actually running th
 			}
 		}
 
-		seq, err := setupkeys.NewKeySetup(resolvedTarget, privateKeyPath, keyType)
+		parsedKeyType, err := setupkeys.ParseKeyType(keyType)
+		if err != nil {
+			return err
+		}
+
+		seq, err := setupkeys.NewKeySetup(resolvedTarget, privateKeyPath, string(parsedKeyType))
 		if err != nil {
 			return err
 		}

--- a/cmd/topo/setup_keys.go
+++ b/cmd/topo/setup_keys.go
@@ -66,6 +66,6 @@ func init() {
 	addTargetFlag(setupKeysCmd)
 	addDryRunFlag(setupKeysCmd)
 	setupKeysCmd.Flags().StringVar(&privateKeyPath, "key-path", "", "Specify the SSH path where the generated key pair will be stored. Default directory: ~/.ssh. Default public key file name: id_ed25519_topo_<target>.pub)")
-	setupKeysCmd.Flags().StringVar(&keyType, "key-type", "", "Specify the type of SSH key to generate. Supported types: ed25519, rsa. Default: ed25519")
+	setupKeysCmd.Flags().StringVar(&keyType, "key-type", "ed25519", "Specify the type of SSH key to generate. Supported types: ed25519, rsa. Default: ed25519")
 	rootCmd.AddCommand(setupKeysCmd)
 }

--- a/cmd/topo/setup_keys.go
+++ b/cmd/topo/setup_keys.go
@@ -48,7 +48,7 @@ Use --dry-run to see what commands would be executed without actually running th
 			return err
 		}
 
-		seq, err := setupkeys.NewKeySetup(resolvedTarget, privateKeyPath, string(parsedKeyType))
+		seq, err := setupkeys.NewKeySetup(resolvedTarget, privateKeyPath, parsedKeyType)
 		if err != nil {
 			return err
 		}

--- a/cmd/topo/setup_keys.go
+++ b/cmd/topo/setup_keys.go
@@ -10,7 +10,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var privateKeyPath string
+var (
+	privateKeyPath string
+	keyType        string
+)
 
 var setupKeysCmd = &cobra.Command{
 	Use:   "setup-keys",
@@ -40,7 +43,7 @@ Use --dry-run to see what commands would be executed without actually running th
 			}
 		}
 
-		seq, err := setupkeys.NewKeySetup(resolvedTarget, privateKeyPath)
+		seq, err := setupkeys.NewKeySetup(resolvedTarget, privateKeyPath, keyType)
 		if err != nil {
 			return err
 		}
@@ -63,5 +66,6 @@ func init() {
 	addTargetFlag(setupKeysCmd)
 	addDryRunFlag(setupKeysCmd)
 	setupKeysCmd.Flags().StringVar(&privateKeyPath, "key-path", "", "Specify the SSH path where the generated key pair will be stored. Default directory: ~/.ssh. Default public key file name: id_ed25519_topo_<target>.pub)")
+	setupKeysCmd.Flags().StringVar(&keyType, "key-type", "", "Specify the type of SSH key to generate. Supported types: ed25519, rsa. Default: ed25519")
 	rootCmd.AddCommand(setupKeysCmd)
 }

--- a/internal/setupkeys/setup_keys.go
+++ b/internal/setupkeys/setup_keys.go
@@ -47,6 +47,6 @@ func ParseKeyType(s string) (KeyType, error) {
 	case KeyTypeRSA:
 		return KeyTypeRSA, nil
 	default:
-		return "", fmt.Errorf("unsupported key type %q, supported types: ed25519, rsa", s)
+		return "", fmt.Errorf("unsupported key type %q, supported types: %s, %s", s, KeyTypeED25519, KeyTypeRSA)
 	}
 }

--- a/internal/setupkeys/setup_keys.go
+++ b/internal/setupkeys/setup_keys.go
@@ -18,13 +18,8 @@ const (
 )
 
 func NewKeySetup(target string, privKeyPath string, keyType string) (operation.Sequence, error) {
-	parsedKeyType, err := ParseKeyType(keyType)
-	if err != nil {
-		return nil, err
-	}
-
 	ops := []operation.Operation{
-		sshkeygen.NewSSHKeyGen("Generate SSH key pair for target", target, string(parsedKeyType), privKeyPath, sshkeygen.SSHKeyGenOptions{}),
+		sshkeygen.NewSSHKeyGen("Generate SSH key pair for target", target, keyType, privKeyPath, sshkeygen.SSHKeyGenOptions{}),
 		pubkeytransfer.NewPubKeyTransfer("Transfer public key to target and set it as an authorized key", target, privKeyPath, pubkeytransfer.PubKeyTransferOptions{}),
 	}
 	return operation.NewSequence(ops...), nil

--- a/internal/setupkeys/setup_keys.go
+++ b/internal/setupkeys/setup_keys.go
@@ -10,9 +10,14 @@ import (
 	"github.com/arm/topo/internal/setupkeys/sshkeygen"
 )
 
+const (
+	KeyTypeED25519 string = "ed25519"
+	KeyTypeRSA     string = "rsa"
+)
+
 func NewKeySetup(target string, privKeyPath string, keyType string) (operation.Sequence, error) {
-	if keyType != "ed25519" && keyType != "rsa" {
-		return nil, fmt.Errorf("unsupported key type: %s", keyType)
+	if err := isValidKeyType(keyType); err != nil {
+		return nil, err
 	}
 
 	ops := []operation.Operation{
@@ -30,4 +35,13 @@ func GetDefaultPrivateKeyPath(targetSlug string) (string, error) {
 	keyName := fmt.Sprintf("id_ed25519_topo_%s", targetSlug)
 	privKeyPath := filepath.Join(home, ".ssh", keyName)
 	return privKeyPath, nil
+}
+
+func isValidKeyType(s string) error {
+	switch s {
+	case KeyTypeED25519, KeyTypeRSA:
+		return nil
+	default:
+		return fmt.Errorf("unsupported key type %q, supported types: %s, %s", s, KeyTypeED25519, KeyTypeRSA)
+	}
 }

--- a/internal/setupkeys/setup_keys.go
+++ b/internal/setupkeys/setup_keys.go
@@ -17,9 +17,9 @@ const (
 	KeyTypeRSA     KeyType = "rsa"
 )
 
-func NewKeySetup(target string, privKeyPath string, keyType string) (operation.Sequence, error) {
+func NewKeySetup(target string, privKeyPath string, keyType KeyType) (operation.Sequence, error) {
 	ops := []operation.Operation{
-		sshkeygen.NewSSHKeyGen("Generate SSH key pair for target", target, keyType, privKeyPath, sshkeygen.SSHKeyGenOptions{}),
+		sshkeygen.NewSSHKeyGen("Generate SSH key pair for target", target, string(keyType), privKeyPath, sshkeygen.SSHKeyGenOptions{}),
 		pubkeytransfer.NewPubKeyTransfer("Transfer public key to target and set it as an authorized key", target, privKeyPath, pubkeytransfer.PubKeyTransferOptions{}),
 	}
 	return operation.NewSequence(ops...), nil

--- a/internal/setupkeys/setup_keys.go
+++ b/internal/setupkeys/setup_keys.go
@@ -10,18 +10,21 @@ import (
 	"github.com/arm/topo/internal/setupkeys/sshkeygen"
 )
 
+type KeyType string
+
 const (
-	KeyTypeED25519 string = "ed25519"
-	KeyTypeRSA     string = "rsa"
+	KeyTypeED25519 KeyType = "ed25519"
+	KeyTypeRSA     KeyType = "rsa"
 )
 
 func NewKeySetup(target string, privKeyPath string, keyType string) (operation.Sequence, error) {
-	if err := isValidKeyType(keyType); err != nil {
+	parsedKeyType, err := ParseKeyType(keyType)
+	if err != nil {
 		return nil, err
 	}
 
 	ops := []operation.Operation{
-		sshkeygen.NewSSHKeyGen("Generate SSH key pair for target", target, keyType, privKeyPath, sshkeygen.SSHKeyGenOptions{}),
+		sshkeygen.NewSSHKeyGen("Generate SSH key pair for target", target, string(parsedKeyType), privKeyPath, sshkeygen.SSHKeyGenOptions{}),
 		pubkeytransfer.NewPubKeyTransfer("Transfer public key to target and set it as an authorized key", target, privKeyPath, pubkeytransfer.PubKeyTransferOptions{}),
 	}
 	return operation.NewSequence(ops...), nil
@@ -37,11 +40,13 @@ func GetDefaultPrivateKeyPath(targetSlug string) (string, error) {
 	return privKeyPath, nil
 }
 
-func isValidKeyType(s string) error {
-	switch s {
-	case KeyTypeED25519, KeyTypeRSA:
-		return nil
+func ParseKeyType(s string) (KeyType, error) {
+	switch KeyType(s) {
+	case KeyTypeED25519:
+		return KeyTypeED25519, nil
+	case KeyTypeRSA:
+		return KeyTypeRSA, nil
 	default:
-		return fmt.Errorf("unsupported key type %q, supported types: %s, %s", s, KeyTypeED25519, KeyTypeRSA)
+		return "", fmt.Errorf("unsupported key type %q, supported types: ed25519, rsa", s)
 	}
 }

--- a/internal/setupkeys/setup_keys.go
+++ b/internal/setupkeys/setup_keys.go
@@ -10,9 +10,13 @@ import (
 	"github.com/arm/topo/internal/setupkeys/sshkeygen"
 )
 
-func NewKeySetup(target string, privKeyPath string) (operation.Sequence, error) {
+func NewKeySetup(target string, privKeyPath string, keyType string) (operation.Sequence, error) {
+	if keyType != "ed25519" && keyType != "rsa" {
+		return nil, fmt.Errorf("unsupported key type: %s", keyType)
+	}
+
 	ops := []operation.Operation{
-		sshkeygen.NewSSHKeyGen("Generate SSH key pair for target", target, "ed25519", privKeyPath, sshkeygen.SSHKeyGenOptions{}),
+		sshkeygen.NewSSHKeyGen("Generate SSH key pair for target", target, keyType, privKeyPath, sshkeygen.SSHKeyGenOptions{}),
 		pubkeytransfer.NewPubKeyTransfer("Transfer public key to target and set it as an authorized key", target, privKeyPath, pubkeytransfer.PubKeyTransferOptions{}),
 	}
 	return operation.NewSequence(ops...), nil

--- a/internal/setupkeys/setup_keys_test.go
+++ b/internal/setupkeys/setup_keys_test.go
@@ -13,86 +13,73 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestNewKeySetupReturnsExpectedSequence(t *testing.T) {
+func TestNewKeySetupDryRun(t *testing.T) {
 	tests := []struct {
-		name        string
-		keyType     string
-		privKeyPath string
-		target      string
+		name         string
+		keyType      string
+		wantTarget   string
+		inputKeyPath string
+		wantKeyPath  string
 	}{
 		{
-			name:        "ed25519 key type",
-			keyType:     "ed25519",
-			privKeyPath: filepath.Join(t.TempDir(), "id_ed25519_custom"),
-			target:      "user@some1thing.com",
+			name:         "default key path",
+			keyType:      "ed25519",
+			inputKeyPath: "",
+			wantTarget:   "user@some1thing.com",
+			wantKeyPath:  filepath.Join(".ssh", "id_ed25519_topo_user_some1thing.com"),
 		},
 		{
-			name:        "rsa key type",
-			keyType:     "rsa",
-			privKeyPath: filepath.Join(t.TempDir(), "id_rsa_custom"),
-			target:      "user@some2thing.com",
+			name:         "custom key path",
+			keyType:      "ed25519",
+			inputKeyPath: filepath.Join("custom_keys", "id_ed25519_custom"),
+			wantTarget:   "user@some2thing.com",
+			wantKeyPath:  filepath.Join("custom_keys", "id_ed25519_custom"),
+		},
+		{
+			name:         "rsa key type",
+			keyType:      "rsa",
+			inputKeyPath: filepath.Join("custom_keys", "id_rsa_custom"),
+			wantTarget:   "user@some3thing.com",
+			wantKeyPath:  filepath.Join("custom_keys", "id_rsa_custom"),
 		},
 	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := setupkeys.NewKeySetup(tt.target, tt.privKeyPath, tt.keyType)
+			tmp := t.TempDir()
+			testutil.SetHomeDir(t, tmp)
+
+			wantKeyPath := tt.wantKeyPath
+			if tt.inputKeyPath == "" {
+				wantKeyPath = filepath.Join(tmp, tt.wantKeyPath)
+			}
+			targetSlug := ssh.Host(tt.wantTarget).Slugify()
+			inputKeyPath := tt.inputKeyPath
+			if inputKeyPath == "" {
+				var err error
+				inputKeyPath, err = setupkeys.GetDefaultPrivateKeyPath(targetSlug)
+				require.NoError(t, err)
+			}
+			got, err := setupkeys.NewKeySetup(tt.wantTarget, inputKeyPath, tt.keyType)
 			require.NoError(t, err)
 			require.Len(t, got, 2)
 			require.IsType(t, &sshkeygen.SSHKeyGen{}, got[0])
 			require.IsType(t, &pubkeytransfer.PubKeyTransfer{}, got[1])
+			require.Equal(t, "Generate SSH key pair for target", got[0].Description())
+			require.Equal(t, "Transfer public key to target and set it as an authorized key", got[1].Description())
+			var buf bytes.Buffer
+			require.NoError(t, got.DryRun(&buf))
+
+			wantKeygen := "ssh-keygen -t " + tt.keyType + " -f " + wantKeyPath + " -C " + tt.wantTarget
+			wantSSH := "ssh -- " + tt.wantTarget
+			wantCmd := "mkdir -p ~/.ssh && chmod 700 ~/.ssh && cat >> ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys"
+			require.Contains(t, buf.String(), wantKeygen, "DryRun output should include keygen command")
+			require.Contains(t, buf.String(), wantSSH, "DryRun output should include ssh command with correct target")
+			require.Contains(t, buf.String(), wantCmd, "DryRun output should include correct authorized key addition command to be executed on target")
 		})
 	}
 }
 
-func TestGetDefaultPrivateKeyPath(t *testing.T) {
-	tmp := t.TempDir()
-	testutil.SetHomeDir(t, tmp)
-
-	target := "user@some1thing.com"
-	targetSlug := ssh.Host(target).Slugify()
-
-	got, err := setupkeys.GetDefaultPrivateKeyPath(targetSlug)
-	require.NoError(t, err)
-	require.Equal(t, filepath.Join(tmp, ".ssh", "id_ed25519_topo_user_some1thing.com"), got)
-}
-
-func TestSSHKeyGenOperationDryRunAndDescription(t *testing.T) {
-	keyPath := filepath.Join(t.TempDir(), "custom_keys", "id_ed25519_custom")
-	op := sshkeygen.NewSSHKeyGen(
-		"Generate SSH key pair for target",
-		"user@some2thing.com",
-		"ed25519",
-		keyPath,
-		sshkeygen.SSHKeyGenOptions{},
-	)
-
-	require.Equal(t, "Generate SSH key pair for target", op.Description())
-
-	var buf bytes.Buffer
-	require.NoError(t, op.DryRun(&buf))
-	require.Contains(t, buf.String(), "ssh-keygen -t ed25519 -f "+keyPath+" -C user@some2thing.com")
-}
-
-func TestPubKeyTransferOperationDryRunAndDescription(t *testing.T) {
-	privKeyPath := filepath.Join(t.TempDir(), "custom_keys", "id_ed25519_custom")
-	op := pubkeytransfer.NewPubKeyTransfer(
-		"Transfer public key to target and set it as an authorized key",
-		"user@some3thing.com",
-		privKeyPath,
-		pubkeytransfer.PubKeyTransferOptions{},
-	)
-
-	require.Equal(t, "Transfer public key to target and set it as an authorized key", op.Description())
-
-	var buf bytes.Buffer
-	require.NoError(t, op.DryRun(&buf))
-	require.Contains(t, buf.String(), "ssh -- user@some3thing.com")
-	require.Contains(t, buf.String(), "mkdir -p ~/.ssh && chmod 700 ~/.ssh && cat >> ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys")
-}
-
 func TestNewKeySetupUnsupportedKeyType(t *testing.T) {
-	_, err := setupkeys.NewKeySetup("user@example.com", "/tmp/id_invalid", "arrivederci")
-	require.ErrorContains(t, err, "unsupported key type")
-	require.ErrorContains(t, err, "arrivederci")
+	_, err := setupkeys.NewKeySetup("user@example.com", "/tmp/id_invalid", "ecdsa")
+	require.EqualError(t, err, "unsupported key type: ecdsa")
 }

--- a/internal/setupkeys/setup_keys_test.go
+++ b/internal/setupkeys/setup_keys_test.go
@@ -16,28 +16,28 @@ import (
 func TestNewKeySetupDryRun(t *testing.T) {
 	tests := []struct {
 		name         string
-		keyType      string
+		keyType      setupkeys.KeyType
 		wantTarget   string
 		inputKeyPath string
 		wantKeyPath  string
 	}{
 		{
 			name:         "default key path",
-			keyType:      "ed25519",
+			keyType:      setupkeys.KeyTypeED25519,
 			inputKeyPath: "",
 			wantTarget:   "user@some1thing.com",
 			wantKeyPath:  filepath.Join(".ssh", "id_ed25519_topo_user_some1thing.com"),
 		},
 		{
 			name:         "custom key path",
-			keyType:      "ed25519",
+			keyType:      setupkeys.KeyTypeED25519,
 			inputKeyPath: filepath.Join("custom_keys", "id_ed25519_custom"),
 			wantTarget:   "user@some2thing.com",
 			wantKeyPath:  filepath.Join("custom_keys", "id_ed25519_custom"),
 		},
 		{
 			name:         "rsa key type",
-			keyType:      "rsa",
+			keyType:      setupkeys.KeyTypeRSA,
 			inputKeyPath: filepath.Join("custom_keys", "id_rsa_custom"),
 			wantTarget:   "user@some3thing.com",
 			wantKeyPath:  filepath.Join("custom_keys", "id_rsa_custom"),
@@ -69,7 +69,7 @@ func TestNewKeySetupDryRun(t *testing.T) {
 			var buf bytes.Buffer
 			require.NoError(t, got.DryRun(&buf))
 
-			wantKeygen := "ssh-keygen -t " + tt.keyType + " -f " + wantKeyPath + " -C " + tt.wantTarget
+			wantKeygen := "ssh-keygen -t " + string(tt.keyType) + " -f " + wantKeyPath + " -C " + tt.wantTarget
 			wantSSH := "ssh -- " + tt.wantTarget
 			wantCmd := "mkdir -p ~/.ssh && chmod 700 ~/.ssh && cat >> ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys"
 			require.Contains(t, buf.String(), wantKeygen, "DryRun output should include keygen command")
@@ -79,7 +79,21 @@ func TestNewKeySetupDryRun(t *testing.T) {
 	}
 }
 
-func TestNewKeySetupUnsupportedKeyType(t *testing.T) {
-	_, err := setupkeys.ParseKeyType("ecdsa")
-	require.EqualError(t, err, `unsupported key type "ecdsa", supported types: ed25519, rsa`)
+func TestParseKeyType(t *testing.T) {
+	t.Run("ed25519", func(t *testing.T) {
+		got, err := setupkeys.ParseKeyType("ed25519")
+		require.NoError(t, err)
+		require.Equal(t, setupkeys.KeyTypeED25519, got)
+	})
+
+	t.Run("rsa", func(t *testing.T) {
+		got, err := setupkeys.ParseKeyType("rsa")
+		require.NoError(t, err)
+		require.Equal(t, setupkeys.KeyTypeRSA, got)
+	})
+
+	t.Run("ecdsa", func(t *testing.T) {
+		_, err := setupkeys.ParseKeyType("ecdsa")
+		require.EqualError(t, err, `unsupported key type "ecdsa", supported types: ed25519, rsa`)
+	})
 }

--- a/internal/setupkeys/setup_keys_test.go
+++ b/internal/setupkeys/setup_keys_test.go
@@ -81,5 +81,5 @@ func TestNewKeySetupDryRun(t *testing.T) {
 
 func TestNewKeySetupUnsupportedKeyType(t *testing.T) {
 	_, err := setupkeys.ParseKeyType("ecdsa")
-	require.EqualError(t, err, "unsupported key type \"ecdsa\", supported types: ed25519, rsa")
+	require.EqualError(t, err, `unsupported key type "ecdsa", supported types: ed25519, rsa`)
 }

--- a/internal/setupkeys/setup_keys_test.go
+++ b/internal/setupkeys/setup_keys_test.go
@@ -81,5 +81,5 @@ func TestNewKeySetupDryRun(t *testing.T) {
 
 func TestNewKeySetupUnsupportedKeyType(t *testing.T) {
 	_, err := setupkeys.NewKeySetup("user@example.com", "/tmp/id_invalid", "ecdsa")
-	require.EqualError(t, err, "unsupported key type: ecdsa")
+	require.EqualError(t, err, "unsupported key type \"ecdsa\", supported types: ed25519, rsa")
 }

--- a/internal/setupkeys/setup_keys_test.go
+++ b/internal/setupkeys/setup_keys_test.go
@@ -13,73 +13,86 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestNewKeySetupDryRun(t *testing.T) {
+func TestNewKeySetupReturnsExpectedSequence(t *testing.T) {
 	tests := []struct {
-		name         string
-		keyType      string
-		wantTarget   string
-		inputKeyPath string
-		wantKeyPath  string
+		name        string
+		keyType     string
+		privKeyPath string
+		target      string
 	}{
 		{
-			name:         "default key path",
-			keyType:      "ed25519",
-			inputKeyPath: "",
-			wantTarget:   "user@some1thing.com",
-			wantKeyPath:  filepath.Join(".ssh", "id_ed25519_topo_user_some1thing.com"),
+			name:        "ed25519 key type",
+			keyType:     "ed25519",
+			privKeyPath: filepath.Join(t.TempDir(), "id_ed25519_custom"),
+			target:      "user@some1thing.com",
 		},
 		{
-			name:         "custom key path",
-			keyType:      "ed25519",
-			inputKeyPath: filepath.Join("custom_keys", "id_ed25519_custom"),
-			wantTarget:   "user@some2thing.com",
-			wantKeyPath:  filepath.Join("custom_keys", "id_ed25519_custom"),
-		},
-		{
-			name:         "rsa key type",
-			keyType:      "rsa",
-			inputKeyPath: filepath.Join("custom_keys", "id_rsa_custom"),
-			wantTarget:   "user@some3thing.com",
-			wantKeyPath:  filepath.Join("custom_keys", "id_rsa_custom"),
+			name:        "rsa key type",
+			keyType:     "rsa",
+			privKeyPath: filepath.Join(t.TempDir(), "id_rsa_custom"),
+			target:      "user@some2thing.com",
 		},
 	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tmp := t.TempDir()
-			testutil.SetHomeDir(t, tmp)
-
-			wantKeyPath := tt.wantKeyPath
-			if tt.inputKeyPath == "" {
-				wantKeyPath = filepath.Join(tmp, tt.wantKeyPath)
-			}
-			targetSlug := ssh.Host(tt.wantTarget).Slugify()
-			inputKeyPath := tt.inputKeyPath
-			if inputKeyPath == "" {
-				var err error
-				inputKeyPath, err = setupkeys.GetDefaultPrivateKeyPath(targetSlug)
-				require.NoError(t, err)
-			}
-			got, err := setupkeys.NewKeySetup(tt.wantTarget, inputKeyPath, tt.keyType)
+			got, err := setupkeys.NewKeySetup(tt.target, tt.privKeyPath, tt.keyType)
 			require.NoError(t, err)
 			require.Len(t, got, 2)
 			require.IsType(t, &sshkeygen.SSHKeyGen{}, got[0])
 			require.IsType(t, &pubkeytransfer.PubKeyTransfer{}, got[1])
-			require.Equal(t, "Generate SSH key pair for target", got[0].Description())
-			require.Equal(t, "Transfer public key to target and set it as an authorized key", got[1].Description())
-			var buf bytes.Buffer
-			require.NoError(t, got.DryRun(&buf))
-
-			wantKeygen := "ssh-keygen -t " + tt.keyType + " -f " + wantKeyPath + " -C " + tt.wantTarget
-			wantSSH := "ssh -- " + tt.wantTarget
-			wantCmd := "mkdir -p ~/.ssh && chmod 700 ~/.ssh && cat >> ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys"
-			require.Contains(t, buf.String(), wantKeygen, "DryRun output should include keygen command")
-			require.Contains(t, buf.String(), wantSSH, "DryRun output should include ssh command with correct target")
-			require.Contains(t, buf.String(), wantCmd, "DryRun output should include correct authorized key addition command to be executed on target")
 		})
 	}
 }
 
+func TestGetDefaultPrivateKeyPath(t *testing.T) {
+	tmp := t.TempDir()
+	testutil.SetHomeDir(t, tmp)
+
+	target := "user@some1thing.com"
+	targetSlug := ssh.Host(target).Slugify()
+
+	got, err := setupkeys.GetDefaultPrivateKeyPath(targetSlug)
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(tmp, ".ssh", "id_ed25519_topo_user_some1thing.com"), got)
+}
+
+func TestSSHKeyGenOperationDryRunAndDescription(t *testing.T) {
+	keyPath := filepath.Join(t.TempDir(), "custom_keys", "id_ed25519_custom")
+	op := sshkeygen.NewSSHKeyGen(
+		"Generate SSH key pair for target",
+		"user@some2thing.com",
+		"ed25519",
+		keyPath,
+		sshkeygen.SSHKeyGenOptions{},
+	)
+
+	require.Equal(t, "Generate SSH key pair for target", op.Description())
+
+	var buf bytes.Buffer
+	require.NoError(t, op.DryRun(&buf))
+	require.Contains(t, buf.String(), "ssh-keygen -t ed25519 -f "+keyPath+" -C user@some2thing.com")
+}
+
+func TestPubKeyTransferOperationDryRunAndDescription(t *testing.T) {
+	privKeyPath := filepath.Join(t.TempDir(), "custom_keys", "id_ed25519_custom")
+	op := pubkeytransfer.NewPubKeyTransfer(
+		"Transfer public key to target and set it as an authorized key",
+		"user@some3thing.com",
+		privKeyPath,
+		pubkeytransfer.PubKeyTransferOptions{},
+	)
+
+	require.Equal(t, "Transfer public key to target and set it as an authorized key", op.Description())
+
+	var buf bytes.Buffer
+	require.NoError(t, op.DryRun(&buf))
+	require.Contains(t, buf.String(), "ssh -- user@some3thing.com")
+	require.Contains(t, buf.String(), "mkdir -p ~/.ssh && chmod 700 ~/.ssh && cat >> ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys")
+}
+
 func TestNewKeySetupUnsupportedKeyType(t *testing.T) {
-	_, err := setupkeys.NewKeySetup("user@example.com", "/tmp/id_invalid", "ecdsa")
-	require.EqualError(t, err, "unsupported key type: ecdsa")
+	_, err := setupkeys.NewKeySetup("user@example.com", "/tmp/id_invalid", "arrivederci")
+	require.ErrorContains(t, err, "unsupported key type")
+	require.ErrorContains(t, err, "arrivederci")
 }

--- a/internal/setupkeys/setup_keys_test.go
+++ b/internal/setupkeys/setup_keys_test.go
@@ -16,21 +16,31 @@ import (
 func TestNewKeySetupDryRun(t *testing.T) {
 	tests := []struct {
 		name         string
+		keyType      string
 		wantTarget   string
 		inputKeyPath string
 		wantKeyPath  string
 	}{
 		{
 			name:         "default key path",
+			keyType:      "ed25519",
 			inputKeyPath: "",
 			wantTarget:   "user@some1thing.com",
 			wantKeyPath:  filepath.Join(".ssh", "id_ed25519_topo_user_some1thing.com"),
 		},
 		{
 			name:         "custom key path",
+			keyType:      "ed25519",
 			inputKeyPath: filepath.Join("custom_keys", "id_ed25519_custom"),
 			wantTarget:   "user@some2thing.com",
 			wantKeyPath:  filepath.Join("custom_keys", "id_ed25519_custom"),
+		},
+		{
+			name:         "rsa key type",
+			keyType:      "rsa",
+			inputKeyPath: filepath.Join("custom_keys", "id_rsa_custom"),
+			wantTarget:   "user@some3thing.com",
+			wantKeyPath:  filepath.Join("custom_keys", "id_rsa_custom"),
 		},
 	}
 	for _, tt := range tests {
@@ -49,7 +59,7 @@ func TestNewKeySetupDryRun(t *testing.T) {
 				inputKeyPath, err = setupkeys.GetDefaultPrivateKeyPath(targetSlug)
 				require.NoError(t, err)
 			}
-			got, err := setupkeys.NewKeySetup(tt.wantTarget, inputKeyPath)
+			got, err := setupkeys.NewKeySetup(tt.wantTarget, inputKeyPath, tt.keyType)
 			require.NoError(t, err)
 			require.Len(t, got, 2)
 			require.IsType(t, &sshkeygen.SSHKeyGen{}, got[0])
@@ -59,7 +69,7 @@ func TestNewKeySetupDryRun(t *testing.T) {
 			var buf bytes.Buffer
 			require.NoError(t, got.DryRun(&buf))
 
-			wantKeygen := "ssh-keygen -t ed25519 -f " + wantKeyPath + " -C " + tt.wantTarget
+			wantKeygen := "ssh-keygen -t " + tt.keyType + " -f " + wantKeyPath + " -C " + tt.wantTarget
 			wantSSH := "ssh -- " + tt.wantTarget
 			wantCmd := "mkdir -p ~/.ssh && chmod 700 ~/.ssh && cat >> ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys"
 			require.Contains(t, buf.String(), wantKeygen, "DryRun output should include keygen command")
@@ -67,4 +77,9 @@ func TestNewKeySetupDryRun(t *testing.T) {
 			require.Contains(t, buf.String(), wantCmd, "DryRun output should include correct authorized key addition command to be executed on target")
 		})
 	}
+}
+
+func TestNewKeySetupUnsupportedKeyType(t *testing.T) {
+	_, err := setupkeys.NewKeySetup("user@example.com", "/tmp/id_invalid", "ecdsa")
+	require.EqualError(t, err, "unsupported key type: ecdsa")
 }

--- a/internal/setupkeys/setup_keys_test.go
+++ b/internal/setupkeys/setup_keys_test.go
@@ -80,6 +80,6 @@ func TestNewKeySetupDryRun(t *testing.T) {
 }
 
 func TestNewKeySetupUnsupportedKeyType(t *testing.T) {
-	_, err := setupkeys.NewKeySetup("user@example.com", "/tmp/id_invalid", "ecdsa")
+	_, err := setupkeys.ParseKeyType("ecdsa")
 	require.EqualError(t, err, "unsupported key type \"ecdsa\", supported types: ed25519, rsa")
 }


### PR DESCRIPTION
Not all targets support ed25519, but this key type should be the default one for modern systems.
However, we do need to offer support for setting up keys in older systems.

 * Add key-type selection to the setup-keys flow. Allow the user to use RSA as their key type.

