### PR TITLE
refactor: remove useless `GenerateTargetDescription` proxy

### DIFF
--- a/cmd/topo/describe.go
+++ b/cmd/topo/describe.go
@@ -25,7 +25,7 @@ var describeCmd = &cobra.Command{
 		}
 
 		conn := target.NewConnection(sshTarget, target.ConnectionOptions{Multiplex: true, ConnectTimeout: sshConnectTimeout})
-		report, err := describe.GenerateTargetDescription(conn)
+		hwProfile, err := conn.ProbeHardware()
 		if err != nil {
 			return err
 		}
@@ -35,7 +35,7 @@ var describeCmd = &cobra.Command{
 			return err
 		}
 
-		outputPath, err := describe.WriteTargetDescriptionToFile(workDir, report)
+		outputPath, err := describe.WriteTargetDescriptionToFile(workDir, hwProfile)
 		if err != nil {
 			return err
 		}

--- a/cmd/topo/templates.go
+++ b/cmd/topo/templates.go
@@ -38,7 +38,7 @@ var templatesCmd = &cobra.Command{
 			resolvedTarget, exists := lookupTarget(cmd)
 			if exists {
 				conn := target.NewConnection(resolvedTarget, target.ConnectionOptions{Multiplex: true, ConnectTimeout: sshConnectTimeout})
-				hwProfile, err := describe.GenerateTargetDescription(conn)
+				hwProfile, err := conn.ProbeHardware()
 				if err != nil {
 					return err
 				}

--- a/internal/describe/describe.go
+++ b/internal/describe/describe.go
@@ -12,15 +12,6 @@ import (
 
 const TargetDescriptionFilename = "target-description.yaml"
 
-func GenerateTargetDescription(conn target.Connection) (target.HardwareProfile, error) {
-	hwProfile, err := conn.ProbeHardware()
-	if err != nil {
-		return target.HardwareProfile{}, err
-	}
-
-	return hwProfile, nil
-}
-
 func WriteTargetDescriptionToFile(dir string, report target.HardwareProfile) (string, error) {
 	outputFile := filepath.Join(dir, TargetDescriptionFilename)
 	f, err := os.Create(outputFile)

--- a/internal/describe/describe_test.go
+++ b/internal/describe/describe_test.go
@@ -2,67 +2,15 @@ package describe_test
 
 import (
 	"os"
-	"os/exec"
-	"strings"
 	"testing"
 
 	"github.com/arm/topo/internal/describe"
 	"github.com/arm/topo/internal/target"
-	"github.com/arm/topo/internal/testutil"
 
-	"github.com/arm/topo/internal/ssh"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/assert/yaml"
 	"github.com/stretchr/testify/require"
 )
-
-func TestGenerate(t *testing.T) {
-	t.Run("returns hardware profile for given target", func(t *testing.T) {
-		mockExecSSH := func(target ssh.Destination, command string, _ []byte, sshArgs ...string) *exec.Cmd {
-			if command == "lscpu --json" {
-				return testutil.CmdWithOutput(testutil.LsCpuOutputRaw, 0)
-			}
-			if strings.Contains(command, "remoteproc") {
-				return testutil.CmdWithOutput("remoteproc1 remoteproc2", 0)
-			}
-			if strings.Contains(command, "meminfo") {
-				return testutil.CmdWithOutput("MemTotal:       16384000 kB", 0)
-			}
-			return testutil.CmdWithOutput("", 0)
-		}
-		expected := target.HardwareProfile{
-			HostProcessor: []target.HostProcessor{
-				{
-					Model:    "Cortex-A55",
-					Features: []string{"fp", "asimd"},
-					Cores:    2,
-				},
-			},
-			RemoteCPU: []target.RemoteprocCPU{
-				{Name: "remoteproc1"},
-				{Name: "remoteproc2"},
-			},
-			TotalMemoryKb: 16384000,
-		}
-
-		conn := target.NewConnection("test", target.ConnectionOptions{WithMockExec: mockExecSSH})
-		report, err := describe.GenerateTargetDescription(conn)
-
-		require.NoError(t, err)
-		assert.Equal(t, expected, report)
-	})
-
-	t.Run("fails if ssh commands cannot be executed", func(t *testing.T) {
-		mockExecSSH := func(target ssh.Destination, command string, _ []byte, sshArgs ...string) *exec.Cmd {
-			return testutil.CmdWithOutput(assert.AnError.Error(), 1)
-		}
-
-		conn := target.NewConnection("test", target.ConnectionOptions{WithMockExec: mockExecSSH})
-		_, err := describe.GenerateTargetDescription(conn)
-
-		assert.Error(t, err)
-	})
-}
 
 func TestWriteTargetDescriptionFile(t *testing.T) {
 	t.Run("writes full target to description to given directory", func(t *testing.T) {


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- Removes a one-liner wrapping `conn.ProbeHardware()` with no additional logic. Call sites now invoke `ProbeHardware` directly.
