### PR TITLE
fix: ensure predictable order or `topo health` output

### DIFF
--- a/internal/collections/collections.go
+++ b/internal/collections/collections.go
@@ -5,6 +5,8 @@ type Group[I any, K comparable] struct {
 	Members []I
 }
 
+// GroupBy partitions items into groups by applying keyFn to each element.
+// Groups are returned in the order their keys first appear in items.
 func GroupBy[I any, K comparable](items []I, keyFn func(I) K) []Group[I, K] {
 	order, groupMap := groupBy(items, keyFn)
 

--- a/internal/collections/collections.go
+++ b/internal/collections/collections.go
@@ -8,7 +8,7 @@ type Group[I any, K comparable] struct {
 // GroupBy partitions items into groups by applying keyFn to each element.
 // Groups are returned in the order their keys first appear in items.
 func GroupBy[I any, K comparable](items []I, keyFn func(I) K) []Group[I, K] {
-	order, groupMap := groupBy(items, keyFn)
+	order, groupMap := groupAndCollectOrderBy(items, keyFn)
 
 	groups := make([]Group[I, K], len(order))
 
@@ -22,7 +22,7 @@ func GroupBy[I any, K comparable](items []I, keyFn func(I) K) []Group[I, K] {
 	return groups
 }
 
-func groupBy[I any, K comparable](slice []I, keyFn func(I) K) ([]K, map[K][]I) {
+func groupAndCollectOrderBy[I any, K comparable](slice []I, keyFn func(I) K) ([]K, map[K][]I) {
 	order := []K{}
 	groups := map[K][]I{}
 

--- a/internal/collections/collections.go
+++ b/internal/collections/collections.go
@@ -1,0 +1,36 @@
+package collections
+
+type Group[I any, K comparable] struct {
+	Key     K
+	Members []I
+}
+
+func GroupBy[I any, K comparable](items []I, keyFn func(I) K) []Group[I, K] {
+	order, groupMap := groupBy(items, keyFn)
+
+	groups := make([]Group[I, K], len(order))
+
+	for i, key := range order {
+		groups[i] = Group[I, K]{
+			Key:     key,
+			Members: groupMap[key],
+		}
+	}
+
+	return groups
+}
+
+func groupBy[I any, K comparable](slice []I, keyFn func(I) K) ([]K, map[K][]I) {
+	order := []K{}
+	groups := map[K][]I{}
+
+	for _, item := range slice {
+		key := keyFn(item)
+		if _, exists := groups[key]; !exists {
+			order = append(order, key)
+		}
+		groups[key] = append(groups[key], item)
+	}
+
+	return order, groups
+}

--- a/internal/collections/collections_test.go
+++ b/internal/collections/collections_test.go
@@ -1,0 +1,55 @@
+package collections_test
+
+import (
+	"testing"
+
+	"github.com/arm/topo/internal/collections"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGroupBy(t *testing.T) {
+	t.Run("groups items by key returned from key function", func(t *testing.T) {
+		type food struct {
+			name  string
+			tasty bool
+		}
+		tastyPizza := food{name: "pizza", tasty: true}
+		tastyBurrito := food{name: "burrito", tasty: true}
+		disgustingVeggies := food{name: "veggies", tasty: false}
+
+		got := collections.GroupBy(
+			[]food{tastyPizza, tastyBurrito, disgustingVeggies},
+			func(f food) bool { return f.tasty },
+		)
+
+		want := []collections.Group[food, bool]{
+			{Key: true, Members: []food{tastyPizza, tastyBurrito}},
+			{Key: false, Members: []food{disgustingVeggies}},
+		}
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("retains order of grouped items", func(t *testing.T) {
+		type vegetable struct {
+			name string
+			kind string
+		}
+		crunchyCarrot := vegetable{kind: "crunchy", name: "carrot"}
+		crunchyBroccoli := vegetable{kind: "crunchy", name: "broccoli"}
+		leafySpinach := vegetable{kind: "leafy", name: "spinach"}
+		leafyKale := vegetable{kind: "leafy", name: "kale"}
+		softTomato := vegetable{kind: "soft", name: "tomato"}
+
+		got := collections.GroupBy(
+			[]vegetable{leafyKale, softTomato, crunchyCarrot, crunchyBroccoli, leafySpinach},
+			func(v vegetable) string { return v.kind },
+		)
+
+		want := []collections.Group[vegetable, string]{
+			{Key: "leafy", Members: []vegetable{leafyKale, leafySpinach}},
+			{Key: "soft", Members: []vegetable{softTomato}},
+			{Key: "crunchy", Members: []vegetable{crunchyCarrot, crunchyBroccoli}},
+		}
+		assert.Equal(t, want, got)
+	})
+}

--- a/internal/health/dependencies.go
+++ b/internal/health/dependencies.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os/exec"
 
+	"github.com/arm/topo/internal/collections"
 	"github.com/arm/topo/internal/ssh"
 )
 
@@ -114,10 +115,9 @@ func BinaryExistsLocally(bin string) error {
 	return nil
 }
 
-func groupByCategory(statuses []DependencyStatus) map[string][]DependencyStatus {
-	grouped := map[string][]DependencyStatus{}
-	for _, status := range statuses {
-		grouped[status.Dependency.Category] = append(grouped[status.Dependency.Category], status)
-	}
-	return grouped
+func groupByCategory(statuses []DependencyStatus) []collections.Group[DependencyStatus, string] {
+	return collections.GroupBy(
+		statuses,
+		func(ds DependencyStatus) string { return ds.Dependency.Category },
+	)
 }

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -37,9 +37,9 @@ type Report struct {
 
 func generateDependencyReport(statuses []DependencyStatus) []HealthCheck {
 	res := []HealthCheck{}
-	for category, deps := range groupByCategory(statuses) {
+	for _, group := range groupByCategory(statuses) {
 		var installedNames, errorMessages []string
-		for _, dep := range deps {
+		for _, dep := range group.Members {
 			if dep.Error == nil {
 				installedNames = append(installedNames, dep.Dependency.Name)
 			} else {
@@ -53,7 +53,7 @@ func generateDependencyReport(statuses []DependencyStatus) []HealthCheck {
 			value = strings.Join(errorMessages, ", ")
 		}
 		res = append(res, HealthCheck{
-			Name:    category,
+			Name:    group.Key,
 			Healthy: len(installedNames) > 0,
 			Value:   value,
 		})


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- Introduce reusable `collections.GroupBy`, which retains the order of grouped items
- Use the above when aggregating health check results
