### PR TITLE
feat: verify Docker is runnable during health dependency checks

### DIFF
--- a/internal/health/dependencies.go
+++ b/internal/health/dependencies.go
@@ -78,7 +78,7 @@ var HostRequiredDependencies = []Dependency{
 			Kind:     CheckCommandSuccessful,
 			Arg:      "docker info",
 			Severity: SeverityError,
-			Fix:      "Ensure docker can be executed successfully by the current user",
+			Fix:      "Ensure current user can run docker commands",
 		}},
 	},
 }
@@ -92,7 +92,7 @@ var TargetRequiredDependencies = []Dependency{
 			Kind:     CheckCommandSuccessful,
 			Arg:      "docker info",
 			Severity: SeverityError,
-			Fix:      "Ensure docker can be executed successfully by the current user",
+			Fix:      "Ensure current user can run docker commands",
 		}},
 	},
 	{

--- a/internal/health/dependencies.go
+++ b/internal/health/dependencies.go
@@ -3,6 +3,7 @@ package health
 import (
 	"fmt"
 	"os/exec"
+	"strings"
 
 	"github.com/arm/topo/internal/ssh"
 )
@@ -11,6 +12,7 @@ type CheckKind int
 
 const (
 	CheckBinaryExists CheckKind = iota
+	CheckCommandSuccessful
 )
 
 type CheckSeverity int
@@ -72,7 +74,12 @@ var HostRequiredDependencies = []Dependency{
 		Binary:         "docker",
 		Label:          "Container Engine",
 		SoftwareEnumID: Docker,
-		Checks:         []Check{BinaryExists()},
+		Checks: []Check{BinaryExists(), {
+			Kind:     CheckCommandSuccessful,
+			Arg:      "docker info",
+			Severity: SeverityError,
+			Fix:      "Ensure docker can be executed successfully by the current user",
+		}},
 	},
 }
 
