### PR TITLE
refactor: Rename SSH connection structs accurately

### DIFF
--- a/cmd/topo/deploy.go
+++ b/cmd/topo/deploy.go
@@ -87,7 +87,7 @@ Use --dry-run to see what commands would be executed without actually running th
 			return err
 		}
 
-		targetHost := ssh.Host(resolvedTarget)
+		targetHost := ssh.SSHDestination(resolvedTarget)
 		deployOpts.TargetHost = targetHost
 
 		if !skipProjectChecks {

--- a/cmd/topo/deploy.go
+++ b/cmd/topo/deploy.go
@@ -87,7 +87,7 @@ Use --dry-run to see what commands would be executed without actually running th
 			return err
 		}
 
-		targetHost := ssh.SSHDestination(resolvedTarget)
+		targetHost := ssh.Destination(resolvedTarget)
 		deployOpts.TargetHost = targetHost
 
 		if !skipProjectChecks {

--- a/cmd/topo/install_remoteproc_runtime.go
+++ b/cmd/topo/install_remoteproc_runtime.go
@@ -35,7 +35,7 @@ Falls back to ~/bin if no suitable locations are automatically found.
 		if err != nil {
 			return err
 		}
-		p, err := installRemoteprocRuntime(ssh.Host(sshTarget))
+		p, err := installRemoteprocRuntime(ssh.SSHDestination(sshTarget))
 		if err != nil {
 			return err
 		}
@@ -43,7 +43,7 @@ Falls back to ~/bin if no suitable locations are automatically found.
 	},
 }
 
