### PR TITLE
Remove unsigned binary releases. Use Signed Artifact urls

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,10 +17,13 @@ on:
 permissions:
   contents: write
   packages: read
+  actions: read
 
 jobs:
   release:
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -53,6 +56,7 @@ jobs:
           echo "Next version: $new"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Set git config
         run: |
           git config --global user.email "topo-release@users.noreply.github.com"
@@ -73,7 +77,7 @@ jobs:
         with:
           distribution: goreleaser
           version: '~> v2'
-          args: release --clean
+          args: release --clean --skip=publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_CURRENT_TAG: v${{ steps.version.outputs.version }}
@@ -114,58 +118,8 @@ jobs:
             dist/topo_windows_arm64
           if-no-files-found: error
 
-      - name: Create GitHub App token for signer
-        id: app-token
-        uses: actions/create-github-app-token@v2
-        with:
-          app-id: ${{ secrets.ML_REPO_ACCESS_APP_ID }}
-          private-key: ${{ secrets.ML_REPO_ACCESS_PRIVATE_KEY }}
-          owner: Arm-debug
-          repositories: signer
-
-      - name: Trigger macOS signer workflow
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          OWNER: Arm-debug
-          REPO: signer
-          WORKFLOW_FILE: sign-and-post-macos.yml
-          REF: main
-          UPSTREAM_RUN_ID: ${{ github.run_id }}
-        run: |
-          gh workflow run "$WORKFLOW_FILE" \
-            --repo "$OWNER/$REPO" \
-            --ref "$REF" \
-            -f "run-id=$UPSTREAM_RUN_ID" \
-            -f "artifact=topo-v${{ steps.version.outputs.version }}-macos-unsigned" \
-            -f "release-version=${{ steps.version.outputs.version }}" \
-            -f "repo-name=topo" \
-            -f "org-name=arm" \
-            -f "binary-name=topo" \
-            -f "artifactory-uploadables=topo_darwin_*"
-
-      - name: Trigger Windows signer workflow
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          OWNER: Arm-debug
-          REPO: signer
-          WORKFLOW_FILE: sign-and-post-windows.yml
-          REF: main
-          UPSTREAM_RUN_ID: ${{ github.run_id }}
-        run: |
-          gh workflow run "$WORKFLOW_FILE" \
-            --repo "$OWNER/$REPO" \
-            --ref "$REF" \
-            -f "run-id=$UPSTREAM_RUN_ID" \
-            -f "artifact=topo-v${{ steps.version.outputs.version }}-windows-unsigned" \
-            -f "release-version=${{ steps.version.outputs.version }}" \
-            -f "repo-name=topo" \
-            -f "org-name=arm" \
-            -f "binary-name=topo.exe" \
-            -f "signing-artifactory-repo=edge-ai-tooling.topo-cli-signing" \
-            -f "artifactory-uploadables=topo_windows_*"
-
       - name: Upload linux artifacts
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: topo-v${{ steps.version.outputs.version }}-linux
           path: |
@@ -173,24 +127,55 @@ jobs:
             dist/topo_linux_arm64
           if-no-files-found: error
 
-      - name: Trigger archive and upload to artifactory workflow for linux artifacts
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          OWNER: Arm-debug
-          REPO: signer
-          WORKFLOW_FILE: archive-and-upload-to-artifactory.yml
-          REF: main
-          UPSTREAM_RUN_ID: ${{ github.run_id }}
+  sign-macos:
+    needs: build
+    uses: Arm-debug/signer/.github/workflows/sign-and-post-macos.yml@main
+    with:
+      run-id: ${{ github.run_id }}
+      artifact: topo-v${{ needs.build.outputs.version }}-macos-unsigned
+      release-version: ${{ needs.build.outputs.version }}
+      repo-name: topo
+      org-name: arm
+      binary-name: topo
+      artifactory-uploadables: topo_darwin_*
+
+  sign-windows:
+    needs: build
+    uses: Arm-debug/signer/.github/workflows/sign-and-post-windows.yml@main
+    with:
+      run-id: ${{ github.run_id }}
+      artifact: topo-v${{ needs.build.outputs.version }}-windows-unsigned
+      release-version: ${{ needs.build.outputs.version }}
+      repo-name: topo
+      org-name: arm
+      binary-name: topo.exe
+      signing-artifactory-repo: edge-ai-tooling.topo-cli-signing
+      artifactory-uploadables: topo_windows_*
+
+  sign-linux:
+    needs: build
+    uses: Arm-debug/signer/.github/workflows/archive-and-upload-to-artifactory.yml@main
+    with:
+      run-id: ${{ github.run_id }}
+      archive-name: topo-v${{ needs.build.outputs.version }}-linux
+      release-version: ${{ needs.build.outputs.version }}
+      repo-name: topo
+      org-name: arm
+      artifactory-path: linux
+      artifactory-uploadables: topo_linux_*
+      archive-format: tar.gz
+      executables: "*/topo"
+
+  post-release:
+    needs: [sign-macos, sign-windows, sign-linux]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Output artifact URLs
         run: |
