### PR TITLE
refactor: extract ssh error classification

### DIFF
--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -25,10 +25,17 @@ const (
 	downloadTimeout = 2 * time.Minute
 )
 
-var (
-	ErrPermissionDenied = errors.New("permission denied")
-	ErrSSHAuthFailed    = errors.New("SSH authentication failed")
-)
+var ErrPermissionDenied = errors.New("permission denied")
+
+func classifyStderr(stderr string) error {
+	lower := strings.ToLower(stderr)
+	if strings.Contains(lower, "permission denied") ||
+		strings.Contains(lower, "cannot create") ||
+		strings.Contains(lower, "read-only") {
+		return ErrPermissionDenied
+	}
+	return nil
+}
 
 var defaultCandidatePaths = []string{"/usr/local/bin", "/usr/bin", "~/bin"}
 
@@ -286,20 +293,15 @@ func install(installPath string, targetHost ssh.Host, binaries map[string][]byte
 
 		installCmd := fmt.Sprintf("install -D -m %s /dev/stdin %s/%s", mode, installPath, binaryName)
 		conn := target.NewConnection(string(targetHost), target.ConnectionOptions{WithLoginShell: true, WithStdin: binaryData})
-		stderr, err := conn.Run(installCmd)
+		output, err := conn.Run(installCmd)
 		if err != nil {
-			stderrStr := strings.ToLower(stderr)
-			if strings.Contains(stderrStr, "publickey") ||
-				strings.Contains(stderrStr, "authentication") ||
-				strings.Contains(stderrStr, "connection refused") {
-				return fmt.Errorf("%w: %s", ErrSSHAuthFailed, stderr)
+			if errors.Is(err, ssh.ErrSSH) {
+				return err
 			}
-			if strings.Contains(stderrStr, "permission denied") ||
-				strings.Contains(stderrStr, "cannot create") ||
-				strings.Contains(stderrStr, "read-only") {
-				return fmt.Errorf("%w: %s", ErrPermissionDenied, stderr)
+			if classified := classifyStderr(output); classified != nil {
+				return classified
 			}
-			return errors.New(stderr)
+			return err
 		}
 	}
 	return nil

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -25,18 +25,6 @@ const (
 	downloadTimeout = 2 * time.Minute
 )
 
-var ErrPermissionDenied = errors.New("permission denied")
-
-func classifyStderr(stderr string) error {
-	lower := strings.ToLower(stderr)
-	if strings.Contains(lower, "permission denied") ||
-		strings.Contains(lower, "cannot create") ||
-		strings.Contains(lower, "read-only") {
-		return ErrPermissionDenied
-	}
-	return nil
-}
-
 var defaultCandidatePaths = []string{"/usr/local/bin", "/usr/bin", "~/bin"}
 
 type PathCandidate struct {
@@ -411,4 +399,16 @@ func InstallBinariesFromGithubRelease(targetHost ssh.Host, repoURL string, binar
 	}
 
 	return results, nil
+}
+
+var ErrPermissionDenied = errors.New("permission denied")
+
+func classifyStderr(stderr string) error {
+	lower := strings.ToLower(stderr)
+	if strings.Contains(lower, "permission denied") ||
+		strings.Contains(lower, "cannot create") ||
+		strings.Contains(lower, "read-only") {
+		return ErrPermissionDenied
+	}
+	return nil
 }

--- a/internal/ssh/errors.go
+++ b/internal/ssh/errors.go
@@ -1,0 +1,27 @@
+package ssh
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+var (
+	ErrSSH              = errors.New("SSH failed")
+	ErrAuthFailed       = fmt.Errorf("%w: authentication failed", ErrSSH)
+	ErrConnectionFailed = fmt.Errorf("%w: connection failed", ErrSSH)
+)
+
+// ClassifyStderr inspects SSH stderr output and returns a typed error when a
+// known failure pattern is detected, or nil if the output is unrecognised.
+func ClassifyStderr(stderr string) error {
+	lower := strings.ToLower(stderr)
+	if strings.Contains(lower, "publickey") ||
+		strings.Contains(lower, "authentication") {
+		return ErrAuthFailed
+	}
+	if strings.Contains(lower, "connection refused") {
+		return ErrConnectionFailed
+	}
+	return nil
+}

--- a/internal/ssh/errors_test.go
+++ b/internal/ssh/errors_test.go
@@ -1,0 +1,37 @@
+package ssh
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClassifyStderr(t *testing.T) {
+	t.Run("returns ErrAuthFailed for publickey message", func(t *testing.T) {
+		assert.ErrorIs(t, ClassifyStderr("Permission denied (publickey)"), ErrAuthFailed)
+	})
+
+	t.Run("returns ErrAuthFailed for authentication message", func(t *testing.T) {
+		assert.ErrorIs(t, ClassifyStderr("Authentication failed"), ErrAuthFailed)
+	})
+
+	t.Run("returns ErrConnectionFailed for connection refused", func(t *testing.T) {
+		assert.ErrorIs(t, ClassifyStderr("ssh: connect to host foo port 22: Connection refused"), ErrConnectionFailed)
+	})
+
+	t.Run("ErrAuthFailed satisfies ErrSSH", func(t *testing.T) {
+		assert.ErrorIs(t, ErrAuthFailed, ErrSSH)
+	})
+
+	t.Run("ErrConnectionFailed satisfies ErrSSH", func(t *testing.T) {
+		assert.ErrorIs(t, ErrConnectionFailed, ErrSSH)
+	})
+
+	t.Run("returns nil for unrecognised output", func(t *testing.T) {
+		assert.Nil(t, ClassifyStderr("some unexpected error"))
+	})
+
+	t.Run("returns nil for empty stderr", func(t *testing.T) {
+		assert.Nil(t, ClassifyStderr(""))
+	})
+}

--- a/internal/target/connection.go
+++ b/internal/target/connection.go
@@ -83,8 +83,11 @@ func (c *Connection) Run(command string) (string, error) {
 
 	err := cmd.Run()
 	if err != nil {
-		combined := stdoutBuf.String() + stderrBuf.String()
-		return combined, fmt.Errorf("ssh command to %s failed: %w | stderr: %s", string(c.SSHTarget), err, stderrBuf.String())
+		stderr := stderrBuf.String()
+		if classified := ssh.ClassifyStderr(stderr); classified != nil {
+			err = classified
+		}
+		return stdoutBuf.String() + stderr, fmt.Errorf("ssh command to %s failed: %w | stderr: %s", string(c.SSHTarget), err, stderr)
 	}
 	return stdoutBuf.String(), nil
 }

--- a/internal/target/connection_test.go
+++ b/internal/target/connection_test.go
@@ -36,6 +36,28 @@ func TestRun(t *testing.T) {
 		assert.Empty(t, out)
 	})
 
+	t.Run("returns ErrAuthFailed when stderr contains auth failure", func(t *testing.T) {
+		mockExec := func(_ ssh.Host, _ string, _ []byte, _ ...string) *exec.Cmd {
+			return testutil.CmdWithStderr("Permission denied (publickey)", 1)
+		}
+		conn := target.NewConnection("hostname", target.ConnectionOptions{WithMockExec: mockExec})
+
+		_, err := conn.Run("ls")
+
+		assert.ErrorIs(t, err, ssh.ErrAuthFailed)
+	})
+
+	t.Run("returns ErrConnectionFailed when stderr contains connection refused", func(t *testing.T) {
+		mockExec := func(_ ssh.Host, _ string, _ []byte, _ ...string) *exec.Cmd {
+			return testutil.CmdWithStderr("ssh: connect to host foo port 22: Connection refused", 1)
+		}
+		conn := target.NewConnection("hostname", target.ConnectionOptions{WithMockExec: mockExec})
+
+		_, err := conn.Run("ls")
+
+		assert.ErrorIs(t, err, ssh.ErrConnectionFailed)
+	})
+
 	t.Run("run with mutliplexing enabled includes Control args", func(t *testing.T) {
 		testutil.RequireOS(t, "linux")
 		var capturedArgs string

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -73,6 +73,17 @@ func WriteComposeFile(t *testing.T, dir, content string) string {
 	return composePath
 }
 
+func CmdWithStderr(output string, exitCode int) *exec.Cmd {
+	if runtime.GOOS == "windows" {
+		script := "$OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; [Console]::Error.Write($env:TOPO_CMD_OUT); exit [int]$env:TOPO_CMD_CODE"
+		cmd := exec.Command("powershell", "-NoProfile", "-Command", script)
+		cmd.Env = append(os.Environ(), "TOPO_CMD_OUT="+output, fmt.Sprintf("TOPO_CMD_CODE=%d", exitCode))
+		return cmd
+	}
+	// #nosec G204 -- ignore as its a test helper
+	return exec.Command("sh", "-c", fmt.Sprintf("printf %%s \"$1\" >&2; exit %d", exitCode), "sh", output)
+}
+
 func CmdWithOutput(output string, exitCode int) *exec.Cmd {
 	if runtime.GOOS == "windows" {
 		// PowerShell: emit exact bytes (no extra newline), UTF-8, and requested exit code.


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- Introduce `ssh.ErrSSH`, `ssh.ErrAuthFailed`, and `ssh.ErrConnectionFailed` a small error hierarchy where the specific errors wrap the base, allowing callers to handle them individually or catch both with `errors.Is(err, ssh.ErrSSH)`
- Add `ssh.ClassifyStderr` to pattern-match SSH stderr output into typed errors
- Call `ClassifyStderr` in `conn.Run` so all callers automatically get structured errors without inspecting strings themselves
- Remove `ErrSSHAuthFailed` from `install` and replace the SSH pattern matching in `install()` with `errors.Is(err, ssh.ErrSSH)`
  - Keep `install.ErrPermissionDenied` and a local `classifyStderr` for install-command-specific patterns (`permission denied`, `cannot create`, `read-only`), since these are not SSH errors

