### PR TITLE
refactor: always resolve ssh destination

### DIFF
--- a/internal/ssh/ssh_tunnel.go
+++ b/internal/ssh/ssh_tunnel.go
@@ -254,16 +254,3 @@ func resolveHost(raw string) string {
 	config := NewConfig(raw)
 	return config.host
 }
-
-func isExplicitHost(raw string) bool {
-	if strings.HasPrefix(raw, "ssh://") {
-		return true
-	}
-	if strings.Contains(raw, "@") || strings.Contains(raw, ":") {
-		return true
-	}
-	if strings.HasPrefix(raw, "[") {
-		return true
-	}
-	return false
-}

--- a/internal/ssh/ssh_tunnel.go
+++ b/internal/ssh/ssh_tunnel.go
@@ -251,11 +251,6 @@ func (s *SSHTunnelProcessStop) DryRun(w io.Writer) error {
 }
 
 func resolveHost(raw string) string {
-	if raw == "" || isExplicitHost(raw) {
-		_, host, _ := SplitUserHostPort(raw)
-		return host
-	}
-
 	config := NewConfig(raw)
 	return config.host
 }


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- Always resolve ssh destination as `ssh -G` command will take non alias as inputs as well. This will reduce some code
