### PR TITLE
feat: support --target for template compatibility markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,11 @@ topo templates --target-description target-description.yaml
 ```
 
 This lists available templates and indicates compatibility with your target hardware.
+If you don't already have a target description file for your board, you can still use:
+
+```sh
+topo templates --target my-board
+```
 
 ### 4. Clone a template into a new project
 

--- a/cmd/topo/templates.go
+++ b/cmd/topo/templates.go
@@ -34,6 +34,16 @@ var templatesCmd = &cobra.Command{
 			if err != nil {
 				return err
 			}
+		} else {
+			resolvedTarget, exists := lookupTarget(cmd)
+			if exists {
+				conn := target.NewConnection(resolvedTarget, target.ConnectionOptions{Multiplex: true})
+				hwProfile, err := describe.GenerateTargetDescription(conn)
+				if err != nil {
+					return err
+				}
+				profile = &hwProfile
+			}
 		}
 
 		reposWithCompatibility := catalog.AnnotateCompatibility(profile, repos)
@@ -42,11 +52,13 @@ var templatesCmd = &cobra.Command{
 }
 
 func init() {
+	addTargetFlag(templatesCmd)
 	templatesCmd.Flags().StringVar(
 		&targetDescriptionPath,
 		"target-description",
 		"",
 		"Path to the target description file used to show template compatibility",
 	)
+	templatesCmd.MarkFlagsMutuallyExclusive("target", "target-description")
 	rootCmd.AddCommand(templatesCmd)
 }

--- a/e2e/templates_test.go
+++ b/e2e/templates_test.go
@@ -1,0 +1,54 @@
+package e2e
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/arm/topo/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTemplatesTargetDescription(t *testing.T) {
+	t.Run("matches templates to target description", func(t *testing.T) {
+		bin := buildBinary(t)
+
+		targetDescriptionYAML := `host:
+  - model: Cortex-A
+    cores: 4
+    features:
+      - asimd
+totalmemory_kb: 4194304
+`
+		targetDescriptionPath := writeTargetDescription(t, targetDescriptionYAML)
+
+		cmd := exec.Command(bin, "templates", "--target-description", targetDescriptionPath)
+		out, err := cmd.CombinedOutput()
+		output := string(out)
+
+		require.NoError(t, err, output)
+		assert.Contains(t, output, "✅ Hello-World")
+		assert.Contains(t, output, "❌ Lightbulb-moment")
+	})
+	t.Run("correctly handles the --target flag when no target description is provided", func(t *testing.T) {
+		bin := buildBinary(t)
+		target := testutil.StartTargetContainer(t)
+
+		cmd := exec.Command(bin, "templates", "--target", target.SSHDestination)
+		out, err := cmd.CombinedOutput()
+		output := string(out)
+
+		require.NoError(t, err, output)
+		assert.Contains(t, output, "✅ Hello-World")
+	})
+}
+
+func writeTargetDescription(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "target-description.yaml")
+
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+	return path
+}


### PR DESCRIPTION
## Changes

Use `--target` on topo templates to generate a target description on the fly and annotate compatibility markers without requiring `--target-description`.
Keep --target-description behavior unchanged, make the flags mutually exclusive.
