### PR TITLE
ci: push to public artifactory

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -141,7 +141,7 @@ jobs:
             -f "repo-name=topo" \
             -f "org-name=arm" \
             -f "binary-name=topo" \
-            -f "artifactory-uploadables=topo_darwin_*"
+            -f "artifactory-uploadables=topo_darwin_*" \
             -f "artifactory-host=https://arm.jfrog.io"
 
       - name: Trigger Windows signer workflow

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -142,7 +142,8 @@ jobs:
             -f "org-name=arm" \
             -f "binary-name=topo" \
             -f "artifactory-uploadables=topo_darwin_*" \
-            -f "artifactory-host=https://arm.jfrog.io"
+            -f "artifactory-host=https://arm.jfrog.io" \
+            -f "artifactory-repo-name=devx-topo"
 
       - name: Trigger Windows signer workflow
         env:
@@ -164,7 +165,8 @@ jobs:
             -f "binary-name=topo.exe" \
             -f "signing-artifactory-repo=edge-ai-tooling.topo-cli-signing" \
             -f "artifactory-uploadables=topo_windows_*" \
-            -f "artifactory-host=https://arm.jfrog.io"
+            -f "artifactory-host=https://arm.jfrog.io" \
+            -f "artifactory-repo-name=devx-topo"
 
       - name: Upload linux artifacts
         uses: actions/upload-artifact@v6
@@ -196,4 +198,5 @@ jobs:
             -f "artifactory-uploadables=topo_linux_*" \
             -f "archive-format=tar.gz" \
             -f "executables=*/topo" \
-            -f "artifactory-host=https://arm.jfrog.io"
+            -f "artifactory-host=https://arm.jfrog.io" \
+            -f "artifactory-repo-name=devx-topo"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -150,7 +150,7 @@ jobs:
           OWNER: Arm-debug
           REPO: signer
           WORKFLOW_FILE: sign-and-post-windows.yml
-          REF: main
+          REF: switch-to-public-artifactory
           UPSTREAM_RUN_ID: ${{ github.run_id }}
         run: |
           gh workflow run "$WORKFLOW_FILE" \
@@ -163,7 +163,8 @@ jobs:
             -f "org-name=arm" \
             -f "binary-name=topo.exe" \
             -f "signing-artifactory-repo=edge-ai-tooling.topo-cli-signing" \
-            -f "artifactory-uploadables=topo_windows_*"
+            -f "artifactory-uploadables=topo_windows_*" \
+            -f "artifactory-host=https://arm.jfrog.io"
 
       - name: Upload linux artifacts
         uses: actions/upload-artifact@v6
@@ -180,7 +181,7 @@ jobs:
           OWNER: Arm-debug
           REPO: signer
           WORKFLOW_FILE: archive-and-upload-to-artifactory.yml
-          REF: main
+          REF: switch-to-public-artifactory
           UPSTREAM_RUN_ID: ${{ github.run_id }}
         run: |
           gh workflow run "$WORKFLOW_FILE" \
@@ -194,4 +195,5 @@ jobs:
             -f "org-name=arm" \
             -f "artifactory-uploadables=topo_linux_*" \
             -f "archive-format=tar.gz" \
-            -f "executables=*/topo"
+            -f "executables=*/topo" \
+            -f "artifactory-host=https://arm.jfrog.io"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -129,7 +129,7 @@ jobs:
           OWNER: Arm-debug
           REPO: signer
           WORKFLOW_FILE: sign-and-post-macos.yml
-          REF: switch-to-public-artifactory
+          REF: main
           UPSTREAM_RUN_ID: ${{ github.run_id }}
         run: |
           gh workflow run "$WORKFLOW_FILE" \
@@ -151,7 +151,7 @@ jobs:
           OWNER: Arm-debug
           REPO: signer
           WORKFLOW_FILE: sign-and-post-windows.yml
-          REF: switch-to-public-artifactory
+          REF: main
           UPSTREAM_RUN_ID: ${{ github.run_id }}
         run: |
           gh workflow run "$WORKFLOW_FILE" \
@@ -183,7 +183,7 @@ jobs:
           OWNER: Arm-debug
           REPO: signer
           WORKFLOW_FILE: archive-and-upload-to-artifactory.yml
-          REF: switch-to-public-artifactory
+          REF: main
           UPSTREAM_RUN_ID: ${{ github.run_id }}
         run: |
           gh workflow run "$WORKFLOW_FILE" \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -129,7 +129,7 @@ jobs:
           OWNER: Arm-debug
           REPO: signer
           WORKFLOW_FILE: sign-and-post-macos.yml
-          REF: main
+          REF: switch-to-public-artifactory
           UPSTREAM_RUN_ID: ${{ github.run_id }}
         run: |
           gh workflow run "$WORKFLOW_FILE" \
@@ -142,6 +142,7 @@ jobs:
             -f "org-name=arm" \
             -f "binary-name=topo" \
             -f "artifactory-uploadables=topo_darwin_*"
+            -f "artifactory-host=https://arm.jfrog.io"
 
       - name: Trigger Windows signer workflow
         env:


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- Push to what will soon to be public artifactory(https://arm.jfrog.io/ui/repos/tree/General/devx-topo)
- Send couple more parameters to specify artifactory host/repo