-func installRemoteprocRuntime(targetHost ssh.Host) (printable.Printable, error) {
+func installRemoteprocRuntime(targetHost ssh.SSHDestination) (printable.Printable, error) {
 	results, err := install.InstallBinariesFromGithubRelease(targetHost, remoteprocRuntimeRepoURL, []string{"remoteproc-runtime", "containerd-shim-remoteproc-v1"})
 	if err != nil {
 		return nil, err

--- a/cmd/topo/install_remoteproc_runtime.go
+++ b/cmd/topo/install_remoteproc_runtime.go
@@ -35,7 +35,7 @@ Falls back to ~/bin if no suitable locations are automatically found.
 		if err != nil {
 			return err
 		}
-		p, err := installRemoteprocRuntime(ssh.SSHDestination(sshTarget))
+		p, err := installRemoteprocRuntime(ssh.Destination(sshTarget))
 		if err != nil {
 			return err
 		}
@@ -43,7 +43,7 @@ Falls back to ~/bin if no suitable locations are automatically found.
 	},
 }
 
-func installRemoteprocRuntime(targetHost ssh.SSHDestination) (printable.Printable, error) {
+func installRemoteprocRuntime(targetHost ssh.Destination) (printable.Printable, error) {
 	results, err := install.InstallBinariesFromGithubRelease(targetHost, remoteprocRuntimeRepoURL, []string{"remoteproc-runtime", "containerd-shim-remoteproc-v1"})
 	if err != nil {
 		return nil, err

--- a/cmd/topo/install_remoteproc_runtime.go
+++ b/cmd/topo/install_remoteproc_runtime.go
@@ -43,8 +43,8 @@ Falls back to ~/bin if no suitable locations are automatically found.
 	},
 }
 
-func installRemoteprocRuntime(targetHost ssh.Destination) (printable.Printable, error) {
-	results, err := install.InstallBinariesFromGithubRelease(targetHost, remoteprocRuntimeRepoURL, []string{"remoteproc-runtime", "containerd-shim-remoteproc-v1"})
+func installRemoteprocRuntime(targetDest ssh.Destination) (printable.Printable, error) {
+	results, err := install.InstallBinariesFromGithubRelease(targetDest, remoteprocRuntimeRepoURL, []string{"remoteproc-runtime", "containerd-shim-remoteproc-v1"})
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/topo/setup_keys.go
+++ b/cmd/topo/setup_keys.go
@@ -35,7 +35,7 @@ Use --dry-run to see what commands would be executed without actually running th
 			return err
 		}
 
-		targetSlug := ssh.SSHDestination(resolvedTarget).Slugify()
+		targetSlug := ssh.Destination(resolvedTarget).Slugify()
 		if privateKeyPath == "" {
 			privateKeyPath, err = setupkeys.GetDefaultPrivateKeyPath(targetSlug)
 			if err != nil {

--- a/cmd/topo/setup_keys.go
+++ b/cmd/topo/setup_keys.go
@@ -35,7 +35,7 @@ Use --dry-run to see what commands would be executed without actually running th
 			return err
 		}
 
-		targetSlug := ssh.Host(resolvedTarget).Slugify()
+		targetSlug := ssh.SSHDestination(resolvedTarget).Slugify()
 		if privateKeyPath == "" {
 			privateKeyPath, err = setupkeys.GetDefaultPrivateKeyPath(targetSlug)
 			if err != nil {

--- a/cmd/topo/stop.go
+++ b/cmd/topo/stop.go
@@ -39,7 +39,7 @@ Use --dry-run to see what commands would be executed without actually running th
 			return err
 		}
 
-		targetHost := ssh.Host(resolvedTarget)
+		targetHost := ssh.SSHDestination(resolvedTarget)
 
 		stop := docker.NewDeploymentStop(composeFile, targetHost)
 		if dryRun {

--- a/cmd/topo/stop.go
+++ b/cmd/topo/stop.go
@@ -39,7 +39,7 @@ Use --dry-run to see what commands would be executed without actually running th
 			return err
 		}
 
-		targetHost := ssh.SSHDestination(resolvedTarget)
+		targetHost := ssh.Destination(resolvedTarget)
 
 		stop := docker.NewDeploymentStop(composeFile, targetHost)
 		if dryRun {

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -7,12 +7,12 @@ import (
 	"github.com/arm/topo/internal/ssh"
 )
 
-func Docker(h ssh.Host, args ...string) *exec.Cmd {
+func Docker(h ssh.SSHDestination, args ...string) *exec.Cmd {
 	cmdArgs := append(hostToArgs(h), args...)
 	return exec.Command("docker", cmdArgs...)
 }
 
-func DockerCompose(h ssh.Host, composeFile string, args ...string) *exec.Cmd {
+func DockerCompose(h ssh.SSHDestination, composeFile string, args ...string) *exec.Cmd {
 	composeArgs := append([]string{"compose", "-f", composeFile}, args...)
 	cmdArgs := append(hostToArgs(h), composeArgs...)
 	return exec.Command("docker", cmdArgs...)
@@ -27,7 +27,7 @@ func String(cmd *exec.Cmd) string {
 	return strings.Join(cmd.Args, " ")
 }
 
-func hostToArgs(h ssh.Host) []string {
+func hostToArgs(h ssh.SSHDestination) []string {
 	if h.IsPlainLocalhost() {
 		return nil
 	}

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -7,12 +7,12 @@ import (
 	"github.com/arm/topo/internal/ssh"
 )
 
-func Docker(h ssh.SSHDestination, args ...string) *exec.Cmd {
+func Docker(h ssh.Destination, args ...string) *exec.Cmd {
 	cmdArgs := append(hostToArgs(h), args...)
 	return exec.Command("docker", cmdArgs...)
 }
 
-func DockerCompose(h ssh.SSHDestination, composeFile string, args ...string) *exec.Cmd {
+func DockerCompose(h ssh.Destination, composeFile string, args ...string) *exec.Cmd {
 	composeArgs := append([]string{"compose", "-f", composeFile}, args...)
 	cmdArgs := append(hostToArgs(h), composeArgs...)
 	return exec.Command("docker", cmdArgs...)
@@ -27,7 +27,7 @@ func String(cmd *exec.Cmd) string {
 	return strings.Join(cmd.Args, " ")
 }
 
-func hostToArgs(h ssh.SSHDestination) []string {
+func hostToArgs(h ssh.Destination) []string {
 	if h.IsPlainLocalhost() {
 		return nil
 	}

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestString(t *testing.T) {
 	t.Run("converts docker command to string", func(t *testing.T) {
-		h := ssh.SSHDestination("user@remote")
+		h := ssh.Destination("user@remote")
 		cmd := command.Docker(h, "save", "alpine:latest")
 
 		got := command.String(cmd)
@@ -20,7 +20,7 @@ func TestString(t *testing.T) {
 	})
 
 	t.Run("converts docker compose command to string", func(t *testing.T) {
-		h := ssh.SSHDestination("user@remote")
+		h := ssh.Destination("user@remote")
 		cmd := command.DockerCompose(h, "/path/to/compose.yaml", "up", "-d")
 
 		got := command.String(cmd)

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestString(t *testing.T) {
 	t.Run("converts docker command to string", func(t *testing.T) {
-		h := ssh.Host("user@remote")
+		h := ssh.SSHDestination("user@remote")
 		cmd := command.Docker(h, "save", "alpine:latest")
 
 		got := command.String(cmd)
@@ -20,7 +20,7 @@ func TestString(t *testing.T) {
 	})
 
 	t.Run("converts docker compose command to string", func(t *testing.T) {
-		h := ssh.Host("user@remote")
+		h := ssh.SSHDestination("user@remote")
 		cmd := command.DockerCompose(h, "/path/to/compose.yaml", "up", "-d")
 
 		got := command.String(cmd)

--- a/internal/deploy/docker/deploy.go
+++ b/internal/deploy/docker/deploy.go
@@ -13,11 +13,11 @@ type RegistryConfig struct {
 
 type DeployOptions struct {
 	RecreateMode operation.RecreateMode
-	TargetHost   ssh.SSHDestination
+	TargetHost   ssh.Destination
 	Registry     *RegistryConfig
 }
 
-func SupportsRegistry(noRegistry bool, targetHost ssh.SSHDestination) bool {
+func SupportsRegistry(noRegistry bool, targetHost ssh.Destination) bool {
 	return !noRegistry && !targetHost.IsPlainLocalhost()
 }
 
@@ -25,7 +25,7 @@ func SupportsSSHControlSockets(goos string) bool {
 	return goos != "windows"
 }
 
-func NewDeploymentStop(composeFile string, targetHost ssh.SSHDestination) goperation.Sequence {
+func NewDeploymentStop(composeFile string, targetHost ssh.Destination) goperation.Sequence {
 	return goperation.Sequence{operation.NewDockerComposeStop(composeFile, targetHost)}
 }
 

--- a/internal/deploy/docker/deploy.go
+++ b/internal/deploy/docker/deploy.go
@@ -13,11 +13,11 @@ type RegistryConfig struct {
 
 type DeployOptions struct {
 	RecreateMode operation.RecreateMode
-	TargetHost   ssh.Host
+	TargetHost   ssh.SSHDestination
 	Registry     *RegistryConfig
 }
 
-func SupportsRegistry(noRegistry bool, targetHost ssh.Host) bool {
+func SupportsRegistry(noRegistry bool, targetHost ssh.SSHDestination) bool {
 	return !noRegistry && !targetHost.IsPlainLocalhost()
 }
 
@@ -25,7 +25,7 @@ func SupportsSSHControlSockets(goos string) bool {
 	return goos != "windows"
 }
 
-func NewDeploymentStop(composeFile string, targetHost ssh.Host) goperation.Sequence {
+func NewDeploymentStop(composeFile string, targetHost ssh.SSHDestination) goperation.Sequence {
 	return goperation.Sequence{operation.NewDockerComposeStop(composeFile, targetHost)}
 }
 

--- a/internal/deploy/docker/deploy_test.go
+++ b/internal/deploy/docker/deploy_test.go
@@ -20,7 +20,7 @@ func TestNewDeployment(t *testing.T) {
 	composeFile := "compose.yaml"
 
 	t.Run("includes transfer operation for remote host", func(t *testing.T) {
-		remoteHost := ssh.Host("user@remote")
+		remoteHost := ssh.SSHDestination("user@remote")
 		deployOpts := docker.DeployOptions{TargetHost: remoteHost}
 		got, _ := docker.NewDeployment(composeFile, deployOpts)
 
@@ -34,7 +34,7 @@ func TestNewDeployment(t *testing.T) {
 	})
 
 	t.Run("includes registry operations for remote host when enabled", func(t *testing.T) {
-		remoteHost := ssh.Host("user@remote")
+		remoteHost := ssh.SSHDestination("user@remote")
 		port := operation.DefaultRegistryPort
 		opts := docker.DeployOptions{TargetHost: remoteHost, Registry: &docker.RegistryConfig{Port: port, UseControlSockets: true}}
 		got, _ := docker.NewDeployment(composeFile, opts)
@@ -93,7 +93,7 @@ func TestNewDeployment(t *testing.T) {
 	})
 
 	t.Run("returns an SSH tunnel cleanup operation for remote host", func(t *testing.T) {
-		remoteHost := ssh.Host("user@remote")
+		remoteHost := ssh.SSHDestination("user@remote")
 		deployOpts := docker.DeployOptions{TargetHost: remoteHost, Registry: &docker.RegistryConfig{UseControlSockets: true}}
 		_, cleanup := docker.NewDeployment(composeFile, deployOpts)
 
@@ -111,7 +111,7 @@ func TestNewDeployment(t *testing.T) {
 	})
 
 	t.Run("does not use SSH control sockets when disabled", func(t *testing.T) {
-		remoteHost := ssh.Host("user@remote")
+		remoteHost := ssh.SSHDestination("user@remote")
 		port := operation.DefaultRegistryPort
 		opts := docker.DeployOptions{TargetHost: remoteHost, Registry: &docker.RegistryConfig{Port: port, UseControlSockets: false}}
 		got, _ := docker.NewDeployment(composeFile, opts)
@@ -141,7 +141,7 @@ func TestDeployment(t *testing.T) {
 		target := testutil.StartTargetContainer(t)
 
 		t.Run("builds images, transfers them, and starts services", func(t *testing.T) {
-			remoteDockerHost := ssh.Host(target.SSHDestination)
+			remoteDockerHost := ssh.SSHDestination(target.SSHDestination)
 			tmpDir := t.TempDir()
 			dockerFilePath := filepath.Join(tmpDir, "Dockerfile")
 			dockerFileContent := `
@@ -185,7 +185,7 @@ services:
     image: busybox
 `
 			testutil.RequireWriteFile(t, composeFilePath, composeFileContent)
-			deployOpts := docker.DeployOptions{TargetHost: ssh.Host("user@remote")}
+			deployOpts := docker.DeployOptions{TargetHost: ssh.SSHDestination("user@remote")}
 			d, _ := docker.NewDeployment(composeFilePath, deployOpts)
 
 			err := d.DryRun(&buf)

--- a/internal/deploy/docker/deploy_test.go
+++ b/internal/deploy/docker/deploy_test.go
@@ -20,7 +20,7 @@ func TestNewDeployment(t *testing.T) {
 	composeFile := "compose.yaml"
 
 	t.Run("includes transfer operation for remote host", func(t *testing.T) {
-		remoteHost := ssh.SSHDestination("user@remote")
+		remoteHost := ssh.Destination("user@remote")
 		deployOpts := docker.DeployOptions{TargetHost: remoteHost}
 		got, _ := docker.NewDeployment(composeFile, deployOpts)
 
@@ -34,7 +34,7 @@ func TestNewDeployment(t *testing.T) {
 	})
 
 	t.Run("includes registry operations for remote host when enabled", func(t *testing.T) {
-		remoteHost := ssh.SSHDestination("user@remote")
+		remoteHost := ssh.Destination("user@remote")
 		port := operation.DefaultRegistryPort
 		opts := docker.DeployOptions{TargetHost: remoteHost, Registry: &docker.RegistryConfig{Port: port, UseControlSockets: true}}
 		got, _ := docker.NewDeployment(composeFile, opts)
@@ -93,7 +93,7 @@ func TestNewDeployment(t *testing.T) {
 	})
 
 	t.Run("returns an SSH tunnel cleanup operation for remote host", func(t *testing.T) {
-		remoteHost := ssh.SSHDestination("user@remote")
+		remoteHost := ssh.Destination("user@remote")
 		deployOpts := docker.DeployOptions{TargetHost: remoteHost, Registry: &docker.RegistryConfig{UseControlSockets: true}}
 		_, cleanup := docker.NewDeployment(composeFile, deployOpts)
 
@@ -111,7 +111,7 @@ func TestNewDeployment(t *testing.T) {
 	})
 
 	t.Run("does not use SSH control sockets when disabled", func(t *testing.T) {
-		remoteHost := ssh.SSHDestination("user@remote")
+		remoteHost := ssh.Destination("user@remote")
 		port := operation.DefaultRegistryPort
 		opts := docker.DeployOptions{TargetHost: remoteHost, Registry: &docker.RegistryConfig{Port: port, UseControlSockets: false}}
 		got, _ := docker.NewDeployment(composeFile, opts)
@@ -141,7 +141,7 @@ func TestDeployment(t *testing.T) {
 		target := testutil.StartTargetContainer(t)
 
 		t.Run("builds images, transfers them, and starts services", func(t *testing.T) {
-			remoteDockerHost := ssh.SSHDestination(target.SSHDestination)
+			remoteDockerHost := ssh.Destination(target.SSHDestination)
 			tmpDir := t.TempDir()
 			dockerFilePath := filepath.Join(tmpDir, "Dockerfile")
 			dockerFileContent := `
@@ -185,7 +185,7 @@ services:
     image: busybox
 `
 			testutil.RequireWriteFile(t, composeFilePath, composeFileContent)
-			deployOpts := docker.DeployOptions{TargetHost: ssh.SSHDestination("user@remote")}
+			deployOpts := docker.DeployOptions{TargetHost: ssh.Destination("user@remote")}
 			d, _ := docker.NewDeployment(composeFilePath, deployOpts)
 
 			err := d.DryRun(&buf)

--- a/internal/deploy/docker/operation/docker.go
+++ b/internal/deploy/docker/operation/docker.go
@@ -11,11 +11,11 @@ import (
 
 type Docker struct {
 	description string
-	host        ssh.SSHDestination
+	host        ssh.Destination
 	args        []string
 }
 
-func NewDocker(description string, h ssh.SSHDestination, args []string) *Docker {
+func NewDocker(description string, h ssh.Destination, args []string) *Docker {
 	return &Docker{
 		description: description,
 		host:        h,
@@ -44,17 +44,17 @@ func (d *Docker) buildCommand() *exec.Cmd {
 	return command.Docker(d.host, d.args...)
 }
 
-func NewDockerPull(host ssh.SSHDestination, image string) *Docker {
+func NewDockerPull(host ssh.Destination, image string) *Docker {
 	description := fmt.Sprintf("Pull image %s", image)
 	return NewDocker(description, host, []string{"pull", image})
 }
 
-func NewDockerStart(host ssh.SSHDestination, container string) *Docker {
+func NewDockerStart(host ssh.Destination, container string) *Docker {
 	description := fmt.Sprintf("Start container %s", container)
 	return NewDocker(description, host, []string{"start", container})
 }
 
-func NewDockerRun(host ssh.SSHDestination, image string, container string, dockerArgs []string) *Docker {
+func NewDockerRun(host ssh.Destination, image string, container string, dockerArgs []string) *Docker {
 	description := fmt.Sprintf("Run image %s as container %s", image, container)
 	allArgs := []string{"run"}
 	allArgs = append(allArgs, dockerArgs...)

--- a/internal/deploy/docker/operation/docker.go
+++ b/internal/deploy/docker/operation/docker.go
@@ -11,11 +11,11 @@ import (
 
 type Docker struct {
 	description string
-	host        ssh.Host
+	host        ssh.SSHDestination
 	args        []string
 }
 
-func NewDocker(description string, h ssh.Host, args []string) *Docker {
+func NewDocker(description string, h ssh.SSHDestination, args []string) *Docker {
 	return &Docker{
 		description: description,
 		host:        h,
@@ -44,17 +44,17 @@ func (d *Docker) buildCommand() *exec.Cmd {
 	return command.Docker(d.host, d.args...)
 }
 
-func NewDockerPull(host ssh.Host, image string) *Docker {
+func NewDockerPull(host ssh.SSHDestination, image string) *Docker {
 	description := fmt.Sprintf("Pull image %s", image)
 	return NewDocker(description, host, []string{"pull", image})
 }
 
-func NewDockerStart(host ssh.Host, container string) *Docker {
+func NewDockerStart(host ssh.SSHDestination, container string) *Docker {
 	description := fmt.Sprintf("Start container %s", container)
 	return NewDocker(description, host, []string{"start", container})
 }
 
-func NewDockerRun(host ssh.Host, image string, container string, dockerArgs []string) *Docker {
+func NewDockerRun(host ssh.SSHDestination, image string, container string, dockerArgs []string) *Docker {
 	description := fmt.Sprintf("Run image %s as container %s", image, container)
 	allArgs := []string{"run"}
 	allArgs = append(allArgs, dockerArgs...)

--- a/internal/deploy/docker/operation/docker_compose.go
+++ b/internal/deploy/docker/operation/docker_compose.go
@@ -12,11 +12,11 @@ import (
 type DockerCompose struct {
 	description string
 	composeFile string
-	host        ssh.SSHDestination
+	host        ssh.Destination
 	args        []string
 }
 
-func NewDockerCompose(description string, composeFile string, h ssh.SSHDestination, args []string) *DockerCompose {
+func NewDockerCompose(description string, composeFile string, h ssh.Destination, args []string) *DockerCompose {
 	return &DockerCompose{
 		description: description,
 		composeFile: composeFile,
@@ -46,15 +46,15 @@ func (dc *DockerCompose) buildCommand() *exec.Cmd {
 	return command.DockerCompose(dc.host, dc.composeFile, dc.args...)
 }
 
-func NewDockerComposeBuild(composeFile string, h ssh.SSHDestination) *DockerCompose {
+func NewDockerComposeBuild(composeFile string, h ssh.Destination) *DockerCompose {
 	return NewDockerCompose("Build images", composeFile, h, []string{"build"})
 }
 
-func NewDockerComposePull(composeFile string, h ssh.SSHDestination) *DockerCompose {
+func NewDockerComposePull(composeFile string, h ssh.Destination) *DockerCompose {
 	return NewDockerCompose("Pull images", composeFile, h, []string{"pull"})
 }
 
-func NewDockerComposeStop(composeFile string, h ssh.SSHDestination) *DockerCompose {
+func NewDockerComposeStop(composeFile string, h ssh.Destination) *DockerCompose {
 	return NewDockerCompose("Stop services", composeFile, h, []string{"stop"})
 }
 
@@ -66,7 +66,7 @@ const (
 	RecreateModeNone
 )
 
-func NewDockerComposeUp(composeFile string, h ssh.SSHDestination, mode RecreateMode) *DockerCompose {
+func NewDockerComposeUp(composeFile string, h ssh.Destination, mode RecreateMode) *DockerCompose {
 	args := []string{"up", "-d", "--no-build", "--pull", "never"}
 	switch mode {
 	case RecreateModeForce:

--- a/internal/deploy/docker/operation/docker_compose.go
+++ b/internal/deploy/docker/operation/docker_compose.go
@@ -12,11 +12,11 @@ import (
 type DockerCompose struct {
 	description string
 	composeFile string
-	host        ssh.Host
+	host        ssh.SSHDestination
 	args        []string
 }
 
-func NewDockerCompose(description string, composeFile string, h ssh.Host, args []string) *DockerCompose {
+func NewDockerCompose(description string, composeFile string, h ssh.SSHDestination, args []string) *DockerCompose {
 	return &DockerCompose{
 		description: description,
 		composeFile: composeFile,
@@ -46,15 +46,15 @@ func (dc *DockerCompose) buildCommand() *exec.Cmd {
 	return command.DockerCompose(dc.host, dc.composeFile, dc.args...)
 }
 
-func NewDockerComposeBuild(composeFile string, h ssh.Host) *DockerCompose {
+func NewDockerComposeBuild(composeFile string, h ssh.SSHDestination) *DockerCompose {
 	return NewDockerCompose("Build images", composeFile, h, []string{"build"})
 }
 
-func NewDockerComposePull(composeFile string, h ssh.Host) *DockerCompose {
+func NewDockerComposePull(composeFile string, h ssh.SSHDestination) *DockerCompose {
 	return NewDockerCompose("Pull images", composeFile, h, []string{"pull"})
 }
 
-func NewDockerComposeStop(composeFile string, h ssh.Host) *DockerCompose {
+func NewDockerComposeStop(composeFile string, h ssh.SSHDestination) *DockerCompose {
 	return NewDockerCompose("Stop services", composeFile, h, []string{"stop"})
 }
 
@@ -66,7 +66,7 @@ const (
 	RecreateModeNone
 )
 
-func NewDockerComposeUp(composeFile string, h ssh.Host, mode RecreateMode) *DockerCompose {
+func NewDockerComposeUp(composeFile string, h ssh.SSHDestination, mode RecreateMode) *DockerCompose {
 	args := []string{"up", "-d", "--no-build", "--pull", "never"}
 	switch mode {
 	case RecreateModeForce:

--- a/internal/deploy/docker/operation/docker_compose_test.go
+++ b/internal/deploy/docker/operation/docker_compose_test.go
@@ -41,7 +41,7 @@ services:
 			var buf bytes.Buffer
 			tmpDir := t.TempDir()
 			composeFilePath := filepath.Join(tmpDir, "compose.yaml")
-			remoteHost := ssh.Host("user@remote")
+			remoteHost := ssh.SSHDestination("user@remote")
 			op := operation.NewDockerCompose("", composeFilePath, remoteHost, []string{"up", "-d", "--no-build"})
 
 			err := op.DryRun(&buf)
@@ -56,7 +56,7 @@ services:
 
 func TestNewDockerComposeBuild(t *testing.T) {
 	composeFilePath := "/path/to/compose.yaml"
-	remoteHost := ssh.Host("user@remote")
+	remoteHost := ssh.SSHDestination("user@remote")
 	op := operation.NewDockerComposeBuild(composeFilePath, remoteHost)
 
 	t.Run("Description", func(t *testing.T) {
@@ -78,7 +78,7 @@ func TestNewDockerComposeBuild(t *testing.T) {
 
 func TestNewDockerComposePull(t *testing.T) {
 	composeFilePath := "/path/to/compose.yaml"
-	remoteHost := ssh.Host("user@remote")
+	remoteHost := ssh.SSHDestination("user@remote")
 	op := operation.NewDockerComposePull(composeFilePath, remoteHost)
 
 	t.Run("Description", func(t *testing.T) {
@@ -100,7 +100,7 @@ func TestNewDockerComposePull(t *testing.T) {
 
 func TestNewDockerComposeRun(t *testing.T) {
 	composeFilePath := "/path/to/compose.yaml"
-	remoteHost := ssh.Host("user@remote")
+	remoteHost := ssh.SSHDestination("user@remote")
 	opDefault := operation.NewDockerComposeUp(composeFilePath, remoteHost, operation.RecreateModeDefault)
 
 	t.Run("Description", func(t *testing.T) {

--- a/internal/deploy/docker/operation/docker_compose_test.go
+++ b/internal/deploy/docker/operation/docker_compose_test.go
@@ -41,7 +41,7 @@ services:
 			var buf bytes.Buffer
 			tmpDir := t.TempDir()
 			composeFilePath := filepath.Join(tmpDir, "compose.yaml")
-			remoteHost := ssh.SSHDestination("user@remote")
+			remoteHost := ssh.Destination("user@remote")
 			op := operation.NewDockerCompose("", composeFilePath, remoteHost, []string{"up", "-d", "--no-build"})
 
 			err := op.DryRun(&buf)
@@ -56,7 +56,7 @@ services:
 
 func TestNewDockerComposeBuild(t *testing.T) {
 	composeFilePath := "/path/to/compose.yaml"
-	remoteHost := ssh.SSHDestination("user@remote")
+	remoteHost := ssh.Destination("user@remote")
 	op := operation.NewDockerComposeBuild(composeFilePath, remoteHost)
 
 	t.Run("Description", func(t *testing.T) {
@@ -78,7 +78,7 @@ func TestNewDockerComposeBuild(t *testing.T) {
 
 func TestNewDockerComposePull(t *testing.T) {
 	composeFilePath := "/path/to/compose.yaml"
-	remoteHost := ssh.SSHDestination("user@remote")
+	remoteHost := ssh.Destination("user@remote")
 	op := operation.NewDockerComposePull(composeFilePath, remoteHost)
 
 	t.Run("Description", func(t *testing.T) {
@@ -100,7 +100,7 @@ func TestNewDockerComposePull(t *testing.T) {
 
 func TestNewDockerComposeRun(t *testing.T) {
 	composeFilePath := "/path/to/compose.yaml"
-	remoteHost := ssh.SSHDestination("user@remote")
+	remoteHost := ssh.Destination("user@remote")
 	opDefault := operation.NewDockerComposeUp(composeFilePath, remoteHost, operation.RecreateModeDefault)
 
 	t.Run("Description", func(t *testing.T) {

--- a/internal/deploy/docker/operation/docker_compose_transfer.go
+++ b/internal/deploy/docker/operation/docker_compose_transfer.go
@@ -14,11 +14,11 @@ import (
 
 type DockerComposePipeTransfer struct {
 	composeFile string
-	sourceHost  ssh.SSHDestination
-	targetHost  ssh.SSHDestination
+	sourceHost  ssh.Destination
+	targetHost  ssh.Destination
 }
 
-func NewDockerComposePipeTransfer(composeFile string, sourceHost, targetHost ssh.SSHDestination) *DockerComposePipeTransfer {
+func NewDockerComposePipeTransfer(composeFile string, sourceHost, targetHost ssh.Destination) *DockerComposePipeTransfer {
 	return &DockerComposePipeTransfer{
 		composeFile: composeFile,
 		sourceHost:  sourceHost,

--- a/internal/deploy/docker/operation/docker_compose_transfer.go
+++ b/internal/deploy/docker/operation/docker_compose_transfer.go
@@ -14,11 +14,11 @@ import (
 
 type DockerComposePipeTransfer struct {
 	composeFile string
-	sourceHost  ssh.Host
-	targetHost  ssh.Host
+	sourceHost  ssh.SSHDestination
+	targetHost  ssh.SSHDestination
 }
 
-func NewDockerComposePipeTransfer(composeFile string, sourceHost, targetHost ssh.Host) *DockerComposePipeTransfer {
+func NewDockerComposePipeTransfer(composeFile string, sourceHost, targetHost ssh.SSHDestination) *DockerComposePipeTransfer {
 	return &DockerComposePipeTransfer{
 		composeFile: composeFile,
 		sourceHost:  sourceHost,

--- a/internal/deploy/docker/operation/docker_compose_transfer_test.go
+++ b/internal/deploy/docker/operation/docker_compose_transfer_test.go
@@ -80,7 +80,7 @@ services:
     image: nginx:latest
 `
 			testutil.RequireWriteFile(t, composeFilePath, composeFileContent)
-			transfer := operation.NewDockerComposePipeTransfer(composeFilePath, h, ssh.Host("user@remote"))
+			transfer := operation.NewDockerComposePipeTransfer(composeFilePath, h, ssh.SSHDestination("user@remote"))
 
 			err := transfer.DryRun(&buf)
 

--- a/internal/deploy/docker/operation/docker_compose_transfer_test.go
+++ b/internal/deploy/docker/operation/docker_compose_transfer_test.go
@@ -80,7 +80,7 @@ services:
     image: nginx:latest
 `
 			testutil.RequireWriteFile(t, composeFilePath, composeFileContent)
-			transfer := operation.NewDockerComposePipeTransfer(composeFilePath, h, ssh.SSHDestination("user@remote"))
+			transfer := operation.NewDockerComposePipeTransfer(composeFilePath, h, ssh.Destination("user@remote"))
 
 			err := transfer.DryRun(&buf)
 

--- a/internal/deploy/docker/operation/docker_test.go
+++ b/internal/deploy/docker/operation/docker_test.go
@@ -30,7 +30,7 @@ func TestDocker(t *testing.T) {
 	t.Run("DryRun", func(t *testing.T) {
 		t.Run("prints command with multiple args and remote host", func(t *testing.T) {
 			var buf bytes.Buffer
-			remoteHost := ssh.SSHDestination("user@remote")
+			remoteHost := ssh.Destination("user@remote")
 			op := operation.NewDocker("Test operation", remoteHost, []string{"ps", "-a", "--format", "json"})
 
 			err := op.DryRun(&buf)
@@ -68,7 +68,7 @@ func TestDocker(t *testing.T) {
 
 func TestNewDockerPull(t *testing.T) {
 	image := "nginx:latest"
-	remoteHost := ssh.SSHDestination("user@remote")
+	remoteHost := ssh.Destination("user@remote")
 	op := operation.NewDockerPull(remoteHost, image)
 
 	t.Run("Description", func(t *testing.T) {
@@ -90,7 +90,7 @@ func TestNewDockerPull(t *testing.T) {
 
 func TestNewDockerStart(t *testing.T) {
 	container := "my-container"
-	remoteHost := ssh.SSHDestination("user@remote")
+	remoteHost := ssh.Destination("user@remote")
 	op := operation.NewDockerStart(remoteHost, container)
 
 	t.Run("Description", func(t *testing.T) {
@@ -113,7 +113,7 @@ func TestNewDockerStart(t *testing.T) {
 func TestNewDockerRun(t *testing.T) {
 	image := "alpine:latest"
 	container := "test-container"
-	remoteHost := ssh.SSHDestination("user@remote")
+	remoteHost := ssh.Destination("user@remote")
 
 	t.Run("Description", func(t *testing.T) {
 		op := operation.NewDockerRun(remoteHost, image, container, []string{"-d"})

--- a/internal/deploy/docker/operation/docker_test.go
+++ b/internal/deploy/docker/operation/docker_test.go
@@ -30,7 +30,7 @@ func TestDocker(t *testing.T) {
 	t.Run("DryRun", func(t *testing.T) {
 		t.Run("prints command with multiple args and remote host", func(t *testing.T) {
 			var buf bytes.Buffer
-			remoteHost := ssh.Host("user@remote")
+			remoteHost := ssh.SSHDestination("user@remote")
 			op := operation.NewDocker("Test operation", remoteHost, []string{"ps", "-a", "--format", "json"})
 
 			err := op.DryRun(&buf)
@@ -68,7 +68,7 @@ func TestDocker(t *testing.T) {
 
 func TestNewDockerPull(t *testing.T) {
 	image := "nginx:latest"
-	remoteHost := ssh.Host("user@remote")
+	remoteHost := ssh.SSHDestination("user@remote")
 	op := operation.NewDockerPull(remoteHost, image)
 
 	t.Run("Description", func(t *testing.T) {
@@ -90,7 +90,7 @@ func TestNewDockerPull(t *testing.T) {
 
 func TestNewDockerStart(t *testing.T) {
 	container := "my-container"
-	remoteHost := ssh.Host("user@remote")
+	remoteHost := ssh.SSHDestination("user@remote")
 	op := operation.NewDockerStart(remoteHost, container)
 
 	t.Run("Description", func(t *testing.T) {
@@ -113,7 +113,7 @@ func TestNewDockerStart(t *testing.T) {
 func TestNewDockerRun(t *testing.T) {
 	image := "alpine:latest"
 	container := "test-container"
-	remoteHost := ssh.Host("user@remote")
+	remoteHost := ssh.SSHDestination("user@remote")
 
 	t.Run("Description", func(t *testing.T) {
 		op := operation.NewDockerRun(remoteHost, image, container, []string{"-d"})

--- a/internal/deploy/docker/operation/registry.go
+++ b/internal/deploy/docker/operation/registry.go
@@ -55,11 +55,11 @@ func (r *RegistryRunWrapper) Run(w io.Writer) error {
 }
 
 type ContainerExistsPredicate struct {
-	host          ssh.Host
+	host          ssh.SSHDestination
 	containerName string
 }
 
-func NewContainerExistsPredicate(host ssh.Host, containerName string) *ContainerExistsPredicate {
+func NewContainerExistsPredicate(host ssh.SSHDestination, containerName string) *ContainerExistsPredicate {
 	return &ContainerExistsPredicate{host: host, containerName: containerName}
 }
 

--- a/internal/deploy/docker/operation/registry.go
+++ b/internal/deploy/docker/operation/registry.go
@@ -55,11 +55,11 @@ func (r *RegistryRunWrapper) Run(w io.Writer) error {
 }
 
 type ContainerExistsPredicate struct {
-	host          ssh.SSHDestination
+	host          ssh.Destination
 	containerName string
 }
 
-func NewContainerExistsPredicate(host ssh.SSHDestination, containerName string) *ContainerExistsPredicate {
+func NewContainerExistsPredicate(host ssh.Destination, containerName string) *ContainerExistsPredicate {
 	return &ContainerExistsPredicate{host: host, containerName: containerName}
 }
 

--- a/internal/deploy/docker/operation/registry_transfer.go
+++ b/internal/deploy/docker/operation/registry_transfer.go
@@ -17,12 +17,12 @@ var digestRegexp = regexp.MustCompile(`digest: (sha256:[a-f0-9]+)`)
 
 type RegistryTransfer struct {
 	composeFile string
-	sourceHost  ssh.SSHDestination
-	targetHost  ssh.SSHDestination
+	sourceHost  ssh.Destination
+	targetHost  ssh.Destination
 	port        string
 }
 
-func NewRegistryTransfer(composeFile string, sourceHost, targetHost ssh.SSHDestination, port string) *RegistryTransfer {
+func NewRegistryTransfer(composeFile string, sourceHost, targetHost ssh.Destination, port string) *RegistryTransfer {
 	return &RegistryTransfer{composeFile: composeFile, sourceHost: sourceHost, targetHost: targetHost, port: port}
 }
 

--- a/internal/deploy/docker/operation/registry_transfer.go
+++ b/internal/deploy/docker/operation/registry_transfer.go
@@ -17,12 +17,12 @@ var digestRegexp = regexp.MustCompile(`digest: (sha256:[a-f0-9]+)`)
 
 type RegistryTransfer struct {
 	composeFile string
-	sourceHost  ssh.Host
-	targetHost  ssh.Host
+	sourceHost  ssh.SSHDestination
+	targetHost  ssh.SSHDestination
 	port        string
 }
 
-func NewRegistryTransfer(composeFile string, sourceHost, targetHost ssh.Host, port string) *RegistryTransfer {
+func NewRegistryTransfer(composeFile string, sourceHost, targetHost ssh.SSHDestination, port string) *RegistryTransfer {
 	return &RegistryTransfer{composeFile: composeFile, sourceHost: sourceHost, targetHost: targetHost, port: port}
 }
 

--- a/internal/deploy/docker/operation/registry_transfer_test.go
+++ b/internal/deploy/docker/operation/registry_transfer_test.go
@@ -82,7 +82,7 @@ services:
     image: nginx:latest
 `
 			testutil.RequireWriteFile(t, composeFilePath, composeFileContent)
-			transfer := operation.NewRegistryTransfer(composeFilePath, h, ssh.SSHDestination("user@remote"), port)
+			transfer := operation.NewRegistryTransfer(composeFilePath, h, ssh.Destination("user@remote"), port)
 
 			err := transfer.DryRun(&buf)
 

--- a/internal/deploy/docker/operation/registry_transfer_test.go
+++ b/internal/deploy/docker/operation/registry_transfer_test.go
@@ -82,7 +82,7 @@ services:
     image: nginx:latest
 `
 			testutil.RequireWriteFile(t, composeFilePath, composeFileContent)
-			transfer := operation.NewRegistryTransfer(composeFilePath, h, ssh.Host("user@remote"), port)
+			transfer := operation.NewRegistryTransfer(composeFilePath, h, ssh.SSHDestination("user@remote"), port)
 
 			err := transfer.DryRun(&buf)
 

--- a/internal/deploy/docker/stop_test.go
+++ b/internal/deploy/docker/stop_test.go
@@ -20,7 +20,7 @@ func TestNewDeploymentStop(t *testing.T) {
 	composeFile := "compose.yaml"
 
 	t.Run("runs stop operation for remote host", func(t *testing.T) {
-		remoteHost := ssh.SSHDestination("user@remote")
+		remoteHost := ssh.Destination("user@remote")
 
 		got := docker.NewDeploymentStop(composeFile, remoteHost)
 
@@ -47,7 +47,7 @@ func TestDeploymentStop(t *testing.T) {
 		target := testutil.StartTargetContainer(t)
 
 		t.Run("deploys services then confirms stop shuts down containers", func(t *testing.T) {
-			remoteDockerHost := ssh.SSHDestination(target.SSHDestination)
+			remoteDockerHost := ssh.Destination(target.SSHDestination)
 			tmpDir := t.TempDir()
 			dockerFilePath := filepath.Join(tmpDir, "Dockerfile")
 			dockerFileContent := `
@@ -93,7 +93,7 @@ services:
     image: alpine:latest
 `
 			testutil.RequireWriteFile(t, composeFilePath, composeFileContent)
-			targetHost := ssh.SSHDestination("user@remote")
+			targetHost := ssh.Destination("user@remote")
 			stop := docker.NewDeploymentStop(composeFilePath, targetHost)
 
 			err := stop.DryRun(&buf)

--- a/internal/deploy/docker/stop_test.go
+++ b/internal/deploy/docker/stop_test.go
@@ -20,7 +20,7 @@ func TestNewDeploymentStop(t *testing.T) {
 	composeFile := "compose.yaml"
 
 	t.Run("runs stop operation for remote host", func(t *testing.T) {
-		remoteHost := ssh.Host("user@remote")
+		remoteHost := ssh.SSHDestination("user@remote")
 
 		got := docker.NewDeploymentStop(composeFile, remoteHost)
 
@@ -47,7 +47,7 @@ func TestDeploymentStop(t *testing.T) {
 		target := testutil.StartTargetContainer(t)
 
 		t.Run("deploys services then confirms stop shuts down containers", func(t *testing.T) {
-			remoteDockerHost := ssh.Host(target.SSHDestination)
+			remoteDockerHost := ssh.SSHDestination(target.SSHDestination)
 			tmpDir := t.TempDir()
 			dockerFilePath := filepath.Join(tmpDir, "Dockerfile")
 			dockerFileContent := `
@@ -93,7 +93,7 @@ services:
     image: alpine:latest
 `
 			testutil.RequireWriteFile(t, composeFilePath, composeFileContent)
-			targetHost := ssh.Host("user@remote")
+			targetHost := ssh.SSHDestination("user@remote")
 			stop := docker.NewDeploymentStop(composeFilePath, targetHost)
 
 			err := stop.DryRun(&buf)

--- a/internal/deploy/docker/testutil/testutil.go
+++ b/internal/deploy/docker/testutil/testutil.go
@@ -33,14 +33,14 @@ func TestProjectName(t *testing.T) string {
 	return "test-project-" + gtestutil.SanitiseTestName(t)
 }
 
-func RequireImageExists(t *testing.T, h ssh.SSHDestination, imageName string) {
+func RequireImageExists(t *testing.T, h ssh.Destination, imageName string) {
 	t.Helper()
 	inspectCmd := command.Docker(h, "image", "inspect", imageName)
 	output, err := inspectCmd.CombinedOutput()
 	require.NoError(t, err, "image %s doesn't exist: %s output: %s", imageName, command.String(inspectCmd), string(output))
 }
 
-func BuildMinimalImage(t *testing.T, h ssh.SSHDestination, imageName string) {
+func BuildMinimalImage(t *testing.T, h ssh.Destination, imageName string) {
 	t.Helper()
 	dockerfileContent := `
 FROM alpine:latest
@@ -69,7 +69,7 @@ func ForceComposeDown(t *testing.T, composeFilePath string) {
 	}
 }
 
-func AssertContainersRunning(t *testing.T, h ssh.SSHDestination, composeFilePath string) {
+func AssertContainersRunning(t *testing.T, h ssh.Destination, composeFilePath string) {
 	t.Helper()
 	dockerCmd := command.DockerCompose(h, composeFilePath, "ps", "--format", "json")
 	output, err := dockerCmd.CombinedOutput()
@@ -85,7 +85,7 @@ func AssertContainersRunning(t *testing.T, h ssh.SSHDestination, composeFilePath
 	}
 }
 
-func AssertContainersStopped(t *testing.T, h ssh.SSHDestination, composeFilePath string) {
+func AssertContainersStopped(t *testing.T, h ssh.Destination, composeFilePath string) {
 	t.Helper()
 	dockerCmd := command.DockerCompose(h, composeFilePath, "ps", "--format", "json", "--all")
 	output, err := dockerCmd.CombinedOutput()

--- a/internal/deploy/docker/testutil/testutil.go
+++ b/internal/deploy/docker/testutil/testutil.go
@@ -33,14 +33,14 @@ func TestProjectName(t *testing.T) string {
 	return "test-project-" + gtestutil.SanitiseTestName(t)
 }
 
-func RequireImageExists(t *testing.T, h ssh.Host, imageName string) {
+func RequireImageExists(t *testing.T, h ssh.SSHDestination, imageName string) {
 	t.Helper()
 	inspectCmd := command.Docker(h, "image", "inspect", imageName)
 	output, err := inspectCmd.CombinedOutput()
 	require.NoError(t, err, "image %s doesn't exist: %s output: %s", imageName, command.String(inspectCmd), string(output))
 }
 
-func BuildMinimalImage(t *testing.T, h ssh.Host, imageName string) {
+func BuildMinimalImage(t *testing.T, h ssh.SSHDestination, imageName string) {
 	t.Helper()
 	dockerfileContent := `
 FROM alpine:latest
@@ -69,7 +69,7 @@ func ForceComposeDown(t *testing.T, composeFilePath string) {
 	}
 }
 
-func AssertContainersRunning(t *testing.T, h ssh.Host, composeFilePath string) {
+func AssertContainersRunning(t *testing.T, h ssh.SSHDestination, composeFilePath string) {
 	t.Helper()
 	dockerCmd := command.DockerCompose(h, composeFilePath, "ps", "--format", "json")
 	output, err := dockerCmd.CombinedOutput()
@@ -85,7 +85,7 @@ func AssertContainersRunning(t *testing.T, h ssh.Host, composeFilePath string) {
 	}
 }
 
-func AssertContainersStopped(t *testing.T, h ssh.Host, composeFilePath string) {
+func AssertContainersStopped(t *testing.T, h ssh.SSHDestination, composeFilePath string) {
 	t.Helper()
 	dockerCmd := command.DockerCompose(h, composeFilePath, "ps", "--format", "json", "--all")
 	output, err := dockerCmd.CombinedOutput()

--- a/internal/describe/describe_test.go
+++ b/internal/describe/describe_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestGenerate(t *testing.T) {
 	t.Run("returns hardware profile for given target", func(t *testing.T) {
-		mockExecSSH := func(target ssh.SSHDestination, command string, _ []byte, sshArgs ...string) *exec.Cmd {
+		mockExecSSH := func(target ssh.Destination, command string, _ []byte, sshArgs ...string) *exec.Cmd {
 			if command == "lscpu --json" {
 				return testutil.CmdWithOutput(testutil.LsCpuOutputRaw, 0)
 			}
@@ -53,7 +53,7 @@ func TestGenerate(t *testing.T) {
 	})
 
 	t.Run("fails if ssh commands cannot be executed", func(t *testing.T) {
-		mockExecSSH := func(target ssh.SSHDestination, command string, _ []byte, sshArgs ...string) *exec.Cmd {
+		mockExecSSH := func(target ssh.Destination, command string, _ []byte, sshArgs ...string) *exec.Cmd {
 			return testutil.CmdWithOutput(assert.AnError.Error(), 1)
 		}
 

--- a/internal/describe/describe_test.go
+++ b/internal/describe/describe_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestGenerate(t *testing.T) {
 	t.Run("returns hardware profile for given target", func(t *testing.T) {
-		mockExecSSH := func(target ssh.Host, command string, _ []byte, sshArgs ...string) *exec.Cmd {
+		mockExecSSH := func(target ssh.SSHDestination, command string, _ []byte, sshArgs ...string) *exec.Cmd {
 			if command == "lscpu --json" {
 				return testutil.CmdWithOutput(testutil.LsCpuOutputRaw, 0)
 			}
@@ -53,7 +53,7 @@ func TestGenerate(t *testing.T) {
 	})
 
 	t.Run("fails if ssh commands cannot be executed", func(t *testing.T) {
-		mockExecSSH := func(target ssh.Host, command string, _ []byte, sshArgs ...string) *exec.Cmd {
+		mockExecSSH := func(target ssh.SSHDestination, command string, _ []byte, sshArgs ...string) *exec.Cmd {
 			return testutil.CmdWithOutput(assert.AnError.Error(), 1)
 		}
 

--- a/internal/health/status.go
+++ b/internal/health/status.go
@@ -18,7 +18,7 @@ func (h HardwareProfile) Capabilities() map[HardwareCapability]struct{} {
 }
 
 type Status struct {
-	SSHTarget       ssh.SSHDestination
+	SSHTarget       ssh.Destination
 	ConnectionError error
 	Dependencies    []DependencyStatus
 	Hardware        HardwareProfile

--- a/internal/health/status.go
+++ b/internal/health/status.go
@@ -18,7 +18,7 @@ func (h HardwareProfile) Capabilities() map[HardwareCapability]struct{} {
 }
 
 type Status struct {
-	SSHTarget       ssh.Host
+	SSHTarget       ssh.SSHDestination
 	ConnectionError error
 	Dependencies    []DependencyStatus
 	Hardware        HardwareProfile

--- a/internal/health/status_test.go
+++ b/internal/health/status_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestProbeHealthStatus(t *testing.T) {
 	t.Run("probe fails connection", func(t *testing.T) {
-		mockExec := func(_ ssh.Host, _ string, _ []byte, _ ...string) *exec.Cmd {
+		mockExec := func(_ ssh.SSHDestination, _ string, _ []byte, _ ...string) *exec.Cmd {
 			return testutil.CmdWithOutput("connection refused", 1)
 		}
 
@@ -26,7 +26,7 @@ func TestProbeHealthStatus(t *testing.T) {
 	})
 
 	t.Run("probe finds remote CPUs", func(t *testing.T) {
-		mockExec := func(_ ssh.Host, command string, _ []byte, _ ...string) *exec.Cmd {
+		mockExec := func(_ ssh.SSHDestination, command string, _ []byte, _ ...string) *exec.Cmd {
 			switch {
 			case command == "true":
 				return testutil.CmdWithOutput("", 0)
@@ -48,7 +48,7 @@ func TestProbeHealthStatus(t *testing.T) {
 	})
 
 	t.Run("probe succeeds when no remoteproc support", func(t *testing.T) {
-		mockExec := func(_ ssh.Host, command string, _ []byte, _ ...string) *exec.Cmd {
+		mockExec := func(_ ssh.SSHDestination, command string, _ []byte, _ ...string) *exec.Cmd {
 			switch command {
 			case "true":
 				return testutil.CmdWithOutput("", 0)

--- a/internal/health/status_test.go
+++ b/internal/health/status_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestProbeHealthStatus(t *testing.T) {
 	t.Run("probe fails connection", func(t *testing.T) {
-		mockExec := func(_ ssh.SSHDestination, _ string, _ []byte, _ ...string) *exec.Cmd {
+		mockExec := func(_ ssh.Destination, _ string, _ []byte, _ ...string) *exec.Cmd {
 			return testutil.CmdWithOutput("connection refused", 1)
 		}
 
@@ -26,7 +26,7 @@ func TestProbeHealthStatus(t *testing.T) {
 	})
 
 	t.Run("probe finds remote CPUs", func(t *testing.T) {
-		mockExec := func(_ ssh.SSHDestination, command string, _ []byte, _ ...string) *exec.Cmd {
+		mockExec := func(_ ssh.Destination, command string, _ []byte, _ ...string) *exec.Cmd {
 			switch {
 			case command == "true":
 				return testutil.CmdWithOutput("", 0)
@@ -48,7 +48,7 @@ func TestProbeHealthStatus(t *testing.T) {
 	})
 
 	t.Run("probe succeeds when no remoteproc support", func(t *testing.T) {
-		mockExec := func(_ ssh.SSHDestination, command string, _ []byte, _ ...string) *exec.Cmd {
+		mockExec := func(_ ssh.Destination, command string, _ []byte, _ ...string) *exec.Cmd {
 			switch command {
 			case "true":
 				return testutil.CmdWithOutput("", 0)

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -32,8 +32,8 @@ type PathCandidate struct {
 	OnPath bool
 }
 
-func getPathDirs(targetHost ssh.Destination) ([]string, error) {
-	conn := target.NewConnection(string(targetHost), target.ConnectionOptions{WithLoginShell: true})
+func getPathDirs(targetDest ssh.Destination) ([]string, error) {
+	conn := target.NewConnection(string(targetDest), target.ConnectionOptions{WithLoginShell: true})
 	output, err := conn.Run("echo $PATH")
 	if err != nil {
 		return nil, err
@@ -45,8 +45,8 @@ func getPathDirs(targetHost ssh.Destination) ([]string, error) {
 	return paths, nil
 }
 
-func getHomeDir(targetHost ssh.Destination) (string, error) {
-	conn := target.NewConnection(string(targetHost), target.ConnectionOptions{WithLoginShell: true})
+func getHomeDir(targetDest ssh.Destination) (string, error) {
+	conn := target.NewConnection(string(targetDest), target.ConnectionOptions{WithLoginShell: true})
 	output, err := conn.Run("echo $HOME")
 	if err != nil {
 		return "", err
@@ -54,8 +54,8 @@ func getHomeDir(targetHost ssh.Destination) (string, error) {
 	return strings.TrimSpace(output), nil
 }
 
-func getExistingBinaryDir(targetHost ssh.Destination, binaryName string) (string, error) {
-	conn := target.NewConnection(string(targetHost), target.ConnectionOptions{WithLoginShell: true})
+func getExistingBinaryDir(targetDest ssh.Destination, binaryName string) (string, error) {
+	conn := target.NewConnection(string(targetDest), target.ConnectionOptions{WithLoginShell: true})
 	output, err := conn.Run(fmt.Sprintf("command -v %s", binaryName))
 	if err != nil {
 		return "", nil
@@ -74,13 +74,13 @@ func getExistingBinaryDir(targetHost ssh.Destination, binaryName string) (string
 	return fullPath[:lastSlash], nil
 }
 
-func FindPathDirs(targetHost ssh.Destination) ([]PathCandidate, error) {
-	pathDirs, err := getPathDirs(targetHost)
+func FindPathDirs(targetDest ssh.Destination) ([]PathCandidate, error) {
+	pathDirs, err := getPathDirs(targetDest)
 	if err != nil {
 		return nil, err
 	}
 
-	homeDir, err := getHomeDir(targetHost)
+	homeDir, err := getHomeDir(targetDest)
 	if err != nil {
 		return nil, err
 	}
@@ -271,7 +271,7 @@ func FetchLatestReleaseBinaries(githubRepoSlug string, binaries []string) (map[s
 	return files, err
 }
 
-func install(installPath string, targetHost ssh.Destination, binaries map[string][]byte) error {
+func install(installPath string, targetDest ssh.Destination, binaries map[string][]byte) error {
 	mode := "0755"
 
 	for binaryName, binaryData := range binaries {
@@ -280,7 +280,7 @@ func install(installPath string, targetHost ssh.Destination, binaries map[string
 		}
 
 		installCmd := fmt.Sprintf("install -D -m %s /dev/stdin %s/%s", mode, installPath, binaryName)
-		conn := target.NewConnection(string(targetHost), target.ConnectionOptions{WithLoginShell: true, WithStdin: binaryData})
+		conn := target.NewConnection(string(targetDest), target.ConnectionOptions{WithLoginShell: true, WithStdin: binaryData})
 		output, err := conn.Run(installCmd)
 		if err != nil {
 			if errors.Is(err, ssh.ErrSSH) {

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -325,7 +325,7 @@ type InstallResult struct {
 	Binary   string
 }
 
-func InstallBinariesFromGithubRelease(targetHost ssh.Destination, repoURL string, binaryNames []string) ([]InstallResult, error) {
+func InstallBinariesFromGithubRelease(targetDest ssh.Destination, repoURL string, binaryNames []string) ([]InstallResult, error) {
 	for _, binaryName := range binaryNames {
 		if err := ssh.ValidateBinaryName(binaryName); err != nil {
 			return nil, err
@@ -341,7 +341,7 @@ func InstallBinariesFromGithubRelease(targetHost ssh.Destination, repoURL string
 	var binariesNotOnPath []string
 
 	for _, binaryName := range binaryNames {
-		existingPath, err := getExistingBinaryDir(targetHost, binaryName)
+		existingPath, err := getExistingBinaryDir(targetDest, binaryName)
 		if err != nil {
 			return nil, fmt.Errorf("failed to check existing path for %s: %w", binaryName, err)
 		}
@@ -362,7 +362,7 @@ func InstallBinariesFromGithubRelease(targetHost ssh.Destination, repoURL string
 		}
 
 		singleBinary := map[string][]byte{binaryName: binaryData}
-		err := install(dirPath, targetHost, singleBinary)
+		err := install(dirPath, targetDest, singleBinary)
 		if err != nil {
 			return nil, fmt.Errorf("failed to install %s to existing location %s: %w", binaryName, dirPath, err)
 		}
@@ -375,7 +375,7 @@ func InstallBinariesFromGithubRelease(targetHost ssh.Destination, repoURL string
 
 	// if not already on path, find a good spot for them.
 	if len(binariesNotOnPath) > 0 {
-		paths, err := FindPathDirs(targetHost)
+		paths, err := FindPathDirs(targetDest)
 		if err != nil {
 			return nil, fmt.Errorf("failed to find valid PATH directories: %w", err)
 		}
@@ -385,7 +385,7 @@ func InstallBinariesFromGithubRelease(targetHost ssh.Destination, repoURL string
 			newBinariesMap[binaryName] = binaries[binaryName]
 		}
 
-		installLoc, installedBinaries, err := installToFirstWriteableDir(paths, targetHost, newBinariesMap)
+		installLoc, installedBinaries, err := installToFirstWriteableDir(paths, targetDest, newBinariesMap)
 		if err != nil {
 			return nil, fmt.Errorf("installation of new binaries failed: %w", err)
 		}

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -32,7 +32,7 @@ type PathCandidate struct {
 	OnPath bool
 }
 
-func getPathDirs(targetHost ssh.SSHDestination) ([]string, error) {
+func getPathDirs(targetHost ssh.Destination) ([]string, error) {
 	conn := target.NewConnection(string(targetHost), target.ConnectionOptions{WithLoginShell: true})
 	output, err := conn.Run("echo $PATH")
 	if err != nil {
@@ -45,7 +45,7 @@ func getPathDirs(targetHost ssh.SSHDestination) ([]string, error) {
 	return paths, nil
 }
 
-func getHomeDir(targetHost ssh.SSHDestination) (string, error) {
+func getHomeDir(targetHost ssh.Destination) (string, error) {
 	conn := target.NewConnection(string(targetHost), target.ConnectionOptions{WithLoginShell: true})
 	output, err := conn.Run("echo $HOME")
 	if err != nil {
@@ -54,7 +54,7 @@ func getHomeDir(targetHost ssh.SSHDestination) (string, error) {
 	return strings.TrimSpace(output), nil
 }
 
-func getExistingBinaryDir(targetHost ssh.SSHDestination, binaryName string) (string, error) {
+func getExistingBinaryDir(targetHost ssh.Destination, binaryName string) (string, error) {
 	conn := target.NewConnection(string(targetHost), target.ConnectionOptions{WithLoginShell: true})
 	output, err := conn.Run(fmt.Sprintf("command -v %s", binaryName))
 	if err != nil {
@@ -74,7 +74,7 @@ func getExistingBinaryDir(targetHost ssh.SSHDestination, binaryName string) (str
 	return fullPath[:lastSlash], nil
 }
 
-func FindPathDirs(targetHost ssh.SSHDestination) ([]PathCandidate, error) {
+func FindPathDirs(targetHost ssh.Destination) ([]PathCandidate, error) {
 	pathDirs, err := getPathDirs(targetHost)
 	if err != nil {
 		return nil, err
@@ -271,7 +271,7 @@ func FetchLatestReleaseBinaries(githubRepoSlug string, binaries []string) (map[s
 	return files, err
 }
 
-func install(installPath string, targetHost ssh.SSHDestination, binaries map[string][]byte) error {
+func install(installPath string, targetHost ssh.Destination, binaries map[string][]byte) error {
 	mode := "0755"
 
 	for binaryName, binaryData := range binaries {
@@ -298,7 +298,7 @@ func install(installPath string, targetHost ssh.SSHDestination, binaries map[str
 // installToFirstWriteableDir attempts to install binaries to the highest preference path that the user has permissions for.
 // Silently ignores permission failures until the last path.
 // Returns the installation location and a list of installed binary names.
-func installToFirstWriteableDir(paths []PathCandidate, targetHost ssh.SSHDestination, binaries map[string][]byte) (PathCandidate, []string, error) {
+func installToFirstWriteableDir(paths []PathCandidate, targetHost ssh.Destination, binaries map[string][]byte) (PathCandidate, []string, error) {
 	var binaryNames []string
 	for name := range binaries {
 		binaryNames = append(binaryNames, name)
@@ -325,7 +325,7 @@ type InstallResult struct {
 	Binary   string
 }
 
-func InstallBinariesFromGithubRelease(targetHost ssh.SSHDestination, repoURL string, binaryNames []string) ([]InstallResult, error) {
+func InstallBinariesFromGithubRelease(targetHost ssh.Destination, repoURL string, binaryNames []string) ([]InstallResult, error) {
 	for _, binaryName := range binaryNames {
 		if err := ssh.ValidateBinaryName(binaryName); err != nil {
 			return nil, err

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -298,14 +298,14 @@ func install(installPath string, targetDest ssh.Destination, binaries map[string
 // installToFirstWriteableDir attempts to install binaries to the highest preference path that the user has permissions for.
 // Silently ignores permission failures until the last path.
 // Returns the installation location and a list of installed binary names.
-func installToFirstWriteableDir(paths []PathCandidate, targetHost ssh.Destination, binaries map[string][]byte) (PathCandidate, []string, error) {
+func installToFirstWriteableDir(paths []PathCandidate, targetDest ssh.Destination, binaries map[string][]byte) (PathCandidate, []string, error) {
 	var binaryNames []string
 	for name := range binaries {
 		binaryNames = append(binaryNames, name)
 	}
 
 	for i, dir := range paths {
-		err := install(dir.Path, targetHost, binaries)
+		err := install(dir.Path, targetDest, binaries)
 		if err == nil {
 			return paths[i], binaryNames, nil
 		}
@@ -395,7 +395,7 @@ func InstallBinariesFromGithubRelease(targetDest ssh.Destination, repoURL string
 		// Creating the directory during install means a new login shell will now
 		// include the path, even though it wasn't present during the earlier check.
 		if !installLoc.OnPath {
-			if pathDirs, pathErr := getPathDirs(targetHost); pathErr == nil {
+			if pathDirs, pathErr := getPathDirs(targetDest); pathErr == nil {
 				installLoc.OnPath = slices.Contains(pathDirs, installLoc.Path)
 			}
 		}

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -32,7 +32,7 @@ type PathCandidate struct {
 	OnPath bool
 }
 
-func getPathDirs(targetHost ssh.Host) ([]string, error) {
+func getPathDirs(targetHost ssh.SSHDestination) ([]string, error) {
 	conn := target.NewConnection(string(targetHost), target.ConnectionOptions{WithLoginShell: true})
 	output, err := conn.Run("echo $PATH")
 	if err != nil {
@@ -45,7 +45,7 @@ func getPathDirs(targetHost ssh.Host) ([]string, error) {
 	return paths, nil
 }
 
-func getHomeDir(targetHost ssh.Host) (string, error) {
+func getHomeDir(targetHost ssh.SSHDestination) (string, error) {
 	conn := target.NewConnection(string(targetHost), target.ConnectionOptions{WithLoginShell: true})
 	output, err := conn.Run("echo $HOME")
 	if err != nil {
@@ -54,7 +54,7 @@ func getHomeDir(targetHost ssh.Host) (string, error) {
 	return strings.TrimSpace(output), nil
 }
 
-func getExistingBinaryDir(targetHost ssh.Host, binaryName string) (string, error) {
+func getExistingBinaryDir(targetHost ssh.SSHDestination, binaryName string) (string, error) {
 	conn := target.NewConnection(string(targetHost), target.ConnectionOptions{WithLoginShell: true})
 	output, err := conn.Run(fmt.Sprintf("command -v %s", binaryName))
 	if err != nil {
@@ -74,7 +74,7 @@ func getExistingBinaryDir(targetHost ssh.Host, binaryName string) (string, error
 	return fullPath[:lastSlash], nil
 }
 
-func FindPathDirs(targetHost ssh.Host) ([]PathCandidate, error) {
+func FindPathDirs(targetHost ssh.SSHDestination) ([]PathCandidate, error) {
 	pathDirs, err := getPathDirs(targetHost)
 	if err != nil {
 		return nil, err
@@ -271,7 +271,7 @@ func FetchLatestReleaseBinaries(githubRepoSlug string, binaries []string) (map[s
 	return files, err
 }
 
-func install(installPath string, targetHost ssh.Host, binaries map[string][]byte) error {
+func install(installPath string, targetHost ssh.SSHDestination, binaries map[string][]byte) error {
 	mode := "0755"
 
 	for binaryName, binaryData := range binaries {
@@ -298,7 +298,7 @@ func install(installPath string, targetHost ssh.Host, binaries map[string][]byte
 // installToFirstWriteableDir attempts to install binaries to the highest preference path that the user has permissions for.
 // Silently ignores permission failures until the last path.
 // Returns the installation location and a list of installed binary names.
-func installToFirstWriteableDir(paths []PathCandidate, targetHost ssh.Host, binaries map[string][]byte) (PathCandidate, []string, error) {
+func installToFirstWriteableDir(paths []PathCandidate, targetHost ssh.SSHDestination, binaries map[string][]byte) (PathCandidate, []string, error) {
 	var binaryNames []string
 	for name := range binaries {
 		binaryNames = append(binaryNames, name)
@@ -325,7 +325,7 @@ type InstallResult struct {
 	Binary   string
 }
 
-func InstallBinariesFromGithubRelease(targetHost ssh.Host, repoURL string, binaryNames []string) ([]InstallResult, error) {
+func InstallBinariesFromGithubRelease(targetHost ssh.SSHDestination, repoURL string, binaryNames []string) ([]InstallResult, error) {
 	for _, binaryName := range binaryNames {
 		if err := ssh.ValidateBinaryName(binaryName); err != nil {
 			return nil, err

--- a/internal/setupkeys/pubkeytransfer/pub_key_transfer_test.go
+++ b/internal/setupkeys/pubkeytransfer/pub_key_transfer_test.go
@@ -33,14 +33,14 @@ func TestPubKeyTransferRun(t *testing.T) {
 	require.NoError(t, os.WriteFile(pubKeyPath, pubKeyContent, 0o600))
 
 	type call struct {
-		host  ssh.SSHDestination
+		host  ssh.Destination
 		cmd   string
 		stdin []byte
 		args  []string
 	}
 	var got call
 
-	opts := pubkeytransfer.PubKeyTransferOptions{WithMockExec: func(h ssh.SSHDestination, command string, stdin []byte, args ...string) *exec.Cmd {
+	opts := pubkeytransfer.PubKeyTransferOptions{WithMockExec: func(h ssh.Destination, command string, stdin []byte, args ...string) *exec.Cmd {
 		got = call{host: h, cmd: command, stdin: stdin, args: args}
 		cmd := testutil.CmdWithOutput("ssh invoked", 0)
 		if stdin != nil {
@@ -53,7 +53,7 @@ func TestPubKeyTransferRun(t *testing.T) {
 	var buf bytes.Buffer
 	require.NoError(t, op.Run(&buf))
 	require.Contains(t, buf.String(), "ssh invoked")
-	require.Equal(t, ssh.SSHDestination("thing1@thing2.com"), got.host)
+	require.Equal(t, ssh.Destination("thing1@thing2.com"), got.host)
 	require.Contains(t, got.cmd, "mkdir -p ~/.ssh && chmod 700 ~/.ssh && cat >> ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys")
 	require.Equal(t, pubKeyContent, got.stdin)
 	require.Empty(t, got.args)

--- a/internal/setupkeys/pubkeytransfer/pub_key_transfer_test.go
+++ b/internal/setupkeys/pubkeytransfer/pub_key_transfer_test.go
@@ -33,15 +33,15 @@ func TestPubKeyTransferRun(t *testing.T) {
 	require.NoError(t, os.WriteFile(pubKeyPath, pubKeyContent, 0o600))
 
 	type call struct {
-		host  ssh.Destination
+		dest  ssh.Destination
 		cmd   string
 		stdin []byte
 		args  []string
 	}
 	var got call
 
-	opts := pubkeytransfer.PubKeyTransferOptions{WithMockExec: func(h ssh.Destination, command string, stdin []byte, args ...string) *exec.Cmd {
-		got = call{host: h, cmd: command, stdin: stdin, args: args}
+	opts := pubkeytransfer.PubKeyTransferOptions{WithMockExec: func(d ssh.Destination, command string, stdin []byte, args ...string) *exec.Cmd {
+		got = call{dest: d, cmd: command, stdin: stdin, args: args}
 		cmd := testutil.CmdWithOutput("ssh invoked", 0)
 		if stdin != nil {
 			cmd.Stdin = bytes.NewReader(stdin)
@@ -53,7 +53,7 @@ func TestPubKeyTransferRun(t *testing.T) {
 	var buf bytes.Buffer
 	require.NoError(t, op.Run(&buf))
 	require.Contains(t, buf.String(), "ssh invoked")
-	require.Equal(t, ssh.Destination("thing1@thing2.com"), got.host)
+	require.Equal(t, ssh.Destination("thing1@thing2.com"), got.dest)
 	require.Contains(t, got.cmd, "mkdir -p ~/.ssh && chmod 700 ~/.ssh && cat >> ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys")
 	require.Equal(t, pubKeyContent, got.stdin)
 	require.Empty(t, got.args)

--- a/internal/setupkeys/pubkeytransfer/pub_key_transfer_test.go
+++ b/internal/setupkeys/pubkeytransfer/pub_key_transfer_test.go
@@ -33,14 +33,14 @@ func TestPubKeyTransferRun(t *testing.T) {
 	require.NoError(t, os.WriteFile(pubKeyPath, pubKeyContent, 0o600))
 
 	type call struct {
-		host  ssh.Host
+		host  ssh.SSHDestination
 		cmd   string
 		stdin []byte
 		args  []string
 	}
 	var got call
 
-	opts := pubkeytransfer.PubKeyTransferOptions{WithMockExec: func(h ssh.Host, command string, stdin []byte, args ...string) *exec.Cmd {
+	opts := pubkeytransfer.PubKeyTransferOptions{WithMockExec: func(h ssh.SSHDestination, command string, stdin []byte, args ...string) *exec.Cmd {
 		got = call{host: h, cmd: command, stdin: stdin, args: args}
 		cmd := testutil.CmdWithOutput("ssh invoked", 0)
 		if stdin != nil {
@@ -53,7 +53,7 @@ func TestPubKeyTransferRun(t *testing.T) {
 	var buf bytes.Buffer
 	require.NoError(t, op.Run(&buf))
 	require.Contains(t, buf.String(), "ssh invoked")
-	require.Equal(t, ssh.Host("thing1@thing2.com"), got.host)
+	require.Equal(t, ssh.SSHDestination("thing1@thing2.com"), got.host)
 	require.Contains(t, got.cmd, "mkdir -p ~/.ssh && chmod 700 ~/.ssh && cat >> ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys")
 	require.Equal(t, pubKeyContent, got.stdin)
 	require.Empty(t, got.args)

--- a/internal/setupkeys/setup_keys_test.go
+++ b/internal/setupkeys/setup_keys_test.go
@@ -57,7 +57,7 @@ func TestGetDefaultPrivateKeyPath(t *testing.T) {
 		testutil.SetHomeDir(t, tmp)
 
 		target := "user@some1thing.com"
-		targetSlug := ssh.Host(target).Slugify()
+		targetSlug := ssh.SSHDestination(target).Slugify()
 
 		got, err := setupkeys.GetDefaultPrivateKeyPath(targetSlug)
 

--- a/internal/setupkeys/setup_keys_test.go
+++ b/internal/setupkeys/setup_keys_test.go
@@ -57,7 +57,7 @@ func TestGetDefaultPrivateKeyPath(t *testing.T) {
 		testutil.SetHomeDir(t, tmp)
 
 		target := "user@some1thing.com"
-		targetSlug := ssh.SSHDestination(target).Slugify()
+		targetSlug := ssh.Destination(target).Slugify()
 
 		got, err := setupkeys.GetDefaultPrivateKeyPath(targetSlug)
 

--- a/internal/ssh/dest.go
+++ b/internal/ssh/dest.go
@@ -1,6 +1,7 @@
 package ssh
 
 import (
+	"fmt"
 	"net"
 	"strings"
 	"unicode"
@@ -20,6 +21,12 @@ func (h Destination) IsLocalhost() bool {
 	}
 	_, host, _ := SplitUserHostPort(string(h))
 	return Destination(host).IsPlainLocalhost()
+}
+
+func (h Destination) AsURI() string {
+	const scheme = "ssh://"
+	withoutScheme := strings.TrimPrefix(string(h), scheme)
+	return fmt.Sprintf("ssh://%s", withoutScheme)
 }
 
 func (h Destination) Slugify() string {

--- a/internal/ssh/dest.go
+++ b/internal/ssh/dest.go
@@ -11,27 +11,27 @@ type Destination string
 
 const PlainLocalhost = Destination("localhost")
 
-func (h Destination) IsPlainLocalhost() bool {
-	return strings.EqualFold(string(h), "localhost") || h == "127.0.0.1"
+func (d Destination) IsPlainLocalhost() bool {
+	return strings.EqualFold(string(d), "localhost") || d == "127.0.0.1"
 }
 
-func (h Destination) IsLocalhost() bool {
-	if h.IsPlainLocalhost() {
+func (d Destination) IsLocalhost() bool {
+	if d.IsPlainLocalhost() {
 		return true
 	}
-	_, host, _ := SplitUserHostPort(string(h))
+	_, host, _ := SplitUserHostPort(string(d))
 	return Destination(host).IsPlainLocalhost()
 }
 
-func (h Destination) AsURI() string {
+func (d Destination) AsURI() string {
 	const scheme = "ssh://"
-	withoutScheme := strings.TrimPrefix(string(h), scheme)
+	withoutScheme := strings.TrimPrefix(string(d), scheme)
 	return fmt.Sprintf("ssh://%s", withoutScheme)
 }
 
-func (h Destination) Slugify() string {
+func (d Destination) Slugify() string {
 	var b strings.Builder
-	for _, r := range h {
+	for _, r := range d {
 		toWrite := '_'
 		if unicode.IsLetter(r) || unicode.IsDigit(r) || r == '-' || r == '_' || r == '.' {
 			toWrite = r

--- a/internal/ssh/dest.go
+++ b/internal/ssh/dest.go
@@ -1,7 +1,6 @@
 package ssh
 
 import (
-	"fmt"
 	"net"
 	"strings"
 	"unicode"
@@ -21,12 +20,6 @@ func (h Destination) IsLocalhost() bool {
 	}
 	_, host, _ := SplitUserHostPort(string(h))
 	return Destination(host).IsPlainLocalhost()
-}
-
-func (h Destination) AsURI() string {
-	const scheme = "ssh://"
-	withoutScheme := strings.TrimPrefix(string(h), scheme)
-	return fmt.Sprintf("ssh://%s", withoutScheme)
 }
 
 func (h Destination) Slugify() string {

--- a/internal/ssh/dest.go
+++ b/internal/ssh/dest.go
@@ -7,29 +7,29 @@ import (
 	"unicode"
 )
 
-type SSHDestination string
+type Destination string
 
-const PlainLocalhost = SSHDestination("localhost")
+const PlainLocalhost = Destination("localhost")
 
-func (h SSHDestination) IsPlainLocalhost() bool {
+func (h Destination) IsPlainLocalhost() bool {
 	return strings.EqualFold(string(h), "localhost") || h == "127.0.0.1"
 }
 
-func (h SSHDestination) IsLocalhost() bool {
+func (h Destination) IsLocalhost() bool {
 	if h.IsPlainLocalhost() {
 		return true
 	}
 	_, host, _ := SplitUserHostPort(string(h))
-	return SSHDestination(host).IsPlainLocalhost()
+	return Destination(host).IsPlainLocalhost()
 }
 
-func (h SSHDestination) AsURI() string {
+func (h Destination) AsURI() string {
 	const scheme = "ssh://"
 	withoutScheme := strings.TrimPrefix(string(h), scheme)
 	return fmt.Sprintf("ssh://%s", withoutScheme)
 }
 
-func (h SSHDestination) Slugify() string {
+func (h Destination) Slugify() string {
 	var b strings.Builder
 	for _, r := range h {
 		toWrite := '_'

--- a/internal/ssh/dest_test.go
+++ b/internal/ssh/dest_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSSHDestination(t *testing.T) {
+func TestDestination(t *testing.T) {
 	t.Run("IsPlainLocalhost", func(t *testing.T) {
 		t.Run("returns true for plain localhost", func(t *testing.T) {
 			tests := []string{
@@ -20,7 +20,7 @@ func TestSSHDestination(t *testing.T) {
 
 			for _, input := range tests {
 				t.Run(input, func(t *testing.T) {
-					h := ssh.SSHDestination(input)
+					h := ssh.Destination(input)
 
 					assert.True(t, h.IsPlainLocalhost())
 				})
@@ -37,7 +37,7 @@ func TestSSHDestination(t *testing.T) {
 
 			for _, input := range tests {
 				t.Run(input, func(t *testing.T) {
-					h := ssh.SSHDestination(input)
+					h := ssh.Destination(input)
 
 					assert.False(t, h.IsPlainLocalhost())
 				})
@@ -53,7 +53,7 @@ func TestSSHDestination(t *testing.T) {
 
 			for _, input := range tests {
 				t.Run(input, func(t *testing.T) {
-					h := ssh.SSHDestination(input)
+					h := ssh.Destination(input)
 
 					assert.False(t, h.IsPlainLocalhost())
 				})
@@ -71,7 +71,7 @@ func TestSSHDestination(t *testing.T) {
 
 			for _, input := range tests {
 				t.Run(input, func(t *testing.T) {
-					h := ssh.SSHDestination(input)
+					h := ssh.Destination(input)
 
 					assert.True(t, h.IsLocalhost())
 				})
@@ -88,7 +88,7 @@ func TestSSHDestination(t *testing.T) {
 
 			for _, input := range tests {
 				t.Run(input, func(t *testing.T) {
-					h := ssh.SSHDestination(input)
+					h := ssh.Destination(input)
 
 					assert.True(t, h.IsLocalhost())
 				})
@@ -98,13 +98,13 @@ func TestSSHDestination(t *testing.T) {
 
 	t.Run("AsURI", func(t *testing.T) {
 		t.Run("returns uri form of host string", func(t *testing.T) {
-			h := ssh.SSHDestination("user@host")
+			h := ssh.Destination("user@host")
 
 			assert.Equal(t, "ssh://user@host", h.AsURI())
 		})
 
 		t.Run("doesn't duplicate ssh:// scheme", func(t *testing.T) {
-			h := ssh.SSHDestination("ssh://user@host:123")
+			h := ssh.Destination("ssh://user@host:123")
 
 			assert.Equal(t, "ssh://user@host:123", h.AsURI())
 		})
@@ -122,7 +122,7 @@ func TestSSHDestination(t *testing.T) {
 
 		for _, tt := range tests {
 			t.Run(tt.input, func(t *testing.T) {
-				require.Equal(t, tt.want, ssh.SSHDestination(tt.input).Slugify(), "Slugify should replace special characters with underscores and keep allowed characters")
+				require.Equal(t, tt.want, ssh.Destination(tt.input).Slugify(), "Slugify should replace special characters with underscores and keep allowed characters")
 			})
 		}
 	})

--- a/internal/ssh/dest_test.go
+++ b/internal/ssh/dest_test.go
@@ -20,9 +20,9 @@ func TestDestination(t *testing.T) {
 
 			for _, input := range tests {
 				t.Run(input, func(t *testing.T) {
-					h := ssh.Destination(input)
+					d := ssh.Destination(input)
 
-					assert.True(t, h.IsPlainLocalhost())
+					assert.True(t, d.IsPlainLocalhost())
 				})
 			}
 		})
@@ -37,9 +37,9 @@ func TestDestination(t *testing.T) {
 
 			for _, input := range tests {
 				t.Run(input, func(t *testing.T) {
-					h := ssh.Destination(input)
+					d := ssh.Destination(input)
 
-					assert.False(t, h.IsPlainLocalhost())
+					assert.False(t, d.IsPlainLocalhost())
 				})
 			}
 		})
@@ -53,9 +53,9 @@ func TestDestination(t *testing.T) {
 
 			for _, input := range tests {
 				t.Run(input, func(t *testing.T) {
-					h := ssh.Destination(input)
+					d := ssh.Destination(input)
 
-					assert.False(t, h.IsPlainLocalhost())
+					assert.False(t, d.IsPlainLocalhost())
 				})
 			}
 		})
@@ -71,9 +71,9 @@ func TestDestination(t *testing.T) {
 
 			for _, input := range tests {
 				t.Run(input, func(t *testing.T) {
-					h := ssh.Destination(input)
+					d := ssh.Destination(input)
 
-					assert.True(t, h.IsLocalhost())
+					assert.True(t, d.IsLocalhost())
 				})
 			}
 		})
@@ -88,9 +88,9 @@ func TestDestination(t *testing.T) {
 
 			for _, input := range tests {
 				t.Run(input, func(t *testing.T) {
-					h := ssh.Destination(input)
+					d := ssh.Destination(input)
 
-					assert.True(t, h.IsLocalhost())
+					assert.True(t, d.IsLocalhost())
 				})
 			}
 		})
@@ -98,15 +98,15 @@ func TestDestination(t *testing.T) {
 
 	t.Run("AsURI", func(t *testing.T) {
 		t.Run("returns uri form of host string", func(t *testing.T) {
-			h := ssh.Destination("user@host")
+			d := ssh.Destination("user@host")
 
-			assert.Equal(t, "ssh://user@host", h.AsURI())
+			assert.Equal(t, "ssh://user@host", d.AsURI())
 		})
 
 		t.Run("doesn't duplicate ssh:// scheme", func(t *testing.T) {
-			h := ssh.Destination("ssh://user@host:123")
+			d := ssh.Destination("ssh://user@host:123")
 
-			assert.Equal(t, "ssh://user@host:123", h.AsURI())
+			assert.Equal(t, "ssh://user@host:123", d.AsURI())
 		})
 	})
 

--- a/internal/ssh/exec.go
+++ b/internal/ssh/exec.go
@@ -37,7 +37,7 @@ func ShellCommand(command string) string {
 
 // ExecCmd builds a command to be executed on the target host. If the target is localhost, it will run locally when executed.
 // Pass stdin data as optional parameter, or nil for no stdin.
-func ExecCmd(target SSHDestination, command string, stdin []byte, sshArgs ...string) *exec.Cmd {
+func ExecCmd(target Destination, command string, stdin []byte, sshArgs ...string) *exec.Cmd {
 	var cmd *exec.Cmd
 	if target.IsPlainLocalhost() {
 		// #nosec G204 -- command should be validated by callers

--- a/internal/ssh/exec.go
+++ b/internal/ssh/exec.go
@@ -37,7 +37,7 @@ func ShellCommand(command string) string {
 
 // ExecCmd builds a command to be executed on the target host. If the target is localhost, it will run locally when executed.
 // Pass stdin data as optional parameter, or nil for no stdin.
-func ExecCmd(target Host, command string, stdin []byte, sshArgs ...string) *exec.Cmd {
+func ExecCmd(target SSHDestination, command string, stdin []byte, sshArgs ...string) *exec.Cmd {
 	var cmd *exec.Cmd
 	if target.IsPlainLocalhost() {
 		// #nosec G204 -- command should be validated by callers

--- a/internal/ssh/ssh_dest.go
+++ b/internal/ssh/ssh_dest.go
@@ -7,29 +7,29 @@ import (
 	"unicode"
 )
 
-type Host string
+type SSHDestination string
 
-const PlainLocalhost = Host("localhost")
+const PlainLocalhost = SSHDestination("localhost")
 
-func (h Host) IsPlainLocalhost() bool {
+func (h SSHDestination) IsPlainLocalhost() bool {
 	return strings.EqualFold(string(h), "localhost") || h == "127.0.0.1"
 }
 
-func (h Host) IsLocalhost() bool {
+func (h SSHDestination) IsLocalhost() bool {
 	if h.IsPlainLocalhost() {
 		return true
 	}
 	_, host, _ := SplitUserHostPort(string(h))
-	return Host(host).IsPlainLocalhost()
+	return SSHDestination(host).IsPlainLocalhost()
 }
 
-func (h Host) AsURI() string {
+func (h SSHDestination) AsURI() string {
 	const scheme = "ssh://"
 	withoutScheme := strings.TrimPrefix(string(h), scheme)
 	return fmt.Sprintf("ssh://%s", withoutScheme)
 }
 
-func (h Host) Slugify() string {
+func (h SSHDestination) Slugify() string {
 	var b strings.Builder
 	for _, r := range h {
 		toWrite := '_'

--- a/internal/ssh/ssh_dest_test.go
+++ b/internal/ssh/ssh_dest_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestHost(t *testing.T) {
+func TestSSHDestination(t *testing.T) {
 	t.Run("IsPlainLocalhost", func(t *testing.T) {
 		t.Run("returns true for plain localhost", func(t *testing.T) {
 			tests := []string{
@@ -20,7 +20,7 @@ func TestHost(t *testing.T) {
 
 			for _, input := range tests {
 				t.Run(input, func(t *testing.T) {
-					h := ssh.Host(input)
+					h := ssh.SSHDestination(input)
 
 					assert.True(t, h.IsPlainLocalhost())
 				})
@@ -37,7 +37,7 @@ func TestHost(t *testing.T) {
 
 			for _, input := range tests {
 				t.Run(input, func(t *testing.T) {
-					h := ssh.Host(input)
+					h := ssh.SSHDestination(input)
 
 					assert.False(t, h.IsPlainLocalhost())
 				})
@@ -53,7 +53,7 @@ func TestHost(t *testing.T) {
 
 			for _, input := range tests {
 				t.Run(input, func(t *testing.T) {
-					h := ssh.Host(input)
+					h := ssh.SSHDestination(input)
 
 					assert.False(t, h.IsPlainLocalhost())
 				})
@@ -71,7 +71,7 @@ func TestHost(t *testing.T) {
 
 			for _, input := range tests {
 				t.Run(input, func(t *testing.T) {
-					h := ssh.Host(input)
+					h := ssh.SSHDestination(input)
 
 					assert.True(t, h.IsLocalhost())
 				})
@@ -88,7 +88,7 @@ func TestHost(t *testing.T) {
 
 			for _, input := range tests {
 				t.Run(input, func(t *testing.T) {
-					h := ssh.Host(input)
+					h := ssh.SSHDestination(input)
 
 					assert.True(t, h.IsLocalhost())
 				})
@@ -98,13 +98,13 @@ func TestHost(t *testing.T) {
 
 	t.Run("AsURI", func(t *testing.T) {
 		t.Run("returns uri form of host string", func(t *testing.T) {
-			h := ssh.Host("user@host")
+			h := ssh.SSHDestination("user@host")
 
 			assert.Equal(t, "ssh://user@host", h.AsURI())
 		})
 
 		t.Run("doesn't duplicate ssh:// scheme", func(t *testing.T) {
-			h := ssh.Host("ssh://user@host:123")
+			h := ssh.SSHDestination("ssh://user@host:123")
 
 			assert.Equal(t, "ssh://user@host:123", h.AsURI())
 		})
@@ -122,7 +122,7 @@ func TestHost(t *testing.T) {
 
 		for _, tt := range tests {
 			t.Run(tt.input, func(t *testing.T) {
-				require.Equal(t, tt.want, ssh.Host(tt.input).Slugify(), "Slugify should replace special characters with underscores and keep allowed characters")
+				require.Equal(t, tt.want, ssh.SSHDestination(tt.input).Slugify(), "Slugify should replace special characters with underscores and keep allowed characters")
 			})
 		}
 	})

--- a/internal/ssh/ssh_tunnel.go
+++ b/internal/ssh/ssh_tunnel.go
@@ -35,7 +35,7 @@ func formatSSHHost(raw string, user string, host string) string {
 	return user + "@" + hostPart
 }
 
-func NewSSHTunnel(targetHost SSHDestination, port string, useControlSockets bool) (operation.Operation, operation.Operation, operation.Operation) {
+func NewSSHTunnel(targetHost Destination, port string, useControlSockets bool) (operation.Operation, operation.Operation, operation.Operation) {
 	start := NewSSHTunnelStart(targetHost, port, useControlSockets)
 	securityCheck := NewCheckSSHTunnelSecurity(targetHost, port)
 
@@ -50,7 +50,7 @@ func NewSSHTunnel(targetHost SSHDestination, port string, useControlSockets bool
 }
 
 type SSHTunnelStart struct {
-	TargetHost        SSHDestination
+	TargetHost        Destination
 	UseControlSockets bool
 	Port              string
 	Process           *os.Process
@@ -60,7 +60,7 @@ func (s *SSHTunnelStart) Description() string {
 	return "Open registry SSH tunnel"
 }
 
-func NewSSHTunnelStart(targetHost SSHDestination, port string, useControlSockets bool) *SSHTunnelStart {
+func NewSSHTunnelStart(targetHost Destination, port string, useControlSockets bool) *SSHTunnelStart {
 	return &SSHTunnelStart{TargetHost: targetHost, Port: port, UseControlSockets: useControlSockets}
 }
 
@@ -109,7 +109,7 @@ func (s *SSHTunnelStart) DryRun(w io.Writer) error {
 }
 
 type CheckSSHTunnelSecurity struct {
-	TargetHost SSHDestination
+	TargetHost Destination
 	Port       string
 }
 
@@ -117,7 +117,7 @@ func (ct *CheckSSHTunnelSecurity) Description() string {
 	return "Check SSH tunnel security"
 }
 
-func NewCheckSSHTunnelSecurity(targetHost SSHDestination, port string) *CheckSSHTunnelSecurity {
+func NewCheckSSHTunnelSecurity(targetHost Destination, port string) *CheckSSHTunnelSecurity {
 	return &CheckSSHTunnelSecurity{TargetHost: targetHost, Port: port}
 }
 
@@ -160,14 +160,14 @@ func (ct *CheckSSHTunnelSecurity) DryRun(w io.Writer) error {
 }
 
 type SSHTunnelStop struct {
-	TargetHost SSHDestination
+	TargetHost Destination
 }
 
 func (s *SSHTunnelStop) Description() string {
 	return "Close registry SSH tunnel"
 }
 
-func NewSSHTunnelStop(targetHost SSHDestination) *SSHTunnelStop {
+func NewSSHTunnelStop(targetHost Destination) *SSHTunnelStop {
 	return &SSHTunnelStop{TargetHost: targetHost}
 }
 

--- a/internal/ssh/ssh_tunnel.go
+++ b/internal/ssh/ssh_tunnel.go
@@ -35,13 +35,13 @@ func formatSSHHost(raw string, user string, host string) string {
 	return user + "@" + hostPart
 }
 
-func NewSSHTunnel(targetHost Destination, port string, useControlSockets bool) (operation.Operation, operation.Operation, operation.Operation) {
-	start := NewSSHTunnelStart(targetHost, port, useControlSockets)
-	securityCheck := NewCheckSSHTunnelSecurity(targetHost, port)
+func NewSSHTunnel(targetDest Destination, port string, useControlSockets bool) (operation.Operation, operation.Operation, operation.Operation) {
+	start := NewSSHTunnelStart(targetDest, port, useControlSockets)
+	securityCheck := NewCheckSSHTunnelSecurity(targetDest, port)
 
 	var stop operation.Operation
 	if useControlSockets {
-		stop = NewSSHTunnelStop(targetHost)
+		stop = NewSSHTunnelStop(targetDest)
 	} else {
 		stop = NewSSHTunnelProcessStop(start)
 	}
@@ -50,7 +50,7 @@ func NewSSHTunnel(targetHost Destination, port string, useControlSockets bool) (
 }
 
 type SSHTunnelStart struct {
-	TargetHost        Destination
+	TargetDest        Destination
 	UseControlSockets bool
 	Port              string
 	Process           *os.Process
@@ -60,12 +60,12 @@ func (s *SSHTunnelStart) Description() string {
 	return "Open registry SSH tunnel"
 }
 
-func NewSSHTunnelStart(targetHost Destination, port string, useControlSockets bool) *SSHTunnelStart {
-	return &SSHTunnelStart{TargetHost: targetHost, Port: port, UseControlSockets: useControlSockets}
+func NewSSHTunnelStart(targetDest Destination, port string, useControlSockets bool) *SSHTunnelStart {
+	return &SSHTunnelStart{TargetDest: targetDest, Port: port, UseControlSockets: useControlSockets}
 }
 
 func (s *SSHTunnelStart) Command() *exec.Cmd {
-	rawHost := string(s.TargetHost)
+	rawHost := string(s.TargetDest)
 	user, host, port := SplitUserHostPort(rawHost)
 	hostArg := formatSSHHost(rawHost, user, host)
 	args := []string{"ssh", "-N", "-o", "ExitOnForwardFailure=yes"}
@@ -74,7 +74,7 @@ func (s *SSHTunnelStart) Command() *exec.Cmd {
 	}
 	if s.UseControlSockets {
 		args = append(args,
-			"-fMS", ControlSocketPath(string(s.TargetHost)),
+			"-fMS", ControlSocketPath(string(s.TargetDest)),
 		)
 	}
 	args = append(args,
@@ -94,7 +94,7 @@ func (s *SSHTunnelStart) Run(w io.Writer) error {
 		run = cmd.Run
 	}
 	if err := run(); err != nil {
-		return fmt.Errorf("failed to open SSH tunnel to %s: %w", s.TargetHost, err)
+		return fmt.Errorf("failed to open SSH tunnel to %s: %w", s.TargetDest, err)
 	}
 	if cmd.Process != nil {
 		s.Process = cmd.Process
@@ -109,7 +109,7 @@ func (s *SSHTunnelStart) DryRun(w io.Writer) error {
 }
 
 type CheckSSHTunnelSecurity struct {
-	TargetHost Destination
+	TargetDest Destination
 	Port       string
 }
 
@@ -117,13 +117,13 @@ func (ct *CheckSSHTunnelSecurity) Description() string {
 	return "Check SSH tunnel security"
 }
 
-func NewCheckSSHTunnelSecurity(targetHost Destination, port string) *CheckSSHTunnelSecurity {
-	return &CheckSSHTunnelSecurity{TargetHost: targetHost, Port: port}
+func NewCheckSSHTunnelSecurity(targetDest Destination, port string) *CheckSSHTunnelSecurity {
+	return &CheckSSHTunnelSecurity{TargetDest: targetDest, Port: port}
 }
 
 func (ct *CheckSSHTunnelSecurity) Command() *exec.Cmd {
-	if !ct.TargetHost.IsLocalhost() {
-		host := resolveHost(string(ct.TargetHost))
+	if !ct.TargetDest.IsLocalhost() {
+		host := resolveHost(string(ct.TargetDest))
 		if host == "" {
 			return nil
 		}
@@ -133,26 +133,26 @@ func (ct *CheckSSHTunnelSecurity) Command() *exec.Cmd {
 }
 
 func (ct *CheckSSHTunnelSecurity) Run(w io.Writer) error {
-	if ct.TargetHost.IsLocalhost() {
+	if ct.TargetDest.IsLocalhost() {
 		return nil
 	}
 	cmd := ct.Command()
 	if cmd == nil {
-		panic(fmt.Sprintf("BUG: security check called for unresolvable host %q; caller must validate host before invoking", ct.TargetHost))
+		panic(fmt.Sprintf("BUG: security check called for unresolvable host %q; caller must validate host before invoking", ct.TargetDest))
 	}
 	cmd.Stdout = w
 	cmd.Stderr = w
 
 	err := cmd.Run()
 	if err == nil {
-		return fmt.Errorf("SSH tunnel to %s is not secure: able to access registry port without authentication", ct.TargetHost)
+		return fmt.Errorf("SSH tunnel to %s is not secure: able to access registry port without authentication", ct.TargetDest)
 	}
 
 	return nil
 }
 
 func (ct *CheckSSHTunnelSecurity) DryRun(w io.Writer) error {
-	if ct.TargetHost.IsLocalhost() {
+	if ct.TargetDest.IsLocalhost() {
 		return nil
 	}
 	_, err := fmt.Fprintln(w, strings.Join(ct.Command().Args, " "))
@@ -160,19 +160,19 @@ func (ct *CheckSSHTunnelSecurity) DryRun(w io.Writer) error {
 }
 
 type SSHTunnelStop struct {
-	TargetHost Destination
+	TargetDest Destination
 }
 
 func (s *SSHTunnelStop) Description() string {
 	return "Close registry SSH tunnel"
 }
 
-func NewSSHTunnelStop(targetHost Destination) *SSHTunnelStop {
-	return &SSHTunnelStop{TargetHost: targetHost}
+func NewSSHTunnelStop(targetDest Destination) *SSHTunnelStop {
+	return &SSHTunnelStop{TargetDest: targetDest}
 }
 
 func (s *SSHTunnelStop) Command() *exec.Cmd {
-	rawHost := string(s.TargetHost)
+	rawHost := string(s.TargetDest)
 	user, host, port := SplitUserHostPort(rawHost)
 	hostArg := formatSSHHost(rawHost, user, host)
 	args := []string{"ssh"}
@@ -180,7 +180,7 @@ func (s *SSHTunnelStop) Command() *exec.Cmd {
 		args = append(args, "-p", port)
 	}
 	args = append(args,
-		"-S", ControlSocketPath(string(s.TargetHost)),
+		"-S", ControlSocketPath(string(s.TargetDest)),
 		"-O", "exit",
 		hostArg,
 	)
@@ -189,14 +189,14 @@ func (s *SSHTunnelStop) Command() *exec.Cmd {
 }
 
 func (s *SSHTunnelStop) Run(w io.Writer) error {
-	if _, err := os.Stat(ControlSocketPath(string(s.TargetHost))); os.IsNotExist(err) {
+	if _, err := os.Stat(ControlSocketPath(string(s.TargetDest))); os.IsNotExist(err) {
 		return nil
 	}
 	cmd := s.Command()
 	cmd.Stdout = w
 	cmd.Stderr = w
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("failed to close SSH tunnel to %s: %w", s.TargetHost, err)
+		return fmt.Errorf("failed to close SSH tunnel to %s: %w", s.TargetDest, err)
 	}
 	return nil
 }

--- a/internal/ssh/ssh_tunnel.go
+++ b/internal/ssh/ssh_tunnel.go
@@ -35,7 +35,7 @@ func formatSSHHost(raw string, user string, host string) string {
 	return user + "@" + hostPart
 }
 
-func NewSSHTunnel(targetHost Host, port string, useControlSockets bool) (operation.Operation, operation.Operation, operation.Operation) {
+func NewSSHTunnel(targetHost SSHDestination, port string, useControlSockets bool) (operation.Operation, operation.Operation, operation.Operation) {
 	start := NewSSHTunnelStart(targetHost, port, useControlSockets)
 	securityCheck := NewCheckSSHTunnelSecurity(targetHost, port)
 
@@ -50,7 +50,7 @@ func NewSSHTunnel(targetHost Host, port string, useControlSockets bool) (operati
 }
 
 type SSHTunnelStart struct {
-	TargetHost        Host
+	TargetHost        SSHDestination
 	UseControlSockets bool
 	Port              string
 	Process           *os.Process
@@ -60,7 +60,7 @@ func (s *SSHTunnelStart) Description() string {
 	return "Open registry SSH tunnel"
 }
 
-func NewSSHTunnelStart(targetHost Host, port string, useControlSockets bool) *SSHTunnelStart {
+func NewSSHTunnelStart(targetHost SSHDestination, port string, useControlSockets bool) *SSHTunnelStart {
 	return &SSHTunnelStart{TargetHost: targetHost, Port: port, UseControlSockets: useControlSockets}
 }
 
@@ -109,7 +109,7 @@ func (s *SSHTunnelStart) DryRun(w io.Writer) error {
 }
 
 type CheckSSHTunnelSecurity struct {
-	TargetHost Host
+	TargetHost SSHDestination
 	Port       string
 }
 
@@ -117,7 +117,7 @@ func (ct *CheckSSHTunnelSecurity) Description() string {
 	return "Check SSH tunnel security"
 }
 
-func NewCheckSSHTunnelSecurity(targetHost Host, port string) *CheckSSHTunnelSecurity {
+func NewCheckSSHTunnelSecurity(targetHost SSHDestination, port string) *CheckSSHTunnelSecurity {
 	return &CheckSSHTunnelSecurity{TargetHost: targetHost, Port: port}
 }
 
@@ -160,14 +160,14 @@ func (ct *CheckSSHTunnelSecurity) DryRun(w io.Writer) error {
 }
 
 type SSHTunnelStop struct {
-	TargetHost Host
+	TargetHost SSHDestination
 }
 
 func (s *SSHTunnelStop) Description() string {
 	return "Close registry SSH tunnel"
 }
 
-func NewSSHTunnelStop(targetHost Host) *SSHTunnelStop {
+func NewSSHTunnelStop(targetHost SSHDestination) *SSHTunnelStop {
 	return &SSHTunnelStop{TargetHost: targetHost}
 }
 

--- a/internal/ssh/ssh_tunnel_test.go
+++ b/internal/ssh/ssh_tunnel_test.go
@@ -17,9 +17,9 @@ import (
 func TestSSHTunnel(t *testing.T) {
 	t.Run("NewSSHTunnel", func(t *testing.T) {
 		t.Run("it returns start and stop operations with control sockets", func(t *testing.T) {
-			host := ssh.Destination("user@remote")
+			dest := ssh.Destination("user@remote")
 
-			start, _, stop := ssh.NewSSHTunnel(host, operation.DefaultRegistryPort, true)
+			start, _, stop := ssh.NewSSHTunnel(dest, operation.DefaultRegistryPort, true)
 
 			_, ok := start.(*ssh.SSHTunnelStart)
 			assert.True(t, ok, "start operation is not of type SSHTunnelStart")
@@ -28,9 +28,9 @@ func TestSSHTunnel(t *testing.T) {
 		})
 
 		t.Run("it returns start and stop operations without control sockets", func(t *testing.T) {
-			host := ssh.Destination("user@remote")
+			dest := ssh.Destination("user@remote")
 
-			start, _, stop := ssh.NewSSHTunnel(host, operation.DefaultRegistryPort, false)
+			start, _, stop := ssh.NewSSHTunnel(dest, operation.DefaultRegistryPort, false)
 
 			_, ok := start.(*ssh.SSHTunnelStart)
 			assert.True(t, ok, "start operation is not of type SSHTunnelStart")
@@ -39,9 +39,9 @@ func TestSSHTunnel(t *testing.T) {
 		})
 
 		t.Run("stop operation has access to start operation process", func(t *testing.T) {
-			host := ssh.Destination("user@remote")
+			dest := ssh.Destination("user@remote")
 
-			start, _, stop := ssh.NewSSHTunnel(host, operation.DefaultRegistryPort, false)
+			start, _, stop := ssh.NewSSHTunnel(dest, operation.DefaultRegistryPort, false)
 			startOp, ok := start.(*ssh.SSHTunnelStart)
 			require.True(t, ok, "start operation is not of type SSHTunnelStart")
 
@@ -51,9 +51,9 @@ func TestSSHTunnel(t *testing.T) {
 		})
 
 		t.Run("it returns security check operation", func(t *testing.T) {
-			host := ssh.Destination("user@remote")
+			dest := ssh.Destination("user@remote")
 
-			_, securityCheck, _ := ssh.NewSSHTunnel(host, operation.DefaultRegistryPort, true)
+			_, securityCheck, _ := ssh.NewSSHTunnel(dest, operation.DefaultRegistryPort, true)
 
 			_, ok := securityCheck.(*ssh.CheckSSHTunnelSecurity)
 			assert.True(t, ok, "security check operation is not of type CheckSSHTunnelSecurity")
@@ -64,32 +64,32 @@ func TestSSHTunnel(t *testing.T) {
 func TestSSHTunnelStart(t *testing.T) {
 	t.Run("Command", func(t *testing.T) {
 		t.Run("it generates correct ssh command", func(t *testing.T) {
-			host := ssh.Destination("user@remote")
+			dest := ssh.Destination("user@remote")
 			port := operation.DefaultRegistryPort
 
-			st := ssh.NewSSHTunnelStart(host, port, true)
+			st := ssh.NewSSHTunnelStart(dest, port, true)
 			got := strings.Join(st.Command().Args, " ")
 
-			want := fmt.Sprintf("ssh -N -o ExitOnForwardFailure=yes -fMS %s -R %s:127.0.0.1:%s user@remote", ssh.ControlSocketPath(string(host)), port, port)
+			want := fmt.Sprintf("ssh -N -o ExitOnForwardFailure=yes -fMS %s -R %s:127.0.0.1:%s user@remote", ssh.ControlSocketPath(string(dest)), port, port)
 			assert.Equal(t, want, got)
 		})
 
 		t.Run("it includes port flag when host has custom port", func(t *testing.T) {
-			host := ssh.Destination("user@remote:2222")
+			dest := ssh.Destination("user@remote:2222")
 			port := operation.DefaultRegistryPort
 
-			st := ssh.NewSSHTunnelStart(host, port, true)
+			st := ssh.NewSSHTunnelStart(dest, port, true)
 			got := strings.Join(st.Command().Args, " ")
 
-			want := fmt.Sprintf("ssh -N -o ExitOnForwardFailure=yes -p 2222 -fMS %s -R %s:127.0.0.1:%s user@remote", ssh.ControlSocketPath(string(host)), port, port)
+			want := fmt.Sprintf("ssh -N -o ExitOnForwardFailure=yes -p 2222 -fMS %s -R %s:127.0.0.1:%s user@remote", ssh.ControlSocketPath(string(dest)), port, port)
 			assert.Equal(t, want, got)
 		})
 
 		t.Run("it does not include control socket flag when disabled", func(t *testing.T) {
-			host := ssh.Destination("user@remote")
+			dest := ssh.Destination("user@remote")
 			port := operation.DefaultRegistryPort
 
-			st := ssh.NewSSHTunnelStart(host, port, false)
+			st := ssh.NewSSHTunnelStart(dest, port, false)
 			got := strings.Join(st.Command().Args, " ")
 
 			want := fmt.Sprintf("ssh -N -o ExitOnForwardFailure=yes -R %s:127.0.0.1:%s user@remote", port, port)
@@ -100,30 +100,30 @@ func TestSSHTunnelStart(t *testing.T) {
 	t.Run("DryRun", func(t *testing.T) {
 		t.Run("it outputs the ssh command", func(t *testing.T) {
 			var buf bytes.Buffer
-			host := ssh.Destination("user@remote")
+			dest := ssh.Destination("user@remote")
 			port := operation.DefaultRegistryPort
 
-			st := ssh.NewSSHTunnelStart(host, port, true)
+			st := ssh.NewSSHTunnelStart(dest, port, true)
 			err := st.DryRun(&buf)
 			got := strings.TrimSpace(buf.String())
 
 			require.NoError(t, err)
-			wantSuffix := fmt.Sprintf("ssh -N -o ExitOnForwardFailure=yes -fMS %s -R %s:127.0.0.1:%s user@remote", ssh.ControlSocketPath(string(host)), port, port)
+			wantSuffix := fmt.Sprintf("ssh -N -o ExitOnForwardFailure=yes -fMS %s -R %s:127.0.0.1:%s user@remote", ssh.ControlSocketPath(string(dest)), port, port)
 			assert.True(t, strings.HasSuffix(got, wantSuffix),
 				"DryRun output %q does not end with %q", got, wantSuffix)
 		})
 
 		t.Run("it includes port flag when host has custom port", func(t *testing.T) {
 			var buf bytes.Buffer
-			host := ssh.Destination("user@remote:2222")
+			dest := ssh.Destination("user@remote:2222")
 			port := operation.DefaultRegistryPort
 
-			st := ssh.NewSSHTunnelStart(host, port, true)
+			st := ssh.NewSSHTunnelStart(dest, port, true)
 			err := st.DryRun(&buf)
 			got := strings.TrimSpace(buf.String())
 
 			require.NoError(t, err)
-			wantSuffix := fmt.Sprintf("ssh -N -o ExitOnForwardFailure=yes -p 2222 -fMS %s -R %s:127.0.0.1:%s user@remote", ssh.ControlSocketPath(string(host)), port, port)
+			wantSuffix := fmt.Sprintf("ssh -N -o ExitOnForwardFailure=yes -p 2222 -fMS %s -R %s:127.0.0.1:%s user@remote", ssh.ControlSocketPath(string(dest)), port, port)
 			assert.True(t, strings.HasSuffix(got, wantSuffix),
 				"DryRun output %q does not end with %q", got, wantSuffix)
 		})
@@ -143,46 +143,46 @@ func TestSSHTunnelStart(t *testing.T) {
 func TestSSHTunnelStartEdgeCases(t *testing.T) {
 	t.Run("Command", func(t *testing.T) {
 		t.Run("it handles host without user", func(t *testing.T) {
-			host := ssh.Destination("remote-server")
+			dest := ssh.Destination("remote-server")
 			port := operation.DefaultRegistryPort
 
-			st := ssh.NewSSHTunnelStart(host, port, true)
+			st := ssh.NewSSHTunnelStart(dest, port, true)
 			got := strings.Join(st.Command().Args, " ")
 
-			want := fmt.Sprintf("ssh -N -o ExitOnForwardFailure=yes -fMS %s -R %s:127.0.0.1:%s remote-server", ssh.ControlSocketPath(string(host)), port, port)
+			want := fmt.Sprintf("ssh -N -o ExitOnForwardFailure=yes -fMS %s -R %s:127.0.0.1:%s remote-server", ssh.ControlSocketPath(string(dest)), port, port)
 			assert.Equal(t, want, got)
 		})
 
 		t.Run("it handles host without user but with port", func(t *testing.T) {
-			host := ssh.Destination("remote-server:2222")
+			dest := ssh.Destination("remote-server:2222")
 			port := operation.DefaultRegistryPort
 
-			st := ssh.NewSSHTunnelStart(host, port, true)
+			st := ssh.NewSSHTunnelStart(dest, port, true)
 			got := strings.Join(st.Command().Args, " ")
 
-			want := fmt.Sprintf("ssh -N -o ExitOnForwardFailure=yes -p 2222 -fMS %s -R %s:127.0.0.1:%s remote-server", ssh.ControlSocketPath(string(host)), port, port)
+			want := fmt.Sprintf("ssh -N -o ExitOnForwardFailure=yes -p 2222 -fMS %s -R %s:127.0.0.1:%s remote-server", ssh.ControlSocketPath(string(dest)), port, port)
 			assert.Equal(t, want, got)
 		})
 
 		t.Run("it handles IP address", func(t *testing.T) {
-			host := ssh.Destination("user@192.168.1.100")
+			dest := ssh.Destination("user@192.168.1.100")
 			port := operation.DefaultRegistryPort
 
-			st := ssh.NewSSHTunnelStart(host, port, true)
+			st := ssh.NewSSHTunnelStart(dest, port, true)
 			got := strings.Join(st.Command().Args, " ")
 
-			want := fmt.Sprintf("ssh -N -o ExitOnForwardFailure=yes -fMS %s -R %s:127.0.0.1:%s user@192.168.1.100", ssh.ControlSocketPath(string(host)), port, port)
+			want := fmt.Sprintf("ssh -N -o ExitOnForwardFailure=yes -fMS %s -R %s:127.0.0.1:%s user@192.168.1.100", ssh.ControlSocketPath(string(dest)), port, port)
 			assert.Equal(t, want, got)
 		})
 
 		t.Run("it handles IP address with port", func(t *testing.T) {
-			host := ssh.Destination("user@192.168.1.100:2222")
+			dest := ssh.Destination("user@192.168.1.100:2222")
 			port := operation.DefaultRegistryPort
 
-			st := ssh.NewSSHTunnelStart(host, port, true)
+			st := ssh.NewSSHTunnelStart(dest, port, true)
 			got := strings.Join(st.Command().Args, " ")
 
-			want := fmt.Sprintf("ssh -N -o ExitOnForwardFailure=yes -p 2222 -fMS %s -R %s:127.0.0.1:%s user@192.168.1.100", ssh.ControlSocketPath(string(host)), port, port)
+			want := fmt.Sprintf("ssh -N -o ExitOnForwardFailure=yes -p 2222 -fMS %s -R %s:127.0.0.1:%s user@192.168.1.100", ssh.ControlSocketPath(string(dest)), port, port)
 			assert.Equal(t, want, got)
 		})
 	})
@@ -191,10 +191,10 @@ func TestSSHTunnelStartEdgeCases(t *testing.T) {
 func TestCheckSSHTunnelSecurity(t *testing.T) {
 	t.Run("Command", func(t *testing.T) {
 		t.Run("it generates correct curl command", func(t *testing.T) {
-			host := ssh.Destination("user@remote")
+			dest := ssh.Destination("user@remote")
 			port := operation.DefaultRegistryPort
 
-			cs := ssh.NewCheckSSHTunnelSecurity(host, port)
+			cs := ssh.NewCheckSSHTunnelSecurity(dest, port)
 			got := strings.Join(cs.Command().Args, " ")
 
 			want := fmt.Sprintf("curl remote:%s --max-time 1", port)
@@ -202,10 +202,10 @@ func TestCheckSSHTunnelSecurity(t *testing.T) {
 		})
 
 		t.Run("it returns nil when target is localhost", func(t *testing.T) {
-			host := ssh.Destination("root@localhost")
+			dest := ssh.Destination("root@localhost")
 			port := operation.DefaultRegistryPort
 
-			cs := ssh.NewCheckSSHTunnelSecurity(host, port)
+			cs := ssh.NewCheckSSHTunnelSecurity(dest, port)
 			got := cs.Command()
 			assert.Nil(t, got)
 		})
@@ -214,10 +214,10 @@ func TestCheckSSHTunnelSecurity(t *testing.T) {
 	t.Run("DryRun", func(t *testing.T) {
 		t.Run("it outputs the curl command", func(t *testing.T) {
 			var buf bytes.Buffer
-			host := ssh.Destination("user@remote")
+			dest := ssh.Destination("user@remote")
 			port := operation.DefaultRegistryPort
 
-			cs := ssh.NewCheckSSHTunnelSecurity(host, port)
+			cs := ssh.NewCheckSSHTunnelSecurity(dest, port)
 			err := cs.DryRun(&buf)
 			got := strings.TrimSpace(buf.String())
 			require.NoError(t, err)
@@ -240,22 +240,22 @@ func TestCheckSSHTunnelSecurity(t *testing.T) {
 func TestSSHTunnelStop(t *testing.T) {
 	t.Run("Command", func(t *testing.T) {
 		t.Run("it generates correct ssh command", func(t *testing.T) {
-			host := ssh.Destination("user@remote")
+			dest := ssh.Destination("user@remote")
 
-			st := ssh.NewSSHTunnelStop(host)
+			st := ssh.NewSSHTunnelStop(dest)
 			got := strings.Join(st.Command().Args, " ")
 
-			want := fmt.Sprintf("ssh -S %s -O exit user@remote", ssh.ControlSocketPath(string(host)))
+			want := fmt.Sprintf("ssh -S %s -O exit user@remote", ssh.ControlSocketPath(string(dest)))
 			assert.Equal(t, want, got)
 		})
 
 		t.Run("it includes port flag when host has custom port", func(t *testing.T) {
-			host := ssh.Destination("user@remote:2222")
+			dest := ssh.Destination("user@remote:2222")
 
-			st := ssh.NewSSHTunnelStop(host)
+			st := ssh.NewSSHTunnelStop(dest)
 			got := strings.Join(st.Command().Args, " ")
 
-			want := fmt.Sprintf("ssh -p 2222 -S %s -O exit user@remote", ssh.ControlSocketPath(string(host)))
+			want := fmt.Sprintf("ssh -p 2222 -S %s -O exit user@remote", ssh.ControlSocketPath(string(dest)))
 			assert.Equal(t, want, got)
 		})
 	})
@@ -263,28 +263,28 @@ func TestSSHTunnelStop(t *testing.T) {
 	t.Run("DryRun", func(t *testing.T) {
 		t.Run("generates the correct ssh command", func(t *testing.T) {
 			var buf bytes.Buffer
-			host := ssh.Destination("user@remote")
+			dest := ssh.Destination("user@remote")
 
-			st := ssh.NewSSHTunnelStop(host)
+			st := ssh.NewSSHTunnelStop(dest)
 			err := st.DryRun(&buf)
 			got := strings.TrimSpace(buf.String())
 
 			require.NoError(t, err)
-			wantSuffix := fmt.Sprintf("ssh -S %s -O exit user@remote", ssh.ControlSocketPath(string(host)))
+			wantSuffix := fmt.Sprintf("ssh -S %s -O exit user@remote", ssh.ControlSocketPath(string(dest)))
 			assert.True(t, strings.HasSuffix(got, wantSuffix),
 				"DryRun output %q does not end with %q", got, wantSuffix)
 		})
 
 		t.Run("it includes port flag when host has custom port", func(t *testing.T) {
 			var buf bytes.Buffer
-			host := ssh.Destination("user@remote:2222")
+			dest := ssh.Destination("user@remote:2222")
 
-			st := ssh.NewSSHTunnelStop(host)
+			st := ssh.NewSSHTunnelStop(dest)
 			err := st.DryRun(&buf)
 			got := strings.TrimSpace(buf.String())
 
 			require.NoError(t, err)
-			wantSuffix := fmt.Sprintf("ssh -p 2222 -S %s -O exit user@remote", ssh.ControlSocketPath(string(host)))
+			wantSuffix := fmt.Sprintf("ssh -p 2222 -S %s -O exit user@remote", ssh.ControlSocketPath(string(dest)))
 			assert.True(t, strings.HasSuffix(got, wantSuffix),
 				"DryRun output %q does not end with %q", got, wantSuffix)
 		})
@@ -304,42 +304,42 @@ func TestSSHTunnelStop(t *testing.T) {
 func TestSSHTunnelStopEdgeCases(t *testing.T) {
 	t.Run("Command", func(t *testing.T) {
 		t.Run("handles host without user", func(t *testing.T) {
-			host := ssh.Destination("remote-server")
+			dest := ssh.Destination("remote-server")
 
-			st := ssh.NewSSHTunnelStop(host)
+			st := ssh.NewSSHTunnelStop(dest)
 			got := strings.Join(st.Command().Args, " ")
 
-			want := fmt.Sprintf("ssh -S %s -O exit remote-server", ssh.ControlSocketPath(string(host)))
+			want := fmt.Sprintf("ssh -S %s -O exit remote-server", ssh.ControlSocketPath(string(dest)))
 			assert.Equal(t, want, got)
 		})
 
 		t.Run("handles host without user but with port", func(t *testing.T) {
-			host := ssh.Destination("remote-server:2222")
+			dest := ssh.Destination("remote-server:2222")
 
-			st := ssh.NewSSHTunnelStop(host)
+			st := ssh.NewSSHTunnelStop(dest)
 			got := strings.Join(st.Command().Args, " ")
 
-			want := fmt.Sprintf("ssh -p 2222 -S %s -O exit remote-server", ssh.ControlSocketPath(string(host)))
+			want := fmt.Sprintf("ssh -p 2222 -S %s -O exit remote-server", ssh.ControlSocketPath(string(dest)))
 			assert.Equal(t, want, got)
 		})
 
 		t.Run("handles IP address", func(t *testing.T) {
-			host := ssh.Destination("user@192.168.1.100")
+			dest := ssh.Destination("user@192.168.1.100")
 
-			st := ssh.NewSSHTunnelStop(host)
+			st := ssh.NewSSHTunnelStop(dest)
 			got := strings.Join(st.Command().Args, " ")
 
-			want := fmt.Sprintf("ssh -S %s -O exit user@192.168.1.100", ssh.ControlSocketPath(string(host)))
+			want := fmt.Sprintf("ssh -S %s -O exit user@192.168.1.100", ssh.ControlSocketPath(string(dest)))
 			assert.Equal(t, want, got)
 		})
 
 		t.Run("handles IP address with port", func(t *testing.T) {
-			host := ssh.Destination("user@192.168.1.100:2222")
+			dest := ssh.Destination("user@192.168.1.100:2222")
 
-			st := ssh.NewSSHTunnelStop(host)
+			st := ssh.NewSSHTunnelStop(dest)
 			got := strings.Join(st.Command().Args, " ")
 
-			want := fmt.Sprintf("ssh -p 2222 -S %s -O exit user@192.168.1.100", ssh.ControlSocketPath(string(host)))
+			want := fmt.Sprintf("ssh -p 2222 -S %s -O exit user@192.168.1.100", ssh.ControlSocketPath(string(dest)))
 			assert.Equal(t, want, got)
 		})
 	})

--- a/internal/ssh/ssh_tunnel_test.go
+++ b/internal/ssh/ssh_tunnel_test.go
@@ -17,7 +17,7 @@ import (
 func TestSSHTunnel(t *testing.T) {
 	t.Run("NewSSHTunnel", func(t *testing.T) {
 		t.Run("it returns start and stop operations with control sockets", func(t *testing.T) {
-			host := ssh.SSHDestination("user@remote")
+			host := ssh.Destination("user@remote")
 
 			start, _, stop := ssh.NewSSHTunnel(host, operation.DefaultRegistryPort, true)
 
@@ -28,7 +28,7 @@ func TestSSHTunnel(t *testing.T) {
 		})
 
 		t.Run("it returns start and stop operations without control sockets", func(t *testing.T) {
-			host := ssh.SSHDestination("user@remote")
+			host := ssh.Destination("user@remote")
 
 			start, _, stop := ssh.NewSSHTunnel(host, operation.DefaultRegistryPort, false)
 
@@ -39,7 +39,7 @@ func TestSSHTunnel(t *testing.T) {
 		})
 
 		t.Run("stop operation has access to start operation process", func(t *testing.T) {
-			host := ssh.SSHDestination("user@remote")
+			host := ssh.Destination("user@remote")
 
 			start, _, stop := ssh.NewSSHTunnel(host, operation.DefaultRegistryPort, false)
 			startOp, ok := start.(*ssh.SSHTunnelStart)
@@ -51,7 +51,7 @@ func TestSSHTunnel(t *testing.T) {
 		})
 
 		t.Run("it returns security check operation", func(t *testing.T) {
-			host := ssh.SSHDestination("user@remote")
+			host := ssh.Destination("user@remote")
 
 			_, securityCheck, _ := ssh.NewSSHTunnel(host, operation.DefaultRegistryPort, true)
 
@@ -64,7 +64,7 @@ func TestSSHTunnel(t *testing.T) {
 func TestSSHTunnelStart(t *testing.T) {
 	t.Run("Command", func(t *testing.T) {
 		t.Run("it generates correct ssh command", func(t *testing.T) {
-			host := ssh.SSHDestination("user@remote")
+			host := ssh.Destination("user@remote")
 			port := operation.DefaultRegistryPort
 
 			st := ssh.NewSSHTunnelStart(host, port, true)
@@ -75,7 +75,7 @@ func TestSSHTunnelStart(t *testing.T) {
 		})
 
 		t.Run("it includes port flag when host has custom port", func(t *testing.T) {
-			host := ssh.SSHDestination("user@remote:2222")
+			host := ssh.Destination("user@remote:2222")
 			port := operation.DefaultRegistryPort
 
 			st := ssh.NewSSHTunnelStart(host, port, true)
@@ -86,7 +86,7 @@ func TestSSHTunnelStart(t *testing.T) {
 		})
 
 		t.Run("it does not include control socket flag when disabled", func(t *testing.T) {
-			host := ssh.SSHDestination("user@remote")
+			host := ssh.Destination("user@remote")
 			port := operation.DefaultRegistryPort
 
 			st := ssh.NewSSHTunnelStart(host, port, false)
@@ -100,7 +100,7 @@ func TestSSHTunnelStart(t *testing.T) {
 	t.Run("DryRun", func(t *testing.T) {
 		t.Run("it outputs the ssh command", func(t *testing.T) {
 			var buf bytes.Buffer
-			host := ssh.SSHDestination("user@remote")
+			host := ssh.Destination("user@remote")
 			port := operation.DefaultRegistryPort
 
 			st := ssh.NewSSHTunnelStart(host, port, true)
@@ -115,7 +115,7 @@ func TestSSHTunnelStart(t *testing.T) {
 
 		t.Run("it includes port flag when host has custom port", func(t *testing.T) {
 			var buf bytes.Buffer
-			host := ssh.SSHDestination("user@remote:2222")
+			host := ssh.Destination("user@remote:2222")
 			port := operation.DefaultRegistryPort
 
 			st := ssh.NewSSHTunnelStart(host, port, true)
@@ -131,7 +131,7 @@ func TestSSHTunnelStart(t *testing.T) {
 
 	t.Run("Description", func(t *testing.T) {
 		t.Run("it returns expected string", func(t *testing.T) {
-			st := ssh.NewSSHTunnelStart(ssh.SSHDestination("user@remote"), operation.DefaultRegistryPort, true)
+			st := ssh.NewSSHTunnelStart(ssh.Destination("user@remote"), operation.DefaultRegistryPort, true)
 
 			got := st.Description()
 
@@ -143,7 +143,7 @@ func TestSSHTunnelStart(t *testing.T) {
 func TestSSHTunnelStartEdgeCases(t *testing.T) {
 	t.Run("Command", func(t *testing.T) {
 		t.Run("it handles host without user", func(t *testing.T) {
-			host := ssh.SSHDestination("remote-server")
+			host := ssh.Destination("remote-server")
 			port := operation.DefaultRegistryPort
 
 			st := ssh.NewSSHTunnelStart(host, port, true)
@@ -154,7 +154,7 @@ func TestSSHTunnelStartEdgeCases(t *testing.T) {
 		})
 
 		t.Run("it handles host without user but with port", func(t *testing.T) {
-			host := ssh.SSHDestination("remote-server:2222")
+			host := ssh.Destination("remote-server:2222")
 			port := operation.DefaultRegistryPort
 
 			st := ssh.NewSSHTunnelStart(host, port, true)
@@ -165,7 +165,7 @@ func TestSSHTunnelStartEdgeCases(t *testing.T) {
 		})
 
 		t.Run("it handles IP address", func(t *testing.T) {
-			host := ssh.SSHDestination("user@192.168.1.100")
+			host := ssh.Destination("user@192.168.1.100")
 			port := operation.DefaultRegistryPort
 
 			st := ssh.NewSSHTunnelStart(host, port, true)
@@ -176,7 +176,7 @@ func TestSSHTunnelStartEdgeCases(t *testing.T) {
 		})
 
 		t.Run("it handles IP address with port", func(t *testing.T) {
-			host := ssh.SSHDestination("user@192.168.1.100:2222")
+			host := ssh.Destination("user@192.168.1.100:2222")
 			port := operation.DefaultRegistryPort
 
 			st := ssh.NewSSHTunnelStart(host, port, true)
@@ -191,7 +191,7 @@ func TestSSHTunnelStartEdgeCases(t *testing.T) {
 func TestCheckSSHTunnelSecurity(t *testing.T) {
 	t.Run("Command", func(t *testing.T) {
 		t.Run("it generates correct curl command", func(t *testing.T) {
-			host := ssh.SSHDestination("user@remote")
+			host := ssh.Destination("user@remote")
 			port := operation.DefaultRegistryPort
 
 			cs := ssh.NewCheckSSHTunnelSecurity(host, port)
@@ -202,7 +202,7 @@ func TestCheckSSHTunnelSecurity(t *testing.T) {
 		})
 
 		t.Run("it returns nil when target is localhost", func(t *testing.T) {
-			host := ssh.SSHDestination("root@localhost")
+			host := ssh.Destination("root@localhost")
 			port := operation.DefaultRegistryPort
 
 			cs := ssh.NewCheckSSHTunnelSecurity(host, port)
@@ -214,7 +214,7 @@ func TestCheckSSHTunnelSecurity(t *testing.T) {
 	t.Run("DryRun", func(t *testing.T) {
 		t.Run("it outputs the curl command", func(t *testing.T) {
 			var buf bytes.Buffer
-			host := ssh.SSHDestination("user@remote")
+			host := ssh.Destination("user@remote")
 			port := operation.DefaultRegistryPort
 
 			cs := ssh.NewCheckSSHTunnelSecurity(host, port)
@@ -228,7 +228,7 @@ func TestCheckSSHTunnelSecurity(t *testing.T) {
 
 	t.Run("Description", func(t *testing.T) {
 		t.Run("it returns the expected string", func(t *testing.T) {
-			cs := ssh.NewCheckSSHTunnelSecurity(ssh.SSHDestination("user@remote"), operation.DefaultRegistryPort)
+			cs := ssh.NewCheckSSHTunnelSecurity(ssh.Destination("user@remote"), operation.DefaultRegistryPort)
 
 			got := cs.Description()
 
@@ -240,7 +240,7 @@ func TestCheckSSHTunnelSecurity(t *testing.T) {
 func TestSSHTunnelStop(t *testing.T) {
 	t.Run("Command", func(t *testing.T) {
 		t.Run("it generates correct ssh command", func(t *testing.T) {
-			host := ssh.SSHDestination("user@remote")
+			host := ssh.Destination("user@remote")
 
 			st := ssh.NewSSHTunnelStop(host)
 			got := strings.Join(st.Command().Args, " ")
@@ -250,7 +250,7 @@ func TestSSHTunnelStop(t *testing.T) {
 		})
 
 		t.Run("it includes port flag when host has custom port", func(t *testing.T) {
-			host := ssh.SSHDestination("user@remote:2222")
+			host := ssh.Destination("user@remote:2222")
 
 			st := ssh.NewSSHTunnelStop(host)
 			got := strings.Join(st.Command().Args, " ")
@@ -263,7 +263,7 @@ func TestSSHTunnelStop(t *testing.T) {
 	t.Run("DryRun", func(t *testing.T) {
 		t.Run("generates the correct ssh command", func(t *testing.T) {
 			var buf bytes.Buffer
-			host := ssh.SSHDestination("user@remote")
+			host := ssh.Destination("user@remote")
 
 			st := ssh.NewSSHTunnelStop(host)
 			err := st.DryRun(&buf)
@@ -277,7 +277,7 @@ func TestSSHTunnelStop(t *testing.T) {
 
 		t.Run("it includes port flag when host has custom port", func(t *testing.T) {
 			var buf bytes.Buffer
-			host := ssh.SSHDestination("user@remote:2222")
+			host := ssh.Destination("user@remote:2222")
 
 			st := ssh.NewSSHTunnelStop(host)
 			err := st.DryRun(&buf)
@@ -292,7 +292,7 @@ func TestSSHTunnelStop(t *testing.T) {
 
 	t.Run("Description", func(t *testing.T) {
 		t.Run("it returns expected string", func(t *testing.T) {
-			st := ssh.NewSSHTunnelStop(ssh.SSHDestination("user@remote"))
+			st := ssh.NewSSHTunnelStop(ssh.Destination("user@remote"))
 
 			got := st.Description()
 
@@ -304,7 +304,7 @@ func TestSSHTunnelStop(t *testing.T) {
 func TestSSHTunnelStopEdgeCases(t *testing.T) {
 	t.Run("Command", func(t *testing.T) {
 		t.Run("handles host without user", func(t *testing.T) {
-			host := ssh.SSHDestination("remote-server")
+			host := ssh.Destination("remote-server")
 
 			st := ssh.NewSSHTunnelStop(host)
 			got := strings.Join(st.Command().Args, " ")
@@ -314,7 +314,7 @@ func TestSSHTunnelStopEdgeCases(t *testing.T) {
 		})
 
 		t.Run("handles host without user but with port", func(t *testing.T) {
-			host := ssh.SSHDestination("remote-server:2222")
+			host := ssh.Destination("remote-server:2222")
 
 			st := ssh.NewSSHTunnelStop(host)
 			got := strings.Join(st.Command().Args, " ")
@@ -324,7 +324,7 @@ func TestSSHTunnelStopEdgeCases(t *testing.T) {
 		})
 
 		t.Run("handles IP address", func(t *testing.T) {
-			host := ssh.SSHDestination("user@192.168.1.100")
+			host := ssh.Destination("user@192.168.1.100")
 
 			st := ssh.NewSSHTunnelStop(host)
 			got := strings.Join(st.Command().Args, " ")
@@ -334,7 +334,7 @@ func TestSSHTunnelStopEdgeCases(t *testing.T) {
 		})
 
 		t.Run("handles IP address with port", func(t *testing.T) {
-			host := ssh.SSHDestination("user@192.168.1.100:2222")
+			host := ssh.Destination("user@192.168.1.100:2222")
 
 			st := ssh.NewSSHTunnelStop(host)
 			got := strings.Join(st.Command().Args, " ")

--- a/internal/ssh/ssh_tunnel_test.go
+++ b/internal/ssh/ssh_tunnel_test.go
@@ -17,7 +17,7 @@ import (
 func TestSSHTunnel(t *testing.T) {
 	t.Run("NewSSHTunnel", func(t *testing.T) {
 		t.Run("it returns start and stop operations with control sockets", func(t *testing.T) {
-			host := ssh.Host("user@remote")
+			host := ssh.SSHDestination("user@remote")
 
 			start, _, stop := ssh.NewSSHTunnel(host, operation.DefaultRegistryPort, true)
 
@@ -28,7 +28,7 @@ func TestSSHTunnel(t *testing.T) {
 		})
 
 		t.Run("it returns start and stop operations without control sockets", func(t *testing.T) {
-			host := ssh.Host("user@remote")
+			host := ssh.SSHDestination("user@remote")
 
 			start, _, stop := ssh.NewSSHTunnel(host, operation.DefaultRegistryPort, false)
 
@@ -39,7 +39,7 @@ func TestSSHTunnel(t *testing.T) {
 		})
 
 		t.Run("stop operation has access to start operation process", func(t *testing.T) {
-			host := ssh.Host("user@remote")
+			host := ssh.SSHDestination("user@remote")
 
 			start, _, stop := ssh.NewSSHTunnel(host, operation.DefaultRegistryPort, false)
 			startOp, ok := start.(*ssh.SSHTunnelStart)
@@ -51,7 +51,7 @@ func TestSSHTunnel(t *testing.T) {
 		})
 
 		t.Run("it returns security check operation", func(t *testing.T) {
-			host := ssh.Host("user@remote")
+			host := ssh.SSHDestination("user@remote")
 
 			_, securityCheck, _ := ssh.NewSSHTunnel(host, operation.DefaultRegistryPort, true)
 
@@ -64,7 +64,7 @@ func TestSSHTunnel(t *testing.T) {
 func TestSSHTunnelStart(t *testing.T) {
 	t.Run("Command", func(t *testing.T) {
 		t.Run("it generates correct ssh command", func(t *testing.T) {
-			host := ssh.Host("user@remote")
+			host := ssh.SSHDestination("user@remote")
 			port := operation.DefaultRegistryPort
 
 			st := ssh.NewSSHTunnelStart(host, port, true)
@@ -75,7 +75,7 @@ func TestSSHTunnelStart(t *testing.T) {
 		})
 
 		t.Run("it includes port flag when host has custom port", func(t *testing.T) {
-			host := ssh.Host("user@remote:2222")
+			host := ssh.SSHDestination("user@remote:2222")
 			port := operation.DefaultRegistryPort
 
 			st := ssh.NewSSHTunnelStart(host, port, true)
@@ -86,7 +86,7 @@ func TestSSHTunnelStart(t *testing.T) {
 		})
 
 		t.Run("it does not include control socket flag when disabled", func(t *testing.T) {
-			host := ssh.Host("user@remote")
+			host := ssh.SSHDestination("user@remote")
 			port := operation.DefaultRegistryPort
 
 			st := ssh.NewSSHTunnelStart(host, port, false)
@@ -100,7 +100,7 @@ func TestSSHTunnelStart(t *testing.T) {
 	t.Run("DryRun", func(t *testing.T) {
 		t.Run("it outputs the ssh command", func(t *testing.T) {
 			var buf bytes.Buffer
-			host := ssh.Host("user@remote")
+			host := ssh.SSHDestination("user@remote")
 			port := operation.DefaultRegistryPort
 
 			st := ssh.NewSSHTunnelStart(host, port, true)
@@ -115,7 +115,7 @@ func TestSSHTunnelStart(t *testing.T) {
 
 		t.Run("it includes port flag when host has custom port", func(t *testing.T) {
 			var buf bytes.Buffer
-			host := ssh.Host("user@remote:2222")
+			host := ssh.SSHDestination("user@remote:2222")
 			port := operation.DefaultRegistryPort
 
 			st := ssh.NewSSHTunnelStart(host, port, true)
@@ -131,7 +131,7 @@ func TestSSHTunnelStart(t *testing.T) {
 
 	t.Run("Description", func(t *testing.T) {
 		t.Run("it returns expected string", func(t *testing.T) {
-			st := ssh.NewSSHTunnelStart(ssh.Host("user@remote"), operation.DefaultRegistryPort, true)
+			st := ssh.NewSSHTunnelStart(ssh.SSHDestination("user@remote"), operation.DefaultRegistryPort, true)
 
 			got := st.Description()
 
@@ -143,7 +143,7 @@ func TestSSHTunnelStart(t *testing.T) {
 func TestSSHTunnelStartEdgeCases(t *testing.T) {
 	t.Run("Command", func(t *testing.T) {
 		t.Run("it handles host without user", func(t *testing.T) {
-			host := ssh.Host("remote-server")
+			host := ssh.SSHDestination("remote-server")
 			port := operation.DefaultRegistryPort
 
 			st := ssh.NewSSHTunnelStart(host, port, true)
@@ -154,7 +154,7 @@ func TestSSHTunnelStartEdgeCases(t *testing.T) {
 		})
 
 		t.Run("it handles host without user but with port", func(t *testing.T) {
-			host := ssh.Host("remote-server:2222")
+			host := ssh.SSHDestination("remote-server:2222")
 			port := operation.DefaultRegistryPort
 
 			st := ssh.NewSSHTunnelStart(host, port, true)
@@ -165,7 +165,7 @@ func TestSSHTunnelStartEdgeCases(t *testing.T) {
 		})
 
 		t.Run("it handles IP address", func(t *testing.T) {
-			host := ssh.Host("user@192.168.1.100")
+			host := ssh.SSHDestination("user@192.168.1.100")
 			port := operation.DefaultRegistryPort
 
 			st := ssh.NewSSHTunnelStart(host, port, true)
@@ -176,7 +176,7 @@ func TestSSHTunnelStartEdgeCases(t *testing.T) {
 		})
 
 		t.Run("it handles IP address with port", func(t *testing.T) {
-			host := ssh.Host("user@192.168.1.100:2222")
+			host := ssh.SSHDestination("user@192.168.1.100:2222")
 			port := operation.DefaultRegistryPort
 
 			st := ssh.NewSSHTunnelStart(host, port, true)
@@ -191,7 +191,7 @@ func TestSSHTunnelStartEdgeCases(t *testing.T) {
 func TestCheckSSHTunnelSecurity(t *testing.T) {
 	t.Run("Command", func(t *testing.T) {
 		t.Run("it generates correct curl command", func(t *testing.T) {
-			host := ssh.Host("user@remote")
+			host := ssh.SSHDestination("user@remote")
 			port := operation.DefaultRegistryPort
 
 			cs := ssh.NewCheckSSHTunnelSecurity(host, port)
@@ -202,7 +202,7 @@ func TestCheckSSHTunnelSecurity(t *testing.T) {
 		})
 
 		t.Run("it returns nil when target is localhost", func(t *testing.T) {
-			host := ssh.Host("root@localhost")
+			host := ssh.SSHDestination("root@localhost")
 			port := operation.DefaultRegistryPort
 
 			cs := ssh.NewCheckSSHTunnelSecurity(host, port)
@@ -214,7 +214,7 @@ func TestCheckSSHTunnelSecurity(t *testing.T) {
 	t.Run("DryRun", func(t *testing.T) {
 		t.Run("it outputs the curl command", func(t *testing.T) {
 			var buf bytes.Buffer
-			host := ssh.Host("user@remote")
+			host := ssh.SSHDestination("user@remote")
 			port := operation.DefaultRegistryPort
 
 			cs := ssh.NewCheckSSHTunnelSecurity(host, port)
@@ -228,7 +228,7 @@ func TestCheckSSHTunnelSecurity(t *testing.T) {
 
 	t.Run("Description", func(t *testing.T) {
 		t.Run("it returns the expected string", func(t *testing.T) {
-			cs := ssh.NewCheckSSHTunnelSecurity(ssh.Host("user@remote"), operation.DefaultRegistryPort)
+			cs := ssh.NewCheckSSHTunnelSecurity(ssh.SSHDestination("user@remote"), operation.DefaultRegistryPort)
 
 			got := cs.Description()
 
@@ -240,7 +240,7 @@ func TestCheckSSHTunnelSecurity(t *testing.T) {
 func TestSSHTunnelStop(t *testing.T) {
 	t.Run("Command", func(t *testing.T) {
 		t.Run("it generates correct ssh command", func(t *testing.T) {
-			host := ssh.Host("user@remote")
+			host := ssh.SSHDestination("user@remote")
 
 			st := ssh.NewSSHTunnelStop(host)
 			got := strings.Join(st.Command().Args, " ")
@@ -250,7 +250,7 @@ func TestSSHTunnelStop(t *testing.T) {
 		})
 
 		t.Run("it includes port flag when host has custom port", func(t *testing.T) {
-			host := ssh.Host("user@remote:2222")
+			host := ssh.SSHDestination("user@remote:2222")
 
 			st := ssh.NewSSHTunnelStop(host)
 			got := strings.Join(st.Command().Args, " ")
@@ -263,7 +263,7 @@ func TestSSHTunnelStop(t *testing.T) {
 	t.Run("DryRun", func(t *testing.T) {
 		t.Run("generates the correct ssh command", func(t *testing.T) {
 			var buf bytes.Buffer
-			host := ssh.Host("user@remote")
+			host := ssh.SSHDestination("user@remote")
 
 			st := ssh.NewSSHTunnelStop(host)
 			err := st.DryRun(&buf)
@@ -277,7 +277,7 @@ func TestSSHTunnelStop(t *testing.T) {
 
 		t.Run("it includes port flag when host has custom port", func(t *testing.T) {
 			var buf bytes.Buffer
-			host := ssh.Host("user@remote:2222")
+			host := ssh.SSHDestination("user@remote:2222")
 
 			st := ssh.NewSSHTunnelStop(host)
 			err := st.DryRun(&buf)
@@ -292,7 +292,7 @@ func TestSSHTunnelStop(t *testing.T) {
 
 	t.Run("Description", func(t *testing.T) {
 		t.Run("it returns expected string", func(t *testing.T) {
-			st := ssh.NewSSHTunnelStop(ssh.Host("user@remote"))
+			st := ssh.NewSSHTunnelStop(ssh.SSHDestination("user@remote"))
 
 			got := st.Description()
 
@@ -304,7 +304,7 @@ func TestSSHTunnelStop(t *testing.T) {
 func TestSSHTunnelStopEdgeCases(t *testing.T) {
 	t.Run("Command", func(t *testing.T) {
 		t.Run("handles host without user", func(t *testing.T) {
-			host := ssh.Host("remote-server")
+			host := ssh.SSHDestination("remote-server")
 
 			st := ssh.NewSSHTunnelStop(host)
 			got := strings.Join(st.Command().Args, " ")
@@ -314,7 +314,7 @@ func TestSSHTunnelStopEdgeCases(t *testing.T) {
 		})
 
 		t.Run("handles host without user but with port", func(t *testing.T) {
-			host := ssh.Host("remote-server:2222")
+			host := ssh.SSHDestination("remote-server:2222")
 
 			st := ssh.NewSSHTunnelStop(host)
 			got := strings.Join(st.Command().Args, " ")
@@ -324,7 +324,7 @@ func TestSSHTunnelStopEdgeCases(t *testing.T) {
 		})
 
 		t.Run("handles IP address", func(t *testing.T) {
-			host := ssh.Host("user@192.168.1.100")
+			host := ssh.SSHDestination("user@192.168.1.100")
 
 			st := ssh.NewSSHTunnelStop(host)
 			got := strings.Join(st.Command().Args, " ")
@@ -334,7 +334,7 @@ func TestSSHTunnelStopEdgeCases(t *testing.T) {
 		})
 
 		t.Run("handles IP address with port", func(t *testing.T) {
-			host := ssh.Host("user@192.168.1.100:2222")
+			host := ssh.SSHDestination("user@192.168.1.100:2222")
 
 			st := ssh.NewSSHTunnelStop(host)
 			got := strings.Join(st.Command().Args, " ")

--- a/internal/target/connection.go
+++ b/internal/target/connection.go
@@ -35,10 +35,10 @@ var (
 	}
 )
 
-type ExecSSH func(target ssh.Host, command string, stdin []byte, sshArgs ...string) *exec.Cmd
+type ExecSSH func(target ssh.SSHDestination, command string, stdin []byte, sshArgs ...string) *exec.Cmd
 
 type Connection struct {
-	SSHTarget ssh.Host
+	SSHTarget ssh.SSHDestination
 	exec      ExecSSH
 	opts      ConnectionOptions
 }
@@ -63,7 +63,7 @@ func NewConnection(sshTarget string, opts ConnectionOptions) Connection {
 	}
 	opts.ConnectTimeout = ssh.NewConfig(sshTarget).ConnectTimeout(opts.ConnectTimeout)
 	return Connection{
-		SSHTarget: ssh.Host(sshTarget),
+		SSHTarget: ssh.SSHDestination(sshTarget),
 		exec:      execFn,
 		opts:      opts,
 	}

--- a/internal/target/connection.go
+++ b/internal/target/connection.go
@@ -35,10 +35,10 @@ var (
 	}
 )
 
-type ExecSSH func(target ssh.SSHDestination, command string, stdin []byte, sshArgs ...string) *exec.Cmd
+type ExecSSH func(target ssh.Destination, command string, stdin []byte, sshArgs ...string) *exec.Cmd
 
 type Connection struct {
-	SSHTarget ssh.SSHDestination
+	SSHTarget ssh.Destination
 	exec      ExecSSH
 	opts      ConnectionOptions
 }
@@ -63,7 +63,7 @@ func NewConnection(sshTarget string, opts ConnectionOptions) Connection {
 	}
 	opts.ConnectTimeout = ssh.NewConfig(sshTarget).ConnectTimeout(opts.ConnectTimeout)
 	return Connection{
-		SSHTarget: ssh.SSHDestination(sshTarget),
+		SSHTarget: ssh.Destination(sshTarget),
 		exec:      execFn,
 		opts:      opts,
 	}

--- a/internal/target/connection_auth_test.go
+++ b/internal/target/connection_auth_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 type sshTestCall struct {
-	target  ssh.Host
+	target  ssh.SSHDestination
 	command string
 	args    []string
 }
@@ -24,8 +24,8 @@ type mockResponse struct {
 	err    error
 }
 
-func newMockExec(responses map[string]mockResponse, calls *[]sshTestCall) func(ssh.Host, string, []byte, ...string) *exec.Cmd {
-	return func(target ssh.Host, command string, _ []byte, sshArgs ...string) *exec.Cmd {
+func newMockExec(responses map[string]mockResponse, calls *[]sshTestCall) func(ssh.SSHDestination, string, []byte, ...string) *exec.Cmd {
+	return func(target ssh.SSHDestination, command string, _ []byte, sshArgs ...string) *exec.Cmd {
 		*calls = append(*calls, sshTestCall{
 			target:  target,
 			command: command,

--- a/internal/target/connection_auth_test.go
+++ b/internal/target/connection_auth_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 type sshTestCall struct {
-	target  ssh.SSHDestination
+	target  ssh.Destination
 	command string
 	args    []string
 }
@@ -24,8 +24,8 @@ type mockResponse struct {
 	err    error
 }
 
-func newMockExec(responses map[string]mockResponse, calls *[]sshTestCall) func(ssh.SSHDestination, string, []byte, ...string) *exec.Cmd {
-	return func(target ssh.SSHDestination, command string, _ []byte, sshArgs ...string) *exec.Cmd {
+func newMockExec(responses map[string]mockResponse, calls *[]sshTestCall) func(ssh.Destination, string, []byte, ...string) *exec.Cmd {
+	return func(target ssh.Destination, command string, _ []byte, sshArgs ...string) *exec.Cmd {
 		*calls = append(*calls, sshTestCall{
 			target:  target,
 			command: command,

--- a/internal/target/connection_test.go
+++ b/internal/target/connection_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestRun(t *testing.T) {
 	t.Run("run executes command successfully", func(t *testing.T) {
-		mockExec := func(_ ssh.SSHDestination, _ string, _ []byte, _ ...string) *exec.Cmd {
+		mockExec := func(_ ssh.Destination, _ string, _ []byte, _ ...string) *exec.Cmd {
 			return testutil.CmdWithOutput("success", 0)
 		}
 		conn := target.NewConnection("hostname", target.ConnectionOptions{WithMockExec: mockExec})
@@ -25,7 +25,7 @@ func TestRun(t *testing.T) {
 	})
 
 	t.Run("run returns error", func(t *testing.T) {
-		mockExec := func(_ ssh.SSHDestination, _ string, _ []byte, _ ...string) *exec.Cmd {
+		mockExec := func(_ ssh.Destination, _ string, _ []byte, _ ...string) *exec.Cmd {
 			return testutil.CmdWithOutput("", 1)
 		}
 		conn := target.NewConnection("hostname", target.ConnectionOptions{WithMockExec: mockExec})
@@ -37,7 +37,7 @@ func TestRun(t *testing.T) {
 	})
 
 	t.Run("returns ErrAuthFailed when stderr contains auth failure", func(t *testing.T) {
-		mockExec := func(_ ssh.SSHDestination, _ string, _ []byte, _ ...string) *exec.Cmd {
+		mockExec := func(_ ssh.Destination, _ string, _ []byte, _ ...string) *exec.Cmd {
 			return testutil.CmdWithStderr("Permission denied (publickey)", 1)
 		}
 		conn := target.NewConnection("hostname", target.ConnectionOptions{WithMockExec: mockExec})
@@ -48,7 +48,7 @@ func TestRun(t *testing.T) {
 	})
 
 	t.Run("returns ErrConnectionFailed when stderr contains connection refused", func(t *testing.T) {
-		mockExec := func(_ ssh.SSHDestination, _ string, _ []byte, _ ...string) *exec.Cmd {
+		mockExec := func(_ ssh.Destination, _ string, _ []byte, _ ...string) *exec.Cmd {
 			return testutil.CmdWithStderr("ssh: connect to host foo port 22: Connection refused", 1)
 		}
 		conn := target.NewConnection("hostname", target.ConnectionOptions{WithMockExec: mockExec})
@@ -61,7 +61,7 @@ func TestRun(t *testing.T) {
 	t.Run("run with mutliplexing enabled includes Control args", func(t *testing.T) {
 		testutil.RequireOS(t, "linux")
 		var capturedArgs string
-		mockExec := func(_ ssh.SSHDestination, _ string, _ []byte, sshArgs ...string) *exec.Cmd {
+		mockExec := func(_ ssh.Destination, _ string, _ []byte, sshArgs ...string) *exec.Cmd {
 			capturedArgs = strings.Join(sshArgs, " ")
 			return testutil.CmdWithOutput("success", 0)
 		}
@@ -78,7 +78,7 @@ func TestRun(t *testing.T) {
 	t.Run("run with mutliplexing enabled does not include Control args on windows", func(t *testing.T) {
 		testutil.RequireOS(t, "windows")
 		var capturedArgs string
-		mockExec := func(_ ssh.SSHDestination, _ string, _ []byte, sshArgs ...string) *exec.Cmd {
+		mockExec := func(_ ssh.Destination, _ string, _ []byte, sshArgs ...string) *exec.Cmd {
 			capturedArgs = strings.Join(sshArgs, " ")
 			return testutil.CmdWithOutput("success", 0)
 		}
@@ -95,7 +95,7 @@ func TestRun(t *testing.T) {
 
 func TestBinaryExists(t *testing.T) {
 	t.Run("when binary found returns nil", func(t *testing.T) {
-		mockExec := func(_ ssh.SSHDestination, _ string, _ []byte, _ ...string) *exec.Cmd {
+		mockExec := func(_ ssh.Destination, _ string, _ []byte, _ ...string) *exec.Cmd {
 			return testutil.CmdWithOutput("/foo/bar", 0)
 		}
 		conn := target.NewConnection("hostname", target.ConnectionOptions{WithMockExec: mockExec})
@@ -104,7 +104,7 @@ func TestBinaryExists(t *testing.T) {
 	})
 
 	t.Run("invalid format returns an error", func(t *testing.T) {
-		mockExec := func(_ ssh.SSHDestination, _ string, _ []byte, _ ...string) *exec.Cmd {
+		mockExec := func(_ ssh.Destination, _ string, _ []byte, _ ...string) *exec.Cmd {
 			return testutil.CmdWithOutput("/foo/bar", 0)
 		}
 		conn := target.NewConnection("hostname", target.ConnectionOptions{WithMockExec: mockExec})

--- a/internal/target/connection_test.go
+++ b/internal/target/connection_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestRun(t *testing.T) {
 	t.Run("run executes command successfully", func(t *testing.T) {
-		mockExec := func(_ ssh.Host, _ string, _ []byte, _ ...string) *exec.Cmd {
+		mockExec := func(_ ssh.SSHDestination, _ string, _ []byte, _ ...string) *exec.Cmd {
 			return testutil.CmdWithOutput("success", 0)
 		}
 		conn := target.NewConnection("hostname", target.ConnectionOptions{WithMockExec: mockExec})
@@ -25,7 +25,7 @@ func TestRun(t *testing.T) {
 	})
 
 	t.Run("run returns error", func(t *testing.T) {
-		mockExec := func(_ ssh.Host, _ string, _ []byte, _ ...string) *exec.Cmd {
+		mockExec := func(_ ssh.SSHDestination, _ string, _ []byte, _ ...string) *exec.Cmd {
 			return testutil.CmdWithOutput("", 1)
 		}
 		conn := target.NewConnection("hostname", target.ConnectionOptions{WithMockExec: mockExec})
@@ -37,7 +37,7 @@ func TestRun(t *testing.T) {
 	})
 
 	t.Run("returns ErrAuthFailed when stderr contains auth failure", func(t *testing.T) {
-		mockExec := func(_ ssh.Host, _ string, _ []byte, _ ...string) *exec.Cmd {
+		mockExec := func(_ ssh.SSHDestination, _ string, _ []byte, _ ...string) *exec.Cmd {
 			return testutil.CmdWithStderr("Permission denied (publickey)", 1)
 		}
 		conn := target.NewConnection("hostname", target.ConnectionOptions{WithMockExec: mockExec})
@@ -48,7 +48,7 @@ func TestRun(t *testing.T) {
 	})
 
 	t.Run("returns ErrConnectionFailed when stderr contains connection refused", func(t *testing.T) {
-		mockExec := func(_ ssh.Host, _ string, _ []byte, _ ...string) *exec.Cmd {
+		mockExec := func(_ ssh.SSHDestination, _ string, _ []byte, _ ...string) *exec.Cmd {
 			return testutil.CmdWithStderr("ssh: connect to host foo port 22: Connection refused", 1)
 		}
 		conn := target.NewConnection("hostname", target.ConnectionOptions{WithMockExec: mockExec})
@@ -61,7 +61,7 @@ func TestRun(t *testing.T) {
 	t.Run("run with mutliplexing enabled includes Control args", func(t *testing.T) {
 		testutil.RequireOS(t, "linux")
 		var capturedArgs string
-		mockExec := func(_ ssh.Host, _ string, _ []byte, sshArgs ...string) *exec.Cmd {
+		mockExec := func(_ ssh.SSHDestination, _ string, _ []byte, sshArgs ...string) *exec.Cmd {
 			capturedArgs = strings.Join(sshArgs, " ")
 			return testutil.CmdWithOutput("success", 0)
 		}
@@ -78,7 +78,7 @@ func TestRun(t *testing.T) {
 	t.Run("run with mutliplexing enabled does not include Control args on windows", func(t *testing.T) {
 		testutil.RequireOS(t, "windows")
 		var capturedArgs string
-		mockExec := func(_ ssh.Host, _ string, _ []byte, sshArgs ...string) *exec.Cmd {
+		mockExec := func(_ ssh.SSHDestination, _ string, _ []byte, sshArgs ...string) *exec.Cmd {
 			capturedArgs = strings.Join(sshArgs, " ")
 			return testutil.CmdWithOutput("success", 0)
 		}
@@ -95,7 +95,7 @@ func TestRun(t *testing.T) {
 
 func TestBinaryExists(t *testing.T) {
 	t.Run("when binary found returns nil", func(t *testing.T) {
-		mockExec := func(_ ssh.Host, _ string, _ []byte, _ ...string) *exec.Cmd {
+		mockExec := func(_ ssh.SSHDestination, _ string, _ []byte, _ ...string) *exec.Cmd {
 			return testutil.CmdWithOutput("/foo/bar", 0)
 		}
 		conn := target.NewConnection("hostname", target.ConnectionOptions{WithMockExec: mockExec})
@@ -104,7 +104,7 @@ func TestBinaryExists(t *testing.T) {
 	})
 
 	t.Run("invalid format returns an error", func(t *testing.T) {
-		mockExec := func(_ ssh.Host, _ string, _ []byte, _ ...string) *exec.Cmd {
+		mockExec := func(_ ssh.SSHDestination, _ string, _ []byte, _ ...string) *exec.Cmd {
 			return testutil.CmdWithOutput("/foo/bar", 0)
 		}
 		conn := target.NewConnection("hostname", target.ConnectionOptions{WithMockExec: mockExec})

--- a/internal/target/probe_test.go
+++ b/internal/target/probe_test.go
@@ -37,7 +37,7 @@ func TestExtractArmFeatures(t *testing.T) {
 
 func TestProbeHardware(t *testing.T) {
 	t.Run("returns model name and features", func(t *testing.T) {
-		mockExec := func(_ ssh.Host, command string, _ []byte, _ ...string) *exec.Cmd {
+		mockExec := func(_ ssh.SSHDestination, command string, _ []byte, _ ...string) *exec.Cmd {
 			switch {
 			case strings.Contains(command, "command -v"):
 				return testutil.CmdWithOutput("/usr/bin/lscpu", 0)
@@ -62,7 +62,7 @@ func TestProbeHardware(t *testing.T) {
 	})
 
 	t.Run("returns error when lscpu not found", func(t *testing.T) {
-		mockExec := func(_ ssh.Host, command string, _ []byte, _ ...string) *exec.Cmd {
+		mockExec := func(_ ssh.SSHDestination, command string, _ []byte, _ ...string) *exec.Cmd {
 			return testutil.CmdWithOutput("not found", 1)
 		}
 
@@ -73,7 +73,7 @@ func TestProbeHardware(t *testing.T) {
 	})
 
 	t.Run("returns error when lscpu output is invalid JSON", func(t *testing.T) {
-		mockExec := func(_ ssh.Host, command string, _ []byte, _ ...string) *exec.Cmd {
+		mockExec := func(_ ssh.SSHDestination, command string, _ []byte, _ ...string) *exec.Cmd {
 			switch {
 			case strings.Contains(command, "command -v"):
 				return testutil.CmdWithOutput("/usr/bin/lscpu", 0)

--- a/internal/target/probe_test.go
+++ b/internal/target/probe_test.go
@@ -37,7 +37,7 @@ func TestExtractArmFeatures(t *testing.T) {
 
 func TestProbeHardware(t *testing.T) {
 	t.Run("returns model name and features", func(t *testing.T) {
-		mockExec := func(_ ssh.SSHDestination, command string, _ []byte, _ ...string) *exec.Cmd {
+		mockExec := func(_ ssh.Destination, command string, _ []byte, _ ...string) *exec.Cmd {
 			switch {
 			case strings.Contains(command, "command -v"):
 				return testutil.CmdWithOutput("/usr/bin/lscpu", 0)
@@ -62,7 +62,7 @@ func TestProbeHardware(t *testing.T) {
 	})
 
 	t.Run("returns error when lscpu not found", func(t *testing.T) {
-		mockExec := func(_ ssh.SSHDestination, command string, _ []byte, _ ...string) *exec.Cmd {
+		mockExec := func(_ ssh.Destination, command string, _ []byte, _ ...string) *exec.Cmd {
 			return testutil.CmdWithOutput("not found", 1)
 		}
 
@@ -73,7 +73,7 @@ func TestProbeHardware(t *testing.T) {
 	})
 
 	t.Run("returns error when lscpu output is invalid JSON", func(t *testing.T) {
-		mockExec := func(_ ssh.SSHDestination, command string, _ []byte, _ ...string) *exec.Cmd {
+		mockExec := func(_ ssh.Destination, command string, _ []byte, _ ...string) *exec.Cmd {
 			switch {
 			case strings.Contains(command, "command -v"):
 				return testutil.CmdWithOutput("/usr/bin/lscpu", 0)


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- Config is renamed to SSHAlias to make it more specific
- Host is renamed to SSHDestination. Host actually includes user and port, so this was not an accurate description
