### PR TITLE
refactor: use custom marshaller to ensure non-null slices in json

### DIFF
--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -1,6 +1,7 @@
 package health
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -39,11 +40,27 @@ type HostReport struct {
 	Dependencies []HealthCheck `json:"dependencies"`
 }
 
+func (r HostReport) MarshalJSON() ([]byte, error) {
+	type Alias HostReport
+	if r.Dependencies == nil {
+		r.Dependencies = []HealthCheck{}
+	}
+	return json.Marshal(Alias(r))
+}
+
 type TargetReport struct {
 	IsLocalhost     bool          `json:"isLocalhost"`
 	Connectivity    HealthCheck   `json:"connectivity"`
 	Dependencies    []HealthCheck `json:"dependencies"`
 	SubsystemDriver HealthCheck   `json:"subsystemDriver"`
+}
+
+func (r TargetReport) MarshalJSON() ([]byte, error) {
+	type Alias TargetReport
+	if r.Dependencies == nil {
+		r.Dependencies = []HealthCheck{}
+	}
+	return json.Marshal(Alias(r))
 }
 
 func CheckHost() HostReport {

--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -1,12 +1,14 @@
 package health_test
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 
 	"github.com/arm/topo/internal/health"
 	"github.com/arm/topo/internal/target"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGenerateHostReport(t *testing.T) {
@@ -67,6 +69,35 @@ func TestGenerateTargetReport(t *testing.T) {
 		got := health.GenerateTargetReport(ts)
 
 		assert.Equal(t, health.CheckStatusOK, got.Connectivity.Status)
+	})
+}
+
+func TestHostReport(t *testing.T) {
+	t.Run("MarshalJSON", func(t *testing.T) {
+		t.Run("nil dependencies are [] not null", func(t *testing.T) {
+			tr := health.HostReport{Dependencies: nil}
+
+			b, err := json.Marshal(tr)
+
+			require.NoError(t, err)
+			want := `{ "dependencies": [] }`
+			assert.JSONEq(t, want, string(b))
+		})
+	})
+}
+
+func TestTargetReport(t *testing.T) {
+	t.Run("MarshalJSON", func(t *testing.T) {
+		t.Run("nil dependencies are [] not null", func(t *testing.T) {
+			tr := health.TargetReport{Dependencies: nil}
+
+			b, err := json.Marshal(tr)
+
+			require.NoError(t, err)
+			var result map[string]json.RawMessage
+			require.NoError(t, json.Unmarshal(b, &result))
+			assert.JSONEq(t, `[]`, string(result["dependencies"]))
+		})
 	})
 }
 

--- a/internal/output/templates/health.go
+++ b/internal/output/templates/health.go
@@ -73,13 +73,6 @@ func (r PrintableHealthReport) AsPlain(isTTY bool) (string, error) {
 }
 
 func (r PrintableHealthReport) AsJSON() (string, error) {
-	if r.Host.Dependencies == nil {
-		r.Host.Dependencies = []health.HealthCheck{}
-	}
-	if r.Target.Dependencies == nil {
-		r.Target.Dependencies = []health.HealthCheck{}
-	}
-
 	b, err := json.MarshalIndent(r, "", "  ")
 	if err != nil {
 		return "", fmt.Errorf("encode report as json: %w", err)


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- Replaces _hacky_ way of ensuring absence of `null` in json for `nil` slice values with custom marshaller
