### PR TITLE
refactor: Follow go's `exec` naming patterns 

### DIFF
--- a/internal/describe/describe_test.go
+++ b/internal/describe/describe_test.go
@@ -18,14 +18,14 @@ import (
 
 func TestGenerate(t *testing.T) {
 	t.Run("returns hardware profile for given target", func(t *testing.T) {
-		mockExecSSH := func(target ssh.Host, command string, _ []byte, sshArgs ...string) *exec.Cmd {
-			if command == "lscpu --json" {
+		mockExecSSH := func(target ssh.Host, cmdStr string, _ []byte, sshArgs ...string) *exec.Cmd {
+			if cmdStr == "lscpu --json" {
 				return testutil.CmdWithOutput(testutil.LsCpuOutputRaw, 0)
 			}
-			if strings.Contains(command, "remoteproc") {
+			if strings.Contains(cmdStr, "remoteproc") {
 				return testutil.CmdWithOutput("remoteproc1 remoteproc2", 0)
 			}
-			if strings.Contains(command, "meminfo") {
+			if strings.Contains(cmdStr, "meminfo") {
 				return testutil.CmdWithOutput("MemTotal:       16384000 kB", 0)
 			}
 			return testutil.CmdWithOutput("", 0)
@@ -53,7 +53,7 @@ func TestGenerate(t *testing.T) {
 	})
 
 	t.Run("fails if ssh commands cannot be executed", func(t *testing.T) {
-		mockExecSSH := func(target ssh.Host, command string, _ []byte, sshArgs ...string) *exec.Cmd {
+		mockExecSSH := func(target ssh.Host, cmdStr string, _ []byte, sshArgs ...string) *exec.Cmd {
 			return testutil.CmdWithOutput(assert.AnError.Error(), 1)
 		}
 

--- a/internal/describe/describe_test.go
+++ b/internal/describe/describe_test.go
@@ -45,7 +45,7 @@ func TestGenerate(t *testing.T) {
 			TotalMemoryKb: 16384000,
 		}
 
-		conn := target.NewConnection("test", target.ConnectionOptions{WithMockExec: mockExecSSH})
+		conn := target.NewConnection("test", target.ConnectionOptions{WithMockCommand: mockExecSSH})
 		report, err := describe.GenerateTargetDescription(conn)
 
 		require.NoError(t, err)
@@ -57,7 +57,7 @@ func TestGenerate(t *testing.T) {
 			return testutil.CmdWithOutput(assert.AnError.Error(), 1)
 		}
 
-		conn := target.NewConnection("test", target.ConnectionOptions{WithMockExec: mockExecSSH})
+		conn := target.NewConnection("test", target.ConnectionOptions{WithMockCommand: mockExecSSH})
 		_, err := describe.GenerateTargetDescription(conn)
 
 		assert.Error(t, err)

--- a/internal/describe/describe_test.go
+++ b/internal/describe/describe_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestGenerate(t *testing.T) {
 	t.Run("returns hardware profile for given target", func(t *testing.T) {
-		mockExecSSH := func(target ssh.Host, cmdStr string, _ []byte, sshArgs ...string) *exec.Cmd {
+		mockCommand := func(target ssh.Host, cmdStr string, _ []byte, sshArgs ...string) *exec.Cmd {
 			if cmdStr == "lscpu --json" {
 				return testutil.CmdWithOutput(testutil.LsCpuOutputRaw, 0)
 			}
@@ -45,7 +45,7 @@ func TestGenerate(t *testing.T) {
 			TotalMemoryKb: 16384000,
 		}
 
-		conn := target.NewConnection("test", target.ConnectionOptions{WithMockCommand: mockExecSSH})
+		conn := target.NewConnection("test", target.ConnectionOptions{WithMockCommand: mockCommand})
 		report, err := describe.GenerateTargetDescription(conn)
 
 		require.NoError(t, err)
@@ -53,11 +53,11 @@ func TestGenerate(t *testing.T) {
 	})
 
 	t.Run("fails if ssh commands cannot be executed", func(t *testing.T) {
-		mockExecSSH := func(target ssh.Host, cmdStr string, _ []byte, sshArgs ...string) *exec.Cmd {
+		mockCommand := func(target ssh.Host, cmdStr string, _ []byte, sshArgs ...string) *exec.Cmd {
 			return testutil.CmdWithOutput(assert.AnError.Error(), 1)
 		}
 
-		conn := target.NewConnection("test", target.ConnectionOptions{WithMockCommand: mockExecSSH})
+		conn := target.NewConnection("test", target.ConnectionOptions{WithMockCommand: mockCommand})
 		_, err := describe.GenerateTargetDescription(conn)
 
 		assert.Error(t, err)

--- a/internal/health/status_test.go
+++ b/internal/health/status_test.go
@@ -14,11 +14,11 @@ import (
 
 func TestProbeHealthStatus(t *testing.T) {
 	t.Run("probe fails connection", func(t *testing.T) {
-		mockExec := func(_ ssh.Host, _ string, _ []byte, _ ...string) *exec.Cmd {
+		mockCommand := func(_ ssh.Host, _ string, _ []byte, _ ...string) *exec.Cmd {
 			return testutil.CmdWithOutput("connection refused", 1)
 		}
 
-		conn := target.NewConnection("hostname", target.ConnectionOptions{WithMockCommand: mockExec})
+		conn := target.NewConnection("hostname", target.ConnectionOptions{WithMockCommand: mockCommand})
 		ts := health.ProbeHealthStatus(conn)
 
 		assert.Error(t, ts.ConnectionError)
@@ -26,7 +26,7 @@ func TestProbeHealthStatus(t *testing.T) {
 	})
 
 	t.Run("probe finds remote CPUs", func(t *testing.T) {
-		mockExec := func(_ ssh.Host, cmdStr string, _ []byte, _ ...string) *exec.Cmd {
+		mockCommand := func(_ ssh.Host, cmdStr string, _ []byte, _ ...string) *exec.Cmd {
 			switch {
 			case cmdStr == "true":
 				return testutil.CmdWithOutput("", 0)
@@ -39,7 +39,7 @@ func TestProbeHealthStatus(t *testing.T) {
 			}
 		}
 
-		conn := target.NewConnection("hostname", target.ConnectionOptions{WithMockCommand: mockExec})
+		conn := target.NewConnection("hostname", target.ConnectionOptions{WithMockCommand: mockCommand})
 		ts := health.ProbeHealthStatus(conn)
 
 		want := health.HardwareProfile{RemoteCPU: []target.RemoteprocCPU{{Name: "foo"}, {Name: "bar"}}}
@@ -48,7 +48,7 @@ func TestProbeHealthStatus(t *testing.T) {
 	})
 
 	t.Run("probe succeeds when no remoteproc support", func(t *testing.T) {
-		mockExec := func(_ ssh.Host, cmdStr string, _ []byte, _ ...string) *exec.Cmd {
+		mockCommand := func(_ ssh.Host, cmdStr string, _ []byte, _ ...string) *exec.Cmd {
 			switch cmdStr {
 			case "true":
 				return testutil.CmdWithOutput("", 0)
@@ -57,7 +57,7 @@ func TestProbeHealthStatus(t *testing.T) {
 			}
 		}
 
-		conn := target.NewConnection("hostname", target.ConnectionOptions{WithMockCommand: mockExec})
+		conn := target.NewConnection("hostname", target.ConnectionOptions{WithMockCommand: mockCommand})
 		ts := health.ProbeHealthStatus(conn)
 
 		assert.NoError(t, ts.ConnectionError)

--- a/internal/health/status_test.go
+++ b/internal/health/status_test.go
@@ -18,7 +18,7 @@ func TestProbeHealthStatus(t *testing.T) {
 			return testutil.CmdWithOutput("connection refused", 1)
 		}
 
-		conn := target.NewConnection("hostname", target.ConnectionOptions{WithMockExec: mockExec})
+		conn := target.NewConnection("hostname", target.ConnectionOptions{WithMockCommand: mockExec})
 		ts := health.ProbeHealthStatus(conn)
 
 		assert.Error(t, ts.ConnectionError)
@@ -39,7 +39,7 @@ func TestProbeHealthStatus(t *testing.T) {
 			}
 		}
 
-		conn := target.NewConnection("hostname", target.ConnectionOptions{WithMockExec: mockExec})
+		conn := target.NewConnection("hostname", target.ConnectionOptions{WithMockCommand: mockExec})
 		ts := health.ProbeHealthStatus(conn)
 
 		want := health.HardwareProfile{RemoteCPU: []target.RemoteprocCPU{{Name: "foo"}, {Name: "bar"}}}
@@ -57,7 +57,7 @@ func TestProbeHealthStatus(t *testing.T) {
 			}
 		}
 
-		conn := target.NewConnection("hostname", target.ConnectionOptions{WithMockExec: mockExec})
+		conn := target.NewConnection("hostname", target.ConnectionOptions{WithMockCommand: mockExec})
 		ts := health.ProbeHealthStatus(conn)
 
 		assert.NoError(t, ts.ConnectionError)

--- a/internal/health/status_test.go
+++ b/internal/health/status_test.go
@@ -26,16 +26,16 @@ func TestProbeHealthStatus(t *testing.T) {
 	})
 
 	t.Run("probe finds remote CPUs", func(t *testing.T) {
-		mockExec := func(_ ssh.Host, command string, _ []byte, _ ...string) *exec.Cmd {
+		mockExec := func(_ ssh.Host, cmdStr string, _ []byte, _ ...string) *exec.Cmd {
 			switch {
-			case command == "true":
+			case cmdStr == "true":
 				return testutil.CmdWithOutput("", 0)
-			case strings.Contains(command, "ls /sys/class/remoteproc"):
+			case strings.Contains(cmdStr, "ls /sys/class/remoteproc"):
 				return testutil.CmdWithOutput("remoteproc0\nremoteproc1", 0)
-			case strings.Contains(command, "cat /sys/class/remoteproc"):
+			case strings.Contains(cmdStr, "cat /sys/class/remoteproc"):
 				return testutil.CmdWithOutput("foo\nbar", 0)
 			default:
-				return testutil.CmdWithOutput("unexpected command: "+command, 1)
+				return testutil.CmdWithOutput("unexpected command: "+cmdStr, 1)
 			}
 		}
 
@@ -48,8 +48,8 @@ func TestProbeHealthStatus(t *testing.T) {
 	})
 
 	t.Run("probe succeeds when no remoteproc support", func(t *testing.T) {
-		mockExec := func(_ ssh.Host, command string, _ []byte, _ ...string) *exec.Cmd {
-			switch command {
+		mockExec := func(_ ssh.Host, cmdStr string, _ []byte, _ ...string) *exec.Cmd {
+			switch cmdStr {
 			case "true":
 				return testutil.CmdWithOutput("", 0)
 			default:

--- a/internal/setupkeys/pubkeytransfer/pub_key_transfer.go
+++ b/internal/setupkeys/pubkeytransfer/pub_key_transfer.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 
+	"github.com/arm/topo/internal/ssh"
 	target "github.com/arm/topo/internal/target"
 )
 
@@ -18,7 +19,7 @@ type PubKeyTransfer struct {
 }
 
 type PubKeyTransferOptions struct {
-	WithMockExec target.ExecSSH
+	WithMockCommand ssh.CommandFunc
 }
 
 func NewPubKeyTransfer(description string, targetHost string, privKeyPath string, opts PubKeyTransferOptions) *PubKeyTransfer {
@@ -32,8 +33,8 @@ func (kt *PubKeyTransfer) Description() string {
 func (kt *PubKeyTransfer) buildTransferConnection(stdin []byte) *target.Connection {
 	opts := target.ConnectionOptions{WithLoginShell: true, WithStdin: stdin}
 
-	if kt.opts.WithMockExec != nil {
-		opts.WithMockExec = kt.opts.WithMockExec
+	if kt.opts.WithMockCommand != nil {
+		opts.WithMockCommand = kt.opts.WithMockCommand
 	}
 
 	conn := target.NewConnection(kt.targetHost, opts)

--- a/internal/setupkeys/pubkeytransfer/pub_key_transfer_test.go
+++ b/internal/setupkeys/pubkeytransfer/pub_key_transfer_test.go
@@ -40,7 +40,7 @@ func TestPubKeyTransferRun(t *testing.T) {
 	}
 	var got call
 
-	opts := pubkeytransfer.PubKeyTransferOptions{WithMockExec: func(h ssh.Host, command string, stdin []byte, args ...string) *exec.Cmd {
+	opts := pubkeytransfer.PubKeyTransferOptions{WithMockCommand: func(h ssh.Host, command string, stdin []byte, args ...string) *exec.Cmd {
 		got = call{host: h, cmd: command, stdin: stdin, args: args}
 		cmd := testutil.CmdWithOutput("ssh invoked", 0)
 		if stdin != nil {

--- a/internal/setupkeys/pubkeytransfer/pub_key_transfer_test.go
+++ b/internal/setupkeys/pubkeytransfer/pub_key_transfer_test.go
@@ -40,8 +40,8 @@ func TestPubKeyTransferRun(t *testing.T) {
 	}
 	var got call
 
-	opts := pubkeytransfer.PubKeyTransferOptions{WithMockCommand: func(h ssh.Host, command string, stdin []byte, args ...string) *exec.Cmd {
-		got = call{host: h, cmd: command, stdin: stdin, args: args}
+	opts := pubkeytransfer.PubKeyTransferOptions{WithMockCommand: func(h ssh.Host, cmdStr string, stdin []byte, args ...string) *exec.Cmd {
+		got = call{host: h, cmd: cmdStr, stdin: stdin, args: args}
 		cmd := testutil.CmdWithOutput("ssh invoked", 0)
 		if stdin != nil {
 			cmd.Stdin = bytes.NewReader(stdin)

--- a/internal/ssh/exec.go
+++ b/internal/ssh/exec.go
@@ -30,24 +30,24 @@ func shellEscapeForDoubleQuotes(s string) string {
 	return repl.Replace(s)
 }
 
-func ShellCommand(command string) string {
-	escaped := shellEscapeForDoubleQuotes(command)
+func ShellCommand(cmdStr string) string {
+	escaped := shellEscapeForDoubleQuotes(cmdStr)
 	return fmt.Sprintf(`/bin/sh -c "exec ${SHELL:-/bin/sh} -l -c \"%s\""`, escaped)
 }
 
 // CommandFunc builds a command to be executed on a target host.
-type CommandFunc func(target Host, command string, stdin []byte, sshArgs ...string) *exec.Cmd
+type CommandFunc func(target Host, cmdStr string, stdin []byte, sshArgs ...string) *exec.Cmd
 
 // Command builds a command to be executed on the target host. If the target is localhost, it will run locally when executed.
 // Pass stdin data as optional parameter, or nil for no stdin.
-func Command(target Host, command string, stdin []byte, sshArgs ...string) *exec.Cmd {
+func Command(target Host, cmdStr string, stdin []byte, sshArgs ...string) *exec.Cmd {
 	var cmd *exec.Cmd
 	if target.IsPlainLocalhost() {
-		// #nosec G204 -- command should be validated by callers
-		cmd = exec.Command("/bin/sh", "-c", command)
+		// #nosec G204 -- cmdStr should be validated by callers
+		cmd = exec.Command("/bin/sh", "-c", cmdStr)
 	} else {
-		args := slices.Concat(sshArgs, []string{"--", string(target), command})
-		// #nosec G204 -- command should be validated by callers
+		args := slices.Concat(sshArgs, []string{"--", string(target), cmdStr})
+		// #nosec G204 -- cmdStr should be validated by callers
 		cmd = exec.Command("ssh", args...)
 	}
 

--- a/internal/ssh/exec.go
+++ b/internal/ssh/exec.go
@@ -30,7 +30,7 @@ func shellEscapeForDoubleQuotes(s string) string {
 	return repl.Replace(s)
 }
 
-func ShellCommand(cmdStr string) string {
+func ShellCommandStr(cmdStr string) string {
 	escaped := shellEscapeForDoubleQuotes(cmdStr)
 	return fmt.Sprintf(`/bin/sh -c "exec ${SHELL:-/bin/sh} -l -c \"%s\""`, escaped)
 }

--- a/internal/ssh/exec.go
+++ b/internal/ssh/exec.go
@@ -35,9 +35,12 @@ func ShellCommand(command string) string {
 	return fmt.Sprintf(`/bin/sh -c "exec ${SHELL:-/bin/sh} -l -c \"%s\""`, escaped)
 }
 
-// ExecCmd builds a command to be executed on the target host. If the target is localhost, it will run locally when executed.
+// CommandFunc builds a command to be executed on a target host.
+type CommandFunc func(target Host, command string, stdin []byte, sshArgs ...string) *exec.Cmd
+
+// Command builds a command to be executed on the target host. If the target is localhost, it will run locally when executed.
 // Pass stdin data as optional parameter, or nil for no stdin.
-func ExecCmd(target Host, command string, stdin []byte, sshArgs ...string) *exec.Cmd {
+func Command(target Host, command string, stdin []byte, sshArgs ...string) *exec.Cmd {
 	var cmd *exec.Cmd
 	if target.IsPlainLocalhost() {
 		// #nosec G204 -- command should be validated by callers

--- a/internal/target/connection.go
+++ b/internal/target/connection.go
@@ -66,9 +66,9 @@ func NewConnection(sshTarget string, opts ConnectionOptions) Connection {
 	return connection
 }
 
-func (c *Connection) Run(command string) (string, error) {
+func (c *Connection) Run(cmdStr string) (string, error) {
 	if c.opts.WithLoginShell {
-		command = ssh.ShellCommand(command)
+		cmdStr = ssh.ShellCommand(cmdStr)
 	}
 
 	sshArgs := c.connectTimeoutArgs()
@@ -76,7 +76,7 @@ func (c *Connection) Run(command string) (string, error) {
 		sshArgs = append(sshArgs, "-o", "ControlMaster=auto", "-o", "ControlPersist=10s", "-o", "ControlPath=~/.ssh/topo-cm-%r@%h:%p")
 	}
 
-	cmd := c.command(c.SSHTarget, command, c.opts.WithStdin, sshArgs...)
+	cmd := c.command(c.SSHTarget, cmdStr, c.opts.WithStdin, sshArgs...)
 	var stdoutBuf, stderrBuf bytes.Buffer
 	cmd.Stdout = &stdoutBuf
 	cmd.Stderr = &stderrBuf
@@ -92,12 +92,12 @@ func (c *Connection) Run(command string) (string, error) {
 	return stdoutBuf.String(), nil
 }
 
-func (c *Connection) DryRun(command string, output io.Writer) error {
+func (c *Connection) DryRun(cmdStr string, output io.Writer) error {
 	if c.opts.WithLoginShell {
-		command = ssh.ShellCommand(command)
+		cmdStr = ssh.ShellCommand(cmdStr)
 	}
 
-	cmd := c.command(c.SSHTarget, command, c.opts.WithStdin)
+	cmd := c.command(c.SSHTarget, cmdStr, c.opts.WithStdin)
 	_, err := fmt.Fprintln(output, commandpkg.String(cmd))
 	return err
 }

--- a/internal/target/connection.go
+++ b/internal/target/connection.go
@@ -182,11 +182,7 @@ func (c *Connection) connectTimeoutArgs() []string {
 // All SSH authentication probes run the command "true" to check if the authentication method works.
 // All sshArgs should be hardcoded SSH options, not user-provided arguments.
 func (c *Connection) runSSHAuthenticationProbe(sshArgs []string) error {
-<<<<<<< HEAD
-	cmd := c.exec(c.SSHTarget, "true", nil, slices.Concat(c.connectTimeoutArgs(), sshArgs)...)
-=======
-	cmd := c.command(c.SSHTarget, "true", nil, sshArgs...)
->>>>>>> 629605e (Align naming of `exec.Command` producer with Go's stdlib)
+	cmd := c.command(c.SSHTarget, "true", nil, slices.Concat(c.connectTimeoutArgs(), sshArgs)...)
 	stdoutBytes, err := cmd.CombinedOutput()
 	if err == nil {
 		return nil

--- a/internal/target/connection.go
+++ b/internal/target/connection.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os/exec"
 	"runtime"
 	"slices"
 	"strings"
@@ -35,11 +34,9 @@ var (
 	}
 )
 
-type ExecSSH func(target ssh.Host, command string, stdin []byte, sshArgs ...string) *exec.Cmd
-
 type Connection struct {
 	SSHTarget ssh.Host
-	exec      ExecSSH
+	command   ssh.CommandFunc
 	opts      ConnectionOptions
 }
 
@@ -50,23 +47,23 @@ type ConnectionOptions struct {
 	WithLoginShell    bool
 	WithStdin         []byte
 	Multiplex         bool
-	WithMockExec      ExecSSH
+	WithMockCommand   ssh.CommandFunc
 	ConnectTimeout    time.Duration
 }
 
 var ErrPasswordAuthentication = errors.New("key-based SSH authentication is not setup")
 
 func NewConnection(sshTarget string, opts ConnectionOptions) Connection {
-	execFn := ssh.ExecCmd
-	if opts.WithMockExec != nil {
-		execFn = opts.WithMockExec
-	}
 	opts.ConnectTimeout = ssh.NewConfig(sshTarget).ConnectTimeout(opts.ConnectTimeout)
-	return Connection{
+	connection := Connection{
 		SSHTarget: ssh.Host(sshTarget),
-		exec:      execFn,
+		command:   ssh.Command,
 		opts:      opts,
 	}
+	if opts.WithMockCommand != nil {
+		connection.command = opts.WithMockCommand
+	}
+	return connection
 }
 
 func (c *Connection) Run(command string) (string, error) {
@@ -79,7 +76,7 @@ func (c *Connection) Run(command string) (string, error) {
 		sshArgs = append(sshArgs, "-o", "ControlMaster=auto", "-o", "ControlPersist=10s", "-o", "ControlPath=~/.ssh/topo-cm-%r@%h:%p")
 	}
 
-	cmd := c.exec(c.SSHTarget, command, c.opts.WithStdin, sshArgs...)
+	cmd := c.command(c.SSHTarget, command, c.opts.WithStdin, sshArgs...)
 	var stdoutBuf, stderrBuf bytes.Buffer
 	cmd.Stdout = &stdoutBuf
 	cmd.Stderr = &stderrBuf
@@ -100,7 +97,7 @@ func (c *Connection) DryRun(command string, output io.Writer) error {
 		command = ssh.ShellCommand(command)
 	}
 
-	cmd := c.exec(c.SSHTarget, command, c.opts.WithStdin)
+	cmd := c.command(c.SSHTarget, command, c.opts.WithStdin)
 	_, err := fmt.Fprintln(output, commandpkg.String(cmd))
 	return err
 }
@@ -185,7 +182,11 @@ func (c *Connection) connectTimeoutArgs() []string {
 // All SSH authentication probes run the command "true" to check if the authentication method works.
 // All sshArgs should be hardcoded SSH options, not user-provided arguments.
 func (c *Connection) runSSHAuthenticationProbe(sshArgs []string) error {
+<<<<<<< HEAD
 	cmd := c.exec(c.SSHTarget, "true", nil, slices.Concat(c.connectTimeoutArgs(), sshArgs)...)
+=======
+	cmd := c.command(c.SSHTarget, "true", nil, sshArgs...)
+>>>>>>> 629605e (Align naming of `exec.Command` producer with Go's stdlib)
 	stdoutBytes, err := cmd.CombinedOutput()
 	if err == nil {
 		return nil

--- a/internal/target/connection.go
+++ b/internal/target/connection.go
@@ -68,7 +68,7 @@ func NewConnection(sshTarget string, opts ConnectionOptions) Connection {
 
 func (c *Connection) Run(cmdStr string) (string, error) {
 	if c.opts.WithLoginShell {
-		cmdStr = ssh.ShellCommand(cmdStr)
+		cmdStr = ssh.ShellCommandStr(cmdStr)
 	}
 
 	sshArgs := c.connectTimeoutArgs()
@@ -94,7 +94,7 @@ func (c *Connection) Run(cmdStr string) (string, error) {
 
 func (c *Connection) DryRun(cmdStr string, output io.Writer) error {
 	if c.opts.WithLoginShell {
-		cmdStr = ssh.ShellCommand(cmdStr)
+		cmdStr = ssh.ShellCommandStr(cmdStr)
 	}
 
 	cmd := c.command(c.SSHTarget, cmdStr, c.opts.WithStdin)

--- a/internal/target/connection_auth_test.go
+++ b/internal/target/connection_auth_test.go
@@ -24,7 +24,7 @@ type mockResponse struct {
 	err    error
 }
 
-func newMockExec(responses map[string]mockResponse, calls *[]sshTestCall) func(ssh.Host, string, []byte, ...string) *exec.Cmd {
+func newMockCommand(responses map[string]mockResponse, calls *[]sshTestCall) func(ssh.Host, string, []byte, ...string) *exec.Cmd {
 	return func(target ssh.Host, cmdStr string, _ []byte, sshArgs ...string) *exec.Cmd {
 		*calls = append(*calls, sshTestCall{
 			target: target,
@@ -60,10 +60,10 @@ func TestProbeAuthentication(t *testing.T) {
 
 	t.Run("does not require password when public key succeeds", func(t *testing.T) {
 		var calls []sshTestCall
-		mockExec := newMockExec(map[string]mockResponse{
+		mockCommand := newMockCommand(map[string]mockResponse{
 			"public": {stdout: "", err: nil},
 		}, &calls)
-		opts := target.ConnectionOptions{AcceptNewHostKeys: true, WithMockCommand: mockExec}
+		opts := target.ConnectionOptions{AcceptNewHostKeys: true, WithMockCommand: mockCommand}
 		conn := target.NewConnection("user@host", opts)
 		err := conn.ProbeAuthentication()
 		require.NoError(t, err)
@@ -75,10 +75,10 @@ func TestProbeAuthentication(t *testing.T) {
 
 	t.Run("returns host key verification error for public key probe", func(t *testing.T) {
 		var calls []sshTestCall
-		mockExec := newMockExec(map[string]mockResponse{
+		mockCommand := newMockCommand(map[string]mockResponse{
 			"public": {stdout: "Host key verification failed", err: errSSH},
 		}, &calls)
-		opts := target.ConnectionOptions{AcceptNewHostKeys: true, WithMockCommand: mockExec}
+		opts := target.ConnectionOptions{AcceptNewHostKeys: true, WithMockCommand: mockCommand}
 		conn := target.NewConnection("user@host", opts)
 		err := conn.ProbeAuthentication()
 		require.ErrorIs(t, err, target.ErrHostKeyVerification)
@@ -87,11 +87,11 @@ func TestProbeAuthentication(t *testing.T) {
 
 	t.Run("returns host key verification error for password probe", func(t *testing.T) {
 		var calls []sshTestCall
-		mockExec := newMockExec(map[string]mockResponse{
+		mockCommand := newMockCommand(map[string]mockResponse{
 			"public":   {stdout: "Permission denied", err: errSSH},
 			"password": {stdout: "Host key verification failed", err: errSSH},
 		}, &calls)
-		opts := target.ConnectionOptions{AcceptNewHostKeys: true, WithMockCommand: mockExec}
+		opts := target.ConnectionOptions{AcceptNewHostKeys: true, WithMockCommand: mockCommand}
 		conn := target.NewConnection("user@host", opts)
 		err := conn.ProbeAuthentication()
 		require.ErrorIs(t, err, target.ErrHostKeyVerification)
@@ -101,11 +101,11 @@ func TestProbeAuthentication(t *testing.T) {
 
 	t.Run("returns password-only auth error when auth fails", func(t *testing.T) {
 		var calls []sshTestCall
-		mockExec := newMockExec(map[string]mockResponse{
+		mockCommand := newMockCommand(map[string]mockResponse{
 			"public":   {stdout: "Permission denied", err: errSSH},
 			"password": {stdout: "Authentication failed", err: errSSH},
 		}, &calls)
-		opts := target.ConnectionOptions{AcceptNewHostKeys: true, WithMockCommand: mockExec}
+		opts := target.ConnectionOptions{AcceptNewHostKeys: true, WithMockCommand: mockCommand}
 		conn := target.NewConnection("user@host", opts)
 		err := conn.ProbeAuthentication()
 		require.ErrorIs(t, err, target.ErrPasswordAuthentication)
@@ -113,11 +113,11 @@ func TestProbeAuthentication(t *testing.T) {
 
 	t.Run("does not require password when password probe succeeds", func(t *testing.T) {
 		var calls []sshTestCall
-		mockExec := newMockExec(map[string]mockResponse{
+		mockCommand := newMockCommand(map[string]mockResponse{
 			"public":   {stdout: "Permission denied", err: errSSH},
 			"password": {stdout: "ok", err: nil},
 		}, &calls)
-		opts := target.ConnectionOptions{AcceptNewHostKeys: true, WithMockCommand: mockExec}
+		opts := target.ConnectionOptions{AcceptNewHostKeys: true, WithMockCommand: mockCommand}
 		conn := target.NewConnection("user@host", opts)
 		err := conn.ProbeAuthentication()
 		require.NoError(t, err)
@@ -127,11 +127,11 @@ func TestProbeAuthentication(t *testing.T) {
 
 	t.Run("returns error on non-auth failure for password probe", func(t *testing.T) {
 		var calls []sshTestCall
-		mockExec := newMockExec(map[string]mockResponse{
+		mockCommand := newMockCommand(map[string]mockResponse{
 			"public":   {stdout: "Permission denied", err: errSSH},
 			"password": {stdout: "Some other error", err: errSSH},
 		}, &calls)
-		opts := target.ConnectionOptions{AcceptNewHostKeys: true, WithMockCommand: mockExec}
+		opts := target.ConnectionOptions{AcceptNewHostKeys: true, WithMockCommand: mockCommand}
 		conn := target.NewConnection("user@host", opts)
 		err := conn.ProbeAuthentication()
 		require.Error(t, err)
@@ -140,11 +140,11 @@ func TestProbeAuthentication(t *testing.T) {
 
 	t.Run("ensures known host when not accepting new host keys", func(t *testing.T) {
 		var calls []sshTestCall
-		mockExec := newMockExec(map[string]mockResponse{
+		mockCommand := newMockCommand(map[string]mockResponse{
 			"knownhost": {stdout: "Permission denied", err: errSSH},
 			"public":    {stdout: "", err: nil},
 		}, &calls)
-		opts := target.ConnectionOptions{AcceptNewHostKeys: false, WithMockCommand: mockExec}
+		opts := target.ConnectionOptions{AcceptNewHostKeys: false, WithMockCommand: mockCommand}
 		conn := target.NewConnection("user@host", opts)
 		err := conn.ProbeAuthentication()
 		require.NoError(t, err)
@@ -155,10 +155,10 @@ func TestProbeAuthentication(t *testing.T) {
 
 	t.Run("returns host key verification error when known host fails", func(t *testing.T) {
 		var calls []sshTestCall
-		mockExec := newMockExec(map[string]mockResponse{
+		mockCommand := newMockCommand(map[string]mockResponse{
 			"knownhost": {stdout: "HOST KEY VERIFICATION FAILED", err: errSSH},
 		}, &calls)
-		opts := target.ConnectionOptions{AcceptNewHostKeys: false, WithMockCommand: mockExec}
+		opts := target.ConnectionOptions{AcceptNewHostKeys: false, WithMockCommand: mockCommand}
 		conn := target.NewConnection("user@host", opts)
 		err := conn.ProbeAuthentication()
 		require.ErrorIs(t, err, target.ErrHostKeyVerification)
@@ -167,10 +167,10 @@ func TestProbeAuthentication(t *testing.T) {
 
 	t.Run("returns error when known host fails with other error", func(t *testing.T) {
 		var calls []sshTestCall
-		mockExec := newMockExec(map[string]mockResponse{
+		mockCommand := newMockCommand(map[string]mockResponse{
 			"knownhost": {stdout: "dial tcp: lookup host: no such host", err: errSSH},
 		}, &calls)
-		opts := target.ConnectionOptions{AcceptNewHostKeys: false, WithMockCommand: mockExec}
+		opts := target.ConnectionOptions{AcceptNewHostKeys: false, WithMockCommand: mockCommand}
 		conn := target.NewConnection("user@host", opts)
 		err := conn.ProbeAuthentication()
 		require.Error(t, err)

--- a/internal/target/connection_auth_test.go
+++ b/internal/target/connection_auth_test.go
@@ -14,9 +14,9 @@ import (
 )
 
 type sshTestCall struct {
-	target  ssh.Host
-	command string
-	args    []string
+	target ssh.Host
+	cmdStr string
+	args   []string
 }
 
 type mockResponse struct {
@@ -25,11 +25,11 @@ type mockResponse struct {
 }
 
 func newMockExec(responses map[string]mockResponse, calls *[]sshTestCall) func(ssh.Host, string, []byte, ...string) *exec.Cmd {
-	return func(target ssh.Host, command string, _ []byte, sshArgs ...string) *exec.Cmd {
+	return func(target ssh.Host, cmdStr string, _ []byte, sshArgs ...string) *exec.Cmd {
 		*calls = append(*calls, sshTestCall{
-			target:  target,
-			command: command,
-			args:    sshArgs,
+			target: target,
+			cmdStr: cmdStr,
+			args:   sshArgs,
 		})
 
 		mode := "default"

--- a/internal/target/connection_auth_test.go
+++ b/internal/target/connection_auth_test.go
@@ -63,7 +63,7 @@ func TestProbeAuthentication(t *testing.T) {
 		mockExec := newMockExec(map[string]mockResponse{
 			"public": {stdout: "", err: nil},
 		}, &calls)
-		opts := target.ConnectionOptions{AcceptNewHostKeys: true, WithMockExec: mockExec}
+		opts := target.ConnectionOptions{AcceptNewHostKeys: true, WithMockCommand: mockExec}
 		conn := target.NewConnection("user@host", opts)
 		err := conn.ProbeAuthentication()
 		require.NoError(t, err)
@@ -78,7 +78,7 @@ func TestProbeAuthentication(t *testing.T) {
 		mockExec := newMockExec(map[string]mockResponse{
 			"public": {stdout: "Host key verification failed", err: errSSH},
 		}, &calls)
-		opts := target.ConnectionOptions{AcceptNewHostKeys: true, WithMockExec: mockExec}
+		opts := target.ConnectionOptions{AcceptNewHostKeys: true, WithMockCommand: mockExec}
 		conn := target.NewConnection("user@host", opts)
 		err := conn.ProbeAuthentication()
 		require.ErrorIs(t, err, target.ErrHostKeyVerification)
@@ -91,7 +91,7 @@ func TestProbeAuthentication(t *testing.T) {
 			"public":   {stdout: "Permission denied", err: errSSH},
 			"password": {stdout: "Host key verification failed", err: errSSH},
 		}, &calls)
-		opts := target.ConnectionOptions{AcceptNewHostKeys: true, WithMockExec: mockExec}
+		opts := target.ConnectionOptions{AcceptNewHostKeys: true, WithMockCommand: mockExec}
 		conn := target.NewConnection("user@host", opts)
 		err := conn.ProbeAuthentication()
 		require.ErrorIs(t, err, target.ErrHostKeyVerification)
@@ -105,7 +105,7 @@ func TestProbeAuthentication(t *testing.T) {
 			"public":   {stdout: "Permission denied", err: errSSH},
 			"password": {stdout: "Authentication failed", err: errSSH},
 		}, &calls)
-		opts := target.ConnectionOptions{AcceptNewHostKeys: true, WithMockExec: mockExec}
+		opts := target.ConnectionOptions{AcceptNewHostKeys: true, WithMockCommand: mockExec}
 		conn := target.NewConnection("user@host", opts)
 		err := conn.ProbeAuthentication()
 		require.ErrorIs(t, err, target.ErrPasswordAuthentication)
@@ -117,7 +117,7 @@ func TestProbeAuthentication(t *testing.T) {
 			"public":   {stdout: "Permission denied", err: errSSH},
 			"password": {stdout: "ok", err: nil},
 		}, &calls)
-		opts := target.ConnectionOptions{AcceptNewHostKeys: true, WithMockExec: mockExec}
+		opts := target.ConnectionOptions{AcceptNewHostKeys: true, WithMockCommand: mockExec}
 		conn := target.NewConnection("user@host", opts)
 		err := conn.ProbeAuthentication()
 		require.NoError(t, err)
@@ -131,7 +131,7 @@ func TestProbeAuthentication(t *testing.T) {
 			"public":   {stdout: "Permission denied", err: errSSH},
 			"password": {stdout: "Some other error", err: errSSH},
 		}, &calls)
-		opts := target.ConnectionOptions{AcceptNewHostKeys: true, WithMockExec: mockExec}
+		opts := target.ConnectionOptions{AcceptNewHostKeys: true, WithMockCommand: mockExec}
 		conn := target.NewConnection("user@host", opts)
 		err := conn.ProbeAuthentication()
 		require.Error(t, err)
@@ -144,7 +144,7 @@ func TestProbeAuthentication(t *testing.T) {
 			"knownhost": {stdout: "Permission denied", err: errSSH},
 			"public":    {stdout: "", err: nil},
 		}, &calls)
-		opts := target.ConnectionOptions{AcceptNewHostKeys: false, WithMockExec: mockExec}
+		opts := target.ConnectionOptions{AcceptNewHostKeys: false, WithMockCommand: mockExec}
 		conn := target.NewConnection("user@host", opts)
 		err := conn.ProbeAuthentication()
 		require.NoError(t, err)
@@ -158,7 +158,7 @@ func TestProbeAuthentication(t *testing.T) {
 		mockExec := newMockExec(map[string]mockResponse{
 			"knownhost": {stdout: "HOST KEY VERIFICATION FAILED", err: errSSH},
 		}, &calls)
-		opts := target.ConnectionOptions{AcceptNewHostKeys: false, WithMockExec: mockExec}
+		opts := target.ConnectionOptions{AcceptNewHostKeys: false, WithMockCommand: mockExec}
 		conn := target.NewConnection("user@host", opts)
 		err := conn.ProbeAuthentication()
 		require.ErrorIs(t, err, target.ErrHostKeyVerification)
@@ -170,7 +170,7 @@ func TestProbeAuthentication(t *testing.T) {
 		mockExec := newMockExec(map[string]mockResponse{
 			"knownhost": {stdout: "dial tcp: lookup host: no such host", err: errSSH},
 		}, &calls)
-		opts := target.ConnectionOptions{AcceptNewHostKeys: false, WithMockExec: mockExec}
+		opts := target.ConnectionOptions{AcceptNewHostKeys: false, WithMockCommand: mockExec}
 		conn := target.NewConnection("user@host", opts)
 		err := conn.ProbeAuthentication()
 		require.Error(t, err)

--- a/internal/target/connection_test.go
+++ b/internal/target/connection_test.go
@@ -13,10 +13,10 @@ import (
 
 func TestRun(t *testing.T) {
 	t.Run("run executes command successfully", func(t *testing.T) {
-		mockExec := func(_ ssh.Host, _ string, _ []byte, _ ...string) *exec.Cmd {
+		mockCommand := func(_ ssh.Host, _ string, _ []byte, _ ...string) *exec.Cmd {
 			return testutil.CmdWithOutput("success", 0)
 		}
-		conn := target.NewConnection("hostname", target.ConnectionOptions{WithMockCommand: mockExec})
+		conn := target.NewConnection("hostname", target.ConnectionOptions{WithMockCommand: mockCommand})
 
 		out, err := conn.Run("ls")
 
@@ -25,10 +25,10 @@ func TestRun(t *testing.T) {
 	})
 
 	t.Run("run returns error", func(t *testing.T) {
-		mockExec := func(_ ssh.Host, _ string, _ []byte, _ ...string) *exec.Cmd {
+		mockCommand := func(_ ssh.Host, _ string, _ []byte, _ ...string) *exec.Cmd {
 			return testutil.CmdWithOutput("", 1)
 		}
-		conn := target.NewConnection("hostname", target.ConnectionOptions{WithMockCommand: mockExec})
+		conn := target.NewConnection("hostname", target.ConnectionOptions{WithMockCommand: mockCommand})
 
 		out, err := conn.Run("ls")
 
@@ -37,10 +37,10 @@ func TestRun(t *testing.T) {
 	})
 
 	t.Run("returns ErrAuthFailed when stderr contains auth failure", func(t *testing.T) {
-		mockExec := func(_ ssh.Host, _ string, _ []byte, _ ...string) *exec.Cmd {
+		mockCommand := func(_ ssh.Host, _ string, _ []byte, _ ...string) *exec.Cmd {
 			return testutil.CmdWithStderr("Permission denied (publickey)", 1)
 		}
-		conn := target.NewConnection("hostname", target.ConnectionOptions{WithMockCommand: mockExec})
+		conn := target.NewConnection("hostname", target.ConnectionOptions{WithMockCommand: mockCommand})
 
 		_, err := conn.Run("ls")
 
@@ -48,10 +48,10 @@ func TestRun(t *testing.T) {
 	})
 
 	t.Run("returns ErrConnectionFailed when stderr contains connection refused", func(t *testing.T) {
-		mockExec := func(_ ssh.Host, _ string, _ []byte, _ ...string) *exec.Cmd {
+		mockCommand := func(_ ssh.Host, _ string, _ []byte, _ ...string) *exec.Cmd {
 			return testutil.CmdWithStderr("ssh: connect to host foo port 22: Connection refused", 1)
 		}
-		conn := target.NewConnection("hostname", target.ConnectionOptions{WithMockCommand: mockExec})
+		conn := target.NewConnection("hostname", target.ConnectionOptions{WithMockCommand: mockCommand})
 
 		_, err := conn.Run("ls")
 
@@ -61,11 +61,11 @@ func TestRun(t *testing.T) {
 	t.Run("run with mutliplexing enabled includes Control args", func(t *testing.T) {
 		testutil.RequireOS(t, "linux")
 		var capturedArgs string
-		mockExec := func(_ ssh.Host, _ string, _ []byte, sshArgs ...string) *exec.Cmd {
+		mockCommand := func(_ ssh.Host, _ string, _ []byte, sshArgs ...string) *exec.Cmd {
 			capturedArgs = strings.Join(sshArgs, " ")
 			return testutil.CmdWithOutput("success", 0)
 		}
-		conn := target.NewConnection("hostname", target.ConnectionOptions{Multiplex: true, WithMockCommand: mockExec})
+		conn := target.NewConnection("hostname", target.ConnectionOptions{Multiplex: true, WithMockCommand: mockCommand})
 
 		_, err := conn.Run("ls")
 
@@ -78,11 +78,11 @@ func TestRun(t *testing.T) {
 	t.Run("run with mutliplexing enabled does not include Control args on windows", func(t *testing.T) {
 		testutil.RequireOS(t, "windows")
 		var capturedArgs string
-		mockExec := func(_ ssh.Host, _ string, _ []byte, sshArgs ...string) *exec.Cmd {
+		mockCommand := func(_ ssh.Host, _ string, _ []byte, sshArgs ...string) *exec.Cmd {
 			capturedArgs = strings.Join(sshArgs, " ")
 			return testutil.CmdWithOutput("success", 0)
 		}
-		conn := target.NewConnection("hostname", target.ConnectionOptions{Multiplex: true, WithMockCommand: mockExec})
+		conn := target.NewConnection("hostname", target.ConnectionOptions{Multiplex: true, WithMockCommand: mockCommand})
 
 		_, err := conn.Run("ls")
 
@@ -95,19 +95,19 @@ func TestRun(t *testing.T) {
 
 func TestBinaryExists(t *testing.T) {
 	t.Run("when binary found returns nil", func(t *testing.T) {
-		mockExec := func(_ ssh.Host, _ string, _ []byte, _ ...string) *exec.Cmd {
+		mockCommand := func(_ ssh.Host, _ string, _ []byte, _ ...string) *exec.Cmd {
 			return testutil.CmdWithOutput("/foo/bar", 0)
 		}
-		conn := target.NewConnection("hostname", target.ConnectionOptions{WithMockCommand: mockExec})
+		conn := target.NewConnection("hostname", target.ConnectionOptions{WithMockCommand: mockCommand})
 
 		assert.NoError(t, conn.BinaryExists("bar"))
 	})
 
 	t.Run("invalid format returns an error", func(t *testing.T) {
-		mockExec := func(_ ssh.Host, _ string, _ []byte, _ ...string) *exec.Cmd {
+		mockCommand := func(_ ssh.Host, _ string, _ []byte, _ ...string) *exec.Cmd {
 			return testutil.CmdWithOutput("/foo/bar", 0)
 		}
-		conn := target.NewConnection("hostname", target.ConnectionOptions{WithMockCommand: mockExec})
+		conn := target.NewConnection("hostname", target.ConnectionOptions{WithMockCommand: mockCommand})
 
 		assert.Error(t, conn.BinaryExists("b a r"))
 	})

--- a/internal/target/connection_test.go
+++ b/internal/target/connection_test.go
@@ -16,7 +16,7 @@ func TestRun(t *testing.T) {
 		mockExec := func(_ ssh.Host, _ string, _ []byte, _ ...string) *exec.Cmd {
 			return testutil.CmdWithOutput("success", 0)
 		}
-		conn := target.NewConnection("hostname", target.ConnectionOptions{WithMockExec: mockExec})
+		conn := target.NewConnection("hostname", target.ConnectionOptions{WithMockCommand: mockExec})
 
 		out, err := conn.Run("ls")
 
@@ -28,7 +28,7 @@ func TestRun(t *testing.T) {
 		mockExec := func(_ ssh.Host, _ string, _ []byte, _ ...string) *exec.Cmd {
 			return testutil.CmdWithOutput("", 1)
 		}
-		conn := target.NewConnection("hostname", target.ConnectionOptions{WithMockExec: mockExec})
+		conn := target.NewConnection("hostname", target.ConnectionOptions{WithMockCommand: mockExec})
 
 		out, err := conn.Run("ls")
 
@@ -40,7 +40,7 @@ func TestRun(t *testing.T) {
 		mockExec := func(_ ssh.Host, _ string, _ []byte, _ ...string) *exec.Cmd {
 			return testutil.CmdWithStderr("Permission denied (publickey)", 1)
 		}
-		conn := target.NewConnection("hostname", target.ConnectionOptions{WithMockExec: mockExec})
+		conn := target.NewConnection("hostname", target.ConnectionOptions{WithMockCommand: mockExec})
 
 		_, err := conn.Run("ls")
 
@@ -51,7 +51,7 @@ func TestRun(t *testing.T) {
 		mockExec := func(_ ssh.Host, _ string, _ []byte, _ ...string) *exec.Cmd {
 			return testutil.CmdWithStderr("ssh: connect to host foo port 22: Connection refused", 1)
 		}
-		conn := target.NewConnection("hostname", target.ConnectionOptions{WithMockExec: mockExec})
+		conn := target.NewConnection("hostname", target.ConnectionOptions{WithMockCommand: mockExec})
 
 		_, err := conn.Run("ls")
 
@@ -65,7 +65,7 @@ func TestRun(t *testing.T) {
 			capturedArgs = strings.Join(sshArgs, " ")
 			return testutil.CmdWithOutput("success", 0)
 		}
-		conn := target.NewConnection("hostname", target.ConnectionOptions{Multiplex: true, WithMockExec: mockExec})
+		conn := target.NewConnection("hostname", target.ConnectionOptions{Multiplex: true, WithMockCommand: mockExec})
 
 		_, err := conn.Run("ls")
 
@@ -82,7 +82,7 @@ func TestRun(t *testing.T) {
 			capturedArgs = strings.Join(sshArgs, " ")
 			return testutil.CmdWithOutput("success", 0)
 		}
-		conn := target.NewConnection("hostname", target.ConnectionOptions{Multiplex: true, WithMockExec: mockExec})
+		conn := target.NewConnection("hostname", target.ConnectionOptions{Multiplex: true, WithMockCommand: mockExec})
 
 		_, err := conn.Run("ls")
 
@@ -98,7 +98,7 @@ func TestBinaryExists(t *testing.T) {
 		mockExec := func(_ ssh.Host, _ string, _ []byte, _ ...string) *exec.Cmd {
 			return testutil.CmdWithOutput("/foo/bar", 0)
 		}
-		conn := target.NewConnection("hostname", target.ConnectionOptions{WithMockExec: mockExec})
+		conn := target.NewConnection("hostname", target.ConnectionOptions{WithMockCommand: mockExec})
 
 		assert.NoError(t, conn.BinaryExists("bar"))
 	})
@@ -107,7 +107,7 @@ func TestBinaryExists(t *testing.T) {
 		mockExec := func(_ ssh.Host, _ string, _ []byte, _ ...string) *exec.Cmd {
 			return testutil.CmdWithOutput("/foo/bar", 0)
 		}
-		conn := target.NewConnection("hostname", target.ConnectionOptions{WithMockExec: mockExec})
+		conn := target.NewConnection("hostname", target.ConnectionOptions{WithMockCommand: mockExec})
 
 		assert.Error(t, conn.BinaryExists("b a r"))
 	})

--- a/internal/target/probe_test.go
+++ b/internal/target/probe_test.go
@@ -50,7 +50,7 @@ func TestProbeHardware(t *testing.T) {
 			}
 		}
 
-		conn := target.NewConnection("hostname", target.ConnectionOptions{WithMockExec: mockExec})
+		conn := target.NewConnection("hostname", target.ConnectionOptions{WithMockCommand: mockExec})
 		hw, err := conn.ProbeHardware()
 
 		require.NoError(t, err)
@@ -66,7 +66,7 @@ func TestProbeHardware(t *testing.T) {
 			return testutil.CmdWithOutput("not found", 1)
 		}
 
-		conn := target.NewConnection("hostname", target.ConnectionOptions{WithMockExec: mockExec})
+		conn := target.NewConnection("hostname", target.ConnectionOptions{WithMockCommand: mockExec})
 		_, err := conn.ProbeHardware()
 
 		assert.ErrorContains(t, err, `"lscpu" executable file not found in $PATH`)
@@ -86,7 +86,7 @@ func TestProbeHardware(t *testing.T) {
 			}
 		}
 
-		conn := target.NewConnection("hostname", target.ConnectionOptions{WithMockExec: mockExec})
+		conn := target.NewConnection("hostname", target.ConnectionOptions{WithMockCommand: mockExec})
 		_, err := conn.ProbeHardware()
 
 		assert.ErrorContains(t, err, "collecting CPU info")

--- a/internal/target/probe_test.go
+++ b/internal/target/probe_test.go
@@ -37,13 +37,13 @@ func TestExtractArmFeatures(t *testing.T) {
 
 func TestProbeHardware(t *testing.T) {
 	t.Run("returns model name and features", func(t *testing.T) {
-		mockExec := func(_ ssh.Host, command string, _ []byte, _ ...string) *exec.Cmd {
+		mockExec := func(_ ssh.Host, cmdStr string, _ []byte, _ ...string) *exec.Cmd {
 			switch {
-			case strings.Contains(command, "command -v"):
+			case strings.Contains(cmdStr, "command -v"):
 				return testutil.CmdWithOutput("/usr/bin/lscpu", 0)
-			case command == "lscpu --json":
+			case cmdStr == "lscpu --json":
 				return testutil.CmdWithOutput(testutil.LsCpuOutputRaw, 0)
-			case strings.Contains(command, "meminfo"):
+			case strings.Contains(cmdStr, "meminfo"):
 				return testutil.CmdWithOutput("MemTotal:       16384000 kB", 0)
 			default:
 				return testutil.CmdWithOutput("not found", 1)
@@ -62,7 +62,7 @@ func TestProbeHardware(t *testing.T) {
 	})
 
 	t.Run("returns error when lscpu not found", func(t *testing.T) {
-		mockExec := func(_ ssh.Host, command string, _ []byte, _ ...string) *exec.Cmd {
+		mockExec := func(_ ssh.Host, cmdStr string, _ []byte, _ ...string) *exec.Cmd {
 			return testutil.CmdWithOutput("not found", 1)
 		}
 
@@ -73,13 +73,13 @@ func TestProbeHardware(t *testing.T) {
 	})
 
 	t.Run("returns error when lscpu output is invalid JSON", func(t *testing.T) {
-		mockExec := func(_ ssh.Host, command string, _ []byte, _ ...string) *exec.Cmd {
+		mockExec := func(_ ssh.Host, cmdStr string, _ []byte, _ ...string) *exec.Cmd {
 			switch {
-			case strings.Contains(command, "command -v"):
+			case strings.Contains(cmdStr, "command -v"):
 				return testutil.CmdWithOutput("/usr/bin/lscpu", 0)
-			case command == "lscpu --json":
+			case cmdStr == "lscpu --json":
 				return testutil.CmdWithOutput("not json", 0)
-			case strings.Contains(command, "meminfo"):
+			case strings.Contains(cmdStr, "meminfo"):
 				return testutil.CmdWithOutput("MemTotal:       16384000 kB", 0)
 			default:
 				return testutil.CmdWithOutput("not found", 1)

--- a/internal/target/probe_test.go
+++ b/internal/target/probe_test.go
@@ -37,7 +37,7 @@ func TestExtractArmFeatures(t *testing.T) {
 
 func TestProbeHardware(t *testing.T) {
 	t.Run("returns model name and features", func(t *testing.T) {
-		mockExec := func(_ ssh.Host, cmdStr string, _ []byte, _ ...string) *exec.Cmd {
+		mockCommand := func(_ ssh.Host, cmdStr string, _ []byte, _ ...string) *exec.Cmd {
 			switch {
 			case strings.Contains(cmdStr, "command -v"):
 				return testutil.CmdWithOutput("/usr/bin/lscpu", 0)
@@ -50,7 +50,7 @@ func TestProbeHardware(t *testing.T) {
 			}
 		}
 
-		conn := target.NewConnection("hostname", target.ConnectionOptions{WithMockCommand: mockExec})
+		conn := target.NewConnection("hostname", target.ConnectionOptions{WithMockCommand: mockCommand})
 		hw, err := conn.ProbeHardware()
 
 		require.NoError(t, err)
@@ -62,18 +62,18 @@ func TestProbeHardware(t *testing.T) {
 	})
 
 	t.Run("returns error when lscpu not found", func(t *testing.T) {
-		mockExec := func(_ ssh.Host, cmdStr string, _ []byte, _ ...string) *exec.Cmd {
+		mockCommand := func(_ ssh.Host, cmdStr string, _ []byte, _ ...string) *exec.Cmd {
 			return testutil.CmdWithOutput("not found", 1)
 		}
 
-		conn := target.NewConnection("hostname", target.ConnectionOptions{WithMockCommand: mockExec})
+		conn := target.NewConnection("hostname", target.ConnectionOptions{WithMockCommand: mockCommand})
 		_, err := conn.ProbeHardware()
 
 		assert.ErrorContains(t, err, `"lscpu" executable file not found in $PATH`)
 	})
 
 	t.Run("returns error when lscpu output is invalid JSON", func(t *testing.T) {
-		mockExec := func(_ ssh.Host, cmdStr string, _ []byte, _ ...string) *exec.Cmd {
+		mockCommand := func(_ ssh.Host, cmdStr string, _ []byte, _ ...string) *exec.Cmd {
 			switch {
 			case strings.Contains(cmdStr, "command -v"):
 				return testutil.CmdWithOutput("/usr/bin/lscpu", 0)
@@ -86,7 +86,7 @@ func TestProbeHardware(t *testing.T) {
 			}
 		}
 
-		conn := target.NewConnection("hostname", target.ConnectionOptions{WithMockCommand: mockExec})
+		conn := target.NewConnection("hostname", target.ConnectionOptions{WithMockCommand: mockCommand})
 		_, err := conn.ProbeHardware()
 
 		assert.ErrorContains(t, err, "collecting CPU info")


### PR DESCRIPTION
## Background

After https://github.com/arm/topo/pull/35 `ssh.ExecSSH` no longer does what it says on the tin. The go's stdlib `exec.Command` is what usually returns `*exec.Cmd`, thus I'm making it idiomatic, by renaming `ssh.ExecSSH` to `ssh.Command`.

## Changes

<!-- List the changes this PR introduces -->

- Rename `ssh.ExecSSH` to `ssh.Command`
- Rename/move `target.ExecSSH` to `ssh.CommandFn`
- Wherever `command` variable is used to represent a "command string", use `cmdStr`