### PR TITLE
Use docker digest to pull, rather than tags.

### DIFF
--- a/internal/deploy/docker/operation/registry_transfer.go
+++ b/internal/deploy/docker/operation/registry_transfer.go
@@ -1,15 +1,19 @@
 package operation
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"os/exec"
+	"regexp"
 	"sort"
 	"strings"
 
 	"github.com/arm/topo/internal/command"
 	"github.com/arm/topo/internal/ssh"
 )
+
+var digestRegexp = regexp.MustCompile(`digest: (sha256:[a-f0-9]+)`)
 
 type RegistryTransfer struct {
 	composeFile string
@@ -70,29 +74,74 @@ func (r *RegistryTransfer) getImagesFromCompose(w io.Writer) ([]string, error) {
 
 func (r *RegistryTransfer) buildTransferCommands(image string) []*exec.Cmd {
 	tag := fmt.Sprintf("localhost:%s/%s", r.port, image)
+	digestRef := fmt.Sprintf("localhost:%s/%s@<digest>", r.port, image)
 	return []*exec.Cmd{
 		command.Docker(r.sourceHost, "tag", image, tag),
 		command.Docker(r.sourceHost, "push", tag),
-		command.Docker(r.targetHost, "pull", tag),
-		command.Docker(r.targetHost, "tag", tag, image), // Restore original image name on target
+		command.Docker(r.targetHost, "pull", digestRef),
+		command.Docker(r.targetHost, "tag", digestRef, image),
 	}
 }
 
 func (r *RegistryTransfer) transferImage(w io.Writer, image string) error {
-	cmds := r.buildTransferCommands(image)
-	for _, cmd := range cmds {
-		cmd.Stdout = w
-		cmd.Stderr = w
-		if err := cmd.Run(); err != nil {
-			if len(cmd.Args) >= 2 && cmd.Args[1] == "push" {
-				if hint := r.checkRegistryPortMismatch(); hint != "" {
-					return fmt.Errorf("%s\n%s", err, hint)
-				}
-			}
-			return fmt.Errorf("failed to execute %s: %w", strings.Join(cmd.Args, " "), err)
+	tag := fmt.Sprintf("localhost:%s/%s", r.port, image)
+
+	tagCmd := command.Docker(r.sourceHost, "tag", image, tag)
+	if err := runCmd(tagCmd, w); err != nil {
+		return err
+	}
+
+	pushCmd := command.Docker(r.sourceHost, "push", tag)
+	pushOutput, err := runCmdCaptureOutput(pushCmd, w)
+	if err != nil {
+		if hint := r.checkRegistryPortMismatch(); hint != "" {
+			return fmt.Errorf("%s\n%s", err, hint)
 		}
+		return fmt.Errorf("failed to execute %s: %w", strings.Join(pushCmd.Args, " "), err)
+	}
+
+	digest, err := ParseDigestFromPushOutput(pushOutput)
+	if err != nil {
+		return fmt.Errorf("failed to parse digest after pushing %s: %w", tag, err)
+	}
+
+	digestRef := fmt.Sprintf("localhost:%s/%s@%s", r.port, image, digest)
+	pullCmd := command.Docker(r.targetHost, "pull", digestRef)
+	if err := runCmd(pullCmd, w); err != nil {
+		return err
+	}
+
+	retagCmd := command.Docker(r.targetHost, "tag", digestRef, image)
+	if err := runCmd(retagCmd, w); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func runCmd(cmd *exec.Cmd, w io.Writer) error {
+	cmd.Stdout = w
+	cmd.Stderr = w
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to execute %s: %w", strings.Join(cmd.Args, " "), err)
 	}
 	return nil
+}
+
+func runCmdCaptureOutput(cmd *exec.Cmd, w io.Writer) (string, error) {
+	var buf bytes.Buffer
+	cmd.Stdout = io.MultiWriter(w, &buf)
+	cmd.Stderr = w
+	err := cmd.Run()
+	return buf.String(), err
+}
+
+func ParseDigestFromPushOutput(output string) (string, error) {
+	match := digestRegexp.FindStringSubmatch(output)
+	if match == nil {
+		return "", fmt.Errorf("no digest found in push output")
+	}
+	return match[1], nil
 }
 
 func (r *RegistryTransfer) checkRegistryPortMismatch() string {

--- a/internal/deploy/docker/operation/registry_transfer_test.go
+++ b/internal/deploy/docker/operation/registry_transfer_test.go
@@ -16,6 +16,45 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestParseDigestFromPushOutput(t *testing.T) {
+	t.Run("parses digest from typical push output", func(t *testing.T) {
+		output := `The push refers to repository [localhost:12737/myimage]
+latest: digest: sha256:a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2 size: 1234`
+
+		got, err := operation.ParseDigestFromPushOutput(output)
+
+		require.NoError(t, err)
+		assert.Equal(t, "sha256:a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2", got)
+	})
+
+	t.Run("parses digest with surrounding output", func(t *testing.T) {
+		output := `Using default tag: latest
+The push refers to repository [localhost:12737/alpine]
+5d3e392a13a0: Layer already exists
+latest: digest: sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890 size: 528`
+
+		got, err := operation.ParseDigestFromPushOutput(output)
+
+		require.NoError(t, err)
+		assert.Equal(t, "sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890", got)
+	})
+
+	t.Run("returns error when no digest found", func(t *testing.T) {
+		output := `The push refers to repository [localhost:12737/myimage]
+latest: size: 1234`
+
+		_, err := operation.ParseDigestFromPushOutput(output)
+
+		assert.EqualError(t, err, "no digest found in push output")
+	})
+
+	t.Run("returns error for empty output", func(t *testing.T) {
+		_, err := operation.ParseDigestFromPushOutput("")
+
+		assert.EqualError(t, err, "no digest found in push output")
+	})
+}
+
 func TestRegistryTransfer(t *testing.T) {
 	t.Run("Description", func(t *testing.T) {
 		t.Run("it returns expected string", func(t *testing.T) {
@@ -52,17 +91,19 @@ services:
 
 			alpineTag := fmt.Sprintf("localhost:%s/alpine:latest", port)
 			nginxTag := fmt.Sprintf("localhost:%s/nginx:latest", port)
+			alpineDigestRef := fmt.Sprintf("localhost:%s/alpine:latest@<digest>", port)
+			nginxDigestRef := fmt.Sprintf("localhost:%s/nginx:latest@<digest>", port)
 
 			expected := strings.TrimSpace(fmt.Sprintf(`
 docker tag alpine:latest %[1]s
 docker push %[1]s
-docker -H ssh://user@remote pull %[1]s
-docker -H ssh://user@remote tag %[1]s alpine:latest
+docker -H ssh://user@remote pull %[3]s
+docker -H ssh://user@remote tag %[3]s alpine:latest
 docker tag nginx:latest %[2]s
 docker push %[2]s
-docker -H ssh://user@remote pull %[2]s
-docker -H ssh://user@remote tag %[2]s nginx:latest
-`, alpineTag, nginxTag)) + "\n"
+docker -H ssh://user@remote pull %[4]s
+docker -H ssh://user@remote tag %[4]s nginx:latest
+`, alpineTag, nginxTag, alpineDigestRef, nginxDigestRef)) + "\n"
 
 			assert.Equal(t, expected, got)
 		})


### PR DESCRIPTION
The docker pull by tag on the remote can fail with "not found" or it can use stale cached content when Docker's tag resolution doesn't match what was just pushed to the registry. 

Pulling by the exact digest that docker push reports means the remote always gets the same image that was pushed - and this is cryptographically validated.


FAQ:
Q: **Why did you forego the r.buildtransfercommands feature? This messes up the dryrun! Dryrun and run have now diverged!**
A: We have decided to get rid of dryrun. I want to fix this bug now so I can continue with my actual ticket. We will later delete dryrun. For now, this leaves the buildTransferCommands so that dryrun almost works- it just has a <digest> placeholder.