### PR TITLE
Ensure template names match repo names

### DIFF
--- a/e2e/templates_test.go
+++ b/e2e/templates_test.go
@@ -29,9 +29,10 @@ totalmemory_kb: 4194304
 		output := string(out)
 
 		require.NoError(t, err, output)
-		assert.Contains(t, output, "✅ Hello-World")
-		assert.Contains(t, output, "❌ Lightbulb-moment")
+		assert.Contains(t, output, "✅ topo-welcome")
+		assert.Contains(t, output, "❌ topo-lightbulb-moment")
 	})
+
 	t.Run("correctly handles the --target flag when no target description is provided", func(t *testing.T) {
 		bin := buildBinary(t)
 		target := testutil.StartTargetContainer(t)
@@ -41,7 +42,7 @@ totalmemory_kb: 4194304
 		output := string(out)
 
 		require.NoError(t, err, output)
-		assert.Contains(t, output, "✅ Hello-World")
+		assert.Contains(t, output, "✅ topo-welcome")
 	})
 }
 

--- a/e2e/templates_test.go
+++ b/e2e/templates_test.go
@@ -11,38 +11,54 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestTemplatesTargetDescription(t *testing.T) {
-	t.Run("matches templates to target description", func(t *testing.T) {
-		bin := buildBinary(t)
+func TestTemplates(t *testing.T) {
+	bin := buildBinary(t)
 
-		targetDescriptionYAML := `host:
+	t.Run("lists builtin templates", func(t *testing.T) {
+		cmd := exec.Command(bin, "templates")
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err)
+
+		output := string(out)
+
+		assert.Contains(t, output, "topo-welcome")
+		assert.Contains(t, output, "git@github.com:")
+		assert.Contains(t, output, "Features:")
+	})
+
+	t.Run("filtering", func(t *testing.T) {
+		t.Run("matches templates to target description", func(t *testing.T) {
+			bin := buildBinary(t)
+
+			targetDescriptionYAML := `host:
   - model: Cortex-A
     cores: 4
     features:
       - asimd
 totalmemory_kb: 4194304
 `
-		targetDescriptionPath := writeTargetDescription(t, targetDescriptionYAML)
+			targetDescriptionPath := writeTargetDescription(t, targetDescriptionYAML)
 
-		cmd := exec.Command(bin, "templates", "--target-description", targetDescriptionPath)
-		out, err := cmd.CombinedOutput()
-		output := string(out)
+			cmd := exec.Command(bin, "templates", "--target-description", targetDescriptionPath)
+			out, err := cmd.CombinedOutput()
+			output := string(out)
 
-		require.NoError(t, err, output)
-		assert.Contains(t, output, "✅ topo-welcome")
-		assert.Contains(t, output, "❌ topo-lightbulb-moment")
-	})
+			require.NoError(t, err, output)
+			assert.Contains(t, output, "✅ topo-welcome")
+			assert.Contains(t, output, "❌ topo-lightbulb-moment")
+		})
 
-	t.Run("correctly handles the --target flag when no target description is provided", func(t *testing.T) {
-		bin := buildBinary(t)
-		target := testutil.StartTargetContainer(t)
+		t.Run("correctly handles the --target flag when no target description is provided", func(t *testing.T) {
+			bin := buildBinary(t)
+			target := testutil.StartTargetContainer(t)
 
-		cmd := exec.Command(bin, "templates", "--target", target.SSHDestination)
-		out, err := cmd.CombinedOutput()
-		output := string(out)
+			cmd := exec.Command(bin, "templates", "--target", target.SSHDestination)
+			out, err := cmd.CombinedOutput()
+			output := string(out)
 
-		require.NoError(t, err, output)
-		assert.Contains(t, output, "✅ topo-welcome")
+			require.NoError(t, err, output)
+			assert.Contains(t, output, "✅ topo-welcome")
+		})
 	})
 }
 

--- a/e2e/topo_test.go
+++ b/e2e/topo_test.go
@@ -17,7 +17,7 @@ func TestListTemplates(t *testing.T) {
 
 	output := string(out)
 
-	assert.Contains(t, output, "Hello-World")
+	assert.Contains(t, output, "topo-welcome")
 	assert.Contains(t, output, "git@github.com:")
 	assert.Contains(t, output, "Features:")
 }

--- a/e2e/topo_test.go
+++ b/e2e/topo_test.go
@@ -5,22 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
-
-func TestListTemplates(t *testing.T) {
-	bin := buildBinary(t)
-
-	cmd := exec.Command(bin, "templates")
-	out, err := cmd.CombinedOutput()
-	require.NoError(t, err)
-
-	output := string(out)
-
-	assert.Contains(t, output, "topo-welcome")
-	assert.Contains(t, output, "git@github.com:")
-	assert.Contains(t, output, "Features:")
-}
 
 func TestUnknownCommand(t *testing.T) {
 	bin := buildBinary(t)

--- a/internal/catalog/catalog_test.go
+++ b/internal/catalog/catalog_test.go
@@ -10,11 +10,11 @@ import (
 
 func TestGetTemplateRepo(t *testing.T) {
 	t.Run("when template exists it is found", func(t *testing.T) {
-		template, err := catalog.GetTemplateRepo("Lightbulb-moment")
+		template, err := catalog.GetTemplateRepo("topo-lightbulb-moment")
 
 		require.NoError(t, err)
 		assert.Equal(t, &catalog.Repo{
-			Name:        "Lightbulb-moment",
+			Name:        "topo-lightbulb-moment",
 			Description: "Reads a switch over GPIO pins on an M class cpu, reports switch state over Remoteproc Message, then a web application on the A class reads this and displays a lightbulb in either the on or off state. The lightbulb state is described by an LLM in any user-specified style.",
 			Features:    []string{"remoteproc-runtime"},
 			URL:         "git@github.com:Arm-Examples/topo-lightbulb-moment.git",

--- a/internal/catalog/data/templates.json
+++ b/internal/catalog/data/templates.json
@@ -1,37 +1,29 @@
 [
   {
-    "name": "Hello-World",
+    "name": "topo-welcome",
     "description": "A minimal \"Hello, World\" web app for validating a Topo setup and deployment.\nIt runs a single service that exposes a web page on the target,\nwith the greeting text customizable via the GREETING_NAME parameter.\n",
     "features": null,
     "url": "git@github.com:Arm-Examples/topo-welcome.git",
     "ref": "main"
   },
   {
-    "name": "Lightbulb-moment",
+    "name": "topo-lightbulb-moment",
     "description": "Reads a switch over GPIO pins on an M class cpu, reports switch state over Remoteproc Message, then a web application on the A class reads this and displays a lightbulb in either the on or off state. The lightbulb state is described by an LLM in any user-specified style.",
-    "features": [
-      "remoteproc-runtime"
-    ],
+    "features": ["remoteproc-runtime"],
     "url": "git@github.com:Arm-Examples/topo-lightbulb-moment.git",
     "ref": "main"
   },
   {
-    "name": "armv9-cpu-llm-chat",
+    "name": "topo-v9-cpu-chat",
     "description": "Complete LLM chat application optimized for Arm CPU inference.\n\nThis project demonstrates running large language models on CPU\nusing llama.cpp compiled with Arm baseline optimizations and \naccelerated using NEON SIMD and SVE (when supported and enabled).\n\nThe stack includes:\n- llama.cpp server with Arm NEON optimizations (SVE optional)\n- Quantized Qwen2.5-1.5B-Instruct model bundled in the image (~1.12 GB)\n- Simple web-based chat interface\n- No GPU required - pure CPU inference\n\nPerfect for demos and testing! The bundled Qwen2.5-1.5B model allows the\nproject to run immediately without downloading additional models.\n\nIdeal for testing LLM workloads on Arm hardware without GPU dependencies,\nshowcasing how far you can push NEON acceleration. Rebuild with SVE enabled\nwhen wider vectors are available.\n",
-    "features": [
-      "SVE",
-      "NEON"
-    ],
+    "features": ["SVE", "NEON"],
     "url": "git@github.com:Arm-Examples/topo-v9-cpu-chat.git",
     "ref": "main"
   },
   {
-    "name": "simd-visual-benchmark",
+    "name": "topo-simd-visual-benchmark",
     "description": "Visual demonstration of SIMD performance benefits on Arm processors.\nCompare scalar (no SIMD), NEON (128-bit), and SVE (scalable vector)\nimplementations running identical image processing workloads side-by-side.\n\nThis demo shows real hardware acceleration through three C++ services\ncompiled with different architecture flags, processing the same box blur\nalgorithm on images. Performance differences are measured in real-time\nand displayed in an interactive web dashboard.\n\nPerfect for demonstrating to non-technical audiences the concrete benefits\nof SIMD optimizations, with visual results and quantified speedups.\n",
-    "features": [
-      "NEON",
-      "SVE"
-    ],
+    "features": ["NEON", "SVE"],
     "url": "git@github.com:Arm-Examples/topo-simd-visual-benchmark.git",
     "ref": "main"
   }


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- Synchronises internal template names with git repo names that host them, this makes `topo clone` produce predictable directory names. Otherwise, doing `topo clone template:Hello-World` yields `./topo-welcome`.
