### PR TITLE
refactor: move binary name validation to `command` package

### DIFF
--- a/internal/command/validate.go
+++ b/internal/command/validate.go
@@ -1,0 +1,15 @@
+package command
+
+import (
+	"fmt"
+	"regexp"
+)
+
+var binaryRegex = regexp.MustCompile(`^[A-Za-z0-9_+-]+$`)
+
+func ValidateBinaryName(bin string) error {
+	if !binaryRegex.MatchString(bin) {
+		return fmt.Errorf("%q is not a valid binary name (contains invalid characters)", bin)
+	}
+	return nil
+}

--- a/internal/command/validate_test.go
+++ b/internal/command/validate_test.go
@@ -1,0 +1,22 @@
+package command_test
+
+import (
+	"testing"
+
+	"github.com/arm/topo/internal/command"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateBinaryName(t *testing.T) {
+	t.Run("returns error for invalid binary name", func(t *testing.T) {
+		err := command.ValidateBinaryName("bin ary")
+
+		assert.Error(t, err)
+	})
+
+	t.Run("returns no error for valid binary name", func(t *testing.T) {
+		err := command.ValidateBinaryName("binary")
+
+		assert.NoError(t, err)
+	})
+}

--- a/internal/health/dependencies.go
+++ b/internal/health/dependencies.go
@@ -5,7 +5,7 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/arm/topo/internal/ssh"
+	"github.com/arm/topo/internal/command"
 )
 
 type CheckKind int