@@ -81,7 +88,12 @@ var TargetRequiredDependencies = []Dependency{
 		Binary:         "docker",
 		Label:          "Container Engine",
 		SoftwareEnumID: Docker,
-		Checks:         []Check{BinaryExists()},
+		Checks: []Check{BinaryExists(), {
+			Kind:     CheckCommandSuccessful,
+			Arg:      "docker info",
+			Severity: SeverityError,
+			Fix:      "Ensure docker can be executed successfully by the current user",
+		}},
 	},
 	{
 		Binary:                "remoteproc-runtime",
@@ -142,9 +154,12 @@ func hardwareCapabilityMatches(required []HardwareCapability, available map[Hard
 	return false
 }
 
-type BinaryExistsFn = func(bin string) error
+type (
+	BinaryExistsFn      = func(bin string) error
+	CommandSuccessfulFn = func(fullCmd string) error
+)
 
-func PerformChecks(dependencies []Dependency, binaryExists BinaryExistsFn) []DependencyStatus {
+func PerformChecks(dependencies []Dependency, binaryExists BinaryExistsFn, commandSuccessful CommandSuccessfulFn) []DependencyStatus {
 	installed := make(map[SoftwareDependency]struct{})
 	result := make([]DependencyStatus, 0, len(dependencies))
 
@@ -162,6 +177,8 @@ func PerformChecks(dependencies []Dependency, binaryExists BinaryExistsFn) []Dep
 				if err == nil && dep.SoftwareEnumID != UnsetSoftwareDependency {
 					installed[dep.SoftwareEnumID] = struct{}{}
 				}
+			case CheckCommandSuccessful:
+				err = commandSuccessful(check.Arg)
 			}
 			if err != nil {
 				if check.Severity == SeverityWarning {
@@ -196,6 +213,15 @@ func BinaryExistsLocally(bin string) error {
 	}
 	if _, err := exec.LookPath(bin); err != nil {
 		return fmt.Errorf("%q executable file not found in $PATH", bin)
+	}
+	return nil
+}
+
+func CommandSuccessfulLocally(fullCmd string) error {
+	cmdParts := strings.Fields(fullCmd)
+	execCmd := exec.Command(cmdParts[0], cmdParts[1:]...)
+	if err := execCmd.Run(); err != nil {
+		return fmt.Errorf("failed to run `%s`: %w", fullCmd, err)
 	}
 	return nil
 }

--- a/internal/health/dependencies_test.go
+++ b/internal/health/dependencies_test.go
@@ -206,7 +206,7 @@ func TestPerformChecks(t *testing.T) {
 		assert.Equal(t, want, got)
 	})
 
-	t.Run("captures failure from a command successful check", func(t *testing.T) {
+	t.Run("captures failure from a command successful check and verifies that arguments are passed correctly", func(t *testing.T) {
 		dep := health.Dependency{
 			Binary: "docker",
 			Label:  "Container Engine",
@@ -218,7 +218,12 @@ func TestPerformChecks(t *testing.T) {
 			}},
 		}
 		mockBinaryExists := func(string) error { return nil }
-		mockCommandSuccessful := func(string) error { return errors.New("permission denied") }
+		mockCommandSuccessful := func(cmd string) error {
+			if cmd == "docker --version" {
+				return errors.New("permission denied")
+			}
+			return nil
+		}
 
 		got := health.PerformChecks([]health.Dependency{dep}, mockBinaryExists, mockCommandSuccessful)
 
@@ -230,31 +235,6 @@ func TestPerformChecks(t *testing.T) {
 			},
 		}
 		assert.Equal(t, want, got)
-	})
-
-	t.Run("passes runnable check args through from the check definition", func(t *testing.T) {
-		dep := health.Dependency{
-			Binary: "docker",
-			Label:  "Container Engine",
-			Checks: []health.Check{health.BinaryExists(), {
-				Kind:     health.CheckCommandSuccessful,
-				Arg:      "docker --version",
-				Severity: health.SeverityError,
-				Fix:      "Ensure current user can run docker commands",
-			}},
-		}
-		mockBinaryExists := func(string) error { return nil }
-		calledWithCmd := ""
-		mockCommandSuccessful := func(cmd string) error {
-			calledWithCmd = cmd
-			return nil
-		}
-
-		got := health.PerformChecks([]health.Dependency{dep}, mockBinaryExists, mockCommandSuccessful)
-
-		assert.Len(t, got, 1)
-		assert.Equal(t, "docker --version", calledWithCmd)
-		assert.NoError(t, got[0].Error)
 	})
 }
 

--- a/internal/health/dependencies_test.go
+++ b/internal/health/dependencies_test.go
@@ -214,7 +214,7 @@ func TestPerformChecks(t *testing.T) {
 				Kind:     health.CheckCommandSuccessful,
 				Arg:      "docker --version",
 				Severity: health.SeverityError,
-				Fix:      "Ensure docker can be executed successfully by the current user",
+				Fix:      "Ensure current user can run docker commands",
 			}},
 		}
 		mockBinaryExists := func(string) error { return nil }
@@ -226,7 +226,7 @@ func TestPerformChecks(t *testing.T) {
 			{
 				Dependency: dep,
 				Error:      errors.New("permission denied"),
-				Fix:        "Ensure docker can be executed successfully by the current user",
+				Fix:        "Ensure current user can run docker commands",
 			},
 		}
 		assert.Equal(t, want, got)
@@ -240,7 +240,7 @@ func TestPerformChecks(t *testing.T) {
 				Kind:     health.CheckCommandSuccessful,
 				Arg:      "docker --version",
 				Severity: health.SeverityError,
-				Fix:      "Ensure docker can be executed successfully by the current user",
+				Fix:      "Ensure current user can run docker commands",
 			}},
 		}
 		mockBinaryExists := func(string) error { return nil }

