### PR TITLE
ci: run e2e test packages in series

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -92,6 +92,10 @@ jobs:
       - name: Build
         run: |
           go build -v ./cmd/topo
+  
+      - name: Run unit tests
+        run: |
+          go test ./internal/... -v
 
       - name: Run e2e tests
         env: 
@@ -99,7 +103,3 @@ jobs:
         run: |
           docker build -t topo-e2e-target:latest ./internal/testutil/test-container
           go test ./e2e/... -p 1 -v
-
-      - name: Run unit tests
-        run: |
-          go test ./internal/... -v

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -93,9 +93,13 @@ jobs:
         run: |
           go build -v ./cmd/topo
 
-      - name: Run tests with coverage
+      - name: Run e2e tests
         env: 
           DOCKER_HOST: ${{ matrix.docker_host }}
         run: |
           docker build -t topo-e2e-target:latest ./internal/testutil/test-container
-          go test ./... -p 1 -v -covermode=atomic -coverprofile=coverage.out
+          go test ./e2e/... -p 1 -v
+
+      - name: Run unit tests
+        run: |
+          go test ./internal/... -v

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -98,4 +98,4 @@ jobs:
           DOCKER_HOST: ${{ matrix.docker_host }}
         run: |
           docker build -t topo-e2e-target:latest ./internal/testutil/test-container
-          go test ./... -v -covermode=atomic -coverprofile=coverage.out
+          go test ./... -p 1 -v -covermode=atomic -coverprofile=coverage.out


### PR DESCRIPTION
## Background

<!-- List the changes this PR introduces -->

- My suspicion is that most of the flaky e2e tests are race conditions stemming from the parallelization of go's test runner at the package level since our e2e tests are spread across different packages


## Changes

- This PR runs all test packages in series w/ `-p 1` (default is `-p <cores>`) as a simple bandaid that will slow the CI down but should improve its stability. We can revisit this in the future if speed becomes a problem.
