### PR TITLE
fix(security): upgrade golang to 1.26.1 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/arm/topo
 
-go 1.26.0
+go 1.26.1
 
 require (
 	github.com/compose-spec/compose-go/v2 v2.10.1


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- Fixes a bunch of warnings from `govulncheck` ([detail](https://github.com/arm/topo/actions/runs/22847168607/job/66266362514?pr=82))
