### PR TITLE
feat!: make path optional in clone command

### DIFF
--- a/cmd/topo/clone.go
+++ b/cmd/topo/clone.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"strings"
 
 	"github.com/arm/topo/internal/arguments"
 	"github.com/arm/topo/internal/output/console"
@@ -12,7 +13,7 @@ import (
 )
 
 var topoCloneCmd = &cobra.Command{
-	Use:   "clone <path> <project-source>",
+	Use:   "clone <project-source> [<path>]",
 	Short: "Clone an example project",
 	Long: `Clone an example project to the specified path.
 
@@ -20,28 +21,30 @@ The project-source argument uses scheme prefixes to specify the source type.
 The git: prefix is optional for git@host and https:// URLs.
 
 Template Name (from built-in catalog):
-  topo clone my-demo template:Hello-World
+  topo clone template:Hello-World
 
 Git repository:
-  topo clone my-demo git@github.com:user/repo.git
-  topo clone my-demo https://github.com/user/repo.git#develop
-  topo clone my-demo git:git@github.com:user/repo.git
-  topo clone my-demo git:https://github.com/user/repo.git#main
-  topo clone my-demo git:ubuntu@example.com:repo.git
-  topo clone my-demo git:builder@host:tools/platform.git#v2
+  topo clone git@github.com:user/repo.git
+  topo clone https://github.com/user/repo.git#develop
+  topo clone git:git@github.com:user/repo.git
+  topo clone git:https://github.com/user/repo.git#main
+  topo clone git:ubuntu@example.com:repo.git
+  topo clone git:builder@host:tools/platform.git#v2
 
 Local directory (must contain a Topo template):
-  topo clone my-demo dir:/path/to/template/folder
-  topo clone my-demo dir:./relative/path
+  topo clone dir:/path/to/template/folder
+  topo clone dir:./relative/path
 
 Some projects require build arguments. Supply them on the command line or answer prompts:
 
-  # Will prompt for required args
-  topo clone my-demo template:Hello-World
+  # Will prompt for required args (path defaults to template name)
+  topo clone template:Hello-World
   # Provide args explicitly
-  topo clone my-demo template:Hello-World GREETING_NAME="World"
+  topo clone template:Hello-World GREETING_NAME="World"
+  # With an explicit path
+  topo clone template:Hello-World my-demo GREETING_NAME="World"
 `,
-	Args: cobra.MinimumNArgs(2),
+	Args: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		outputFormat, err := resolveOutput(cmd)
 		if err != nil {
@@ -49,14 +52,27 @@ Some projects require build arguments. Supply them on the command line or answer
 		}
 		c := console.NewLogger(os.Stderr, outputFormat)
 		cmd.SilenceUsage = true
-		path := args[0]
-		src := args[1]
+		src := args[0]
+
+		projectSource, err := template.NewSource(src)
+		if err != nil {
+			return err
+		}
+
+		var path string
+		var cliArgs []string
+		if len(args) >= 2 && !strings.Contains(args[1], "=") {
+			path = args[1]
+			cliArgs = args[2:]
+		} else {
+			path, err = projectSource.GetName()
+			if err != nil {
+				return err
+			}
+			cliArgs = args[1:]
+		}
 
 		var providers []arguments.Provider
-		var cliArgs []string
-		if len(args) > 2 {
-			cliArgs = args[2:]
-		}
 		if len(cliArgs) > 0 {
 			cliProvider, err := arguments.NewCLIProvider(cliArgs)
 			if err != nil {
@@ -69,11 +85,6 @@ Some projects require build arguments. Supply them on the command line or answer
 		}
 
 		argProvider := arguments.NewStrictProviderChain(providers...)
-
-		projectSource, err := template.NewSource(src)
-		if err != nil {
-			return err
-		}
 
 		logs, err := project.Clone(path, projectSource, argProvider)
 

--- a/cmd/topo/clone.go
+++ b/cmd/topo/clone.go
@@ -37,7 +37,7 @@ Local directory (must contain a Topo template):
 
 Some projects require build arguments. Supply them on the command line or answer prompts:
 
-  # Will prompt for required args (path defaults to template name)
+  # Will prompt for required args
   topo clone template:Hello-World
   # Provide args explicitly
   topo clone template:Hello-World GREETING_NAME="World"

--- a/e2e/deploy_test.go
+++ b/e2e/deploy_test.go
@@ -62,7 +62,7 @@ func requireClone(t *testing.T, topo string, projectDir string, cloneDir string,
 	cloneDirPath, err := filepath.Abs(cloneDir)
 	require.NoError(t, err)
 
-	args := []string{"clone", cloneDirPath, fmt.Sprintf("dir:%s", remoteDirPath)}
+	args := []string{"clone", fmt.Sprintf("dir:%s", remoteDirPath), cloneDirPath}
 	args = append(args, extraArgs...)
 	cloneCmd := exec.Command(topo, args...)
 	cloneCmd.Dir = projectDir


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- Make path in `topo clone` optional
- This is a breaking change as it required reordering the arguments: `topo <path> <source>` becomes `topo <source> [path]`
