### PR TITLE
test: refactor test to use less function call

### DIFF
--- a/internal/deploy/docker/deploy_test.go
+++ b/internal/deploy/docker/deploy_test.go
@@ -44,11 +44,12 @@ func TestNewDeployment(t *testing.T) {
 			operation.NewDockerComposePull(composeFile, ssh.PlainLocalhost),
 		}
 		want = append(want, operation.NewRunRegistry(port)...)
+		wantTunnelStart, wantSecurityCheck, wantTunnelStop := ssh.NewSSHTunnel(remoteHost, port, opts.UseSSHControlSockets)
 		want = append(want,
-			ssh.NewSSHTunnelStart(remoteHost, port, opts.Registry.UseControlSockets),
-			ssh.NewCheckSSHTunnelSecurity(remoteHost, port),
+			wantTunnelStart,
+			wantSecurityCheck,
 			operation.NewRegistryTransfer(composeFile, ssh.PlainLocalhost, remoteHost, port),
-			ssh.NewSSHTunnelStop(remoteHost),
+			wantTunnelStop,
 			operation.NewDockerComposeUp(composeFile, remoteHost, operation.RecreateModeDefault),
 		)
 

--- a/internal/deploy/docker/deploy_test.go
+++ b/internal/deploy/docker/deploy_test.go
@@ -44,7 +44,7 @@ func TestNewDeployment(t *testing.T) {
 			operation.NewDockerComposePull(composeFile, ssh.PlainLocalhost),
 		}
 		want = append(want, operation.NewRunRegistry(port)...)
-		wantTunnelStart, wantSecurityCheck, wantTunnelStop := ssh.NewSSHTunnel(remoteHost, port, opts.UseSSHControlSockets)
+		wantTunnelStart, wantSecurityCheck, wantTunnelStop := ssh.NewSSHTunnel(remoteHost, port, opts.Registry.UseControlSockets)
 		want = append(want,
 			wantTunnelStart,
 			wantSecurityCheck,


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- Fix one test to call ssh.NewSSHTunnel instead of each NewSSHTunnelStart, NewCheckSSHTunnelSecurity and NewSSHTunnelStop
