### PR TITLE
feat!: missing remoteproc endpoint is a warning, not an error

### DIFF
--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -14,10 +14,25 @@ const passwordAuthErrorMessage = `note: Topo does not support SSH password-based
 - create your own SSH keys for the target, or
 - run 'topo setup-keys --target %s' to let Topo generate keys and configure passwordless authentication`
 
+type CheckStatus string
+
+func NewCheckStatusFromError(err error) CheckStatus {
+	if err != nil {
+		return CheckStatusError
+	}
+	return CheckStatusOK
+}
+
+const (
+	CheckStatusOK      CheckStatus = "ok"
+	CheckStatusWarning CheckStatus = "warning"
+	CheckStatusError   CheckStatus = "error"
+)
+
 type HealthCheck struct {
-	Name    string `json:"name"`
-	Healthy bool   `json:"healthy"`
-	Value   string `json:"value"`
+	Name   string      `json:"name"`
+	Status CheckStatus `json:"status"`
+	Value  string      `json:"value"`
 }
 type HostReport struct {
 	Dependencies []HealthCheck `json:"dependencies"`
@@ -38,6 +53,8 @@ type Report struct {
 func generateDependencyReport(statuses []DependencyStatus) []HealthCheck {
 	res := []HealthCheck{}
 	for _, group := range groupByCategory(statuses) {
+		hc := HealthCheck{Name: group.Key}
+
 		var installedNames, errorMessages []string
 		for _, dep := range group.Members {
 			if dep.Error == nil {
@@ -46,17 +63,16 @@ func generateDependencyReport(statuses []DependencyStatus) []HealthCheck {
 				errorMessages = append(errorMessages, dep.Error.Error())
 			}
 		}
-		var value string
+
 		if len(installedNames) > 0 {
-			value = strings.Join(installedNames, ", ")
+			hc.Value = strings.Join(installedNames, ", ")
+			hc.Status = CheckStatusOK
 		} else {
-			value = strings.Join(errorMessages, ", ")
+			hc.Value = strings.Join(errorMessages, ", ")
+			hc.Status = CheckStatusError
 		}
-		res = append(res, HealthCheck{
-			Name:    group.Key,
-			Healthy: len(installedNames) > 0,
-			Value:   value,
-		})
+
+		res = append(res, hc)
 	}
 	return res
 }
@@ -72,9 +88,9 @@ func generateTargetReport(targetStatus Status) TargetReport {
 	report := TargetReport{}
 	report.IsLocalhost = targetStatus.SSHTarget.IsPlainLocalhost()
 	report.Connectivity = HealthCheck{
-		Name:    "Connected",
-		Healthy: targetStatus.ConnectionError == nil,
-		Value:   "",
+		Name:   "Connected",
+		Status: NewCheckStatusFromError(targetStatus.ConnectionError),
+		Value:  "",
 	}
 
 	report.SubsystemDriver.Name = "Subsystem Driver (remoteproc)"
@@ -84,10 +100,10 @@ func generateTargetReport(targetStatus Status) TargetReport {
 		for i, remoteProc := range remoteCPUs {
 			names[i] = remoteProc.Name
 		}
-		report.SubsystemDriver.Healthy = true
+		report.SubsystemDriver.Status = CheckStatusOK
 		report.SubsystemDriver.Value = strings.Join(names, ", ")
 	} else {
-		report.SubsystemDriver.Healthy = false
+		report.SubsystemDriver.Status = CheckStatusWarning
 		report.SubsystemDriver.Value = "no remoteproc devices found"
 	}
 

--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -19,14 +19,14 @@ func TestGenerateReport(t *testing.T) {
 		got := health.GenerateReport(dependencyStatuses, health.Status{})
 
 		want := health.HealthCheck{
-			Name:    "Baz",
-			Healthy: true,
-			Value:   "foo, bar",
+			Name:   "Baz",
+			Status: health.CheckStatusOK,
+			Value:  "foo, bar",
 		}
 		assert.Contains(t, got.Host.Dependencies, want)
 	})
 
-	t.Run("when a dependency is not installed, the health check is unhealthy", func(t *testing.T) {
+	t.Run("when a dependency is not installed, health check reports error", func(t *testing.T) {
 		dependencyStatuses := []health.DependencyStatus{
 			{
 				Dependency: health.Dependency{Name: "whatever", Category: "Rube Golberg"},
@@ -38,20 +38,20 @@ func TestGenerateReport(t *testing.T) {
 
 		assert.Len(t, got.Host.Dependencies, 1)
 		assert.Equal(t, "Rube Golberg", got.Host.Dependencies[0].Name)
-		assert.False(t, got.Host.Dependencies[0].Healthy)
+		assert.Equal(t, health.CheckStatusError, got.Host.Dependencies[0].Status)
 		assert.Equal(t, "whatever not found on path", got.Host.Dependencies[0].Value)
 	})
 
-	t.Run("when no remoteproc devices are found, SubsystemDriver is unhealthy with an error message", func(t *testing.T) {
+	t.Run("when no remoteproc devices are found, SubsystemDriver health check reports error", func(t *testing.T) {
 		ts := health.Status{}
 
 		got := health.GenerateReport(nil, ts)
 
-		assert.False(t, got.Target.SubsystemDriver.Healthy)
+		assert.Equal(t, health.CheckStatusWarning, got.Target.SubsystemDriver.Status)
 		assert.Equal(t, "no remoteproc devices found", got.Target.SubsystemDriver.Value)
 	})
 
-	t.Run("when remoteproc devices are found, SubsystemDriver is healthy with device names", func(t *testing.T) {
+	t.Run("when remoteproc devices are found, SubsystemDriver status is ok and includes device names", func(t *testing.T) {
 		ts := health.Status{
 			Hardware: health.HardwareProfile{
 				RemoteCPU: []target.RemoteprocCPU{{Name: "m4_0"}, {Name: "m4_1"}},
@@ -60,24 +60,35 @@ func TestGenerateReport(t *testing.T) {
 
 		got := health.GenerateReport(nil, ts)
 
-		assert.True(t, got.Target.SubsystemDriver.Healthy)
+		assert.Equal(t, health.CheckStatusOK, got.Target.SubsystemDriver.Status)
 		assert.Equal(t, "m4_0, m4_1", got.Target.SubsystemDriver.Value)
 	})
 
-	t.Run("when the target has a connection error, Connectivity is unhealthy", func(t *testing.T) {
+	t.Run("when no remoteproc devices are found, SubsystemDriver status reports a warning", func(t *testing.T) {
+		ts := health.Status{
+			Hardware: health.HardwareProfile{RemoteCPU: nil},
+		}
+
+		got := health.GenerateReport(nil, ts)
+
+		assert.Equal(t, health.CheckStatusWarning, got.Target.SubsystemDriver.Status)
+		assert.Equal(t, "no remoteproc devices found", got.Target.SubsystemDriver.Value)
+	})
+
+	t.Run("when the target has a connection error, Connectivity status reports error", func(t *testing.T) {
 		ts := health.Status{ConnectionError: assert.AnError}
 
 		got := health.GenerateReport(nil, ts)
 
-		assert.False(t, got.Target.Connectivity.Healthy)
+		assert.Equal(t, health.CheckStatusError, got.Target.Connectivity.Status)
 	})
 
-	t.Run("when the target has no connection error, the Connectivity is healthy", func(t *testing.T) {
+	t.Run("when the target has no connection error, Connectivity status is ok", func(t *testing.T) {
 		ts := health.Status{}
 
 		got := health.GenerateReport(nil, ts)
 
-		assert.True(t, got.Target.Connectivity.Healthy)
+		assert.Equal(t, health.CheckStatusOK, got.Target.Connectivity.Status)
 	})
 
 	t.Run("target dependencies are listed", func(t *testing.T) {
@@ -98,7 +109,7 @@ func TestGenerateReport(t *testing.T) {
 		got := health.GenerateReport(nil, ts)
 
 		want := []health.HealthCheck{
-			{Name: "bar", Healthy: true, Value: "foo"},
+			{Name: "bar", Status: health.CheckStatusOK, Value: "foo"},
 		}
 		assert.Equal(t, want, got.Target.Dependencies)
 	})

--- a/internal/output/templates/health.go
+++ b/internal/output/templates/health.go
@@ -13,7 +13,7 @@ type PrintableHealthReport health.Report
 
 const healthCheckTemplate = `
 {{- define "checkRow" -}}
-  {{ .Name }}:{{- if .Healthy }} ✅{{- else }} ❌{{- end }}{{- if .Value }} ({{ .Value }}){{- end }}
+  {{ .Name }}:{{ statusIcon .Status }}{{- if .Value }} ({{ .Value }}){{- end }}
 {{- end -}}
 Host
 ----
@@ -26,7 +26,7 @@ Target
 {{- if not .Target.IsLocalhost }}
 {{ template "checkRow" .Target.Connectivity }}
 {{- end }}
-{{- if or .Target.IsLocalhost .Target.Connectivity.Healthy }}
+{{- if or .Target.IsLocalhost (isOK .Target.Connectivity.Status) }}
 {{- range $targetCheckRow := .Target.Dependencies }}
 {{ template "checkRow" $targetCheckRow }}
 {{- end }}
@@ -36,6 +36,19 @@ Target
 
 func (r PrintableHealthReport) AsPlain(isTTY bool) (string, error) {
 	funcMap := getFuncMap(isTTY)
+	funcMap["statusIcon"] = func(s health.CheckStatus) string {
+		switch s {
+		case health.CheckStatusOK:
+			return " ✅"
+		case health.CheckStatusWarning:
+			return " ⚠️"
+		default:
+			return " ❌"
+		}
+	}
+	funcMap["isOK"] = func(s health.CheckStatus) bool {
+		return s == health.CheckStatusOK
+	}
 	tmpl, err := template.
 		New("healthcheck").
 		Funcs(funcMap).

--- a/internal/output/templates/health_test.go
+++ b/internal/output/templates/health_test.go
@@ -14,13 +14,13 @@ import (
 
 func TestPrintHealthReport(t *testing.T) {
 	t.Run("PlainFormat", func(t *testing.T) {
-		t.Run("it renders the host dependencies", func(t *testing.T) {
+		t.Run("it renders the healthy host dependencies", func(t *testing.T) {
 			report := health.Report{
 				Host: health.HostReport{
 					Dependencies: []health.HealthCheck{
 						{
-							Name:    "Flux Capacitor",
-							Healthy: true,
+							Name:   "Flux Capacitor",
+							Status: health.CheckStatusOK,
 						},
 					},
 				},
@@ -39,14 +39,14 @@ func TestPrintHealthReport(t *testing.T) {
 			assert.Contains(t, out.String(), "✅")
 		})
 
-		t.Run("it renders the error detail for unhealthy dependencies", func(t *testing.T) {
+		t.Run("it renders the details when dependencies fail the health check", func(t *testing.T) {
 			report := health.Report{
 				Host: health.HostReport{
 					Dependencies: []health.HealthCheck{
 						{
-							Name:    "Container Engine",
-							Healthy: false,
-							Value:   "docker not found on path",
+							Name:   "Container Engine",
+							Status: health.CheckStatusError,
+							Value:  "docker not found on path",
 						},
 					},
 				},
@@ -66,12 +66,40 @@ func TestPrintHealthReport(t *testing.T) {
 			assert.Contains(t, out.String(), "docker not found on path")
 		})
 
+		t.Run("it renders a warning icon for warning checks", func(t *testing.T) {
+			report := health.Report{
+				Target: health.TargetReport{
+					Connectivity: health.HealthCheck{
+						Name:   "Connected",
+						Status: health.CheckStatusOK,
+					},
+					SubsystemDriver: health.HealthCheck{
+						Name:   "Subsystem Driver (remoteproc)",
+						Status: health.CheckStatusWarning,
+						Value:  "no remoteproc devices found",
+					},
+				},
+			}
+
+			var out bytes.Buffer
+
+			err := printable.Print(
+				templates.PrintableHealthReport(report),
+				&out,
+				term.Plain,
+			)
+			require.NoError(t, err)
+
+			assert.Contains(t, out.String(), "⚠️")
+			assert.Contains(t, out.String(), "no remoteproc devices found")
+		})
+
 		t.Run("it renders connection failures", func(t *testing.T) {
 			report := health.Report{
 				Target: health.TargetReport{
 					Connectivity: health.HealthCheck{
-						Name:    "Connected",
-						Healthy: false,
+						Name:   "Connected",
+						Status: health.CheckStatusError,
 					},
 				},
 			}
@@ -93,8 +121,8 @@ func TestPrintHealthReport(t *testing.T) {
 			report := health.Report{
 				Target: health.TargetReport{
 					Connectivity: health.HealthCheck{
-						Name:    "Connected",
-						Healthy: false,
+						Name:   "Connected",
+						Status: health.CheckStatusError,
 					},
 				},
 			}
@@ -118,15 +146,18 @@ func TestPrintHealthReport(t *testing.T) {
 				Host: health.HostReport{
 					Dependencies: []health.HealthCheck{
 						{
-							Name:    "Flux Capacitor",
-							Healthy: true,
+							Name:   "Flux Capacitor",
+							Status: health.CheckStatusOK,
 						},
 					},
 				},
 				Target: health.TargetReport{
 					Connectivity: health.HealthCheck{
-						Name:    "Connected",
-						Healthy: true,
+						Name:   "Connected",
+						Status: health.CheckStatusOK,
+					},
+					SubsystemDriver: health.HealthCheck{
+						Status: health.CheckStatusWarning,
 					},
 				},
 			}
@@ -143,14 +174,14 @@ func TestPrintHealthReport(t *testing.T) {
 			want := `{
 				"host": {
 					"dependencies": [
-						{"name":"Flux Capacitor","healthy":true,"value":""}
+						{"name":"Flux Capacitor","status":"ok","value":""}
 					]
 				},
 				"target": {
 					"isLocalhost": false,
-					"connectivity": {"name":"Connected","healthy":true,"value":""},
+					"connectivity": {"name":"Connected","status":"ok","value":""},
 					"dependencies": [],
-					"subsystemDriver": {"name":"","healthy":false,"value":""}
+					"subsystemDriver": {"name":"","status":"warning","value":""}
 				}
 			}`
 


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- Introduce enum to represent health check status in place of boolean healthy/unhealthy
- When no remoteproc devices are found on the target, it's a warning not an error
- ⚠️ This is a breaking change for consumers of `health --output=json`, as the field is no longer boolean but a string

<img width="474" height="175" alt="Screenshot 2026-03-09 at 15 19 09" src="https://github.com/user-attachments/assets/062c2356-7153-4644-ba79-d261252d16d2" />

