### PR TITLE
fix: handle conditional `$PATH` inclusions on Ubuntu/Debian

### DIFF
--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -400,6 +400,16 @@ func InstallBinariesFromGithubRelease(targetHost ssh.Host, repoURL string, binar
 			return nil, fmt.Errorf("installation of new binaries failed: %w", err)
 		}
 
+		// Re-check PATH after installation: on some systems (e.g. Ubuntu/Debian),
+		// ~/.profile only adds ~/bin to PATH if the directory already exists.
+		// Creating the directory during install means a new login shell will now
+		// include the path, even though it wasn't present during the earlier check.
+		if !installLoc.OnPath {
+			if pathDirs, pathErr := getPathDirs(targetHost); pathErr == nil {
+				installLoc.OnPath = slices.Contains(pathDirs, installLoc.Path)
+			}
+		}
+
 		for _, binaryName := range installedBinaries {
 			results = append(results, InstallResult{
 				Location: installLoc,


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- Fixes the problem on beagle, where user's private bin is added conditionally

```
beagle@beagle:~$ cat ~/.profile
# ~/.profile: executed by the command interpreter for login shells.
# This file is not read by bash(1), if ~/.bash_profile or ~/.bash_login
# exists.
# see /usr/share/doc/bash/examples/startup-files for examples.
# the files are located in the bash-doc package.

# the default umask is set in /etc/profile; for setting the umask
# for ssh logins, install and configure the libpam-umask package.
#umask 022

# if running bash
if [ -n "$BASH_VERSION" ]; then
    # include .bashrc if it exists
    if [ -f "$HOME/.bashrc" ]; then
	. "$HOME/.bashrc"
    fi
fi

# set PATH so it includes user's private bin if it exists
if [ -d "$HOME/bin" ] ; then
    PATH="$HOME/bin:$PATH"
fi

# set PATH so it includes user's private bin if it exists
if [ -d "$HOME/.local/bin" ] ; then
    PATH="$HOME/.local/bin:$PATH"
fi
```
