### PR TITLE
refactor: nil-able registry config drives registry enablement

### DIFF
--- a/cmd/topo/deploy.go
+++ b/cmd/topo/deploy.go
@@ -89,7 +89,6 @@ Use --dry-run to see what commands would be executed without actually running th
 
 		targetHost := ssh.Host(resolvedTarget)
 		deployOpts.TargetHost = targetHost
-		deployOpts.RegistryPort = resolvedPort
 
 		if !skipProjectChecks {
 			if err := checks.EnsureProjectIsLinuxArm64Ready(composeFile); err != nil {
@@ -98,8 +97,12 @@ Use --dry-run to see what commands would be executed without actually running th
 		}
 
 		goos := runtime.GOOS
-		deployOpts.WithRegistry = docker.SupportsRegistry(noRegistry, targetHost)
-		deployOpts.UseSSHControlSockets = docker.SupportsSSHControlSockets(goos)
+		if docker.SupportsRegistry(noRegistry, targetHost) {
+			deployOpts.Registry = &docker.RegistryConfig{
+				Port:              resolvedPort,
+				UseControlSockets: docker.SupportsSSHControlSockets(goos),
+			}
+		}
 		switch {
 		case forceRecreate:
 			deployOpts.RecreateMode = operation.RecreateModeForce
@@ -107,7 +110,7 @@ Use --dry-run to see what commands would be executed without actually running th
 			deployOpts.RecreateMode = operation.RecreateModeNone
 		}
 
-		if !deployOpts.WithRegistry {
+		if deployOpts.Registry == nil {
 			c.Log(logger.Entry{
 				Level:   logger.Warning,
 				Message: "registry transfer is not yet supported with this configuration. Falling back to direct transfer.",

--- a/internal/deploy/docker/deploy.go
+++ b/internal/deploy/docker/deploy.go
@@ -6,12 +6,15 @@ import (
 	"github.com/arm/topo/internal/ssh"
 )
 
+type RegistryConfig struct {
+	Port              string
+	UseControlSockets bool
+}
+
 type DeployOptions struct {
-	RecreateMode         operation.RecreateMode
-	WithRegistry         bool
-	TargetHost           ssh.Host
-	RegistryPort         string
-	UseSSHControlSockets bool
+	RecreateMode operation.RecreateMode
+	TargetHost   ssh.Host
+	Registry     *RegistryConfig
 }
 
 func SupportsRegistry(noRegistry bool, targetHost ssh.Host) bool {
@@ -35,13 +38,13 @@ func NewDeployment(composeFile string, opts DeployOptions) (goperation.Sequence,
 
 	var cleanup goperation.Operation
 	if !opts.TargetHost.IsPlainLocalhost() {
-		if opts.WithRegistry {
-			start, securityCheck, stop := ssh.NewSSHTunnel(opts.TargetHost, opts.RegistryPort, opts.UseSSHControlSockets)
+		if opts.Registry != nil {
+			start, securityCheck, stop := ssh.NewSSHTunnel(opts.TargetHost, opts.Registry.Port, opts.Registry.UseControlSockets)
 			cleanup = stop
-			ops = append(ops, operation.NewRunRegistry(opts.RegistryPort)...)
+			ops = append(ops, operation.NewRunRegistry(opts.Registry.Port)...)
 			ops = append(ops, start)
 			ops = append(ops, securityCheck)
-			ops = append(ops, operation.NewRegistryTransfer(composeFile, sourceHost, opts.TargetHost, opts.RegistryPort))
+			ops = append(ops, operation.NewRegistryTransfer(composeFile, sourceHost, opts.TargetHost, opts.Registry.Port))
 			ops = append(ops, stop)
 		} else {
 			ops = append(ops, operation.NewDockerComposePipeTransfer(composeFile, sourceHost, opts.TargetHost))

--- a/internal/deploy/docker/deploy_test.go
+++ b/internal/deploy/docker/deploy_test.go
@@ -36,7 +36,7 @@ func TestNewDeployment(t *testing.T) {
 	t.Run("includes registry operations for remote host when enabled", func(t *testing.T) {
 		remoteHost := ssh.Host("user@remote")
 		port := operation.DefaultRegistryPort
-		opts := docker.DeployOptions{TargetHost: remoteHost, WithRegistry: true, RegistryPort: port, UseSSHControlSockets: true}
+		opts := docker.DeployOptions{TargetHost: remoteHost, Registry: &docker.RegistryConfig{Port: port, UseControlSockets: true}}
 		got, _ := docker.NewDeployment(composeFile, opts)
 
 		want := goperation.Sequence{
@@ -45,7 +45,7 @@ func TestNewDeployment(t *testing.T) {
 		}
 		want = append(want, operation.NewRunRegistry(port)...)
 		want = append(want,
-			ssh.NewSSHTunnelStart(remoteHost, port, opts.UseSSHControlSockets),
+			ssh.NewSSHTunnelStart(remoteHost, port, opts.Registry.UseControlSockets),
 			ssh.NewCheckSSHTunnelSecurity(remoteHost, port),
 			operation.NewRegistryTransfer(composeFile, ssh.PlainLocalhost, remoteHost, port),
 			ssh.NewSSHTunnelStop(remoteHost),
@@ -94,7 +94,7 @@ func TestNewDeployment(t *testing.T) {
 
 	t.Run("returns an SSH tunnel cleanup operation for remote host", func(t *testing.T) {
 		remoteHost := ssh.Host("user@remote")
-		deployOpts := docker.DeployOptions{TargetHost: remoteHost, WithRegistry: true, UseSSHControlSockets: true}
+		deployOpts := docker.DeployOptions{TargetHost: remoteHost, Registry: &docker.RegistryConfig{UseControlSockets: true}}
 		_, cleanup := docker.NewDeployment(composeFile, deployOpts)
 
 		want := ssh.NewSSHTunnelStop(remoteHost)
@@ -103,7 +103,7 @@ func TestNewDeployment(t *testing.T) {
 
 	t.Run("does not return an SSH tunnel cleanup operation for local host", func(t *testing.T) {
 		localHost := ssh.PlainLocalhost
-		deployOpts := docker.DeployOptions{TargetHost: localHost, WithRegistry: true}
+		deployOpts := docker.DeployOptions{TargetHost: localHost, Registry: &docker.RegistryConfig{}}
 		_, cleanup := docker.NewDeployment(composeFile, deployOpts)
 
 		var want goperation.Operation = nil
@@ -113,10 +113,10 @@ func TestNewDeployment(t *testing.T) {
 	t.Run("does not use SSH control sockets when disabled", func(t *testing.T) {
 		remoteHost := ssh.Host("user@remote")
 		port := operation.DefaultRegistryPort
-		opts := docker.DeployOptions{TargetHost: remoteHost, WithRegistry: true, RegistryPort: port, UseSSHControlSockets: false}
+		opts := docker.DeployOptions{TargetHost: remoteHost, Registry: &docker.RegistryConfig{Port: port, UseControlSockets: false}}
 		got, _ := docker.NewDeployment(composeFile, opts)
 
-		wantTunnelStart, wantSecurityCheck, wantTunnelEnd := ssh.NewSSHTunnel(remoteHost, opts.RegistryPort, opts.UseSSHControlSockets)
+		wantTunnelStart, wantSecurityCheck, wantTunnelEnd := ssh.NewSSHTunnel(remoteHost, opts.Registry.Port, opts.Registry.UseControlSockets)
 		want := goperation.Sequence{
 			operation.NewDockerComposeBuild(composeFile, ssh.PlainLocalhost),
 			operation.NewDockerComposePull(composeFile, ssh.PlainLocalhost),


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- Replaces the flat registry fields on `DeployOptions` with a single nullable `*RegistryConfig` 
   - A `nil` `Registry` now means "no registry" while a non-`nil` value improves the coherency of associated fields