-          gh workflow run "$WORKFLOW_FILE" \
-            --repo "$OWNER/$REPO" \
-            --ref "$REF" \
-            -f "run-id=$UPSTREAM_RUN_ID" \
-            -f "release-version=${{ steps.version.outputs.version }}" \
-            -f "archive-name=topo-v${{ steps.version.outputs.version }}-linux" \
-            -f "artifactory-path=linux" \
-            -f "repo-name=topo" \
-            -f "org-name=arm" \
-            -f "artifactory-uploadables=topo_linux_*" \
-            -f "archive-format=tar.gz" \
-            -f "executables=*/topo"
+          echo "## Artifactory URLs" >> $GITHUB_STEP_SUMMARY
+          echo "### macOS" >> $GITHUB_STEP_SUMMARY
+          echo "${{ needs.sign-macos.outputs.artifact-urls }}" >> $GITHUB_STEP_SUMMARY
+          echo "### Windows" >> $GITHUB_STEP_SUMMARY
+          echo "${{ needs.sign-windows.outputs.artifact-urls }}" >> $GITHUB_STEP_SUMMARY
+          echo "### Linux" >> $GITHUB_STEP_SUMMARY
+          echo "${{ needs.sign-linux.outputs.artifact-urls }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -129,7 +129,7 @@ jobs:
 
   sign-macos:
     needs: build
-    uses: Arm-debug/signer/.github/workflows/sign-and-post-macos.yml@return-release-urls
+    uses: Arm-debug/signer/.github/workflows/sign-and-post-macos.yml@workflow-calls
     with:
       run-id: ${{ github.run_id }}
       artifact: topo-v${{ needs.build.outputs.version }}-macos-unsigned
@@ -143,7 +143,7 @@ jobs:
 
   sign-windows:
     needs: build
-    uses: Arm-debug/signer/.github/workflows/sign-and-post-windows.yml@return-release-urls
+    uses: Arm-debug/signer/.github/workflows/sign-and-post-windows.yml@workflow-calls
     with:
       run-id: ${{ github.run_id }}
       artifact: topo-v${{ needs.build.outputs.version }}-windows-unsigned
@@ -158,7 +158,7 @@ jobs:
 
   upload-linux:
     needs: build
-    uses: Arm-debug/signer/.github/workflows/archive-and-upload-to-artifactory.yml@return-release-urls
+    uses: Arm-debug/signer/.github/workflows/archive-and-upload-to-artifactory.yml@workflow-calls
     with:
       run-id: ${{ github.run_id }}
       archive-name: topo-v${{ needs.build.outputs.version }}-linux

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -129,7 +129,7 @@ jobs:
 
   sign-macos:
     needs: build
-    uses: Arm-debug/signer/.github/workflows/sign-and-post-macos.yml@main
+    uses: Arm-debug/signer/.github/workflows/sign-and-post-macos.yml@return-release-urls
     with:
       run-id: ${{ github.run_id }}
       artifact: topo-v${{ needs.build.outputs.version }}-macos-unsigned
@@ -141,7 +141,7 @@ jobs:
 
   sign-windows:
     needs: build
-    uses: Arm-debug/signer/.github/workflows/sign-and-post-windows.yml@main
+    uses: Arm-debug/signer/.github/workflows/sign-and-post-windows.yml@return-release-urls
     with:
       run-id: ${{ github.run_id }}
       artifact: topo-v${{ needs.build.outputs.version }}-windows-unsigned
