### PR TITLE
refactor: decouple host and target reporting

### DIFF
--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -34,6 +34,7 @@ type HealthCheck struct {
 	Status CheckStatus `json:"status"`
 	Value  string      `json:"value"`
 }
+
 type HostReport struct {
 	Dependencies []HealthCheck `json:"dependencies"`
 }

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -51,31 +51,33 @@ type Report struct {
 	Target TargetReport `json:"target"`
 }
 
-func generateDependencyReport(statuses []DependencyStatus) []HealthCheck {
-	res := []HealthCheck{}
-	for _, group := range groupByCategory(statuses) {
-		hc := HealthCheck{Name: group.Key}
+func GenerateReport(hostDependencies []DependencyStatus, targetStatus Status) Report {
+	report := Report{}
+	report.Host = generateHostReport(hostDependencies)
+	report.Target = generateTargetReport(targetStatus)
 
-		var installedNames, errorMessages []string
-		for _, dep := range group.Members {
-			if dep.Error == nil {
-				installedNames = append(installedNames, dep.Dependency.Name)
-			} else {
-				errorMessages = append(errorMessages, dep.Error.Error())
-			}
-		}
+	return report
+}
 
-		if len(installedNames) > 0 {
-			hc.Value = strings.Join(installedNames, ", ")
-			hc.Status = CheckStatusOK
-		} else {
-			hc.Value = strings.Join(errorMessages, ", ")
-			hc.Status = CheckStatusError
-		}
-
-		res = append(res, hc)
+func Check(sshTarget string, acceptNewHostKeys bool) (Report, error) {
+	dependencyStatuses := CheckInstalled(HostRequiredDependencies, BinaryExistsLocally)
+	opts := target.ConnectionOptions{
+		AcceptNewHostKeys: acceptNewHostKeys,
+		AuthProbeInput:    os.Stdin,
+		AuthProbeOutput:   os.Stdout,
+		Multiplex:         true,
+		WithLoginShell:    true,
 	}
-	return res
+	conn := target.NewConnection(sshTarget, opts)
+	targetStatus := ProbeHealthStatus(conn)
+	report := GenerateReport(dependencyStatuses, targetStatus)
+	if err := targetStatus.ConnectionError; err != nil {
+		if errors.Is(err, target.ErrPasswordAuthentication) {
+			return report, fmt.Errorf(passwordAuthErrorMessage, sshTarget)
+		}
+		return report, nil
+	}
+	return report, nil
 }
 
 func generateHostReport(statuses []DependencyStatus) HostReport {
@@ -113,31 +115,29 @@ func generateTargetReport(targetStatus Status) TargetReport {
 	return report
 }
 
-func GenerateReport(hostDependencies []DependencyStatus, targetStatus Status) Report {
-	report := Report{}
-	report.Host = generateHostReport(hostDependencies)
-	report.Target = generateTargetReport(targetStatus)
+func generateDependencyReport(statuses []DependencyStatus) []HealthCheck {
+	res := []HealthCheck{}
+	for _, group := range groupByCategory(statuses) {
+		hc := HealthCheck{Name: group.Key}
 
-	return report
-}
-
-func Check(sshTarget string, acceptNewHostKeys bool) (Report, error) {
-	dependencyStatuses := CheckInstalled(HostRequiredDependencies, BinaryExistsLocally)
-	opts := target.ConnectionOptions{
-		AcceptNewHostKeys: acceptNewHostKeys,
-		AuthProbeInput:    os.Stdin,
-		AuthProbeOutput:   os.Stdout,
-		Multiplex:         true,
-		WithLoginShell:    true,
-	}
-	conn := target.NewConnection(sshTarget, opts)
-	targetStatus := ProbeHealthStatus(conn)
-	report := GenerateReport(dependencyStatuses, targetStatus)
-	if err := targetStatus.ConnectionError; err != nil {
-		if errors.Is(err, target.ErrPasswordAuthentication) {
-			return report, fmt.Errorf(passwordAuthErrorMessage, sshTarget)
+		var installedNames, errorMessages []string
+		for _, dep := range group.Members {
+			if dep.Error == nil {
+				installedNames = append(installedNames, dep.Dependency.Name)
+			} else {
+				errorMessages = append(errorMessages, dep.Error.Error())
+			}
 		}
-		return report, nil
+
+		if len(installedNames) > 0 {
+			hc.Value = strings.Join(installedNames, ", ")
+			hc.Status = CheckStatusOK
+		} else {
+			hc.Value = strings.Join(errorMessages, ", ")
+			hc.Status = CheckStatusError
+		}
+
+		res = append(res, hc)
 	}
-	return report, nil
+	return res
 }

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -54,7 +54,7 @@ type Report struct {
 func Check(sshTarget string, acceptNewHostKeys bool) (Report, error) {
 	targetReport, err := CheckTarget(sshTarget, acceptNewHostKeys)
 	if err != nil {
-		return Report{}, nil
+		return Report{}, err
 	}
 	return Report{
 		Host:   CheckHost(),

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -83,14 +83,6 @@ func CheckTarget(sshTarget string, acceptNewHostKeys bool) (TargetReport, error)
 	return GenerateTargetReport(targetStatus), nil
 }
 
-func GenerateReport(hostDependencies []DependencyStatus, targetStatus Status) Report {
-	report := Report{}
-	report.Host = GenerateHostReport(hostDependencies)
-	report.Target = GenerateTargetReport(targetStatus)
-
-	return report
-}
-
 func GenerateHostReport(statuses []DependencyStatus) HostReport {
 	report := HostReport{}
 	report.Dependencies = generateDependencyReport(statuses)

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -52,7 +52,22 @@ type Report struct {
 }
 
 func Check(sshTarget string, acceptNewHostKeys bool) (Report, error) {
+	targetReport, err := CheckTarget(sshTarget, acceptNewHostKeys)
+	if err != nil {
+		return Report{}, nil
+	}
+	return Report{
+		Host:   CheckHost(),
+		Target: targetReport,
+	}, nil
+}
+
+func CheckHost() HostReport {
 	dependencyStatuses := CheckInstalled(HostRequiredDependencies, BinaryExistsLocally)
+	return GenerateHostReport(dependencyStatuses)
+}
+
+func CheckTarget(sshTarget string, acceptNewHostKeys bool) (TargetReport, error) {
 	opts := target.ConnectionOptions{
 		AcceptNewHostKeys: acceptNewHostKeys,
 		AuthProbeInput:    os.Stdin,
@@ -62,32 +77,28 @@ func Check(sshTarget string, acceptNewHostKeys bool) (Report, error) {
 	}
 	conn := target.NewConnection(sshTarget, opts)
 	targetStatus := ProbeHealthStatus(conn)
-	report := GenerateReport(dependencyStatuses, targetStatus)
-	if err := targetStatus.ConnectionError; err != nil {
-		if errors.Is(err, target.ErrPasswordAuthentication) {
-			return report, fmt.Errorf(passwordAuthErrorMessage, sshTarget)
-		}
-		return report, nil
+	if errors.Is(targetStatus.ConnectionError, target.ErrPasswordAuthentication) {
+		return TargetReport{}, fmt.Errorf(passwordAuthErrorMessage, sshTarget)
 	}
-	return report, nil
+	return GenerateTargetReport(targetStatus), nil
 }
 
 func GenerateReport(hostDependencies []DependencyStatus, targetStatus Status) Report {
 	report := Report{}
-	report.Host = generateHostReport(hostDependencies)
-	report.Target = generateTargetReport(targetStatus)
+	report.Host = GenerateHostReport(hostDependencies)
+	report.Target = GenerateTargetReport(targetStatus)
 
 	return report
 }
 
-func generateHostReport(statuses []DependencyStatus) HostReport {
+func GenerateHostReport(statuses []DependencyStatus) HostReport {
 	report := HostReport{}
 	report.Dependencies = generateDependencyReport(statuses)
 
 	return report
 }
 
-func generateTargetReport(targetStatus Status) TargetReport {
+func GenerateTargetReport(targetStatus Status) TargetReport {
 	report := TargetReport{}
 	report.IsLocalhost = targetStatus.SSHTarget.IsPlainLocalhost()
 	report.Connectivity = HealthCheck{

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -51,14 +51,6 @@ type Report struct {
 	Target TargetReport `json:"target"`
 }
 
-func GenerateReport(hostDependencies []DependencyStatus, targetStatus Status) Report {
-	report := Report{}
-	report.Host = generateHostReport(hostDependencies)
-	report.Target = generateTargetReport(targetStatus)
-
-	return report
-}
-
 func Check(sshTarget string, acceptNewHostKeys bool) (Report, error) {
 	dependencyStatuses := CheckInstalled(HostRequiredDependencies, BinaryExistsLocally)
 	opts := target.ConnectionOptions{
@@ -78,6 +70,14 @@ func Check(sshTarget string, acceptNewHostKeys bool) (Report, error) {
 		return report, nil
 	}
 	return report, nil
+}
+
+func GenerateReport(hostDependencies []DependencyStatus, targetStatus Status) Report {
+	report := Report{}
+	report.Host = generateHostReport(hostDependencies)
+	report.Target = generateTargetReport(targetStatus)
+
+	return report
 }
 
 func generateHostReport(statuses []DependencyStatus) HostReport {

--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -10,40 +10,16 @@ import (
 )
 
 func TestGenerateHostReport(t *testing.T) {
-	t.Run("given two host dependencies in the same category, they are grouped in a health check", func(t *testing.T) {
-		dependencyStatuses := []health.DependencyStatus{
-			{Dependency: health.Dependency{Name: "foo", Category: "Baz"}, Error: nil},
-			{Dependency: health.Dependency{Name: "bar", Category: "Baz"}, Error: nil},
-		}
-
-		got := health.GenerateHostReport(dependencyStatuses)
-
-		want := health.HealthCheck{
-			Name:   "Baz",
-			Status: health.CheckStatusOK,
-			Value:  "foo, bar",
-		}
-		assert.Contains(t, got.Dependencies, want)
-	})
-
-	t.Run("when a dependency is not installed, health check reports error", func(t *testing.T) {
-		dependencyStatuses := []health.DependencyStatus{
-			{
-				Dependency: health.Dependency{Name: "whatever", Category: "Rube Golberg"},
-				Error:      fmt.Errorf("whatever not found on path"),
-			},
-		}
-
-		got := health.GenerateHostReport(dependencyStatuses)
-
-		assert.Len(t, got.Dependencies, 1)
-		assert.Equal(t, "Rube Golberg", got.Dependencies[0].Name)
-		assert.Equal(t, health.CheckStatusError, got.Dependencies[0].Status)
-		assert.Equal(t, "whatever not found on path", got.Dependencies[0].Value)
+	testDependencyReporting(t, func(statuses []health.DependencyStatus) []health.HealthCheck {
+		return health.GenerateHostReport(statuses).Dependencies
 	})
 }
 
 func TestGenerateTargetReport(t *testing.T) {
+	testDependencyReporting(t, func(statuses []health.DependencyStatus) []health.HealthCheck {
+		return health.GenerateTargetReport(health.Status{Dependencies: statuses}).Dependencies
+	})
+
 	t.Run("when no remoteproc devices are found, SubsystemDriver health check reports error", func(t *testing.T) {
 		ts := health.Status{}
 
@@ -92,27 +68,31 @@ func TestGenerateTargetReport(t *testing.T) {
 
 		assert.Equal(t, health.CheckStatusOK, got.Connectivity.Status)
 	})
+}
 
-	t.Run("target dependencies are listed", func(t *testing.T) {
-		foo := health.Dependency{
-			Name:     "foo",
-			Category: "bar",
-		}
-		ts := health.Status{
-			ConnectionError: nil,
-			Dependencies: []health.DependencyStatus{
-				{
-					Dependency: foo,
-					Error:      nil,
-				},
-			},
+func testDependencyReporting(t *testing.T, extract func([]health.DependencyStatus) []health.HealthCheck) {
+	t.Helper()
+
+	t.Run("given two dependencies in the same category, they are grouped in a health check", func(t *testing.T) {
+		statuses := []health.DependencyStatus{
+			{Dependency: health.Dependency{Name: "foo", Category: "Baz"}, Error: nil},
+			{Dependency: health.Dependency{Name: "bar", Category: "Baz"}, Error: nil},
 		}
 
-		got := health.GenerateTargetReport(ts)
+		got := extract(statuses)
 
-		want := []health.HealthCheck{
-			{Name: "bar", Status: health.CheckStatusOK, Value: "foo"},
+		assert.Contains(t, got, health.HealthCheck{Name: "Baz", Status: health.CheckStatusOK, Value: "foo, bar"})
+	})
+
+	t.Run("when a dependency is not installed, health check reports error", func(t *testing.T) {
+		statuses := []health.DependencyStatus{
+			{Dependency: health.Dependency{Name: "whatever", Category: "Rube Goldberg"}, Error: fmt.Errorf("whatever not found on path")},
 		}
-		assert.Equal(t, want, got.Dependencies)
+
+		got := extract(statuses)
+
+		assert.Equal(t, []health.HealthCheck{
+			{Name: "Rube Goldberg", Status: health.CheckStatusError, Value: "whatever not found on path"},
+		}, got)
 	})
 }

--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -9,21 +9,21 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGenerateReport(t *testing.T) {
+func TestGenerateHostReport(t *testing.T) {
 	t.Run("given two host dependencies in the same category, they are grouped in a health check", func(t *testing.T) {
 		dependencyStatuses := []health.DependencyStatus{
 			{Dependency: health.Dependency{Name: "foo", Category: "Baz"}, Error: nil},
 			{Dependency: health.Dependency{Name: "bar", Category: "Baz"}, Error: nil},
 		}
 
-		got := health.GenerateReport(dependencyStatuses, health.Status{})
+		got := health.GenerateHostReport(dependencyStatuses)
 
 		want := health.HealthCheck{
 			Name:   "Baz",
 			Status: health.CheckStatusOK,
 			Value:  "foo, bar",
 		}
-		assert.Contains(t, got.Host.Dependencies, want)
+		assert.Contains(t, got.Dependencies, want)
 	})
 
 	t.Run("when a dependency is not installed, health check reports error", func(t *testing.T) {
@@ -34,21 +34,23 @@ func TestGenerateReport(t *testing.T) {
 			},
 		}
 
-		got := health.GenerateReport(dependencyStatuses, health.Status{})
+		got := health.GenerateHostReport(dependencyStatuses)
 
-		assert.Len(t, got.Host.Dependencies, 1)
-		assert.Equal(t, "Rube Golberg", got.Host.Dependencies[0].Name)
-		assert.Equal(t, health.CheckStatusError, got.Host.Dependencies[0].Status)
-		assert.Equal(t, "whatever not found on path", got.Host.Dependencies[0].Value)
+		assert.Len(t, got.Dependencies, 1)
+		assert.Equal(t, "Rube Golberg", got.Dependencies[0].Name)
+		assert.Equal(t, health.CheckStatusError, got.Dependencies[0].Status)
+		assert.Equal(t, "whatever not found on path", got.Dependencies[0].Value)
 	})
+}
 
+func TestGenerateTargetReport(t *testing.T) {
 	t.Run("when no remoteproc devices are found, SubsystemDriver health check reports error", func(t *testing.T) {
 		ts := health.Status{}
 
-		got := health.GenerateReport(nil, ts)
+		got := health.GenerateTargetReport(ts)
 
-		assert.Equal(t, health.CheckStatusWarning, got.Target.SubsystemDriver.Status)
-		assert.Equal(t, "no remoteproc devices found", got.Target.SubsystemDriver.Value)
+		assert.Equal(t, health.CheckStatusWarning, got.SubsystemDriver.Status)
+		assert.Equal(t, "no remoteproc devices found", got.SubsystemDriver.Value)
 	})
 
 	t.Run("when remoteproc devices are found, SubsystemDriver status is ok and includes device names", func(t *testing.T) {
@@ -58,10 +60,10 @@ func TestGenerateReport(t *testing.T) {
 			},
 		}
 
-		got := health.GenerateReport(nil, ts)
+		got := health.GenerateTargetReport(ts)
 
-		assert.Equal(t, health.CheckStatusOK, got.Target.SubsystemDriver.Status)
-		assert.Equal(t, "m4_0, m4_1", got.Target.SubsystemDriver.Value)
+		assert.Equal(t, health.CheckStatusOK, got.SubsystemDriver.Status)
+		assert.Equal(t, "m4_0, m4_1", got.SubsystemDriver.Value)
 	})
 
 	t.Run("when no remoteproc devices are found, SubsystemDriver status reports a warning", func(t *testing.T) {
@@ -69,26 +71,26 @@ func TestGenerateReport(t *testing.T) {
 			Hardware: health.HardwareProfile{RemoteCPU: nil},
 		}
 
-		got := health.GenerateReport(nil, ts)
+		got := health.GenerateTargetReport(ts)
 
-		assert.Equal(t, health.CheckStatusWarning, got.Target.SubsystemDriver.Status)
-		assert.Equal(t, "no remoteproc devices found", got.Target.SubsystemDriver.Value)
+		assert.Equal(t, health.CheckStatusWarning, got.SubsystemDriver.Status)
+		assert.Equal(t, "no remoteproc devices found", got.SubsystemDriver.Value)
 	})
 
 	t.Run("when the target has a connection error, Connectivity status reports error", func(t *testing.T) {
 		ts := health.Status{ConnectionError: assert.AnError}
 
-		got := health.GenerateReport(nil, ts)
+		got := health.GenerateTargetReport(ts)
 
-		assert.Equal(t, health.CheckStatusError, got.Target.Connectivity.Status)
+		assert.Equal(t, health.CheckStatusError, got.Connectivity.Status)
 	})
 
 	t.Run("when the target has no connection error, Connectivity status is ok", func(t *testing.T) {
 		ts := health.Status{}
 
-		got := health.GenerateReport(nil, ts)
+		got := health.GenerateTargetReport(ts)
 
-		assert.Equal(t, health.CheckStatusOK, got.Target.Connectivity.Status)
+		assert.Equal(t, health.CheckStatusOK, got.Connectivity.Status)
 	})
 
 	t.Run("target dependencies are listed", func(t *testing.T) {
@@ -106,11 +108,11 @@ func TestGenerateReport(t *testing.T) {
 			},
 		}
 
-		got := health.GenerateReport(nil, ts)
+		got := health.GenerateTargetReport(ts)
 
 		want := []health.HealthCheck{
 			{Name: "bar", Status: health.CheckStatusOK, Value: "foo"},
 		}
-		assert.Equal(t, want, got.Target.Dependencies)
+		assert.Equal(t, want, got.Dependencies)
 	})
 }


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- Split `Check` into `CheckHost` and `CheckTarget`, which I'm planning to subsequently use in the cli layer to conditionally generate target report only when `--target` has been specified
- Reorder definitions in `health.go` (public api first, private last)
- Split existing `GenerateReport` tests into `GenerateHostReport` and `GenerateTargetReport`
