### PR TITLE
refactor: improve `DockerComposeUp` interface

### DIFF
--- a/cmd/topo/deploy.go
+++ b/cmd/topo/deploy.go
@@ -22,6 +22,8 @@ var (
 	noRegistry        bool
 	registryPort      string
 	skipProjectChecks bool
+	forceRecreate     bool
+	noRecreate        bool
 )
 
 var deployOpts docker.DeployOptions
@@ -98,6 +100,12 @@ Use --dry-run to see what commands would be executed without actually running th
 		goos := runtime.GOOS
 		deployOpts.WithRegistry = docker.SupportsRegistry(noRegistry, targetHost)
 		deployOpts.UseSSHControlSockets = docker.SupportsSSHControlSockets(goos)
+		switch {
+		case forceRecreate:
+			deployOpts.RecreateMode = operation.RecreateModeForce
+		case noRecreate:
+			deployOpts.RecreateMode = operation.RecreateModeNone
+		}
 
 		if !deployOpts.WithRegistry {
 			c.Log(logger.Entry{
@@ -159,8 +167,8 @@ func init() {
 	addDryRunFlag(deployCmd)
 	deployCmd.Flags().StringVarP(&registryPort, "registry-port", "p", operation.DefaultRegistryPort, "Registry and SSH tunnel port (can also be set via TOPO_PORT env var)")
 	deployCmd.Flags().BoolVar(&noRegistry, "no-registry", false, "Disable private registry flow; use direct save/load transfer")
-	deployCmd.Flags().BoolVar(&deployOpts.ForceRecreate, "force-recreate", false, "Force recreation of containers even if their configuration and image haven't changed")
-	deployCmd.Flags().BoolVar(&deployOpts.NoRecreate, "no-recreate", false, "Prevent recreation of containers even if their configuration and image have changed")
+	deployCmd.Flags().BoolVar(&forceRecreate, "force-recreate", false, "Force recreation of containers even if their configuration and image haven't changed")
+	deployCmd.Flags().BoolVar(&noRecreate, "no-recreate", false, "Prevent recreation of containers even if their configuration and image have changed")
 	deployCmd.Flags().BoolVar(&skipProjectChecks, "skip-project-checks", false, "Skip project compatibility checks for the target platform")
 	deployCmd.MarkFlagsMutuallyExclusive("force-recreate", "no-recreate")
 	rootCmd.AddCommand(deployCmd)

--- a/internal/deploy/docker/deploy.go
+++ b/internal/deploy/docker/deploy.go
@@ -7,10 +7,9 @@ import (
 )
 
 type DeployOptions struct {
-	ForceRecreate        bool
+	RecreateMode         operation.RecreateMode
 	WithRegistry         bool
 	TargetHost           ssh.Host
-	NoRecreate           bool
 	RegistryPort         string
 	UseSSHControlSockets bool
 }
@@ -48,10 +47,6 @@ func NewDeployment(composeFile string, opts DeployOptions) (goperation.Sequence,
 			ops = append(ops, operation.NewDockerComposePipeTransfer(composeFile, sourceHost, opts.TargetHost))
 		}
 	}
-	upArgs := operation.DockerComposeUpArgs{
-		ForceRecreate: opts.ForceRecreate,
-		NoRecreate:    opts.NoRecreate,
-	}
-	ops = append(ops, operation.NewDockerComposeUp(composeFile, opts.TargetHost, upArgs))
+	ops = append(ops, operation.NewDockerComposeUp(composeFile, opts.TargetHost, opts.RecreateMode))
 	return goperation.NewSequence(ops...), cleanup
 }

--- a/internal/deploy/docker/deploy.go
+++ b/internal/deploy/docker/deploy.go
@@ -22,8 +22,8 @@ func SupportsSSHControlSockets(goos string) bool {
 	return goos != "windows"
 }
 
-func NewDeploymentStop(composeFile string, targetHost ssh.Host) goperation.Operation {
-	return operation.NewDockerComposeStop(composeFile, targetHost)
+func NewDeploymentStop(composeFile string, targetHost ssh.Host) goperation.Sequence {
+	return goperation.Sequence{operation.NewDockerComposeStop(composeFile, targetHost)}
 }
 
 func NewDeployment(composeFile string, opts DeployOptions) (goperation.Sequence, goperation.Operation) {

--- a/internal/deploy/docker/deploy.go
+++ b/internal/deploy/docker/deploy.go
@@ -23,11 +23,8 @@ func SupportsSSHControlSockets(goos string) bool {
 	return goos != "windows"
 }
 
-func NewDeploymentStop(composeFile string, targetHost ssh.Host) goperation.Sequence {
-	ops := []goperation.Operation{
-		operation.NewDockerComposeStop(composeFile, targetHost),
-	}
-	return goperation.NewSequence(ops...)
+func NewDeploymentStop(composeFile string, targetHost ssh.Host) goperation.Operation {
+	return operation.NewDockerComposeStop(composeFile, targetHost)
 }
 
 func NewDeployment(composeFile string, opts DeployOptions) (goperation.Sequence, goperation.Operation) {
@@ -55,6 +52,6 @@ func NewDeployment(composeFile string, opts DeployOptions) (goperation.Sequence,
 		ForceRecreate: opts.ForceRecreate,
 		NoRecreate:    opts.NoRecreate,
 	}
-	ops = append(ops, operation.NewDockerComposeRun(composeFile, opts.TargetHost, upArgs))
+	ops = append(ops, operation.NewDockerComposeUp(composeFile, opts.TargetHost, upArgs))
 	return goperation.NewSequence(ops...), cleanup
 }

--- a/internal/deploy/docker/deploy_test.go
+++ b/internal/deploy/docker/deploy_test.go
@@ -28,7 +28,7 @@ func TestNewDeployment(t *testing.T) {
 			operation.NewDockerComposeBuild(composeFile, ssh.PlainLocalhost),
 			operation.NewDockerComposePull(composeFile, ssh.PlainLocalhost),
 			operation.NewDockerComposePipeTransfer(composeFile, ssh.PlainLocalhost, remoteHost),
-			operation.NewDockerComposeUp(composeFile, remoteHost, operation.DockerComposeUpArgs{}),
+			operation.NewDockerComposeUp(composeFile, remoteHost, operation.RecreateModeDefault),
 		}
 		assert.Equal(t, want, got)
 	})
@@ -36,10 +36,7 @@ func TestNewDeployment(t *testing.T) {
 	t.Run("includes registry operations for remote host when enabled", func(t *testing.T) {
 		remoteHost := ssh.Host("user@remote")
 		port := operation.DefaultRegistryPort
-		opts := docker.DeployOptions{TargetHost: remoteHost, WithRegistry: true, ForceRecreate: false, RegistryPort: port, UseSSHControlSockets: true}
-		upArgs := operation.DockerComposeUpArgs{
-			ForceRecreate: opts.ForceRecreate,
-		}
+		opts := docker.DeployOptions{TargetHost: remoteHost, WithRegistry: true, RegistryPort: port, UseSSHControlSockets: true}
 		got, _ := docker.NewDeployment(composeFile, opts)
 
 		want := goperation.Sequence{
@@ -52,7 +49,7 @@ func TestNewDeployment(t *testing.T) {
 			ssh.NewCheckSSHTunnelSecurity(remoteHost, port),
 			operation.NewRegistryTransfer(composeFile, ssh.PlainLocalhost, remoteHost, port),
 			ssh.NewSSHTunnelStop(remoteHost),
-			operation.NewDockerComposeUp(composeFile, remoteHost, upArgs),
+			operation.NewDockerComposeUp(composeFile, remoteHost, operation.RecreateModeDefault),
 		)
 
 		assert.Equal(t, want, got)
@@ -60,43 +57,34 @@ func TestNewDeployment(t *testing.T) {
 
 	t.Run("excludes transfer operation for local host", func(t *testing.T) {
 		tests := []struct {
-			name string
-			opts docker.DeployOptions
+			name         string
+			recreateMode operation.RecreateMode
 		}{
 			{
-				name: "default",
-				opts: docker.DeployOptions{},
+				name:         "default",
+				recreateMode: operation.RecreateModeDefault,
 			},
 			{
-				name: "force recreate",
-				opts: docker.DeployOptions{
-					ForceRecreate: true,
-				},
+				name:         "force recreate",
+				recreateMode: operation.RecreateModeForce,
 			},
 			{
-				name: "no recreate",
-				opts: docker.DeployOptions{
-					NoRecreate: true,
-				},
+				name:         "no recreate",
+				recreateMode: operation.RecreateModeNone,
 			},
 		}
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
 				deployOpts := docker.DeployOptions{
-					TargetHost:    ssh.PlainLocalhost,
-					ForceRecreate: tt.opts.ForceRecreate,
-					NoRecreate:    tt.opts.NoRecreate,
+					TargetHost:   ssh.PlainLocalhost,
+					RecreateMode: tt.recreateMode,
 				}
 				got, _ := docker.NewDeployment(composeFile, deployOpts)
 
-				upArgs := operation.DockerComposeUpArgs{
-					ForceRecreate: tt.opts.ForceRecreate,
-					NoRecreate:    tt.opts.NoRecreate,
-				}
 				want := goperation.Sequence{
 					operation.NewDockerComposeBuild(composeFile, ssh.PlainLocalhost),
 					operation.NewDockerComposePull(composeFile, ssh.PlainLocalhost),
-					operation.NewDockerComposeUp(composeFile, ssh.PlainLocalhost, upArgs),
+					operation.NewDockerComposeUp(composeFile, ssh.PlainLocalhost, tt.recreateMode),
 				}
 
 				assert.Equal(t, want, got)
@@ -125,10 +113,7 @@ func TestNewDeployment(t *testing.T) {
 	t.Run("does not use SSH control sockets when disabled", func(t *testing.T) {
 		remoteHost := ssh.Host("user@remote")
 		port := operation.DefaultRegistryPort
-		opts := docker.DeployOptions{TargetHost: remoteHost, WithRegistry: true, ForceRecreate: false, RegistryPort: port, UseSSHControlSockets: false}
-		upArgs := operation.DockerComposeUpArgs{
-			ForceRecreate: opts.ForceRecreate,
-		}
+		opts := docker.DeployOptions{TargetHost: remoteHost, WithRegistry: true, RegistryPort: port, UseSSHControlSockets: false}
 		got, _ := docker.NewDeployment(composeFile, opts)
 
 		wantTunnelStart, wantSecurityCheck, wantTunnelEnd := ssh.NewSSHTunnel(remoteHost, opts.RegistryPort, opts.UseSSHControlSockets)
@@ -142,7 +127,7 @@ func TestNewDeployment(t *testing.T) {
 			wantSecurityCheck,
 			operation.NewRegistryTransfer(composeFile, ssh.PlainLocalhost, remoteHost, port),
 			wantTunnelEnd,
-			operation.NewDockerComposeUp(composeFile, remoteHost, upArgs),
+			operation.NewDockerComposeUp(composeFile, remoteHost, operation.RecreateModeDefault),
 		)
 
 		assert.Equal(t, want, got)

--- a/internal/deploy/docker/deploy_test.go
+++ b/internal/deploy/docker/deploy_test.go
@@ -28,7 +28,7 @@ func TestNewDeployment(t *testing.T) {
 			operation.NewDockerComposeBuild(composeFile, ssh.PlainLocalhost),
 			operation.NewDockerComposePull(composeFile, ssh.PlainLocalhost),
 			operation.NewDockerComposePipeTransfer(composeFile, ssh.PlainLocalhost, remoteHost),
-			operation.NewDockerComposeRun(composeFile, remoteHost, operation.DockerComposeUpArgs{}),
+			operation.NewDockerComposeUp(composeFile, remoteHost, operation.DockerComposeUpArgs{}),
 		}
 		assert.Equal(t, want, got)
 	})
@@ -52,7 +52,7 @@ func TestNewDeployment(t *testing.T) {
 			ssh.NewCheckSSHTunnelSecurity(remoteHost, port),
 			operation.NewRegistryTransfer(composeFile, ssh.PlainLocalhost, remoteHost, port),
 			ssh.NewSSHTunnelStop(remoteHost),
-			operation.NewDockerComposeRun(composeFile, remoteHost, upArgs),
+			operation.NewDockerComposeUp(composeFile, remoteHost, upArgs),
 		)
 
 		assert.Equal(t, want, got)
@@ -96,7 +96,7 @@ func TestNewDeployment(t *testing.T) {
 				want := goperation.Sequence{
 					operation.NewDockerComposeBuild(composeFile, ssh.PlainLocalhost),
 					operation.NewDockerComposePull(composeFile, ssh.PlainLocalhost),
-					operation.NewDockerComposeRun(composeFile, ssh.PlainLocalhost, upArgs),
+					operation.NewDockerComposeUp(composeFile, ssh.PlainLocalhost, upArgs),
 				}
 
 				assert.Equal(t, want, got)
@@ -142,7 +142,7 @@ func TestNewDeployment(t *testing.T) {
 			wantSecurityCheck,
 			operation.NewRegistryTransfer(composeFile, ssh.PlainLocalhost, remoteHost, port),
 			wantTunnelEnd,
-			operation.NewDockerComposeRun(composeFile, remoteHost, upArgs),
+			operation.NewDockerComposeUp(composeFile, remoteHost, upArgs),
 		)
 
 		assert.Equal(t, want, got)

--- a/internal/deploy/docker/operation/docker_compose.go
+++ b/internal/deploy/docker/operation/docker_compose.go
@@ -63,7 +63,7 @@ func NewDockerComposeStop(composeFile string, h ssh.Host) *DockerCompose {
 	return NewDockerCompose("Stop services", composeFile, h, []string{"stop"})
 }
 
-func NewDockerComposeRun(composeFile string, h ssh.Host, upArgs DockerComposeUpArgs) *DockerCompose {
+func NewDockerComposeUp(composeFile string, h ssh.Host, upArgs DockerComposeUpArgs) *DockerCompose {
 	args := []string{"up", "-d", "--no-build", "--pull", "never"}
 	if upArgs.ForceRecreate {
 		args = append(args, "--force-recreate")

--- a/internal/deploy/docker/operation/docker_compose.go
+++ b/internal/deploy/docker/operation/docker_compose.go
@@ -58,17 +58,20 @@ func NewDockerComposeStop(composeFile string, h ssh.Host) *DockerCompose {
 	return NewDockerCompose("Stop services", composeFile, h, []string{"stop"})
 }
 
-type DockerComposeUpArgs struct {
-	ForceRecreate bool
-	NoRecreate    bool
-}
+type RecreateMode int
 
-func NewDockerComposeUp(composeFile string, h ssh.Host, upArgs DockerComposeUpArgs) *DockerCompose {
+const (
+	RecreateModeDefault RecreateMode = iota
+	RecreateModeForce
+	RecreateModeNone
+)
+
+func NewDockerComposeUp(composeFile string, h ssh.Host, mode RecreateMode) *DockerCompose {
 	args := []string{"up", "-d", "--no-build", "--pull", "never"}
-	if upArgs.ForceRecreate {
+	switch mode {
+	case RecreateModeForce:
 		args = append(args, "--force-recreate")
-	}
-	if upArgs.NoRecreate {
+	case RecreateModeNone:
 		args = append(args, "--no-recreate")
 	}
 	return NewDockerCompose("Start services", composeFile, h, args)

--- a/internal/deploy/docker/operation/docker_compose.go
+++ b/internal/deploy/docker/operation/docker_compose.go
@@ -16,11 +16,6 @@ type DockerCompose struct {
 	args        []string
 }
 
-type DockerComposeUpArgs struct {
-	ForceRecreate bool
-	NoRecreate    bool
-}
-
 func NewDockerCompose(description string, composeFile string, h ssh.Host, args []string) *DockerCompose {
 	return &DockerCompose{
 		description: description,
@@ -61,6 +56,11 @@ func NewDockerComposePull(composeFile string, h ssh.Host) *DockerCompose {
 
 func NewDockerComposeStop(composeFile string, h ssh.Host) *DockerCompose {
 	return NewDockerCompose("Stop services", composeFile, h, []string{"stop"})
+}
+
+type DockerComposeUpArgs struct {
+	ForceRecreate bool
+	NoRecreate    bool
 }
 
 func NewDockerComposeUp(composeFile string, h ssh.Host, upArgs DockerComposeUpArgs) *DockerCompose {

--- a/internal/deploy/docker/operation/docker_compose_test.go
+++ b/internal/deploy/docker/operation/docker_compose_test.go
@@ -101,7 +101,7 @@ func TestNewDockerComposePull(t *testing.T) {
 func TestNewDockerComposeRun(t *testing.T) {
 	composeFilePath := "/path/to/compose.yaml"
 	remoteHost := ssh.Host("user@remote")
-	opNoForce := operation.NewDockerComposeRun(composeFilePath, remoteHost, operation.DockerComposeUpArgs{})
+	opNoForce := operation.NewDockerComposeUp(composeFilePath, remoteHost, operation.DockerComposeUpArgs{})
 
 	t.Run("Description", func(t *testing.T) {
 		got := opNoForce.Description()
@@ -119,7 +119,7 @@ func TestNewDockerComposeRun(t *testing.T) {
 		assert.Equal(t, want, buf.String())
 	})
 
-	opForce := operation.NewDockerComposeRun(composeFilePath, remoteHost, operation.DockerComposeUpArgs{
+	opForce := operation.NewDockerComposeUp(composeFilePath, remoteHost, operation.DockerComposeUpArgs{
 		ForceRecreate: true,
 	})
 
@@ -139,7 +139,7 @@ func TestNewDockerComposeRun(t *testing.T) {
 		assert.Equal(t, want, buf.String())
 	})
 
-	opNoRecreate := operation.NewDockerComposeRun(composeFilePath, remoteHost, operation.DockerComposeUpArgs{
+	opNoRecreate := operation.NewDockerComposeUp(composeFilePath, remoteHost, operation.DockerComposeUpArgs{
 		NoRecreate: true,
 	})
 

--- a/internal/deploy/docker/operation/docker_compose_test.go
+++ b/internal/deploy/docker/operation/docker_compose_test.go
@@ -101,10 +101,10 @@ func TestNewDockerComposePull(t *testing.T) {
 func TestNewDockerComposeRun(t *testing.T) {
 	composeFilePath := "/path/to/compose.yaml"
 	remoteHost := ssh.Host("user@remote")
-	opNoForce := operation.NewDockerComposeUp(composeFilePath, remoteHost, operation.DockerComposeUpArgs{})
+	opDefault := operation.NewDockerComposeUp(composeFilePath, remoteHost, operation.RecreateModeDefault)
 
 	t.Run("Description", func(t *testing.T) {
-		got := opNoForce.Description()
+		got := opDefault.Description()
 
 		assert.Equal(t, "Start services", got)
 	})
@@ -112,16 +112,14 @@ func TestNewDockerComposeRun(t *testing.T) {
 	t.Run("DryRun", func(t *testing.T) {
 		var buf bytes.Buffer
 
-		err := opNoForce.DryRun(&buf)
+		err := opDefault.DryRun(&buf)
 
 		require.NoError(t, err)
 		want := fmt.Sprintf("docker -H %s compose -f %s up -d --no-build --pull never\n", remoteHost.AsURI(), composeFilePath)
 		assert.Equal(t, want, buf.String())
 	})
 
-	opForce := operation.NewDockerComposeUp(composeFilePath, remoteHost, operation.DockerComposeUpArgs{
-		ForceRecreate: true,
-	})
+	opForce := operation.NewDockerComposeUp(composeFilePath, remoteHost, operation.RecreateModeForce)
 
 	t.Run("Description with --force-recreate", func(t *testing.T) {
 		got := opForce.Description()
@@ -139,9 +137,7 @@ func TestNewDockerComposeRun(t *testing.T) {
 		assert.Equal(t, want, buf.String())
 	})
 
-	opNoRecreate := operation.NewDockerComposeUp(composeFilePath, remoteHost, operation.DockerComposeUpArgs{
-		NoRecreate: true,
-	})
+	opNoRecreate := operation.NewDockerComposeUp(composeFilePath, remoteHost, operation.RecreateModeNone)
 
 	t.Run("DryRun with --no-recreate", func(t *testing.T) {
 		var buf bytes.Buffer


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- Rename `DockerComposeRun` -> `DockerComposeUp` - where possible, operations are named after the command they actually invoke
- Stop representing mutually exclusive state with a struct - enum is more appropriate
