### PR TITLE
feat: support host-only `topo health`

### DIFF
--- a/cmd/topo/health.go
+++ b/cmd/topo/health.go
@@ -45,7 +45,11 @@ var healthCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		return printable.Print(templates.PrintableHealthReport(report), os.Stdout, outputFormat)
+		toPrint := templates.PrintableHealthReport{
+			Host:   report.Host,
+			Target: &report.Target,
+		}
+		return printable.Print(toPrint, os.Stdout, outputFormat)
 	},
 }
 

--- a/cmd/topo/health.go
+++ b/cmd/topo/health.go
@@ -19,10 +19,6 @@ var healthCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(0),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		sshTarget, err := requireTarget(cmd)
-		if err != nil {
-			return err
-		}
 		outputFormat, err := resolveOutput(cmd)
 		if err != nil {
 			return err
@@ -38,17 +34,27 @@ var healthCmd = &cobra.Command{
 			spinner = term.StartSpinner(os.Stderr, "Checking health...")
 		}
 
-		report, err := health.Check(sshTarget, acceptNewHostKeys)
+		toPrint := templates.PrintableHealthReport{
+			Host: health.CheckHost(),
+		}
+
+		if sshTarget, ok := lookupTarget(cmd); ok {
+			targetReport, err := health.CheckTarget(sshTarget, acceptNewHostKeys)
+			if err != nil {
+				if spinner != nil {
+					spinner.Stop()
+				}
+				return err
+			}
+			toPrint.Target = &targetReport
+		} else {
+			toPrint.TargetHint = "provide --target or set TOPO_TARGET to check target health"
+		}
+
 		if spinner != nil {
 			spinner.Stop()
 		}
-		if err != nil {
-			return err
-		}
-		toPrint := templates.PrintableHealthReport{
-			Host:   report.Host,
-			Target: &report.Target,
-		}
+
 		return printable.Print(toPrint, os.Stdout, outputFormat)
 	},
 }

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -46,22 +46,6 @@ type TargetReport struct {
 	SubsystemDriver HealthCheck   `json:"subsystemDriver"`
 }
 
