### PR TITLE
fix: make authentication errors comply with current schema

### DIFF
--- a/e2e/health_test.go
+++ b/e2e/health_test.go
@@ -25,7 +25,7 @@ func TestHealthCheck(t *testing.T) {
 		out, err := runCheckHealth(topo, target)
 		require.NoError(t, err)
 
-		assert.Contains(t, out, "Connected: ✅")
+		assert.Contains(t, out, "Connectivity: ✅")
 	})
 
 	t.Run("fails to connect to an invalid target", func(t *testing.T) {
@@ -35,7 +35,7 @@ func TestHealthCheck(t *testing.T) {
 		}
 		out, err := runCheckHealth(topo, &fakeContainer)
 		assert.NoError(t, err)
-		assert.Contains(t, out, "Connected: ❌")
+		assert.Contains(t, out, "Connectivity: ❌")
 	})
 }
 

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -10,11 +10,6 @@ import (
 	"github.com/arm/topo/internal/target"
 )
 
-// #nosec G101 -- Does not contain hardcoded credentials
-const passwordAuthErrorMessage = `note: Topo does not support SSH password-based authentication. To connect, either:
-- create your own SSH keys for the target, or
-- run 'topo setup-keys --target %s' to let Topo generate keys and configure passwordless authentication`
-
 type CheckStatus string
 
 func NewCheckStatusFromError(err error) CheckStatus {
@@ -79,9 +74,6 @@ func CheckTarget(sshTarget string, acceptNewHostKeys bool) (TargetReport, error)
 	}
 	conn := target.NewConnection(sshTarget, opts)
 	targetStatus := ProbeHealthStatus(conn)
-	if errors.Is(targetStatus.ConnectionError, target.ErrPasswordAuthentication) {
-		return TargetReport{}, fmt.Errorf(passwordAuthErrorMessage, sshTarget)
-	}
 	return GenerateTargetReport(targetStatus), nil
 }
 
@@ -95,11 +87,7 @@ func GenerateHostReport(statuses []DependencyStatus) HostReport {
 func GenerateTargetReport(targetStatus Status) TargetReport {
 	report := TargetReport{}
 	report.IsLocalhost = targetStatus.SSHTarget.IsPlainLocalhost()
-	report.Connectivity = HealthCheck{
-		Name:   "Connectivity",
-		Status: NewCheckStatusFromError(targetStatus.ConnectionError),
-		Value:  "",
-	}
+	report.Connectivity = connectivityCheck(targetStatus)
 
 	report.SubsystemDriver.Name = "Subsystem Driver (remoteproc)"
 	remoteCPUs := targetStatus.Hardware.RemoteCPU
@@ -118,6 +106,22 @@ func GenerateTargetReport(targetStatus Status) TargetReport {
 	report.Dependencies = generateDependencyReport(targetStatus.Dependencies)
 
 	return report
+}
+
+func connectivityCheck(targetStatus Status) HealthCheck {
+	check := HealthCheck{
+		Name:   "Connectivity",
+		Status: NewCheckStatusFromError(targetStatus.ConnectionError),
+	}
+	if targetStatus.ConnectionError == nil {
+		return check
+	}
+
+	check.Value = targetStatus.ConnectionError.Error()
+	if errors.Is(targetStatus.ConnectionError, target.ErrPasswordAuthentication) {
+		check.Fix = fmt.Sprintf("run `topo setup-keys --target %s` or manually setup SSH keys for the target", targetStatus.SSHTarget)
+	}
+	return check
 }
 
 func generateDependencyReport(statuses []DependencyStatus) []HealthCheck {

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -96,7 +96,7 @@ func GenerateTargetReport(targetStatus Status) TargetReport {
 	report := TargetReport{}
 	report.IsLocalhost = targetStatus.SSHTarget.IsPlainLocalhost()
 	report.Connectivity = HealthCheck{
-		Name:   "Connected",
+		Name:   "Connectivity",
 		Status: NewCheckStatusFromError(targetStatus.ConnectionError),
 		Value:  "",
 	}

--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -63,7 +63,6 @@ func TestGenerateTargetReport(t *testing.T) {
 
 		assert.Equal(t, health.CheckStatusError, got.Connectivity.Status)
 		assert.Equal(t, assert.AnError.Error(), got.Connectivity.Value)
-		assert.Empty(t, got.Connectivity.Fix)
 	})
 
 	t.Run("when the target has no connection error, Connectivity status is ok", func(t *testing.T) {
@@ -72,8 +71,6 @@ func TestGenerateTargetReport(t *testing.T) {
 		got := health.GenerateTargetReport(ts)
 
 		assert.Equal(t, health.CheckStatusOK, got.Connectivity.Status)
-		assert.Empty(t, got.Connectivity.Value)
-		assert.Empty(t, got.Connectivity.Fix)
 	})
 
 	t.Run("when password authentication is required, Connectivity includes a setup-keys fix", func(t *testing.T) {

--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -62,6 +62,8 @@ func TestGenerateTargetReport(t *testing.T) {
 		got := health.GenerateTargetReport(ts)
 
 		assert.Equal(t, health.CheckStatusError, got.Connectivity.Status)
+		assert.Equal(t, assert.AnError.Error(), got.Connectivity.Value)
+		assert.Empty(t, got.Connectivity.Fix)
 	})
 
 	t.Run("when the target has no connection error, Connectivity status is ok", func(t *testing.T) {
@@ -70,6 +72,20 @@ func TestGenerateTargetReport(t *testing.T) {
 		got := health.GenerateTargetReport(ts)
 
 		assert.Equal(t, health.CheckStatusOK, got.Connectivity.Status)
+		assert.Empty(t, got.Connectivity.Value)
+		assert.Empty(t, got.Connectivity.Fix)
+	})
+
+	t.Run("when password authentication is required, Connectivity includes a setup-keys fix", func(t *testing.T) {
+		ts := health.Status{
+			SSHTarget:       "user@my-target",
+			ConnectionError: target.ErrPasswordAuthentication,
+		}
+
+		got := health.GenerateTargetReport(ts)
+
+		assert.Equal(t, health.CheckStatusError, got.Connectivity.Status)
+		assert.Contains(t, got.Connectivity.Fix, "topo setup-keys --target user@my-target")
 	})
 }
 

--- a/internal/target/connection.go
+++ b/internal/target/connection.go
@@ -52,7 +52,7 @@ type ConnectionOptions struct {
 	WithMockExec      ExecSSH
 }
 
-var ErrPasswordAuthentication = errors.New("only password authentication is configured; key-based ssh is required")
+var ErrPasswordAuthentication = errors.New("key-based SSH authentication is not setup")
 
 func NewConnection(sshTarget string, opts ConnectionOptions) Connection {
 	execFn := ssh.ExecCmd


### PR DESCRIPTION
Currently, when authentication errors happen, they are shown to the user in a different way than the rest of the errors in the codebase.


## Changes

- Align `password-based authentication errors` to the current error schema.