@@ -208,7 +208,7 @@ func hasAnyInstalledPrerequisite(required []SoftwareDependency, installed map[So
 }
 
 func BinaryExistsLocally(bin string) error {
-	if err := ssh.ValidateBinaryName(bin); err != nil {
+	if err := command.ValidateBinaryName(bin); err != nil {
 		return err
 	}
 	if _, err := exec.LookPath(bin); err != nil {

--- a/internal/health/dependencies_test.go
+++ b/internal/health/dependencies_test.go
@@ -5,35 +5,21 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/arm/topo/internal/command"
 	"github.com/arm/topo/internal/health"
-	"github.com/arm/topo/internal/ssh"
 	"github.com/stretchr/testify/assert"
 )
-
-func TestBinaryRegex(t *testing.T) {
-	t.Run("binary regex fails an incorrect binary name", func(t *testing.T) {
-		got := "bin ary"
-
-		assert.False(t, ssh.BinaryRegex.MatchString(got))
-	})
-
-	t.Run("binary regex passes a correct binary name", func(t *testing.T) {
-		got := "binary"
-
-		assert.True(t, ssh.BinaryRegex.MatchString(got))
-	})
-}
 
 func TestDependencyFormat(t *testing.T) {
 	t.Run("host dependencies are of the correct format", func(t *testing.T) {
 		for _, dep := range health.HostRequiredDependencies {
-			assert.True(t, ssh.BinaryRegex.MatchString(dep.Binary))
+			assert.NoError(t, command.ValidateBinaryName(dep.Binary))
 		}
 	})
 
 	t.Run("target dependencies are of the correct format", func(t *testing.T) {
 		for _, dep := range health.TargetRequiredDependencies {
-			assert.True(t, ssh.BinaryRegex.MatchString(dep.Binary))
+			assert.NoError(t, command.ValidateBinaryName(dep.Binary))
 		}
 	})
 

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	commandpkg "github.com/arm/topo/internal/command"
 	"github.com/arm/topo/internal/ssh"
 	"github.com/arm/topo/internal/target"
 	"github.com/mholt/archives"
@@ -275,7 +276,7 @@ func install(installPath string, targetDest ssh.Destination, binaries map[string
 	mode := "0755"
 
 	for binaryName, binaryData := range binaries {
-		if err := ssh.ValidateBinaryName(binaryName); err != nil {
+		if err := commandpkg.ValidateBinaryName(binaryName); err != nil {
 			return err
 		}
 
@@ -327,7 +328,7 @@ type InstallResult struct {
 
 func InstallBinariesFromGithubRelease(targetDest ssh.Destination, repoURL string, binaryNames []string) ([]InstallResult, error) {
 	for _, binaryName := range binaryNames {
-		if err := ssh.ValidateBinaryName(binaryName); err != nil {
+		if err := commandpkg.ValidateBinaryName(binaryName); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 	"time"
 
-	commandpkg "github.com/arm/topo/internal/command"
+	"github.com/arm/topo/internal/command"
 	"github.com/arm/topo/internal/ssh"
 	"github.com/arm/topo/internal/target"
 	"github.com/mholt/archives"
@@ -276,7 +276,7 @@ func install(installPath string, targetDest ssh.Destination, binaries map[string
 	mode := "0755"
 
 	for binaryName, binaryData := range binaries {
-		if err := commandpkg.ValidateBinaryName(binaryName); err != nil {
+		if err := command.ValidateBinaryName(binaryName); err != nil {
 			return err
 		}
 
@@ -328,7 +328,7 @@ type InstallResult struct {
 
 func InstallBinariesFromGithubRelease(targetDest ssh.Destination, repoURL string, binaryNames []string) ([]InstallResult, error) {
 	for _, binaryName := range binaryNames {
-		if err := commandpkg.ValidateBinaryName(binaryName); err != nil {
+		if err := command.ValidateBinaryName(binaryName); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/ssh/exec.go
+++ b/internal/ssh/exec.go
@@ -4,19 +4,9 @@ import (
 	"bytes"
 	"fmt"
 	"os/exec"
-	"regexp"
 	"slices"
 	"strings"
 )
-
-var BinaryRegex = regexp.MustCompile(`^[A-Za-z0-9_+-]+$`)
-
-func ValidateBinaryName(bin string) error {
-	if !BinaryRegex.MatchString(bin) {
-		return fmt.Errorf("%q is not a valid binary name (contains invalid characters)", bin)
-	}
-	return nil
-}
 
 func shellEscapeForDoubleQuotes(s string) string {
 	// Escape for TWO nested double-quoted shell layers- need three `\\\`.

--- a/internal/target/connection.go
+++ b/internal/target/connection.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	commandpkg "github.com/arm/topo/internal/command"
+	"github.com/arm/topo/internal/command"
 	"github.com/arm/topo/internal/ssh"
 )
 
@@ -35,7 +35,7 @@ var (
 	}
 )
 
-type ExecSSH func(target ssh.Destination, command string, stdin []byte, sshArgs ...string) *exec.Cmd
+type ExecSSH func(target ssh.Destination, cmdStr string, stdin []byte, sshArgs ...string) *exec.Cmd
 
 type Connection struct {
 	SSHTarget ssh.Destination
@@ -67,9 +67,9 @@ func NewConnection(sshTarget string, opts ConnectionOptions) Connection {
 	}
 }
 
-func (c *Connection) Run(command string) (string, error) {
+func (c *Connection) Run(cmdStr string) (string, error) {
 	if c.opts.WithLoginShell {
-		command = ssh.ShellCommand(command)
+		cmdStr = ssh.ShellCommand(cmdStr)
 	}
 
 	sshArgs := c.connectTimeoutArgs()
@@ -77,7 +77,7 @@ func (c *Connection) Run(command string) (string, error) {
 		sshArgs = append(sshArgs, "-o", "ControlMaster=auto", "-o", "ControlPersist=10s", "-o", "ControlPath=~/.ssh/topo-cm-%r@%h:%p")
 	}
 
-	cmd := c.exec(c.SSHTarget, command, c.opts.WithStdin, sshArgs...)
+	cmd := c.exec(c.SSHTarget, cmdStr, c.opts.WithStdin, sshArgs...)
 	var stdoutBuf, stderrBuf bytes.Buffer
 	cmd.Stdout = &stdoutBuf
 	cmd.Stderr = &stderrBuf
@@ -93,18 +93,18 @@ func (c *Connection) Run(command string) (string, error) {
 	return stdoutBuf.String(), nil
 }
 
-func (c *Connection) DryRun(command string, output io.Writer) error {
+func (c *Connection) DryRun(cmdStr string, output io.Writer) error {
 	if c.opts.WithLoginShell {
-		command = ssh.ShellCommand(command)
+		cmdStr = ssh.ShellCommand(cmdStr)
 	}
 
-	cmd := c.exec(c.SSHTarget, command, c.opts.WithStdin)
-	_, err := fmt.Fprintln(output, commandpkg.String(cmd))
+	cmd := c.exec(c.SSHTarget, cmdStr, c.opts.WithStdin)
+	_, err := fmt.Fprintln(output, command.String(cmd))
 	return err
 }
 
 func (c *Connection) BinaryExists(bin string) error {
-	if err := commandpkg.ValidateBinaryName(bin); err != nil {
+	if err := command.ValidateBinaryName(bin); err != nil {
 		return err
 	}
 

--- a/internal/target/connection.go
+++ b/internal/target/connection.go
@@ -104,7 +104,7 @@ func (c *Connection) DryRun(command string, output io.Writer) error {
 }
 
 func (c *Connection) BinaryExists(bin string) error {
-	if err := ssh.ValidateBinaryName(bin); err != nil {
+	if err := commandpkg.ValidateBinaryName(bin); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- Moved binary validation into `internal/command` (it's not an `ssh` concern)
- Moved and updated tests to validate through `ValidateBinaryName`, not through exported `BinaryRegex`
    - Made regex unexported (`binaryRegex`)