### PR TITLE
feat: add remoteproc as a Lightbulb-moment template feature

### DIFF
--- a/internal/catalog/catalog_test.go
+++ b/internal/catalog/catalog_test.go
@@ -16,7 +16,7 @@ func TestGetTemplateRepo(t *testing.T) {
 		assert.Equal(t, &catalog.Repo{
 			Name:        "Lightbulb-moment",
 			Description: "Reads a switch over GPIO pins on an M class cpu, reports switch state over Remoteproc Message, then a web application on the A class reads this and displays a lightbulb in either the on or off state. The lightbulb state is described by an LLM in any user-specified style.",
-			Features:    []string{"SVE", "NEON", "remoteproc"},
+			Features:    []string{"remoteproc-runtime"},
 			URL:         "git@github.com:Arm-Examples/topo-lightbulb-moment.git",
 			Ref:         "main",
 		}, template)

--- a/internal/catalog/catalog_test.go
+++ b/internal/catalog/catalog_test.go
@@ -16,7 +16,7 @@ func TestGetTemplateRepo(t *testing.T) {
 		assert.Equal(t, &catalog.Repo{
 			Name:        "Lightbulb-moment",
 			Description: "Reads a switch over GPIO pins on an M class cpu, reports switch state over Remoteproc Message, then a web application on the A class reads this and displays a lightbulb in either the on or off state. The lightbulb state is described by an LLM in any user-specified style.",
-			Features:    []string{"SVE", "NEON"},
+			Features:    []string{"SVE", "NEON", "remoteproc"},
 			URL:         "git@github.com:Arm-Examples/topo-lightbulb-moment.git",
 			Ref:         "main",
 		}, template)

--- a/internal/catalog/compatibility.go
+++ b/internal/catalog/compatibility.go
@@ -66,16 +66,19 @@ func extractSupportedFeatures(profile target.HardwareProfile) map[string]struct{
 }
 
 func isRepoSupported(profile target.HardwareProfile, supportedFeatures map[string]struct{}, repo Repo) bool {
-	for _, feature := range repo.Features {
-		normalized := strings.ToLower(strings.TrimSpace(feature))
-		if _, ok := supportedFeatures[normalized]; !ok {
-			return false
-		}
-	}
-
 	if repo.MinRAMKb > 0 && profile.TotalMemoryKb < repo.MinRAMKb {
 		return false
 	}
 
-	return true
+	atLeastOneFeatureIsSupported := len(repo.Features) == 0
+
+	for _, feature := range repo.Features {
+		normalized := strings.ToLower(strings.TrimSpace(feature))
+		if _, ok := supportedFeatures[normalized]; ok {
+			atLeastOneFeatureIsSupported = true
+			break
+		}
+	}
+
+	return atLeastOneFeatureIsSupported
 }

--- a/internal/catalog/compatibility_test.go
+++ b/internal/catalog/compatibility_test.go
@@ -101,6 +101,38 @@ func TestAnnotateCompatibility(t *testing.T) {
 		assert.Equal(t, want, got)
 	})
 
+	t.Run("supports template when any required feature is present", func(t *testing.T) {
+		repo := catalog.Repo{Name: "multi-feature-template", Features: []string{"SVE", "remoteproc"}}
+		repos := []catalog.Repo{repo}
+		profile := target.HardwareProfile{
+			HostProcessor: []target.HostProcessor{
+				{Features: []string{"asimd", "sve"}},
+			},
+		}
+
+		got := catalog.AnnotateCompatibility(&profile, repos)
+		want := []catalog.RepoWithCompatibility{
+			{Repo: repo, Compatibility: catalog.CompatibilitySupported},
+		}
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("marks template unsupported when none of required features are present", func(t *testing.T) {
+		repo := catalog.Repo{Name: "multi-feature-template", Features: []string{"SVE", "remoteproc"}}
+		repos := []catalog.Repo{repo}
+		profile := target.HardwareProfile{
+			HostProcessor: []target.HostProcessor{
+				{Features: []string{"asimd"}},
+			},
+		}
+
+		got := catalog.AnnotateCompatibility(&profile, repos)
+		want := []catalog.RepoWithCompatibility{
+			{Repo: repo, Compatibility: catalog.CompatibilityUnsupported},
+		}
+		assert.Equal(t, want, got)
+	})
+
 	t.Run("marks template unsupported when RAM is below requirement", func(t *testing.T) {
 		repo := catalog.Repo{Name: "ram-template", MinRAMKb: 1024}
 		repos := []catalog.Repo{repo}

--- a/internal/catalog/data/templates.json
+++ b/internal/catalog/data/templates.json
@@ -10,8 +10,7 @@
     "name": "Lightbulb-moment",
     "description": "Reads a switch over GPIO pins on an M class cpu, reports switch state over Remoteproc Message, then a web application on the A class reads this and displays a lightbulb in either the on or off state. The lightbulb state is described by an LLM in any user-specified style.",
     "features": [
-      "SVE",
-      "NEON"
+      "remoteproc-runtime"
     ],
     "url": "git@github.com:Arm-Examples/topo-lightbulb-moment.git",
     "ref": "main"


### PR DESCRIPTION
The templates catalog has the `features` argument.
Currently, this argument is presenting both features that are required to run a template on the target (like `NEON`) and also listing target features that can be optionally used to run in the target (like `SVE`, for performance comparisons).

We therefore only ask for at least one of the requirements to be met for the template to be considered compatible with the target hardware.

## Changes

- make template compatible with the target hardware if any of its feature requirements is met.
- Update the `Lightbulb-moment` template to add `remoteproc` as a required feature.