### PR TITLE
feat: suggest a fix when warning about missing remoteproc runtime

### DIFF
--- a/internal/health/dependencies.go
+++ b/internal/health/dependencies.go
@@ -28,6 +28,7 @@ type Check struct {
 	Kind     CheckKind
 	Arg      string
 	Severity CheckSeverity
+	Fix      string
 }
 
 func BinaryExists() Check {
@@ -87,14 +88,26 @@ var TargetRequiredDependencies = []Dependency{
 		Label:                 "Remoteproc Runtime",
 		SoftwarePrerequisites: []SoftwareDependency{Docker},
 		HardwarePrerequisite:  []HardwareCapability{Remoteproc},
-		Checks:                []Check{BinaryExistsWarning()},
+		Checks: []Check{
+			{
+				Kind:     CheckBinaryExists,
+				Severity: SeverityWarning,
+				Fix:      "run `topo install remoteproc-runtime`",
+			},
+		},
 	},
 	{
 		Binary:                "containerd-shim-remoteproc-v1",
 		Label:                 "Remoteproc Shim",
 		SoftwarePrerequisites: []SoftwareDependency{Docker},
 		HardwarePrerequisite:  []HardwareCapability{Remoteproc},
-		Checks:                []Check{BinaryExistsWarning()},
+		Checks: []Check{
+			{
+				Kind:     CheckBinaryExists,
+				Severity: SeverityWarning,
+				Fix:      "run `topo install remoteproc-runtime`",
+			},
+		},
 	},
 	{
 		Binary:         "lscpu",
@@ -107,6 +120,7 @@ var TargetRequiredDependencies = []Dependency{
 type DependencyStatus struct {
 	Dependency Dependency
 	Error      error
+	Fix        string
 }
 
 func FilterByHardware(deps []Dependency, hardware map[HardwareCapability]struct{}) []Dependency {
@@ -140,6 +154,7 @@ func PerformChecks(dependencies []Dependency, binaryExists BinaryExistsFn) []Dep
 		}
 
 		var err error
+		var fix string
 		for _, check := range dep.Checks {
 			switch check.Kind {
 			case CheckBinaryExists:
@@ -152,6 +167,7 @@ func PerformChecks(dependencies []Dependency, binaryExists BinaryExistsFn) []Dep
 				if check.Severity == SeverityWarning {
 					err = WarningError{Err: err}
 				}
+				fix = check.Fix
 				break
 			}
 		}
@@ -159,6 +175,7 @@ func PerformChecks(dependencies []Dependency, binaryExists BinaryExistsFn) []Dep
 		result = append(result, DependencyStatus{
 			Dependency: dep,
 			Error:      err,
+			Fix:        fix,
 		})
 	}
 	return result

--- a/internal/health/dependencies.go
+++ b/internal/health/dependencies.go
@@ -16,8 +16,8 @@ const (
 type CheckSeverity int
 
 const (
-	SeverityError   CheckSeverity = iota
-	SeverityWarning CheckSeverity = iota
+	SeverityError CheckSeverity = iota
+	SeverityWarning
 )
 
 type WarningError struct{ Err error }

--- a/internal/health/dependencies.go
+++ b/internal/health/dependencies.go
@@ -7,6 +7,21 @@ import (
 	"github.com/arm/topo/internal/ssh"
 )
 
+type CheckKind int
+
+const (
+	CheckBinaryExists CheckKind = iota
+)
+
+type Check struct {
+	Kind CheckKind
+	Arg  string
+}
+
+func BinaryExists(bin string) Check {
+	return Check{Kind: CheckBinaryExists, Arg: bin}
+}
+
 type HardwareCapability int
 
 const (
@@ -24,21 +39,53 @@ const (
 type Dependency struct {
 	Binary                string
 	Label                 string
+	Checks                []Check
 	SoftwareEnumID        SoftwareDependency
 	SoftwarePrerequisites []SoftwareDependency
 	HardwarePrerequisite  []HardwareCapability
 }
 
 var HostRequiredDependencies = []Dependency{
-	{Binary: "ssh", Label: "SSH"},
-	{Binary: "docker", Label: "Container Engine", SoftwareEnumID: Docker},
+	{
+		Binary: "ssh",
+		Label:  "SSH",
+		Checks: []Check{BinaryExists("ssh")},
+	},
+	{
+		Binary:         "docker",
+		Label:          "Container Engine",
+		SoftwareEnumID: Docker,
+		Checks:         []Check{BinaryExists("docker")},
+	},
 }
 
 var TargetRequiredDependencies = []Dependency{
-	{Binary: "docker", Label: "Container Engine", SoftwareEnumID: Docker},
-	{Binary: "remoteproc-runtime", Label: "Remoteproc Runtime", SoftwarePrerequisites: []SoftwareDependency{Docker}, HardwarePrerequisite: []HardwareCapability{Remoteproc}},
-	{Binary: "containerd-shim-remoteproc-v1", Label: "Remoteproc Shim", SoftwarePrerequisites: []SoftwareDependency{Docker}, HardwarePrerequisite: []HardwareCapability{Remoteproc}},
-	{Binary: "lscpu", Label: "Hardware Info", SoftwareEnumID: Lscpu},
+	{
+		Binary:         "docker",
+		Label:          "Container Engine",
+		SoftwareEnumID: Docker,
+		Checks:         []Check{BinaryExists("docker")},
+	},
+	{
+		Binary:                "remoteproc-runtime",
+		Label:                 "Remoteproc Runtime",
+		SoftwarePrerequisites: []SoftwareDependency{Docker},
+		HardwarePrerequisite:  []HardwareCapability{Remoteproc},
+		Checks:                []Check{BinaryExists("remoteproc-runtime")},
+	},
+	{
+		Binary:                "containerd-shim-remoteproc-v1",
+		Label:                 "Remoteproc Shim",
+		SoftwarePrerequisites: []SoftwareDependency{Docker},
+		HardwarePrerequisite:  []HardwareCapability{Remoteproc},
+		Checks:                []Check{BinaryExists("containerd-shim-remoteproc-v1")},
+	},
+	{
+		Binary:         "lscpu",
+		Label:          "Hardware Info",
+		SoftwareEnumID: Lscpu,
+		Checks:         []Check{BinaryExists("lscpu")},
+	},
 }
 
 type DependencyStatus struct {
@@ -67,7 +114,7 @@ func hardwareCapabilityMatches(required []HardwareCapability, available map[Hard
 
 type BinaryExistsFn = func(bin string) error
 
-func CheckInstalled(dependencies []Dependency, binaryExists BinaryExistsFn) []DependencyStatus {
+func PerformChecks(dependencies []Dependency, binaryExists BinaryExistsFn) []DependencyStatus {
 	installed := make(map[SoftwareDependency]struct{})
 	result := make([]DependencyStatus, 0, len(dependencies))
 
@@ -76,7 +123,16 @@ func CheckInstalled(dependencies []Dependency, binaryExists BinaryExistsFn) []De
 			continue
 		}
 
-		err := binaryExists(dep.Binary)
+		var err error
+		for _, check := range dep.Checks {
+			switch check.Kind {
+			case CheckBinaryExists:
+				err = binaryExists(check.Arg)
+			}
+			if err != nil {
+				break
+			}
+		}
 
 		if err == nil && dep.SoftwareEnumID != UnsetSoftwareDependency {
 			installed[dep.SoftwareEnumID] = struct{}{}

--- a/internal/health/dependencies.go
+++ b/internal/health/dependencies.go
@@ -128,14 +128,13 @@ func PerformChecks(dependencies []Dependency, binaryExists BinaryExistsFn) []Dep
 			switch check.Kind {
 			case CheckBinaryExists:
 				err = binaryExists(check.Arg)
+				if err == nil && dep.SoftwareEnumID != UnsetSoftwareDependency {
+					installed[dep.SoftwareEnumID] = struct{}{}
+				}
 			}
 			if err != nil {
 				break
 			}
-		}
-
-		if err == nil && dep.SoftwareEnumID != UnsetSoftwareDependency {
-			installed[dep.SoftwareEnumID] = struct{}{}
 		}
 
 		result = append(result, DependencyStatus{

--- a/internal/health/dependencies.go
+++ b/internal/health/dependencies.go
@@ -13,13 +13,29 @@ const (
 	CheckBinaryExists CheckKind = iota
 )
 
+type CheckSeverity int
+
+const (
+	SeverityError   CheckSeverity = iota
+	SeverityWarning CheckSeverity = iota
+)
+
+type WarningError struct{ Err error }
+
+func (w WarningError) Error() string { return w.Err.Error() }
+
 type Check struct {
-	Kind CheckKind
-	Arg  string
+	Kind     CheckKind
+	Arg      string
+	Severity CheckSeverity
 }
 
 func BinaryExists() Check {
-	return Check{Kind: CheckBinaryExists}
+	return Check{Kind: CheckBinaryExists, Severity: SeverityError}
+}
+
+func BinaryExistsWarning() Check {
+	return Check{Kind: CheckBinaryExists, Severity: SeverityWarning}
 }
 
 type HardwareCapability int
@@ -71,14 +87,14 @@ var TargetRequiredDependencies = []Dependency{
 		Label:                 "Remoteproc Runtime",
 		SoftwarePrerequisites: []SoftwareDependency{Docker},
 		HardwarePrerequisite:  []HardwareCapability{Remoteproc},
-		Checks:                []Check{BinaryExists()},
+		Checks:                []Check{BinaryExistsWarning()},
 	},
 	{
 		Binary:                "containerd-shim-remoteproc-v1",
 		Label:                 "Remoteproc Shim",
 		SoftwarePrerequisites: []SoftwareDependency{Docker},
 		HardwarePrerequisite:  []HardwareCapability{Remoteproc},
-		Checks:                []Check{BinaryExists()},
+		Checks:                []Check{BinaryExistsWarning()},
 	},
 	{
 		Binary:         "lscpu",
@@ -133,6 +149,9 @@ func PerformChecks(dependencies []Dependency, binaryExists BinaryExistsFn) []Dep
 				}
 			}
 			if err != nil {
+				if check.Severity == SeverityWarning {
+					err = WarningError{Err: err}
+				}
 				break
 			}
 		}

--- a/internal/health/dependencies.go
+++ b/internal/health/dependencies.go
@@ -46,11 +46,6 @@ type DependencyStatus struct {
 	Error      error
 }
 
-func CheckDependencies(binaryExists func(string) error, capabilities map[HardwareCapability]struct{}) []DependencyStatus {
-	deps := FilterByHardware(TargetRequiredDependencies, capabilities)
-	return CheckInstalled(deps, binaryExists)
-}
-
 func FilterByHardware(deps []Dependency, hardware map[HardwareCapability]struct{}) []Dependency {
 	result := make([]Dependency, 0, len(deps))
 	for _, dep := range deps {

--- a/internal/health/dependencies.go
+++ b/internal/health/dependencies.go
@@ -18,8 +18,8 @@ type Check struct {
 	Arg  string
 }
 
-func BinaryExists(bin string) Check {
-	return Check{Kind: CheckBinaryExists, Arg: bin}
+func BinaryExists() Check {
+	return Check{Kind: CheckBinaryExists}
 }
 
 type HardwareCapability int
@@ -49,13 +49,13 @@ var HostRequiredDependencies = []Dependency{
 	{
 		Binary: "ssh",
 		Label:  "SSH",
-		Checks: []Check{BinaryExists("ssh")},
+		Checks: []Check{BinaryExists()},
 	},
 	{
 		Binary:         "docker",
 		Label:          "Container Engine",
 		SoftwareEnumID: Docker,
-		Checks:         []Check{BinaryExists("docker")},
+		Checks:         []Check{BinaryExists()},
 	},
 }
 
@@ -64,27 +64,27 @@ var TargetRequiredDependencies = []Dependency{
 		Binary:         "docker",
 		Label:          "Container Engine",
 		SoftwareEnumID: Docker,
-		Checks:         []Check{BinaryExists("docker")},
+		Checks:         []Check{BinaryExists()},
 	},
 	{
 		Binary:                "remoteproc-runtime",
 		Label:                 "Remoteproc Runtime",
 		SoftwarePrerequisites: []SoftwareDependency{Docker},
 		HardwarePrerequisite:  []HardwareCapability{Remoteproc},
-		Checks:                []Check{BinaryExists("remoteproc-runtime")},
+		Checks:                []Check{BinaryExists()},
 	},
 	{
 		Binary:                "containerd-shim-remoteproc-v1",
 		Label:                 "Remoteproc Shim",
 		SoftwarePrerequisites: []SoftwareDependency{Docker},
 		HardwarePrerequisite:  []HardwareCapability{Remoteproc},
-		Checks:                []Check{BinaryExists("containerd-shim-remoteproc-v1")},
+		Checks:                []Check{BinaryExists()},
 	},
 	{
 		Binary:         "lscpu",
 		Label:          "Hardware Info",
 		SoftwareEnumID: Lscpu,
-		Checks:         []Check{BinaryExists("lscpu")},
+		Checks:         []Check{BinaryExists()},
 	},
 }
 
@@ -127,7 +127,7 @@ func PerformChecks(dependencies []Dependency, binaryExists BinaryExistsFn) []Dep
 		for _, check := range dep.Checks {
 			switch check.Kind {
 			case CheckBinaryExists:
-				err = binaryExists(check.Arg)
+				err = binaryExists(dep.Binary)
 				if err == nil && dep.SoftwareEnumID != UnsetSoftwareDependency {
 					installed[dep.SoftwareEnumID] = struct{}{}
 				}

--- a/internal/health/dependencies_test.go
+++ b/internal/health/dependencies_test.go
@@ -64,8 +64,8 @@ func TestDependencyFormat(t *testing.T) {
 
 func TestPerformChecks(t *testing.T) {
 	mockDependencies := []health.Dependency{
-		{Binary: "foo", Label: "bar", Checks: []health.Check{health.BinaryExists("foo")}},
-		{Binary: "baz", Label: "qux", Checks: []health.Check{health.BinaryExists("baz")}},
+		{Binary: "foo", Label: "bar", Checks: []health.Check{health.BinaryExists()}},
+		{Binary: "baz", Label: "qux", Checks: []health.Check{health.BinaryExists()}},
 	}
 
 	t.Run("when no dependencies are found, statuses show not installed", func(t *testing.T) {
@@ -77,11 +77,11 @@ func TestPerformChecks(t *testing.T) {
 
 		want := []health.DependencyStatus{
 			{
-				Dependency: health.Dependency{Binary: "foo", Label: "bar", Checks: []health.Check{health.BinaryExists("foo")}},
+				Dependency: health.Dependency{Binary: "foo", Label: "bar", Checks: []health.Check{health.BinaryExists()}},
 				Error:      mockBinaryExists("foo"),
 			},
 			{
-				Dependency: health.Dependency{Binary: "baz", Label: "qux", Checks: []health.Check{health.BinaryExists("baz")}},
+				Dependency: health.Dependency{Binary: "baz", Label: "qux", Checks: []health.Check{health.BinaryExists()}},
 				Error:      mockBinaryExists("baz"),
 			},
 		}
@@ -100,11 +100,11 @@ func TestPerformChecks(t *testing.T) {
 
 		want := []health.DependencyStatus{
 			{
-				Dependency: health.Dependency{Binary: "foo", Label: "bar", Checks: []health.Check{health.BinaryExists("foo")}},
+				Dependency: health.Dependency{Binary: "foo", Label: "bar", Checks: []health.Check{health.BinaryExists()}},
 				Error:      mockBinaryExists("foo"),
 			},
 			{
-				Dependency: health.Dependency{Binary: "baz", Label: "qux", Checks: []health.Check{health.BinaryExists("baz")}},
+				Dependency: health.Dependency{Binary: "baz", Label: "qux", Checks: []health.Check{health.BinaryExists()}},
 				Error:      nil,
 			},
 		}
@@ -113,8 +113,8 @@ func TestPerformChecks(t *testing.T) {
 
 	t.Run("omits dependency when none of its SoftwarePrerequisites are installed", func(t *testing.T) {
 		deps := []health.Dependency{
-			{Binary: "docker", Label: "Container Engine", Checks: []health.Check{health.BinaryExists("docker")}},
-			{Binary: "runtime", Label: "Runtime", SoftwarePrerequisites: []health.SoftwareDependency{health.Docker}, Checks: []health.Check{health.BinaryExists("runtime")}},
+			{Binary: "docker", Label: "Container Engine", Checks: []health.Check{health.BinaryExists()}},
+			{Binary: "runtime", Label: "Runtime", SoftwarePrerequisites: []health.SoftwareDependency{health.Docker}, Checks: []health.Check{health.BinaryExists()}},
 		}
 		mockBinaryExists := func(bin string) error {
 			if bin == "runtime" {
@@ -126,15 +126,15 @@ func TestPerformChecks(t *testing.T) {
 		got := health.PerformChecks(deps, mockBinaryExists)
 
 		want := []health.DependencyStatus{
-			{Dependency: health.Dependency{Binary: "docker", Label: "Container Engine", Checks: []health.Check{health.BinaryExists("docker")}}, Error: mockBinaryExists("docker")},
+			{Dependency: health.Dependency{Binary: "docker", Label: "Container Engine", Checks: []health.Check{health.BinaryExists()}}, Error: mockBinaryExists("docker")},
 		}
 		assert.Equal(t, want, got)
 	})
 
 	t.Run("checks dependency when one of its SoftwarePrerequisites is installed", func(t *testing.T) {
 		deps := []health.Dependency{
-			{Binary: "docker", Label: "Container Engine", SoftwareEnumID: health.Docker, Checks: []health.Check{health.BinaryExists("docker")}},
-			{Binary: "runtime", Label: "Runtime", SoftwarePrerequisites: []health.SoftwareDependency{health.Docker}, Checks: []health.Check{health.BinaryExists("runtime")}},
+			{Binary: "docker", Label: "Container Engine", SoftwareEnumID: health.Docker, Checks: []health.Check{health.BinaryExists()}},
+			{Binary: "runtime", Label: "Runtime", SoftwarePrerequisites: []health.SoftwareDependency{health.Docker}, Checks: []health.Check{health.BinaryExists()}},
 		}
 		mockBinaryExists := func(bin string) error {
 			return nil
@@ -143,15 +143,15 @@ func TestPerformChecks(t *testing.T) {
 		got := health.PerformChecks(deps, mockBinaryExists)
 
 		want := []health.DependencyStatus{
-			{Dependency: health.Dependency{Binary: "docker", Label: "Container Engine", SoftwareEnumID: health.Docker, Checks: []health.Check{health.BinaryExists("docker")}}, Error: nil},
-			{Dependency: health.Dependency{Binary: "runtime", Label: "Runtime", SoftwarePrerequisites: []health.SoftwareDependency{health.Docker}, Checks: []health.Check{health.BinaryExists("runtime")}}, Error: nil},
+			{Dependency: health.Dependency{Binary: "docker", Label: "Container Engine", SoftwareEnumID: health.Docker, Checks: []health.Check{health.BinaryExists()}}, Error: nil},
+			{Dependency: health.Dependency{Binary: "runtime", Label: "Runtime", SoftwarePrerequisites: []health.SoftwareDependency{health.Docker}, Checks: []health.Check{health.BinaryExists()}}, Error: nil},
 		}
 		assert.Equal(t, want, got)
 	})
 
 	t.Run("checks dependency with no SoftwarePrerequisites unconditionally", func(t *testing.T) {
 		deps := []health.Dependency{
-			{Binary: "standalone", Label: "Tools", Checks: []health.Check{health.BinaryExists("standalone")}},
+			{Binary: "standalone", Label: "Tools", Checks: []health.Check{health.BinaryExists()}},
 		}
 		mockBinaryExists := func(bin string) error {
 			return nil
@@ -160,7 +160,7 @@ func TestPerformChecks(t *testing.T) {
 		got := health.PerformChecks(deps, mockBinaryExists)
 
 		want := []health.DependencyStatus{
-			{Dependency: health.Dependency{Binary: "standalone", Label: "Tools", Checks: []health.Check{health.BinaryExists("standalone")}}, Error: nil},
+			{Dependency: health.Dependency{Binary: "standalone", Label: "Tools", Checks: []health.Check{health.BinaryExists()}}, Error: nil},
 		}
 		assert.Equal(t, want, got)
 	})

--- a/internal/health/dependencies_test.go
+++ b/internal/health/dependencies_test.go
@@ -64,7 +64,6 @@ func TestDependencyFormat(t *testing.T) {
 }
 
 func TestPerformChecks(t *testing.T) {
-
 	t.Run("when no dependencies are found, statuses show not installed", func(t *testing.T) {
 		deps := []health.Dependency{
 			{Binary: "foo", Label: "bar", Checks: []health.Check{health.BinaryExists()}},

--- a/internal/health/dependencies_test.go
+++ b/internal/health/dependencies_test.go
@@ -88,6 +88,25 @@ func TestPerformChecks(t *testing.T) {
 		assert.Equal(t, want, got)
 	})
 
+	t.Run("wraps error as WarningError when binary exists check severity is warning", func(t *testing.T) {
+		missingBin := health.Dependency{Binary: "missing-bin", Label: "Missing", Checks: []health.Check{health.BinaryExistsWarning()}}
+		deps := []health.Dependency{missingBin}
+		mockBinaryExists := func(bin string) error {
+			return fmt.Errorf("%q executable file not found in $PATH", bin)
+		}
+
+		got := health.PerformChecks(deps, mockBinaryExists)
+
+		assert.Len(t, got, 1)
+		want := []health.DependencyStatus{
+			{
+				Dependency: missingBin,
+				Error:      health.WarningError{Err: mockBinaryExists("missing-bin")},
+			},
+		}
+		assert.Equal(t, want, got)
+	})
+
 	t.Run("when a dependency is found, its status entry reflects that", func(t *testing.T) {
 		mockBinaryExists := func(bin string) error {
 			if bin == "baz" {

--- a/internal/health/dependencies_test.go
+++ b/internal/health/dependencies_test.go
@@ -64,17 +64,17 @@ func TestDependencyFormat(t *testing.T) {
 }
 
 func TestPerformChecks(t *testing.T) {
-	mockDependencies := []health.Dependency{
-		{Binary: "foo", Label: "bar", Checks: []health.Check{health.BinaryExists()}},
-		{Binary: "baz", Label: "qux", Checks: []health.Check{health.BinaryExists()}},
-	}
 
 	t.Run("when no dependencies are found, statuses show not installed", func(t *testing.T) {
+		deps := []health.Dependency{
+			{Binary: "foo", Label: "bar", Checks: []health.Check{health.BinaryExists()}},
+			{Binary: "baz", Label: "qux", Checks: []health.Check{health.BinaryExists()}},
+		}
 		mockBinaryExists := func(bin string) error {
 			return fmt.Errorf("%q executable file not found in $PATH", bin)
 		}
 
-		got := health.PerformChecks(mockDependencies, mockBinaryExists)
+		got := health.PerformChecks(deps, mockBinaryExists)
 
 		want := []health.DependencyStatus{
 			{
@@ -109,6 +109,9 @@ func TestPerformChecks(t *testing.T) {
 	})
 
 	t.Run("when a dependency is found, its status entry reflects that", func(t *testing.T) {
+		deps := []health.Dependency{
+			{Binary: "baz", Label: "qux", Checks: []health.Check{health.BinaryExists()}},
+		}
 		mockBinaryExists := func(bin string) error {
 			if bin == "baz" {
 				return nil
@@ -116,13 +119,9 @@ func TestPerformChecks(t *testing.T) {
 			return fmt.Errorf("%q executable file not found in $PATH", bin)
 		}
 
-		got := health.PerformChecks(mockDependencies, mockBinaryExists)
+		got := health.PerformChecks(deps, mockBinaryExists)
 
 		want := []health.DependencyStatus{
-			{
-				Dependency: health.Dependency{Binary: "foo", Label: "bar", Checks: []health.Check{health.BinaryExists()}},
-				Error:      mockBinaryExists("foo"),
-			},
 			{
 				Dependency: health.Dependency{Binary: "baz", Label: "qux", Checks: []health.Check{health.BinaryExists()}},
 				Error:      nil,

--- a/internal/health/dependencies_test.go
+++ b/internal/health/dependencies_test.go
@@ -1,6 +1,7 @@
 package health_test
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
@@ -166,6 +167,22 @@ func TestPerformChecks(t *testing.T) {
 			{Dependency: health.Dependency{Binary: "runtime", Label: "Runtime", SoftwarePrerequisites: []health.SoftwareDependency{health.Docker}, Checks: []health.Check{health.BinaryExists()}}, Error: nil},
 		}
 		assert.Equal(t, want, got)
+	})
+
+	t.Run("captures Fix from failing check", func(t *testing.T) {
+		dep := health.Dependency{
+			Binary: "vader.exe",
+			Label:  "Sith",
+			Checks: []health.Check{{Kind: health.CheckBinaryExists, Severity: health.SeverityWarning, Fix: "turn Anakin into a bad man"}},
+		}
+		mockBinaryExists := func(bin string) error {
+			return errors.New("vader not found")
+		}
+
+		got := health.PerformChecks([]health.Dependency{dep}, mockBinaryExists)
+
+		assert.Len(t, got, 1)
+		assert.Equal(t, "turn Anakin into a bad man", got[0].Fix)
 	})
 
 	t.Run("checks dependency with no SoftwarePrerequisites unconditionally", func(t *testing.T) {

--- a/internal/health/dependencies_test.go
+++ b/internal/health/dependencies_test.go
@@ -62,10 +62,10 @@ func TestDependencyFormat(t *testing.T) {
 	})
 }
 
-func TestCheckInstalled(t *testing.T) {
+func TestPerformChecks(t *testing.T) {
 	mockDependencies := []health.Dependency{
-		{Binary: "foo", Label: "bar"},
-		{Binary: "baz", Label: "qux"},
+		{Binary: "foo", Label: "bar", Checks: []health.Check{health.BinaryExists("foo")}},
+		{Binary: "baz", Label: "qux", Checks: []health.Check{health.BinaryExists("baz")}},
 	}
 
 	t.Run("when no dependencies are found, statuses show not installed", func(t *testing.T) {
@@ -73,15 +73,15 @@ func TestCheckInstalled(t *testing.T) {
 			return fmt.Errorf("%q executable file not found in $PATH", bin)
 		}
 
-		got := health.CheckInstalled(mockDependencies, mockBinaryExists)
+		got := health.PerformChecks(mockDependencies, mockBinaryExists)
 
 		want := []health.DependencyStatus{
 			{
-				Dependency: health.Dependency{Binary: "foo", Label: "bar"},
+				Dependency: health.Dependency{Binary: "foo", Label: "bar", Checks: []health.Check{health.BinaryExists("foo")}},
 				Error:      mockBinaryExists("foo"),
 			},
 			{
-				Dependency: health.Dependency{Binary: "baz", Label: "qux"},
+				Dependency: health.Dependency{Binary: "baz", Label: "qux", Checks: []health.Check{health.BinaryExists("baz")}},
 				Error:      mockBinaryExists("baz"),
 			},
 		}
@@ -96,15 +96,15 @@ func TestCheckInstalled(t *testing.T) {
 			return fmt.Errorf("%q executable file not found in $PATH", bin)
 		}
 
-		got := health.CheckInstalled(mockDependencies, mockBinaryExists)
+		got := health.PerformChecks(mockDependencies, mockBinaryExists)
 
 		want := []health.DependencyStatus{
 			{
-				Dependency: health.Dependency{Binary: "foo", Label: "bar"},
+				Dependency: health.Dependency{Binary: "foo", Label: "bar", Checks: []health.Check{health.BinaryExists("foo")}},
 				Error:      mockBinaryExists("foo"),
 			},
 			{
-				Dependency: health.Dependency{Binary: "baz", Label: "qux"},
+				Dependency: health.Dependency{Binary: "baz", Label: "qux", Checks: []health.Check{health.BinaryExists("baz")}},
 				Error:      nil,
 			},
 		}
@@ -113,8 +113,8 @@ func TestCheckInstalled(t *testing.T) {
 
 	t.Run("omits dependency when none of its SoftwarePrerequisites are installed", func(t *testing.T) {
 		deps := []health.Dependency{
-			{Binary: "docker", Label: "Container Engine"},
-			{Binary: "runtime", Label: "Runtime", SoftwarePrerequisites: []health.SoftwareDependency{health.Docker}},
+			{Binary: "docker", Label: "Container Engine", Checks: []health.Check{health.BinaryExists("docker")}},
+			{Binary: "runtime", Label: "Runtime", SoftwarePrerequisites: []health.SoftwareDependency{health.Docker}, Checks: []health.Check{health.BinaryExists("runtime")}},
 		}
 		mockBinaryExists := func(bin string) error {
 			if bin == "runtime" {
@@ -123,44 +123,44 @@ func TestCheckInstalled(t *testing.T) {
 			return fmt.Errorf("%q executable file not found in $PATH", bin)
 		}
 
-		got := health.CheckInstalled(deps, mockBinaryExists)
+		got := health.PerformChecks(deps, mockBinaryExists)
 
 		want := []health.DependencyStatus{
-			{Dependency: health.Dependency{Binary: "docker", Label: "Container Engine"}, Error: mockBinaryExists("docker")},
+			{Dependency: health.Dependency{Binary: "docker", Label: "Container Engine", Checks: []health.Check{health.BinaryExists("docker")}}, Error: mockBinaryExists("docker")},
 		}
 		assert.Equal(t, want, got)
 	})
 
 	t.Run("checks dependency when one of its SoftwarePrerequisites is installed", func(t *testing.T) {
 		deps := []health.Dependency{
-			{Binary: "docker", Label: "Container Engine", SoftwareEnumID: health.Docker},
-			{Binary: "runtime", Label: "Runtime", SoftwarePrerequisites: []health.SoftwareDependency{health.Docker}},
+			{Binary: "docker", Label: "Container Engine", SoftwareEnumID: health.Docker, Checks: []health.Check{health.BinaryExists("docker")}},
+			{Binary: "runtime", Label: "Runtime", SoftwarePrerequisites: []health.SoftwareDependency{health.Docker}, Checks: []health.Check{health.BinaryExists("runtime")}},
 		}
 		mockBinaryExists := func(bin string) error {
 			return nil
 		}
 
-		got := health.CheckInstalled(deps, mockBinaryExists)
+		got := health.PerformChecks(deps, mockBinaryExists)
 
 		want := []health.DependencyStatus{
-			{Dependency: health.Dependency{Binary: "docker", Label: "Container Engine", SoftwareEnumID: health.Docker}, Error: nil},
-			{Dependency: health.Dependency{Binary: "runtime", Label: "Runtime", SoftwarePrerequisites: []health.SoftwareDependency{health.Docker}}, Error: nil},
+			{Dependency: health.Dependency{Binary: "docker", Label: "Container Engine", SoftwareEnumID: health.Docker, Checks: []health.Check{health.BinaryExists("docker")}}, Error: nil},
+			{Dependency: health.Dependency{Binary: "runtime", Label: "Runtime", SoftwarePrerequisites: []health.SoftwareDependency{health.Docker}, Checks: []health.Check{health.BinaryExists("runtime")}}, Error: nil},
 		}
 		assert.Equal(t, want, got)
 	})
 
 	t.Run("checks dependency with no SoftwarePrerequisites unconditionally", func(t *testing.T) {
 		deps := []health.Dependency{
-			{Binary: "standalone", Label: "Tools"},
+			{Binary: "standalone", Label: "Tools", Checks: []health.Check{health.BinaryExists("standalone")}},
 		}
 		mockBinaryExists := func(bin string) error {
 			return nil
 		}
 
-		got := health.CheckInstalled(deps, mockBinaryExists)
+		got := health.PerformChecks(deps, mockBinaryExists)
 
 		want := []health.DependencyStatus{
-			{Dependency: health.Dependency{Binary: "standalone", Label: "Tools"}, Error: nil},
+			{Dependency: health.Dependency{Binary: "standalone", Label: "Tools", Checks: []health.Check{health.BinaryExists("standalone")}}, Error: nil},
 		}
 		assert.Equal(t, want, got)
 	})

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -64,7 +64,7 @@ func (r TargetReport) MarshalJSON() ([]byte, error) {
 }
 
 func CheckHost() HostReport {
-	dependencyStatuses := CheckInstalled(HostRequiredDependencies, BinaryExistsLocally)
+	dependencyStatuses := PerformChecks(HostRequiredDependencies, BinaryExistsLocally)
 	return GenerateHostReport(dependencyStatuses)
 }
 

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -127,7 +127,11 @@ func generateDependencyReport(statuses []DependencyStatus) []HealthCheck {
 			hc.Status = CheckStatusOK
 			hc.Value = ds.Dependency.Binary
 		} else {
-			hc.Status = CheckStatusError
+			if _, ok := errors.AsType[WarningError](ds.Error); ok {
+				hc.Status = CheckStatusWarning
+			} else {
+				hc.Status = CheckStatusError
+			}
 			hc.Value = ds.Error.Error()
 		}
 		res = append(res, hc)

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -34,6 +34,7 @@ type HealthCheck struct {
 	Name   string      `json:"name"`
 	Status CheckStatus `json:"status"`
 	Value  string      `json:"value"`
+	Fix    string      `json:"fix,omitempty"`
 }
 
 type HostReport struct {
@@ -133,6 +134,7 @@ func generateDependencyReport(statuses []DependencyStatus) []HealthCheck {
 				hc.Status = CheckStatusError
 			}
 			hc.Value = ds.Error.Error()
+			hc.Fix = ds.Fix
 		}
 		res = append(res, hc)
 	}

--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -115,4 +115,16 @@ func testDependencyReporting(t *testing.T, extract func([]health.DependencyStatu
 			{Name: "Rube Goldberg", Status: health.CheckStatusError, Value: "whatever not found on path"},
 		}, got)
 	})
+
+	t.Run("when a dependency has a warning error, health check reports warning", func(t *testing.T) {
+		statuses := []health.DependencyStatus{
+			{Dependency: health.Dependency{Binary: "remoteproc-runtime", Label: "Remoteproc Runtime"}, Error: health.WarningError{Err: fmt.Errorf("remoteproc-runtime not found on path")}},
+		}
+
+		got := extract(statuses)
+
+		assert.Equal(t, []health.HealthCheck{
+			{Name: "Remoteproc Runtime", Status: health.CheckStatusWarning, Value: "remoteproc-runtime not found on path"},
+		}, got)
+	})
 }

--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -2,6 +2,7 @@ package health_test
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -126,5 +127,22 @@ func testDependencyReporting(t *testing.T, extract func([]health.DependencyStatu
 		assert.Equal(t, []health.HealthCheck{
 			{Name: "Remoteproc Runtime", Status: health.CheckStatusWarning, Value: "remoteproc-runtime not found on path"},
 		}, got)
+	})
+
+	t.Run("propagates Fix from DependencyStatus to HealthCheck", func(t *testing.T) {
+		statuses := []health.DependencyStatus{
+			{
+				Dependency: health.Dependency{Binary: "pizza", Label: "Food"},
+				Error:      health.WarningError{Err: errors.New("not enough pineapple")},
+				Fix:        "add more pineapple",
+			},
+		}
+
+		got := extract(statuses)
+
+		want := []health.HealthCheck{
+			{Name: "Food", Status: health.CheckStatusWarning, Value: "not enough pineapple", Fix: "add more pineapple"},
+		}
+		assert.Equal(t, want, got)
 	})
 }

--- a/internal/health/status.go
+++ b/internal/health/status.go
@@ -36,7 +36,7 @@ func ProbeHealthStatus(c target.Connection) Status {
 	remoteprocs, _ := c.ProbeRemoteproc()
 	status.Hardware.RemoteCPU = remoteprocs
 	dependenciesToCheck := FilterByHardware(TargetRequiredDependencies, status.Hardware.Capabilities())
-	status.Dependencies = CheckInstalled(dependenciesToCheck, c.BinaryExists)
+	status.Dependencies = PerformChecks(dependenciesToCheck, c.BinaryExists)
 
 	return status
 }

--- a/internal/health/status.go
+++ b/internal/health/status.go
@@ -35,7 +35,8 @@ func ProbeHealthStatus(c target.Connection) Status {
 
 	remoteprocs, _ := c.ProbeRemoteproc()
 	status.Hardware.RemoteCPU = remoteprocs
-	status.Dependencies = CheckDependencies(c.BinaryExists, status.Hardware.Capabilities())
+	dependenciesToCheck := FilterByHardware(TargetRequiredDependencies, status.Hardware.Capabilities())
+	status.Dependencies = CheckInstalled(dependenciesToCheck, c.BinaryExists)
 
 	return status
 }

--- a/internal/output/templates/health.go
+++ b/internal/output/templates/health.go
@@ -18,6 +18,9 @@ type PrintableHealthReport struct {
 const healthCheckTemplate = `
 {{- define "checkRow" -}}
   {{ .Name }}:{{ statusIcon .Status }}{{- if .Value }} ({{ .Value }}){{- end }}
+{{- if .Fix }}
+  → {{ .Fix }}
+{{- end -}}
 {{- end -}}
 Host
 ----

--- a/internal/output/templates/health_test.go
+++ b/internal/output/templates/health_test.go
@@ -115,6 +115,22 @@ func TestPrintHealthReport(t *testing.T) {
 			assert.NotContains(t, out.String(), "Features (Linux Host)")
 		})
 
+		t.Run("it renders the fix hint when a check has a fix", func(t *testing.T) {
+			toPrint := templates.PrintableHealthReport{
+				Host: health.HostReport{
+					Dependencies: []health.HealthCheck{
+						{Fix: "Apply Working Hands Cream"},
+					},
+				},
+			}
+			var out bytes.Buffer
+
+			err := printable.Print(toPrint, &out, term.Plain)
+
+			require.NoError(t, err)
+			assert.Contains(t, out.String(), "Apply Working Hands Cream")
+		})
+
 		t.Run("when no target is specified, prints the hint", func(t *testing.T) {
 			hint := "Need to work on your aim"
 			toPrint := templates.PrintableHealthReport{TargetHint: hint}


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- Turns missing `remoteproc-runtime` components into warnings instead of errors
- Adds facility to suggest fixes (right now only done for `remoteproc-runtime`)

<img width="676" height="234" alt="Screenshot 2026-03-12 at 19 59 09" src="https://github.com/user-attachments/assets/ba1e1634-aa82-417d-b87d-3fc67ae12072" />

## Implementation details

- `Dependencies` can now have multiple `Checks` - this breaks the implicit "binary exists", where we had no control over the outcome of such check
   - Side effect: will facilitate doing `docker info` check for @tgonzalezorlandoarm 
- We now `PerformChecks` instead of `CheckInstalled` 