@@ -154,7 +154,7 @@ jobs:
 
   sign-linux:
     needs: build
-    uses: Arm-debug/signer/.github/workflows/archive-and-upload-to-artifactory.yml@main
+    uses: Arm-debug/signer/.github/workflows/archive-and-upload-to-artifactory.yml@return-release-urls
     with:
       run-id: ${{ github.run_id }}
       archive-name: topo-v${{ needs.build.outputs.version }}-linux

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,6 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.version }}
+      signer-token: ${{ steps.signer-token.outputs.token }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -126,10 +127,21 @@ jobs:
             dist/topo_linux_amd64
             dist/topo_linux_arm64
           if-no-files-found: error
+      
+      - name: Create GitHub App token for signer
+        id: signer-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.ML_REPO_ACCESS_APP_ID }}
+          private-key: ${{ secrets.ML_REPO_ACCESS_PRIVATE_KEY }}
+          owner: Arm-debug
+          repositories: signer
 
   sign-macos:
     needs: build
     uses: Arm-debug/signer/.github/workflows/sign-and-post-macos.yml@workflow-calls
+    secrets:
+      GH_TOKEN: ${{ needs.build.outputs.signer-token }}
     with:
       run-id: ${{ github.run_id }}
       artifact: topo-v${{ needs.build.outputs.version }}-macos-unsigned
@@ -144,6 +156,8 @@ jobs:
   sign-windows:
     needs: build
     uses: Arm-debug/signer/.github/workflows/sign-and-post-windows.yml@workflow-calls
+    secrets:
+      GH_TOKEN: ${{ needs.build.outputs.signer-token }}
     with:
       run-id: ${{ github.run_id }}
       artifact: topo-v${{ needs.build.outputs.version }}-windows-unsigned
@@ -159,6 +173,8 @@ jobs:
   upload-linux:
     needs: build
     uses: Arm-debug/signer/.github/workflows/archive-and-upload-to-artifactory.yml@workflow-calls
+    secrets:
+      GH_TOKEN: ${{ needs.build.outputs.signer-token }}
     with:
       run-id: ${{ github.run_id }}
       archive-name: topo-v${{ needs.build.outputs.version }}-linux

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ permissions:
   actions: read
 
 jobs:
-  release:
+  build:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.version }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -138,6 +138,8 @@ jobs:
       org-name: arm
       binary-name: topo
       artifactory-uploadables: topo_darwin_*
+      artifactory-host: https://arm.jfrog.io
+      artifactory-repo-name: devx-topo
 
   sign-windows:
     needs: build
@@ -151,8 +153,10 @@ jobs:
       binary-name: topo.exe
       signing-artifactory-repo: edge-ai-tooling.topo-cli-signing
       artifactory-uploadables: topo_windows_*
+      artifactory-host: https://arm.jfrog.io
+      artifactory-repo-name: devx-topo
 
-  sign-linux:
+  upload-linux:
     needs: build
     uses: Arm-debug/signer/.github/workflows/archive-and-upload-to-artifactory.yml@return-release-urls
     with:
@@ -163,11 +167,14 @@ jobs:
       org-name: arm
       artifactory-path: linux
       artifactory-uploadables: topo_linux_*
+      artifactory-host: https://arm.jfrog.io
+      artifactory-repo-name: devx-topo
       archive-format: tar.gz
       executables: "*/topo"
 
+
   post-release:
-    needs: [sign-macos, sign-windows, sign-linux]
+    needs: [sign-macos, sign-windows, upload-linux]
     runs-on: ubuntu-latest
     steps:
       - name: Output artifact URLs
@@ -178,4 +185,4 @@ jobs:
           echo "### Windows" >> $GITHUB_STEP_SUMMARY
           echo "${{ needs.sign-windows.outputs.artifact-urls }}" >> $GITHUB_STEP_SUMMARY
           echo "### Linux" >> $GITHUB_STEP_SUMMARY
-          echo "${{ needs.sign-linux.outputs.artifact-urls }}" >> $GITHUB_STEP_SUMMARY
+          echo "${{ needs.upload-linux.outputs.artifact-urls }}" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Dependent on signer repo changes.

- Removes unsigned binaries from github release releases.
- Uses new signer action changes to allow artifact urls to be returned, to be added to the release page.