--- a/internal/health/dependencies_test.go
+++ b/internal/health/dependencies_test.go
@@ -72,8 +72,9 @@ func TestPerformChecks(t *testing.T) {
 		mockBinaryExists := func(bin string) error {
 			return fmt.Errorf("%q executable file not found in $PATH", bin)
 		}
+		mockCommandSuccessful := func(string) error { return nil }
 
-		got := health.PerformChecks(deps, mockBinaryExists)
+		got := health.PerformChecks(deps, mockBinaryExists, mockCommandSuccessful)
 
 		want := []health.DependencyStatus{
 			{
@@ -94,8 +95,9 @@ func TestPerformChecks(t *testing.T) {
 		mockBinaryExists := func(bin string) error {
 			return fmt.Errorf("%q executable file not found in $PATH", bin)
 		}
+		mockCommandSuccessful := func(string) error { return nil }
 
-		got := health.PerformChecks(deps, mockBinaryExists)
+		got := health.PerformChecks(deps, mockBinaryExists, mockCommandSuccessful)
 
 		assert.Len(t, got, 1)
 		want := []health.DependencyStatus{
@@ -117,8 +119,9 @@ func TestPerformChecks(t *testing.T) {
 			}
 			return fmt.Errorf("%q executable file not found in $PATH", bin)
 		}
+		mockCommandSuccessful := func(string) error { return nil }
 
-		got := health.PerformChecks(deps, mockBinaryExists)
+		got := health.PerformChecks(deps, mockBinaryExists, mockCommandSuccessful)
 
 		want := []health.DependencyStatus{
 			{
@@ -140,8 +143,9 @@ func TestPerformChecks(t *testing.T) {
 			}
 			return fmt.Errorf("%q executable file not found in $PATH", bin)
 		}
+		mockCommandSuccessful := func(string) error { return nil }
 
-		got := health.PerformChecks(deps, mockBinaryExists)
+		got := health.PerformChecks(deps, mockBinaryExists, mockCommandSuccessful)
 
 		want := []health.DependencyStatus{
 			{Dependency: health.Dependency{Binary: "docker", Label: "Container Engine", Checks: []health.Check{health.BinaryExists()}}, Error: mockBinaryExists("docker")},
@@ -157,8 +161,9 @@ func TestPerformChecks(t *testing.T) {
 		mockBinaryExists := func(bin string) error {
 			return nil
 		}
+		mockCommandSuccessful := func(string) error { return nil }
 
-		got := health.PerformChecks(deps, mockBinaryExists)
+		got := health.PerformChecks(deps, mockBinaryExists, mockCommandSuccessful)
 
 		want := []health.DependencyStatus{
 			{Dependency: health.Dependency{Binary: "docker", Label: "Container Engine", SoftwareEnumID: health.Docker, Checks: []health.Check{health.BinaryExists()}}, Error: nil},
@@ -176,8 +181,9 @@ func TestPerformChecks(t *testing.T) {
 		mockBinaryExists := func(bin string) error {
 			return errors.New("vader not found")
 		}
+		mockCommandSuccessful := func(string) error { return nil }
 
-		got := health.PerformChecks([]health.Dependency{dep}, mockBinaryExists)
+		got := health.PerformChecks([]health.Dependency{dep}, mockBinaryExists, mockCommandSuccessful)
 
 		assert.Len(t, got, 1)
 		assert.Equal(t, "turn Anakin into a bad man", got[0].Fix)
@@ -190,13 +196,65 @@ func TestPerformChecks(t *testing.T) {
 		mockBinaryExists := func(bin string) error {
 			return nil
 		}
+		mockCommandSuccessful := func(string) error { return nil }
 
-		got := health.PerformChecks(deps, mockBinaryExists)
+		got := health.PerformChecks(deps, mockBinaryExists, mockCommandSuccessful)
 
 		want := []health.DependencyStatus{
 			{Dependency: health.Dependency{Binary: "standalone", Label: "Tools", Checks: []health.Check{health.BinaryExists()}}, Error: nil},
 		}
 		assert.Equal(t, want, got)
+	})
+
+	t.Run("captures failure from a command successful check", func(t *testing.T) {
+		dep := health.Dependency{
+			Binary: "docker",
+			Label:  "Container Engine",
+			Checks: []health.Check{health.BinaryExists(), {
+				Kind:     health.CheckCommandSuccessful,
+				Arg:      "docker --version",
+				Severity: health.SeverityError,
+				Fix:      "Ensure docker can be executed successfully by the current user",
+			}},
+		}
+		mockBinaryExists := func(string) error { return nil }
+		mockCommandSuccessful := func(string) error { return errors.New("permission denied") }
+
+		got := health.PerformChecks([]health.Dependency{dep}, mockBinaryExists, mockCommandSuccessful)
+
+		want := []health.DependencyStatus{
+			{
+				Dependency: dep,
+				Error:      errors.New("permission denied"),
+				Fix:        "Ensure docker can be executed successfully by the current user",
+			},
+		}
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("passes runnable check args through from the check definition", func(t *testing.T) {
+		dep := health.Dependency{
+			Binary: "docker",
+			Label:  "Container Engine",
+			Checks: []health.Check{health.BinaryExists(), {
+				Kind:     health.CheckCommandSuccessful,
+				Arg:      "docker --version",
+				Severity: health.SeverityError,
+				Fix:      "Ensure docker can be executed successfully by the current user",
+			}},
+		}
+		mockBinaryExists := func(string) error { return nil }
+		calledWithCmd := ""
+		mockCommandSuccessful := func(cmd string) error {
+			calledWithCmd = cmd
+			return nil
+		}
+
+		got := health.PerformChecks([]health.Dependency{dep}, mockBinaryExists, mockCommandSuccessful)
+
+		assert.Len(t, got, 1)
+		assert.Equal(t, "docker --version", calledWithCmd)
+		assert.NoError(t, got[0].Error)
 	})
 }
 

--- a/internal/health/dependencies_test.go
+++ b/internal/health/dependencies_test.go
@@ -208,18 +208,18 @@ func TestPerformChecks(t *testing.T) {
 
 	t.Run("captures failure from a command successful check and verifies that arguments are passed correctly", func(t *testing.T) {
 		dep := health.Dependency{
-			Binary: "docker",
-			Label:  "Container Engine",
+			Binary: "potatoes",
+			Label:  "Air Fryer Engine",
 			Checks: []health.Check{health.BinaryExists(), {
 				Kind:     health.CheckCommandSuccessful,
-				Arg:      "docker --version",
+				Arg:      "potatoes --cook-well",
 				Severity: health.SeverityError,
-				Fix:      "Ensure current user can run docker commands",
+				Fix:      "Ensure current user can run the potatoe cooker",
 			}},
 		}
 		mockBinaryExists := func(string) error { return nil }
 		mockCommandSuccessful := func(cmd string) error {
-			if cmd == "docker --version" {
+			if cmd == "potatoes --cook-well" {
 				return errors.New("permission denied")
 			}
 			return nil
@@ -231,7 +231,7 @@ func TestPerformChecks(t *testing.T) {
 			{
 				Dependency: dep,
 				Error:      errors.New("permission denied"),
-				Fix:        "Ensure current user can run docker commands",
+				Fix:        "Ensure current user can run the potatoe cooker",
 			},
 		}
 		assert.Equal(t, want, got)

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -60,7 +60,7 @@ func (r TargetReport) MarshalJSON() ([]byte, error) {
 }
 
 func CheckHost() HostReport {
-	dependencyStatuses := PerformChecks(HostRequiredDependencies, BinaryExistsLocally)
+	dependencyStatuses := PerformChecks(HostRequiredDependencies, BinaryExistsLocally, CommandSuccessfulLocally)
 	return GenerateHostReport(dependencyStatuses)
 }
 

--- a/internal/health/status.go
+++ b/internal/health/status.go
@@ -36,7 +36,10 @@ func ProbeHealthStatus(c target.Connection) Status {
 	remoteprocs, _ := c.ProbeRemoteproc()
 	status.Hardware.RemoteCPU = remoteprocs
 	dependenciesToCheck := FilterByHardware(TargetRequiredDependencies, status.Hardware.Capabilities())
-	status.Dependencies = PerformChecks(dependenciesToCheck, c.BinaryExists)
+	status.Dependencies = PerformChecks(dependenciesToCheck, c.BinaryExists, func(fullCmd string) error {
+		_, err := c.Run(fullCmd)
+		return err
+	})
 
 	return status
 }


### PR DESCRIPTION
## Changes

- Add a new runnable-binary dependency check alongside the existing binary presence check.
- Use it for the host Docker dependency by running docker info, so health checks fail when Docker is installed but not accessible to the current user.
