### PR TITLE
feat: check that docker is accessible by the user

### DIFF
--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"strings"
 
+	commandpkg "github.com/arm/topo/internal/command"
+	"github.com/arm/topo/internal/ssh"
 	"github.com/arm/topo/internal/target"
 )
 
@@ -64,7 +66,18 @@ func (r TargetReport) MarshalJSON() ([]byte, error) {
 }
 
 func CheckHost() HostReport {
-	dependencyStatuses := CheckInstalled(HostRequiredDependencies, BinaryExistsLocally)
+	dependencyStatuses := CheckInstalled(HostRequiredDependencies, func(bin string) error {
+		if err := BinaryExistsLocally(bin); err != nil {
+			return err
+		}
+		if bin != "docker" {
+			return nil
+		}
+		if err := commandpkg.Docker(ssh.PlainLocalhost, "info").Run(); err != nil {
+			return fmt.Errorf("docker is installed but inaccessible: `docker info` failed: %w", err)
+		}
+		return nil
+	})
 	return GenerateHostReport(dependencyStatuses)
 }
 

--- a/internal/health/status.go
+++ b/internal/health/status.go
@@ -1,6 +1,8 @@
 package health
 
 import (
+	"fmt"
+
 	"github.com/arm/topo/internal/ssh"
 	"github.com/arm/topo/internal/target"
 )
@@ -35,7 +37,18 @@ func ProbeHealthStatus(c target.Connection) Status {
 
 	remoteprocs, _ := c.ProbeRemoteproc()
 	status.Hardware.RemoteCPU = remoteprocs
-	status.Dependencies = CheckDependencies(c.BinaryExists, status.Hardware.Capabilities())
+	status.Dependencies = CheckDependencies(func(bin string) error {
+		if err := c.BinaryExists(bin); err != nil {
+			return err
+		}
+		if bin != "docker" {
+			return nil
+		}
+		if _, err := c.Run("docker info"); err != nil {
+			return fmt.Errorf("docker is installed but inaccessible: `docker info` failed: %w", err)
+		}
+		return nil
+	}, status.Hardware.Capabilities())
 
 	return status
 }


### PR DESCRIPTION
## Changes

Docker may be present in the system but the user may not be able to run it.
Instead of checking for just docker being installed in the system, check if `docker info` is able to run. This guarantees that the user has docker access, which is what we really want to check.