-type Report struct {
-	Host   HostReport   `json:"host"`
-	Target TargetReport `json:"target"`
-}
-
-func Check(sshTarget string, acceptNewHostKeys bool) (Report, error) {
-	targetReport, err := CheckTarget(sshTarget, acceptNewHostKeys)
-	if err != nil {
-		return Report{}, err
-	}
-	return Report{
-		Host:   CheckHost(),
-		Target: targetReport,
-	}, nil
-}
-
 func CheckHost() HostReport {
 	dependencyStatuses := CheckInstalled(HostRequiredDependencies, BinaryExistsLocally)
 	return GenerateHostReport(dependencyStatuses)

--- a/internal/output/templates/health.go
+++ b/internal/output/templates/health.go
@@ -9,7 +9,11 @@ import (
 	"github.com/arm/topo/internal/health"
 )
 
-type PrintableHealthReport health.Report
+type PrintableHealthReport struct {
+	Host       health.HostReport    `json:"host"`
+	Target     *health.TargetReport `json:"target,omitempty"`
+	TargetHint string               `json:"-"`
+}
 
 const healthCheckTemplate = `
 {{- define "checkRow" -}}
@@ -23,14 +27,18 @@ Host
 
 Target
 ------
-{{- if not .Target.IsLocalhost }}
+{{- if .Target }}
+  {{- if not .Target.IsLocalhost }}
 {{ template "checkRow" .Target.Connectivity }}
-{{- end }}
-{{- if or .Target.IsLocalhost (isOK .Target.Connectivity.Status) }}
-{{- range $targetCheckRow := .Target.Dependencies }}
+  {{- end }}
+  {{- if or .Target.IsLocalhost (isOK .Target.Connectivity.Status) }}
+    {{- range $targetCheckRow := .Target.Dependencies }}
 {{ template "checkRow" $targetCheckRow }}
-{{- end }}
+    {{- end }}
 {{ template "checkRow" .Target.SubsystemDriver }}
+  {{- end }}
+{{- else }}
+ℹ️ {{ .TargetHint }}
 {{- end }}
 `
 

--- a/internal/output/templates/health_test.go
+++ b/internal/output/templates/health_test.go
@@ -2,6 +2,7 @@ package templates_test
 
 import (
 	"bytes"
+	"fmt"
 	"testing"
 
 	"github.com/arm/topo/internal/health"
@@ -15,7 +16,7 @@ import (
 func TestPrintHealthReport(t *testing.T) {
 	t.Run("PlainFormat", func(t *testing.T) {
 		t.Run("it renders the healthy host dependencies", func(t *testing.T) {
-			report := health.Report{
+			toPrint := templates.PrintableHealthReport{
 				Host: health.HostReport{
 					Dependencies: []health.HealthCheck{
 						{
@@ -25,22 +26,17 @@ func TestPrintHealthReport(t *testing.T) {
 					},
 				},
 			}
-
 			var out bytes.Buffer
 
-			err := printable.Print(
-				templates.PrintableHealthReport(report),
-				&out,
-				term.Plain,
-			)
-			require.NoError(t, err)
+			err := printable.Print(toPrint, &out, term.Plain)
 
+			require.NoError(t, err)
 			assert.Contains(t, out.String(), "Flux Capacitor")
 			assert.Contains(t, out.String(), "✅")
 		})
 
 		t.Run("it renders the details when dependencies fail the health check", func(t *testing.T) {
-			report := health.Report{
+			toPrint := templates.PrintableHealthReport{
 				Host: health.HostReport{
 					Dependencies: []health.HealthCheck{
 						{
@@ -51,24 +47,19 @@ func TestPrintHealthReport(t *testing.T) {
 					},
 				},
 			}
-
 			var out bytes.Buffer
 
-			err := printable.Print(
-				templates.PrintableHealthReport(report),
-				&out,
-				term.Plain,
-			)
-			require.NoError(t, err)
+			err := printable.Print(toPrint, &out, term.Plain)
 
+			require.NoError(t, err)
 			assert.Contains(t, out.String(), "Container Engine")
 			assert.Contains(t, out.String(), "❌")
 			assert.Contains(t, out.String(), "docker not found on path")
 		})
 
 		t.Run("it renders a warning icon for warning checks", func(t *testing.T) {
-			report := health.Report{
-				Target: health.TargetReport{
+			toPrint := templates.PrintableHealthReport{
+				Target: &health.TargetReport{
 					Connectivity: health.HealthCheck{
 						Name:   "Connected",
 						Status: health.CheckStatusOK,
@@ -80,69 +71,66 @@ func TestPrintHealthReport(t *testing.T) {
 					},
 				},
 			}
-
 			var out bytes.Buffer
 
-			err := printable.Print(
-				templates.PrintableHealthReport(report),
-				&out,
-				term.Plain,
-			)
-			require.NoError(t, err)
+			err := printable.Print(toPrint, &out, term.Plain)
 
+			require.NoError(t, err)
 			assert.Contains(t, out.String(), "⚠️")
 			assert.Contains(t, out.String(), "no remoteproc devices found")
 		})
 
 		t.Run("it renders connection failures", func(t *testing.T) {
-			report := health.Report{
-				Target: health.TargetReport{
+			toPrint := templates.PrintableHealthReport{
+				Target: &health.TargetReport{
 					Connectivity: health.HealthCheck{
 						Name:   "Connected",
 						Status: health.CheckStatusError,
 					},
 				},
 			}
-
 			var out bytes.Buffer
 
-			err := printable.Print(
-				templates.PrintableHealthReport(report),
-				&out,
-				term.Plain,
-			)
-			require.NoError(t, err)
+			err := printable.Print(toPrint, &out, term.Plain)
 
+			require.NoError(t, err)
 			assert.Contains(t, out.String(), "Connected")
 			assert.Contains(t, out.String(), "❌")
 		})
 
 		t.Run("when not connected, it does not render cpu features", func(t *testing.T) {
-			report := health.Report{
-				Target: health.TargetReport{
+			toPrint := templates.PrintableHealthReport{
+				Target: &health.TargetReport{
 					Connectivity: health.HealthCheck{
 						Name:   "Connected",
 						Status: health.CheckStatusError,
 					},
 				},
 			}
-
 			var out bytes.Buffer
 
-			err := printable.Print(
-				templates.PrintableHealthReport(report),
-				&out,
-				term.Plain,
-			)
-			require.NoError(t, err)
+			err := printable.Print(toPrint, &out, term.Plain)
 
+			require.NoError(t, err)
 			assert.NotContains(t, out.String(), "Features (Linux Host)")
+		})
+
+		t.Run("when no target is specified, prints the hint", func(t *testing.T) {
+			hint := "Need to work on your aim"
+			toPrint := templates.PrintableHealthReport{TargetHint: hint}
+			var out bytes.Buffer
+
+			err := printable.Print(toPrint, &out, term.Plain)
+
+			require.NoError(t, err)
+			want := fmt.Sprintf("ℹ️ %s", hint)
+			assert.Contains(t, out.String(), want)
 		})
 	})
 
 	t.Run("JSONFormat", func(t *testing.T) {
 		t.Run("renders report as valid JSON with expected fields", func(t *testing.T) {
-			report := health.Report{
+			toPrint := templates.PrintableHealthReport{
 				Host: health.HostReport{
 					Dependencies: []health.HealthCheck{
 						{
@@ -151,7 +139,7 @@ func TestPrintHealthReport(t *testing.T) {
 						},
 					},
 				},
-				Target: health.TargetReport{
+				Target: &health.TargetReport{
 					Connectivity: health.HealthCheck{
 						Name:   "Connected",
 						Status: health.CheckStatusOK,
@@ -161,16 +149,11 @@ func TestPrintHealthReport(t *testing.T) {
 					},
 				},
 			}
-
 			var out bytes.Buffer
 
-			err := printable.Print(
-				templates.PrintableHealthReport(report),
-				&out,
-				term.JSON,
-			)
-			require.NoError(t, err)
+			err := printable.Print(toPrint, &out, term.JSON)
 
+			require.NoError(t, err)
 			want := `{
 				"host": {
 					"dependencies": [
@@ -184,7 +167,6 @@ func TestPrintHealthReport(t *testing.T) {
 					"subsystemDriver": {"name":"","status":"warning","value":""}
 				}
 			}`
-
 			assert.JSONEq(t, want, out.String())
 		})
 	})


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

⚠️ Builds on top of https://github.com/arm/topo/pull/88

- Removes the requirement to specify target for `topo health`

<img width="466" height="148" alt="Screenshot 2026-03-10 at 09 37 55" src="https://github.com/user-attachments/assets/3fea5808-2fe3-4aea-889b-ab6e40894d6c" />