### PR TITLE
feat: add ssh connection timeout

### DIFF
--- a/cmd/topo/describe.go
+++ b/cmd/topo/describe.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/arm/topo/internal/describe"
 	"github.com/arm/topo/internal/output/console"
@@ -24,7 +25,7 @@ var describeCmd = &cobra.Command{
 			return err
 		}
 
-		conn := target.NewConnection(sshTarget, target.ConnectionOptions{Multiplex: true})
+		conn := target.NewConnection(sshTarget, target.ConnectionOptions{Multiplex: true, ConnectTimeout: 5 * time.Second})
 		report, err := describe.GenerateTargetDescription(conn)
 		if err != nil {
 			return err

--- a/cmd/topo/describe.go
+++ b/cmd/topo/describe.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"time"
 
 	"github.com/arm/topo/internal/describe"
 	"github.com/arm/topo/internal/output/console"
@@ -25,7 +24,7 @@ var describeCmd = &cobra.Command{
 			return err
 		}
 
-		conn := target.NewConnection(sshTarget, target.ConnectionOptions{Multiplex: true, ConnectTimeout: 5 * time.Second})
+		conn := target.NewConnection(sshTarget, target.ConnectionOptions{Multiplex: true, ConnectTimeout: sshConnectTimeout})
 		report, err := describe.GenerateTargetDescription(conn)
 		if err != nil {
 			return err

--- a/cmd/topo/health.go
+++ b/cmd/topo/health.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"time"
 
 	"github.com/arm/topo/internal/health"
 	"github.com/arm/topo/internal/output/printable"
@@ -40,7 +39,7 @@ var healthCmd = &cobra.Command{
 		}
 
 		if sshTarget, ok := lookupTarget(cmd); ok {
-			targetReport, err := health.CheckTarget(sshTarget, acceptNewHostKeys, 5*time.Second)
+			targetReport, err := health.CheckTarget(sshTarget, acceptNewHostKeys, sshConnectTimeout)
 			if err != nil {
 				if spinner != nil {
 					spinner.Stop()

--- a/cmd/topo/health.go
+++ b/cmd/topo/health.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/arm/topo/internal/health"
 	"github.com/arm/topo/internal/output/printable"
@@ -39,7 +40,7 @@ var healthCmd = &cobra.Command{
 		}
 
 		if sshTarget, ok := lookupTarget(cmd); ok {
-			targetReport, err := health.CheckTarget(sshTarget, acceptNewHostKeys)
+			targetReport, err := health.CheckTarget(sshTarget, acceptNewHostKeys, 5*time.Second)
 			if err != nil {
 				if spinner != nil {
 					spinner.Stop()

--- a/cmd/topo/root.go
+++ b/cmd/topo/root.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/arm/topo/internal/output/term"
 	"github.com/arm/topo/internal/version"
@@ -28,6 +29,8 @@ func init() {
 }
 
 const targetEnvVar = "TOPO_TARGET"
+
+const sshConnectTimeout = 5 * time.Second
 
 func addTargetFlag(cmd *cobra.Command) {
 	cmd.Flags().StringP(

--- a/cmd/topo/templates.go
+++ b/cmd/topo/templates.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"os"
-	"time"
 
 	"github.com/arm/topo/internal/catalog"
 	"github.com/arm/topo/internal/describe"
@@ -38,7 +37,7 @@ var templatesCmd = &cobra.Command{
 		} else {
 			resolvedTarget, exists := lookupTarget(cmd)
 			if exists {
-				conn := target.NewConnection(resolvedTarget, target.ConnectionOptions{Multiplex: true, ConnectTimeout: 5 * time.Second})
+				conn := target.NewConnection(resolvedTarget, target.ConnectionOptions{Multiplex: true, ConnectTimeout: sshConnectTimeout})
 				hwProfile, err := describe.GenerateTargetDescription(conn)
 				if err != nil {
 					return err

--- a/cmd/topo/templates.go
+++ b/cmd/topo/templates.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"time"
 
 	"github.com/arm/topo/internal/catalog"
 	"github.com/arm/topo/internal/describe"
@@ -37,7 +38,7 @@ var templatesCmd = &cobra.Command{
 		} else {
 			resolvedTarget, exists := lookupTarget(cmd)
 			if exists {
-				conn := target.NewConnection(resolvedTarget, target.ConnectionOptions{Multiplex: true})
+				conn := target.NewConnection(resolvedTarget, target.ConnectionOptions{Multiplex: true, ConnectTimeout: 5 * time.Second})
 				hwProfile, err := describe.GenerateTargetDescription(conn)
 				if err != nil {
 					return err

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/arm/topo/internal/target"
 )
@@ -64,13 +65,14 @@ func CheckHost() HostReport {
 	return GenerateHostReport(dependencyStatuses)
 }
 
-func CheckTarget(sshTarget string, acceptNewHostKeys bool) (TargetReport, error) {
+func CheckTarget(sshTarget string, acceptNewHostKeys bool, connectTimeout time.Duration) (TargetReport, error) {
 	opts := target.ConnectionOptions{
 		AcceptNewHostKeys: acceptNewHostKeys,
 		AuthProbeInput:    os.Stdin,
 		AuthProbeOutput:   os.Stdout,
 		Multiplex:         true,
 		WithLoginShell:    true,
+		ConnectTimeout:    connectTimeout,
 	}
 	conn := target.NewConnection(sshTarget, opts)
 	targetStatus := ProbeHealthStatus(conn)

--- a/internal/ssh/config.go
+++ b/internal/ssh/config.go
@@ -4,13 +4,16 @@ import (
 	"bufio"
 	"bytes"
 	"os/exec"
+	"strconv"
 	"strings"
+	"time"
 )
 
 type Config struct {
-	host string
-	user string
-	port string
+	host           string
+	user           string
+	port           string
+	connectTimeout time.Duration
 }
 
 func NewConfig(destination string) Config {
@@ -36,7 +39,19 @@ func NewConfigFromBytes(data []byte) Config {
 			config.user = fields[1]
 		case "port":
 			config.port = fields[1]
+		case "connecttimeout":
+			if secs, err := strconv.Atoi(fields[1]); err == nil {
+				config.connectTimeout = time.Duration(secs) * time.Second
+			}
 		}
 	}
 	return config
+}
+
+// ConnectTimeout returns the user's configured ConnectTimeout if set, otherwise the fallback.
+func (c Config) ConnectTimeout(fallback time.Duration) time.Duration {
+	if c.connectTimeout > 0 {
+		return c.connectTimeout
+	}
+	return fallback
 }

--- a/internal/ssh/config_test.go
+++ b/internal/ssh/config_test.go
@@ -2,6 +2,7 @@ package ssh
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -48,5 +49,41 @@ Port 22
 
 		want := Config{host: "kwik.e.mart", user: "apu", port: "22"}
 		assert.Equal(t, want, got)
+	})
+
+	t.Run("parses connecttimeout as duration", func(t *testing.T) {
+		input := []byte(`hostname springfield.nuclear.gov
+connecttimeout 30
+`)
+
+		got := NewConfigFromBytes(input)
+
+		assert.Equal(t, 30*time.Second, got.connectTimeout)
+	})
+
+	t.Run("ignores non-numeric connecttimeout", func(t *testing.T) {
+		input := []byte(`hostname springfield.nuclear.gov
+connecttimeout none
+`)
+
+		got := NewConfigFromBytes(input)
+
+		assert.Equal(t, time.Duration(0), got.connectTimeout)
+	})
+}
+
+func TestConfigConnectTimeout(t *testing.T) {
+	const fallback = 5 * time.Second
+
+	t.Run("returns user config value when set", func(t *testing.T) {
+		config := Config{connectTimeout: 30 * time.Second}
+
+		assert.Equal(t, 30*time.Second, config.ConnectTimeout(fallback))
+	})
+
+	t.Run("returns fallback when not set in config", func(t *testing.T) {
+		config := Config{}
+
+		assert.Equal(t, fallback, config.ConnectTimeout(fallback))
 	})
 }

--- a/internal/target/connection.go
+++ b/internal/target/connection.go
@@ -138,6 +138,17 @@ var (
 	ErrAuthenticationFailure = errors.New("ssh authentication failed")
 )
 
+type ConnectionTimeoutError struct {
+	Timeout time.Duration
+}
+
+func (e ConnectionTimeoutError) Error() string {
+	if e.Timeout > 0 {
+		return fmt.Sprintf("ssh connection timed out after %s", e.Timeout)
+	}
+	return "ssh connection timed out"
+}
+
 func (c *Connection) isPasswordAuthenticated() (bool, error) {
 	var extraArgs []string
 	if c.opts.AcceptNewHostKeys {
@@ -184,6 +195,9 @@ func (c *Connection) runSSHAuthenticationProbe(sshArgs []string) error {
 	}
 	if strings.Contains(output, "permission denied") || strings.Contains(output, "authentication failed") || strings.Contains(output, "password") {
 		return ErrAuthenticationFailure
+	}
+	if strings.Contains(output, "timed out") || strings.Contains(output, "connection timeout") || strings.Contains(output, "did not properly respond after a period of time") {
+		return ConnectionTimeoutError{Timeout: c.opts.ConnectTimeout}
 	}
 	return fmt.Errorf("ssh probe failed: %w", err)
 }

--- a/internal/target/connection.go
+++ b/internal/target/connection.go
@@ -61,6 +61,7 @@ func NewConnection(sshTarget string, opts ConnectionOptions) Connection {
 	if opts.WithMockExec != nil {
 		execFn = opts.WithMockExec
 	}
+	opts.ConnectTimeout = ssh.NewConfig(sshTarget).ConnectTimeout(opts.ConnectTimeout)
 	return Connection{
 		SSHTarget: ssh.Host(sshTarget),
 		exec:      execFn,

--- a/internal/target/connection.go
+++ b/internal/target/connection.go
@@ -9,6 +9,7 @@ import (
 	"runtime"
 	"slices"
 	"strings"
+	"time"
 
 	commandpkg "github.com/arm/topo/internal/command"
 	"github.com/arm/topo/internal/ssh"
@@ -50,6 +51,7 @@ type ConnectionOptions struct {
 	WithStdin         []byte
 	Multiplex         bool
 	WithMockExec      ExecSSH
+	ConnectTimeout    time.Duration
 }
 
 var ErrPasswordAuthentication = errors.New("key-based SSH authentication is not setup")
@@ -71,7 +73,7 @@ func (c *Connection) Run(command string) (string, error) {
 		command = ssh.ShellCommand(command)
 	}
 
-	sshArgs := []string{}
+	sshArgs := c.connectTimeoutArgs()
 	if c.opts.Multiplex && runtime.GOOS != "windows" {
 		sshArgs = append(sshArgs, "-o", "ControlMaster=auto", "-o", "ControlPersist=10s", "-o", "ControlPath=~/.ssh/topo-cm-%r@%h:%p")
 	}
@@ -161,10 +163,17 @@ func (c *Connection) isPasswordAuthenticated() (bool, error) {
 	}
 }
 
+func (c *Connection) connectTimeoutArgs() []string {
+	if c.opts.ConnectTimeout <= 0 {
+		return nil
+	}
+	return []string{"-o", fmt.Sprintf("ConnectTimeout=%d", int(c.opts.ConnectTimeout.Seconds()))}
+}
+
 // All SSH authentication probes run the command "true" to check if the authentication method works.
 // All sshArgs should be hardcoded SSH options, not user-provided arguments.
 func (c *Connection) runSSHAuthenticationProbe(sshArgs []string) error {
-	cmd := c.exec(c.SSHTarget, "true", nil, sshArgs...)
+	cmd := c.exec(c.SSHTarget, "true", nil, slices.Concat(c.connectTimeoutArgs(), sshArgs)...)
 	stdoutBytes, err := cmd.CombinedOutput()
 	if err == nil {
 		return nil


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- Added a configurable connection timeout for SSH operations.
   - A 5-second default timeout is applied to all SSH commands, with a user-friendly error message displayed on a connection timeout.
   - If the user has ConnectTimeout set in their SSH config, that value takes precedence over the default.

<img width="395" height="126" alt="Screenshot 2026-03-17 at 14 15 46" src="https://github.com/user-attachments/assets/b7c18758-8f7a-4019-a20b-162142d3c118" />

---

As a followup PR, I'd like to make this configurable via `--timeout` parameter. I think 5s is a sensible default to start with.
