### PR TITLE
refactor: introduce `Check` abstraction for dependency verification

### DIFF
--- a/internal/health/dependencies.go
+++ b/internal/health/dependencies.go
@@ -129,14 +129,13 @@ func PerformChecks(dependencies []Dependency, binaryExists BinaryExistsFn) []Dep
 			switch check.Kind {
 			case CheckBinaryExists:
 				err = binaryExists(check.Arg)
+				if err == nil && dep.SoftwareEnumID != UnsetSoftwareDependency {
+					installed[dep.SoftwareEnumID] = struct{}{}
+				}
 			}
 			if err != nil {
 				break
 			}
-		}
-
-		if err == nil && dep.SoftwareEnumID != UnsetSoftwareDependency {
-			installed[dep.SoftwareEnumID] = struct{}{}
 		}
 
 		result = append(result, DependencyStatus{

--- a/internal/health/dependencies.go
+++ b/internal/health/dependencies.go
@@ -8,6 +8,21 @@ import (
 	"github.com/arm/topo/internal/ssh"
 )
 
+type CheckKind int
+
+const (
+	CheckBinaryExists CheckKind = iota
+)
+
+type Check struct {
+	Kind CheckKind
+	Arg  string
+}
+
+func BinaryExists(bin string) Check {
+	return Check{Kind: CheckBinaryExists, Arg: bin}
+}
+
 type HardwareCapability int
 
 const (
@@ -25,21 +40,53 @@ const (
 type Dependency struct {
 	Name                  string
 	Category              string
+	Checks                []Check
 	SoftwareEnumID        SoftwareDependency
 	SoftwarePrerequisites []SoftwareDependency
 	HardwarePrerequisite  []HardwareCapability
 }
 
 var HostRequiredDependencies = []Dependency{
-	{Name: "ssh", Category: "SSH"},
-	{Name: "docker", Category: "Container Engine", SoftwareEnumID: Docker},
+	{
+		Name:     "ssh",
+		Category: "SSH",
+		Checks:   []Check{BinaryExists("ssh")},
+	},
+	{
+		Name:           "docker",
+		Category:       "Container Engine",
+		SoftwareEnumID: Docker,
+		Checks:         []Check{BinaryExists("docker")},
+	},
 }
 
 var TargetRequiredDependencies = []Dependency{
-	{Name: "docker", Category: "Container Engine", SoftwareEnumID: Docker},
-	{Name: "remoteproc-runtime", Category: "Remoteproc Runtime", SoftwarePrerequisites: []SoftwareDependency{Docker}, HardwarePrerequisite: []HardwareCapability{Remoteproc}},
-	{Name: "containerd-shim-remoteproc-v1", Category: "Remoteproc Shim", SoftwarePrerequisites: []SoftwareDependency{Docker}, HardwarePrerequisite: []HardwareCapability{Remoteproc}},
-	{Name: "lscpu", Category: "Hardware Info", SoftwareEnumID: Lscpu},
+	{
+		Name:           "docker",
+		Category:       "Container Engine",
+		SoftwareEnumID: Docker,
+		Checks:         []Check{BinaryExists("docker")},
+	},
+	{
+		Name:                  "remoteproc-runtime",
+		Category:              "Remoteproc Runtime",
+		SoftwarePrerequisites: []SoftwareDependency{Docker},
+		HardwarePrerequisite:  []HardwareCapability{Remoteproc},
+		Checks:                []Check{BinaryExists("remoteproc-runtime")},
+	},
+	{
+		Name:                  "containerd-shim-remoteproc-v1",
+		Category:              "Remoteproc Shim",
+		SoftwarePrerequisites: []SoftwareDependency{Docker},
+		HardwarePrerequisite:  []HardwareCapability{Remoteproc},
+		Checks:                []Check{BinaryExists("containerd-shim-remoteproc-v1")},
+	},
+	{
+		Name:           "lscpu",
+		Category:       "Hardware Info",
+		SoftwareEnumID: Lscpu,
+		Checks:         []Check{BinaryExists("lscpu")},
+	},
 }
 
 type DependencyStatus struct {
@@ -68,7 +115,7 @@ func hardwareCapabilityMatches(required []HardwareCapability, available map[Hard
 
 type BinaryExistsFn = func(bin string) error
 
-func CheckInstalled(dependencies []Dependency, binaryExists BinaryExistsFn) []DependencyStatus {
+func PerformChecks(dependencies []Dependency, binaryExists BinaryExistsFn) []DependencyStatus {
 	installed := make(map[SoftwareDependency]struct{})
 	result := make([]DependencyStatus, 0, len(dependencies))
 
@@ -77,7 +124,16 @@ func CheckInstalled(dependencies []Dependency, binaryExists BinaryExistsFn) []De
 			continue
 		}
 
-		err := binaryExists(dep.Name)
+		var err error
+		for _, check := range dep.Checks {
+			switch check.Kind {
+			case CheckBinaryExists:
+				err = binaryExists(check.Arg)
+			}
+			if err != nil {
+				break
+			}
+		}
 
 		if err == nil && dep.SoftwareEnumID != UnsetSoftwareDependency {
 			installed[dep.SoftwareEnumID] = struct{}{}

--- a/internal/health/dependencies.go
+++ b/internal/health/dependencies.go
@@ -47,11 +47,6 @@ type DependencyStatus struct {
 	Error      error
 }
 
-func CheckDependencies(binaryExists func(string) error, capabilities map[HardwareCapability]struct{}) []DependencyStatus {
-	deps := FilterByHardware(TargetRequiredDependencies, capabilities)
-	return CheckInstalled(deps, binaryExists)
-}
-
 func FilterByHardware(deps []Dependency, hardware map[HardwareCapability]struct{}) []Dependency {
 	result := make([]Dependency, 0, len(deps))
 	for _, dep := range deps {

--- a/internal/health/dependencies_test.go
+++ b/internal/health/dependencies_test.go
@@ -62,10 +62,10 @@ func TestDependencyFormat(t *testing.T) {
 	})
 }
 
-func TestCheckInstalled(t *testing.T) {
+func TestPerformChecks(t *testing.T) {
 	mockDependencies := []health.Dependency{
-		{Name: "foo", Category: "bar"},
-		{Name: "baz", Category: "qux"},
+		{Name: "foo", Category: "bar", Checks: []health.Check{health.BinaryExists("foo")}},
+		{Name: "baz", Category: "qux", Checks: []health.Check{health.BinaryExists("baz")}},
 	}
 
 	t.Run("when no dependencies are found, statuses show not installed", func(t *testing.T) {
@@ -73,15 +73,15 @@ func TestCheckInstalled(t *testing.T) {
 			return fmt.Errorf("%q executable file not found in $PATH", bin)
 		}
 
-		got := health.CheckInstalled(mockDependencies, mockBinaryExists)
+		got := health.PerformChecks(mockDependencies, mockBinaryExists)
 
 		want := []health.DependencyStatus{
 			{
-				Dependency: health.Dependency{Name: "foo", Category: "bar"},
+				Dependency: health.Dependency{Name: "foo", Category: "bar", Checks: []health.Check{health.BinaryExists("foo")}},
 				Error:      mockBinaryExists("foo"),
 			},
 			{
-				Dependency: health.Dependency{Name: "baz", Category: "qux"},
+				Dependency: health.Dependency{Name: "baz", Category: "qux", Checks: []health.Check{health.BinaryExists("baz")}},
 				Error:      mockBinaryExists("baz"),
 			},
 		}
@@ -96,15 +96,15 @@ func TestCheckInstalled(t *testing.T) {
 			return fmt.Errorf("%q executable file not found in $PATH", bin)
 		}
 
-		got := health.CheckInstalled(mockDependencies, mockBinaryExists)
+		got := health.PerformChecks(mockDependencies, mockBinaryExists)
 
 		want := []health.DependencyStatus{
 			{
-				Dependency: health.Dependency{Name: "foo", Category: "bar"},
+				Dependency: health.Dependency{Name: "foo", Category: "bar", Checks: []health.Check{health.BinaryExists("foo")}},
 				Error:      mockBinaryExists("foo"),
 			},
 			{
-				Dependency: health.Dependency{Name: "baz", Category: "qux"},
+				Dependency: health.Dependency{Name: "baz", Category: "qux", Checks: []health.Check{health.BinaryExists("baz")}},
 				Error:      nil,
 			},
 		}
@@ -113,8 +113,8 @@ func TestCheckInstalled(t *testing.T) {
 
 	t.Run("omits dependency when none of its SoftwarePrerequisites are installed", func(t *testing.T) {
 		deps := []health.Dependency{
-			{Name: "docker", Category: "Container Engine"},
-			{Name: "runtime", Category: "Runtime", SoftwarePrerequisites: []health.SoftwareDependency{health.Docker}},
+			{Name: "docker", Category: "Container Engine", Checks: []health.Check{health.BinaryExists("docker")}},
+			{Name: "runtime", Category: "Runtime", SoftwarePrerequisites: []health.SoftwareDependency{health.Docker}, Checks: []health.Check{health.BinaryExists("runtime")}},
 		}
 		mockBinaryExists := func(bin string) error {
 			if bin == "runtime" {
@@ -123,44 +123,44 @@ func TestCheckInstalled(t *testing.T) {
 			return fmt.Errorf("%q executable file not found in $PATH", bin)
 		}
 
-		got := health.CheckInstalled(deps, mockBinaryExists)
+		got := health.PerformChecks(deps, mockBinaryExists)
 
 		want := []health.DependencyStatus{
-			{Dependency: health.Dependency{Name: "docker", Category: "Container Engine"}, Error: mockBinaryExists("docker")},
+			{Dependency: health.Dependency{Name: "docker", Category: "Container Engine", Checks: []health.Check{health.BinaryExists("docker")}}, Error: mockBinaryExists("docker")},
 		}
 		assert.Equal(t, want, got)
 	})
 
 	t.Run("checks dependency when one of its SoftwarePrerequisites is installed", func(t *testing.T) {
 		deps := []health.Dependency{
-			{Name: "docker", Category: "Container Engine", SoftwareEnumID: health.Docker},
-			{Name: "runtime", Category: "Runtime", SoftwarePrerequisites: []health.SoftwareDependency{health.Docker}},
+			{Name: "docker", Category: "Container Engine", SoftwareEnumID: health.Docker, Checks: []health.Check{health.BinaryExists("docker")}},
+			{Name: "runtime", Category: "Runtime", SoftwarePrerequisites: []health.SoftwareDependency{health.Docker}, Checks: []health.Check{health.BinaryExists("runtime")}},
 		}
 		mockBinaryExists := func(bin string) error {
 			return nil
 		}
 
-		got := health.CheckInstalled(deps, mockBinaryExists)
+		got := health.PerformChecks(deps, mockBinaryExists)
 
 		want := []health.DependencyStatus{
-			{Dependency: health.Dependency{Name: "docker", Category: "Container Engine", SoftwareEnumID: health.Docker}, Error: nil},
-			{Dependency: health.Dependency{Name: "runtime", Category: "Runtime", SoftwarePrerequisites: []health.SoftwareDependency{health.Docker}}, Error: nil},
+			{Dependency: health.Dependency{Name: "docker", Category: "Container Engine", SoftwareEnumID: health.Docker, Checks: []health.Check{health.BinaryExists("docker")}}, Error: nil},
+			{Dependency: health.Dependency{Name: "runtime", Category: "Runtime", SoftwarePrerequisites: []health.SoftwareDependency{health.Docker}, Checks: []health.Check{health.BinaryExists("runtime")}}, Error: nil},
 		}
 		assert.Equal(t, want, got)
 	})
 
 	t.Run("checks dependency with no SoftwarePrerequisites unconditionally", func(t *testing.T) {
 		deps := []health.Dependency{
-			{Name: "standalone", Category: "Tools"},
+			{Name: "standalone", Category: "Tools", Checks: []health.Check{health.BinaryExists("standalone")}},
 		}
 		mockBinaryExists := func(bin string) error {
 			return nil
 		}
 
-		got := health.CheckInstalled(deps, mockBinaryExists)
+		got := health.PerformChecks(deps, mockBinaryExists)
 
 		want := []health.DependencyStatus{
-			{Dependency: health.Dependency{Name: "standalone", Category: "Tools"}, Error: nil},
+			{Dependency: health.Dependency{Name: "standalone", Category: "Tools", Checks: []health.Check{health.BinaryExists("standalone")}}, Error: nil},
 		}
 		assert.Equal(t, want, got)
 	})

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -64,7 +64,7 @@ func (r TargetReport) MarshalJSON() ([]byte, error) {
 }
 
 func CheckHost() HostReport {
-	dependencyStatuses := CheckInstalled(HostRequiredDependencies, BinaryExistsLocally)
+	dependencyStatuses := PerformChecks(HostRequiredDependencies, BinaryExistsLocally)
 	return GenerateHostReport(dependencyStatuses)
 }
 

--- a/internal/health/status.go
+++ b/internal/health/status.go
@@ -36,7 +36,7 @@ func ProbeHealthStatus(c target.Connection) Status {
 	remoteprocs, _ := c.ProbeRemoteproc()
 	status.Hardware.RemoteCPU = remoteprocs
 	dependenciesToCheck := FilterByHardware(TargetRequiredDependencies, status.Hardware.Capabilities())
-	status.Dependencies = CheckInstalled(dependenciesToCheck, c.BinaryExists)
+	status.Dependencies = PerformChecks(dependenciesToCheck, c.BinaryExists)
 
 	return status
 }

--- a/internal/health/status.go
+++ b/internal/health/status.go
@@ -35,7 +35,8 @@ func ProbeHealthStatus(c target.Connection) Status {
 
 	remoteprocs, _ := c.ProbeRemoteproc()
 	status.Hardware.RemoteCPU = remoteprocs
-	status.Dependencies = CheckDependencies(c.BinaryExists, status.Hardware.Capabilities())
+	dependenciesToCheck := FilterByHardware(TargetRequiredDependencies, status.Hardware.Capabilities())
+	status.Dependencies = CheckInstalled(dependenciesToCheck, c.BinaryExists)
 
 	return status
 }


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- Added a `Check` struct with a `CheckKind` discriminator and an `Arg` field, along with a `BinaryExists(bin string) Check` constructor as the first kind
- Added a `Checks []Check` field to `Dependency`, replacing the implicit assumption that `dep.Name` was the binary to look up
- `PerformChecks` (renamed from `CheckInstalled`) now iterates over a dependency's checks and dispatches on kind
- Removed `CheckDependencies` — callers now compose `FilterByHardware` + `PerformChecks` directly, making the two-step pipeline explicit
- All existing dependency definitions updated to carry their checks explicitly

This is a foundation for supporting additional check kinds beyond binary existence (e.g. version checks, service health, config presence) and for reacting differently to check failures depending on kind — without coupling that logic into `Dependency` itself.