### PR TITLE
feat: check that docker is accessible by the user

### DIFF
--- a/internal/health/dependencies.go
+++ b/internal/health/dependencies.go
@@ -5,6 +5,7 @@ import (
 	"os/exec"
 
 	"github.com/arm/topo/internal/collections"
+	commandpkg "github.com/arm/topo/internal/command"
 	"github.com/arm/topo/internal/ssh"
 )
 
@@ -71,7 +72,10 @@ func hardwareCapabilityMatches(required []HardwareCapability, available map[Hard
 	return false
 }
 
-type BinaryExistsFn = func(bin string) error
+type (
+	BinaryExistsFn = func(bin string) error
+	CheckAccessFn  = func(bin string) error
+)
 
 func CheckInstalled(dependencies []Dependency, binaryExists BinaryExistsFn) []DependencyStatus {
 	installed := make(map[SoftwareDependency]struct{})
@@ -113,6 +117,31 @@ func BinaryExistsLocally(bin string) error {
 		return fmt.Errorf("%q executable file not found in $PATH", bin)
 	}
 	return nil
+}
+
+func CheckBinaryAccessLocally(bin string) error {
+	if bin != "docker" {
+		return nil
+	}
+
+	if err := commandpkg.Docker(ssh.PlainLocalhost, "info").Run(); err != nil {
+		return fmt.Errorf("%s is installed but inaccessible: `%s info` failed: %w", bin, bin, err)
+	}
+	return nil
+}
+
+func CheckAccessible(statuses []DependencyStatus, checkAccess CheckAccessFn) []DependencyStatus {
+	res := make([]DependencyStatus, len(statuses))
+	copy(res, statuses)
+
+	for i := range res {
+		if res[i].Error != nil {
+			continue
+		}
+		res[i].Error = checkAccess(res[i].Dependency.Name)
+	}
+
+	return res
 }
 
 func groupByCategory(statuses []DependencyStatus) []collections.Group[DependencyStatus, string] {

--- a/internal/health/dependencies_test.go
+++ b/internal/health/dependencies_test.go
@@ -216,3 +216,53 @@ func TestFilterByHardware(t *testing.T) {
 		assert.Equal(t, want, got)
 	})
 }
+
+func TestCheckAccessible(t *testing.T) {
+	t.Run("applies access check only to installed dependencies", func(t *testing.T) {
+		statuses := []health.DependencyStatus{
+			{
+				Dependency: health.Dependency{Name: "docker", Category: "Container Engine"},
+				Error:      nil,
+			},
+			{
+				Dependency: health.Dependency{Name: "lscpu", Category: "Hardware Info"},
+				Error:      nil,
+			},
+		}
+		want := []health.DependencyStatus{
+			{
+				Dependency: health.Dependency{Name: "docker", Category: "Container Engine"},
+				Error:      assert.AnError,
+			},
+			{
+				Dependency: health.Dependency{Name: "lscpu", Category: "Hardware Info"},
+				Error:      nil,
+			},
+		}
+
+		got := health.CheckAccessible(statuses, func(bin string) error {
+			if bin == "docker" {
+				return assert.AnError
+			}
+			return nil
+		})
+
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("does not apply access check when dependency is missing", func(t *testing.T) {
+		statuses := []health.DependencyStatus{
+			{
+				Dependency: health.Dependency{Name: "docker", Category: "Container Engine"},
+				Error:      fmt.Errorf("docker not found"),
+			},
+		}
+
+		got := health.CheckAccessible(statuses, func(bin string) error {
+			t.Fatal("access check should not be called when dependency is missing")
+			return nil
+		})
+
+		assert.Equal(t, statuses, got)
+	})
+}

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -65,6 +65,7 @@ func (r TargetReport) MarshalJSON() ([]byte, error) {
 
 func CheckHost() HostReport {
 	dependencyStatuses := CheckInstalled(HostRequiredDependencies, BinaryExistsLocally)
+	dependencyStatuses = CheckAccessible(dependencyStatuses, CheckBinaryAccessLocally)
 	return GenerateHostReport(dependencyStatuses)
 }
 

--- a/internal/health/status.go
+++ b/internal/health/status.go
@@ -1,6 +1,8 @@
 package health
 
 import (
+	"fmt"
+
 	"github.com/arm/topo/internal/ssh"
 	"github.com/arm/topo/internal/target"
 )
@@ -36,6 +38,15 @@ func ProbeHealthStatus(c target.Connection) Status {
 	remoteprocs, _ := c.ProbeRemoteproc()
 	status.Hardware.RemoteCPU = remoteprocs
 	status.Dependencies = CheckDependencies(c.BinaryExists, status.Hardware.Capabilities())
+	status.Dependencies = CheckAccessible(status.Dependencies, func(bin string) error {
+		if bin != "docker" {
+			return nil
+		}
+		if _, err := c.Run("docker info"); err != nil {
+			return fmt.Errorf("%s is installed but inaccessible: `%s info` failed: %w", bin, bin, err)
+		}
+		return nil
+	})
 
 	return status
 }


### PR DESCRIPTION
Docker may be present in the system but the user may not be able to run it.

## Changes

Instead of checking for just docker being installed in the system, check if `docker info` is able to run. This guarantees that the user has docker access, which is what we really want to check.
