### PR TITLE
feat: make setup-keys accept already existing SSH config fragments

### DIFF
--- a/internal/setupkeys/sshconfig/ssh_config.go
+++ b/internal/setupkeys/sshconfig/ssh_config.go
@@ -60,11 +60,11 @@ func ModifySSHConfig(targetHost string, privKeyPath string, targetSlug string, d
 		return errMain
 	}
 
-	configBody := buildSSHConfigFragment(targetHost, privKeyPath)
-	mergedConfigBody := mergeOwnedSSHConfigDirectives(existingTopoContent, configBody, privKeyPath)
+	configContent := buildSSHConfigFragment(targetHost, privKeyPath)
+	mergedConfigContent := mergeOwnedSSHConfigDirectives(existingTopoContent, configContent, privKeyPath)
 
-	if string(existingTopoContent) != mergedConfigBody {
-		if err := os.WriteFile(sshTopoConfigPath, []byte(mergedConfigBody), 0o600); err != nil {
+	if string(existingTopoContent) != mergedConfigContent {
+		if err := os.WriteFile(sshTopoConfigPath, []byte(mergedConfigContent), 0o600); err != nil {
 			return fmt.Errorf("failed to write %s: %w", sshTopoConfigPath, err)
 		}
 	}
@@ -126,9 +126,9 @@ func buildSSHConfigFragment(targetHost string, privKeyPath string) string {
 	return b.String()
 }
 
-func mergeOwnedSSHConfigDirectives(existing []byte, fallbackConfigBody string, privKeyPath string) string {
+func mergeOwnedSSHConfigDirectives(existing []byte, fallbackConfigContent string, privKeyPath string) string {
 	if len(existing) == 0 {
-		return fallbackConfigBody
+		return fallbackConfigContent
 	}
 
 	identityLine := []byte(fmt.Sprintf("  IdentityFile %s", filepath.ToSlash(privKeyPath)))

--- a/internal/setupkeys/sshconfig/ssh_config.go
+++ b/internal/setupkeys/sshconfig/ssh_config.go
@@ -60,11 +60,15 @@ func ModifySSHConfig(targetHost string, privKeyPath string, targetSlug string, d
 		return errMain
 	}
 
-	configContent := buildSSHConfigFragment(targetHost, privKeyPath)
-	mergedConfigContent := mergeOwnedSSHConfigDirectives(existingTopoContent, configContent, privKeyPath)
+	var fragmentToWrite []byte
+	if len(existingTopoContent) == 0 {
+		fragmentToWrite = buildSSHConfigFragment(targetHost, privKeyPath)
+	} else {
+		fragmentToWrite = mergeOwnedSSHConfigDirectives(existingTopoContent, privKeyPath)
+	}
 
-	if string(existingTopoContent) != mergedConfigContent {
-		if err := os.WriteFile(sshTopoConfigPath, []byte(mergedConfigContent), 0o600); err != nil {
+	if !bytes.Equal(existingTopoContent, fragmentToWrite) {
+		if err := os.WriteFile(sshTopoConfigPath, fragmentToWrite, 0o600); err != nil {
 			return fmt.Errorf("failed to write %s: %w", sshTopoConfigPath, err)
 		}
 	}
@@ -101,7 +105,7 @@ func hasIncludeLine(data []byte, includeLine string) bool {
 	return false
 }
 
-func buildSSHConfigFragment(targetHost string, privKeyPath string) string {
+func buildSSHConfigFragment(targetHost string, privKeyPath string) []byte {
 	user, host, port := ssh.SplitUserHostPort(targetHost)
 	hostAlias := host
 	if hostAlias == "" {
@@ -123,14 +127,10 @@ func buildSSHConfigFragment(targetHost string, privKeyPath string) string {
 	// needs to be this way even on Windows to work with ssh config parsing, which generally accepts forward slashes
 	fmt.Fprintf(&b, "  IdentityFile %s\n", filepath.ToSlash(privKeyPath))
 	b.WriteString("  IdentitiesOnly yes\n")
-	return b.String()
+	return []byte(b.String())
 }
 
-func mergeOwnedSSHConfigDirectives(existing []byte, fallbackConfigContent string, privKeyPath string) string {
-	if len(existing) == 0 {
-		return fallbackConfigContent
-	}
-
+func mergeOwnedSSHConfigDirectives(existing []byte, privKeyPath string) []byte {
 	identityLine := []byte(fmt.Sprintf("  IdentityFile %s", filepath.ToSlash(privKeyPath)))
 	identitiesOnlyLine := []byte("  IdentitiesOnly yes")
 	var merged [][]byte
@@ -149,6 +149,5 @@ func mergeOwnedSSHConfigDirectives(existing []byte, fallbackConfigContent string
 	}
 
 	merged = append(merged, identityLine, identitiesOnlyLine)
-
-	return string(bytes.Join(merged, []byte("\n"))) + "\n"
+	return append(bytes.Join(merged, []byte("\n")), '\n')
 }

--- a/internal/setupkeys/sshconfig/ssh_config.go
+++ b/internal/setupkeys/sshconfig/ssh_config.go
@@ -1,6 +1,7 @@
 package sshconfig
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -59,10 +60,11 @@ func ModifySSHConfig(targetHost string, privKeyPath string, targetSlug string, d
 		return errMain
 	}
 
-	configBody := buildSSHConfigFragment(targetHost, privKeyPath)
+	configBody := buildCanonicalSSHConfigFragment(targetHost, privKeyPath)
+	mergedConfigBody := mergeOwnedSSHConfigDirectives(existingTopoContent, configBody, privKeyPath)
 
-	if string(existingTopoContent) != configBody {
-		if err := os.WriteFile(sshTopoConfigPath, []byte(configBody), 0o600); err != nil {
+	if string(existingTopoContent) != mergedConfigBody {
+		if err := os.WriteFile(sshTopoConfigPath, []byte(mergedConfigBody), 0o600); err != nil {
 			return fmt.Errorf("failed to write %s: %w", sshTopoConfigPath, err)
 		}
 	}
@@ -99,7 +101,7 @@ func hasIncludeLine(data []byte, includeLine string) bool {
 	return false
 }
 
-func buildSSHConfigFragment(targetHost string, privKeyPath string) string {
+func buildCanonicalSSHConfigFragment(targetHost string, privKeyPath string) string {
 	user, host, port := ssh.SplitUserHostPort(targetHost)
 	hostAlias := host
 	if hostAlias == "" {
@@ -122,4 +124,31 @@ func buildSSHConfigFragment(targetHost string, privKeyPath string) string {
 	fmt.Fprintf(&b, "  IdentityFile %s\n", filepath.ToSlash(privKeyPath))
 	b.WriteString("  IdentitiesOnly yes\n")
 	return b.String()
+}
+
+func mergeOwnedSSHConfigDirectives(existing []byte, fallbackConfigBody string, privKeyPath string) string {
+	if len(existing) == 0 {
+		return fallbackConfigBody
+	}
+
+	identityLine := []byte(fmt.Sprintf("  IdentityFile %s", filepath.ToSlash(privKeyPath)))
+	identitiesOnlyLine := []byte("  IdentitiesOnly yes")
+	var merged [][]byte
+
+	for line := range bytes.SplitSeq(bytes.TrimRight(existing, "\n"), []byte("\n")) {
+		trimmed := bytes.TrimSpace(line)
+
+		switch {
+		case bytes.HasPrefix(trimmed, []byte("IdentityFile ")):
+			continue
+		case bytes.HasPrefix(trimmed, []byte("IdentitiesOnly ")):
+			continue
+		default:
+			merged = append(merged, line)
+		}
+	}
+
+	merged = append(merged, identityLine, identitiesOnlyLine)
+
+	return string(bytes.Join(merged, []byte("\n"))) + "\n"
 }

--- a/internal/setupkeys/sshconfig/ssh_config.go
+++ b/internal/setupkeys/sshconfig/ssh_config.go
@@ -60,7 +60,7 @@ func ModifySSHConfig(targetHost string, privKeyPath string, targetSlug string, d
 		return errMain
 	}
 
-	configBody := buildCanonicalSSHConfigFragment(targetHost, privKeyPath)
+	configBody := buildSSHConfigFragment(targetHost, privKeyPath)
 	mergedConfigBody := mergeOwnedSSHConfigDirectives(existingTopoContent, configBody, privKeyPath)
 
 	if string(existingTopoContent) != mergedConfigBody {
@@ -101,7 +101,7 @@ func hasIncludeLine(data []byte, includeLine string) bool {
 	return false
 }
 
-func buildCanonicalSSHConfigFragment(targetHost string, privKeyPath string) string {
+func buildSSHConfigFragment(targetHost string, privKeyPath string) string {
 	user, host, port := ssh.SplitUserHostPort(targetHost)
 	hostAlias := host
 	if hostAlias == "" {

--- a/internal/setupkeys/sshconfig/ssh_config_test.go
+++ b/internal/setupkeys/sshconfig/ssh_config_test.go
@@ -12,41 +12,177 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestModifySSHConfigWritesIncludeAndFragment(t *testing.T) {
-	tmp := t.TempDir()
-	t.Setenv("HOME", tmp)
-	if runtime.GOOS == "windows" {
-		t.Setenv("USERPROFILE", tmp)
-		if vol := filepath.VolumeName(tmp); vol != "" {
-			t.Setenv("HOMEDRIVE", vol)
-			t.Setenv("HOMEPATH", strings.TrimPrefix(tmp, vol))
+func TestModifySSHConfig(t *testing.T) {
+	t.Run("writes include and fragment", func(t *testing.T) {
+		tmp := t.TempDir()
+		t.Setenv("HOME", tmp)
+		if runtime.GOOS == "windows" {
+			t.Setenv("USERPROFILE", tmp)
+			if vol := filepath.VolumeName(tmp); vol != "" {
+				t.Setenv("HOMEDRIVE", vol)
+				t.Setenv("HOMEPATH", strings.TrimPrefix(tmp, vol))
+			}
 		}
-	}
 
-	targetHost := "user@example.com:2222"
-	targetFileName := "user_example_com_2222"
-	privKeyPath := filepath.Join(tmp, ".ssh", fmt.Sprintf("id_ed25519_topo_%s", targetFileName))
+		targetHost := "user@example.com:2222"
+		targetFileName := "user_example_com_2222"
+		privKeyPath := filepath.Join(tmp, ".ssh", fmt.Sprintf("id_ed25519_topo_%s", targetFileName))
 
-	err := sshconfig.ModifySSHConfig(targetHost, privKeyPath, targetFileName, false, nil)
-	require.NoError(t, err)
+		err := sshconfig.ModifySSHConfig(targetHost, privKeyPath, targetFileName, false, nil)
+		require.NoError(t, err)
 
-	mainConfigPath := filepath.Join(tmp, ".ssh", "config")
-	mainConfig, err := os.ReadFile(mainConfigPath)
-	require.NoError(t, err)
-	mainConfigText := string(mainConfig)
-	require.Contains(t, mainConfigText, "Include ")
-	require.Contains(t, mainConfigText, filepath.ToSlash(filepath.Join(tmp, ".ssh", "topo_config", "*.conf")))
+		mainConfigPath := filepath.Join(tmp, ".ssh", "config")
+		mainConfig, err := os.ReadFile(mainConfigPath)
+		require.NoError(t, err)
+		mainConfigText := string(mainConfig)
+		require.Contains(t, mainConfigText, "Include ")
+		require.Contains(t, mainConfigText, filepath.ToSlash(filepath.Join(tmp, ".ssh", "topo_config", "*.conf")))
 
-	fragmentPath := filepath.Join(tmp, ".ssh", "topo_config", fmt.Sprintf("topo_%s.conf", targetFileName))
-	fragment, err := os.ReadFile(fragmentPath)
-	require.NoError(t, err)
+		fragmentPath := filepath.Join(tmp, ".ssh", "topo_config", fmt.Sprintf("topo_%s.conf", targetFileName))
+		fragment, err := os.ReadFile(fragmentPath)
+		require.NoError(t, err)
 
-	expected := "" +
-		"Host example.com\n" +
-		"  HostName example.com\n" +
-		"  User user\n" +
-		"  Port 2222\n" +
-		fmt.Sprintf("  IdentityFile %s\n", filepath.ToSlash(privKeyPath)) +
-		"  IdentitiesOnly yes\n"
-	require.Equal(t, expected, string(fragment))
+		expected := "" +
+			"Host example.com\n" +
+			"  HostName example.com\n" +
+			"  User user\n" +
+			"  Port 2222\n" +
+			fmt.Sprintf("  IdentityFile %s\n", filepath.ToSlash(privKeyPath)) +
+			"  IdentitiesOnly yes\n"
+		require.Equal(t, expected, string(fragment))
+	})
+
+	t.Run("preserves existing fragment content", func(t *testing.T) {
+		tmp := t.TempDir()
+		t.Setenv("HOME", tmp)
+		if runtime.GOOS == "windows" {
+			t.Setenv("USERPROFILE", tmp)
+			if vol := filepath.VolumeName(tmp); vol != "" {
+				t.Setenv("HOMEDRIVE", vol)
+				t.Setenv("HOMEPATH", strings.TrimPrefix(tmp, vol))
+			}
+		}
+
+		targetHost := "user@example.com:2222"
+		targetFileName := "user_example_com_2222"
+		privKeyPath := filepath.Join(tmp, ".ssh", fmt.Sprintf("id_ed25519_topo_%s", targetFileName))
+		fragmentPath := filepath.Join(tmp, ".ssh", "topo_config", fmt.Sprintf("topo_%s.conf", targetFileName))
+
+		err := os.MkdirAll(filepath.Dir(fragmentPath), 0o700)
+		require.NoError(t, err)
+
+		existing := "" +
+			"Host board-alias\n" +
+			"  HostName example.com\n" +
+			"  User vscode-user\n" +
+			"  Port 2222\n"
+		err = os.WriteFile(fragmentPath, []byte(existing), 0o600)
+		require.NoError(t, err)
+
+		err = sshconfig.ModifySSHConfig(targetHost, privKeyPath, targetFileName, false, nil)
+		require.NoError(t, err)
+
+		fragment, err := os.ReadFile(fragmentPath)
+		require.NoError(t, err)
+
+		expected := "" +
+			"Host board-alias\n" +
+			"  HostName example.com\n" +
+			"  User vscode-user\n" +
+			"  Port 2222\n" +
+			fmt.Sprintf("  IdentityFile %s\n", filepath.ToSlash(privKeyPath)) +
+			"  IdentitiesOnly yes\n"
+		require.Equal(t, expected, string(fragment))
+	})
+
+	t.Run("updates existing key settings without replacing other fields", func(t *testing.T) {
+		tmp := t.TempDir()
+		t.Setenv("HOME", tmp)
+		if runtime.GOOS == "windows" {
+			t.Setenv("USERPROFILE", tmp)
+			if vol := filepath.VolumeName(tmp); vol != "" {
+				t.Setenv("HOMEDRIVE", vol)
+				t.Setenv("HOMEPATH", strings.TrimPrefix(tmp, vol))
+			}
+		}
+
+		targetHost := "user@example.com:2222"
+		targetFileName := "user_example_com_2222"
+		privKeyPath := filepath.Join(tmp, ".ssh", fmt.Sprintf("id_ed25519_topo_%s", targetFileName))
+		fragmentPath := filepath.Join(tmp, ".ssh", "topo_config", fmt.Sprintf("topo_%s.conf", targetFileName))
+
+		err := os.MkdirAll(filepath.Dir(fragmentPath), 0o700)
+		require.NoError(t, err)
+
+		existing := "" +
+			"Host board-alias\n" +
+			"  HostName example.com\n" +
+			"  User vscode-user\n" +
+			"  Port 2222\n" +
+			"  IdentityFile /old/key\n" +
+			"  IdentitiesOnly no\n"
+		err = os.WriteFile(fragmentPath, []byte(existing), 0o600)
+		require.NoError(t, err)
+
+		err = sshconfig.ModifySSHConfig(targetHost, privKeyPath, targetFileName, false, nil)
+		require.NoError(t, err)
+
+		fragment, err := os.ReadFile(fragmentPath)
+		require.NoError(t, err)
+
+		expected := "" +
+			"Host board-alias\n" +
+			"  HostName example.com\n" +
+			"  User vscode-user\n" +
+			"  Port 2222\n" +
+			fmt.Sprintf("  IdentityFile %s\n", filepath.ToSlash(privKeyPath)) +
+			"  IdentitiesOnly yes\n"
+		require.Equal(t, expected, string(fragment))
+	})
+
+	t.Run("deduplicates existing owned key settings", func(t *testing.T) {
+		tmp := t.TempDir()
+		t.Setenv("HOME", tmp)
+		if runtime.GOOS == "windows" {
+			t.Setenv("USERPROFILE", tmp)
+			if vol := filepath.VolumeName(tmp); vol != "" {
+				t.Setenv("HOMEDRIVE", vol)
+				t.Setenv("HOMEPATH", strings.TrimPrefix(tmp, vol))
+			}
+		}
+
+		targetHost := "user@example.com:2222"
+		targetFileName := "user_example_com_2222"
+		privKeyPath := filepath.Join(tmp, ".ssh", fmt.Sprintf("id_ed25519_topo_%s", targetFileName))
+		fragmentPath := filepath.Join(tmp, ".ssh", "topo_config", fmt.Sprintf("topo_%s.conf", targetFileName))
+
+		err := os.MkdirAll(filepath.Dir(fragmentPath), 0o700)
+		require.NoError(t, err)
+
+		existing := "" +
+			"Host board-alias\n" +
+			"  HostName example.com\n" +
+			"  IdentityFile /old/key1\n" +
+			"  User vscode-user\n" +
+			"  IdentityFile /old/key2\n" +
+			"  IdentitiesOnly no\n" +
+			"  Port 2222\n"
+		err = os.WriteFile(fragmentPath, []byte(existing), 0o600)
+		require.NoError(t, err)
+
+		err = sshconfig.ModifySSHConfig(targetHost, privKeyPath, targetFileName, false, nil)
+		require.NoError(t, err)
+
+		fragment, err := os.ReadFile(fragmentPath)
+		require.NoError(t, err)
+
+		expected := "" +
+			"Host board-alias\n" +
+			"  HostName example.com\n" +
+			"  User vscode-user\n" +
+			"  Port 2222\n" +
+			fmt.Sprintf("  IdentityFile %s\n", filepath.ToSlash(privKeyPath)) +
+			"  IdentitiesOnly yes\n"
+		require.Equal(t, expected, string(fragment))
+	})
 }

--- a/internal/setupkeys/sshconfig/ssh_config_test.go
+++ b/internal/setupkeys/sshconfig/ssh_config_test.go
@@ -4,25 +4,17 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
-	"strings"
 	"testing"
 
 	"github.com/arm/topo/internal/setupkeys/sshconfig"
+	"github.com/arm/topo/internal/testutil"
 	"github.com/stretchr/testify/require"
 )
 
 func TestModifySSHConfig(t *testing.T) {
 	t.Run("writes include and fragment", func(t *testing.T) {
 		tmp := t.TempDir()
-		t.Setenv("HOME", tmp)
-		if runtime.GOOS == "windows" {
-			t.Setenv("USERPROFILE", tmp)
-			if vol := filepath.VolumeName(tmp); vol != "" {
-				t.Setenv("HOMEDRIVE", vol)
-				t.Setenv("HOMEPATH", strings.TrimPrefix(tmp, vol))
-			}
-		}
+		testutil.SetHomeDir(t, tmp)
 
 		targetHost := "user@example.com:2222"
 		targetFileName := "user_example_com_2222"
@@ -54,14 +46,7 @@ func TestModifySSHConfig(t *testing.T) {
 
 	t.Run("preserves existing fragment content", func(t *testing.T) {
 		tmp := t.TempDir()
-		t.Setenv("HOME", tmp)
-		if runtime.GOOS == "windows" {
-			t.Setenv("USERPROFILE", tmp)
-			if vol := filepath.VolumeName(tmp); vol != "" {
-				t.Setenv("HOMEDRIVE", vol)
-				t.Setenv("HOMEPATH", strings.TrimPrefix(tmp, vol))
-			}
-		}
+		testutil.SetHomeDir(t, tmp)
 
 		targetHost := "user@example.com:2222"
 		targetFileName := "user_example_com_2222"
@@ -97,14 +82,7 @@ func TestModifySSHConfig(t *testing.T) {
 
 	t.Run("updates existing key settings without replacing other fields", func(t *testing.T) {
 		tmp := t.TempDir()
-		t.Setenv("HOME", tmp)
-		if runtime.GOOS == "windows" {
-			t.Setenv("USERPROFILE", tmp)
-			if vol := filepath.VolumeName(tmp); vol != "" {
-				t.Setenv("HOMEDRIVE", vol)
-				t.Setenv("HOMEPATH", strings.TrimPrefix(tmp, vol))
-			}
-		}
+		testutil.SetHomeDir(t, tmp)
 
 		targetHost := "user@example.com:2222"
 		targetFileName := "user_example_com_2222"
@@ -142,14 +120,7 @@ func TestModifySSHConfig(t *testing.T) {
 
 	t.Run("deduplicates existing owned key settings", func(t *testing.T) {
 		tmp := t.TempDir()
-		t.Setenv("HOME", tmp)
-		if runtime.GOOS == "windows" {
-			t.Setenv("USERPROFILE", tmp)
-			if vol := filepath.VolumeName(tmp); vol != "" {
-				t.Setenv("HOMEDRIVE", vol)
-				t.Setenv("HOMEPATH", strings.TrimPrefix(tmp, vol))
-			}
-		}
+		testutil.SetHomeDir(t, tmp)
 
 		targetHost := "user@example.com:2222"
 		targetFileName := "user_example_com_2222"

--- a/internal/setupkeys/sshconfig/ssh_config_test.go
+++ b/internal/setupkeys/sshconfig/ssh_config_test.go
@@ -24,24 +24,19 @@ func TestModifySSHConfig(t *testing.T) {
 		require.NoError(t, err)
 
 		mainConfigPath := filepath.Join(tmp, ".ssh", "config")
-		mainConfig, err := os.ReadFile(mainConfigPath)
-		require.NoError(t, err)
-		mainConfigText := string(mainConfig)
-		require.Contains(t, mainConfigText, "Include ")
-		require.Contains(t, mainConfigText, filepath.ToSlash(filepath.Join(tmp, ".ssh", "topo_config", "*.conf")))
+		wantIncludedFragmentPath := filepath.ToSlash(filepath.Join(tmp, ".ssh", "topo_config", "*.conf"))
+		wantSSHConfigContents := fmt.Sprintf("Include %s\n\n", wantIncludedFragmentPath)
+		testutil.AssertFileContents(t, wantSSHConfigContents, mainConfigPath)
 
 		fragmentPath := filepath.Join(tmp, ".ssh", "topo_config", fmt.Sprintf("topo_%s.conf", targetFileName))
-		fragment, err := os.ReadFile(fragmentPath)
-		require.NoError(t, err)
-
-		expected := "" +
-			"Host example.com\n" +
-			"  HostName example.com\n" +
-			"  User user\n" +
-			"  Port 2222\n" +
-			fmt.Sprintf("  IdentityFile %s\n", filepath.ToSlash(privKeyPath)) +
-			"  IdentitiesOnly yes\n"
-		require.Equal(t, expected, string(fragment))
+		wantFragmentContents := fmt.Sprintf(`Host example.com
+  HostName example.com
+  User user
+  Port 2222
+  IdentityFile %s
+  IdentitiesOnly yes
+`, filepath.ToSlash(privKeyPath))
+		testutil.AssertFileContents(t, wantFragmentContents, fragmentPath)
 	})
 
 	t.Run("preserves existing fragment content", func(t *testing.T) {
@@ -56,28 +51,25 @@ func TestModifySSHConfig(t *testing.T) {
 		err := os.MkdirAll(filepath.Dir(fragmentPath), 0o700)
 		require.NoError(t, err)
 
-		existing := "" +
-			"Host board-alias\n" +
-			"  HostName example.com\n" +
-			"  User vscode-user\n" +
-			"  Port 2222\n"
+		existing := `Host board-alias
+  HostName example.com
+  User vscode-user
+  Port 2222
+`
 		err = os.WriteFile(fragmentPath, []byte(existing), 0o600)
 		require.NoError(t, err)
 
 		err = sshconfig.ModifySSHConfig(targetHost, privKeyPath, targetFileName, false, nil)
 		require.NoError(t, err)
 
-		fragment, err := os.ReadFile(fragmentPath)
-		require.NoError(t, err)
-
-		expected := "" +
-			"Host board-alias\n" +
-			"  HostName example.com\n" +
-			"  User vscode-user\n" +
-			"  Port 2222\n" +
-			fmt.Sprintf("  IdentityFile %s\n", filepath.ToSlash(privKeyPath)) +
-			"  IdentitiesOnly yes\n"
-		require.Equal(t, expected, string(fragment))
+		wantFragmentContents := fmt.Sprintf(`Host board-alias
+  HostName example.com
+  User vscode-user
+  Port 2222
+  IdentityFile %s
+  IdentitiesOnly yes
+`, filepath.ToSlash(privKeyPath))
+		testutil.AssertFileContents(t, wantFragmentContents, fragmentPath)
 	})
 
 	t.Run("updates existing key settings without replacing other fields", func(t *testing.T) {
@@ -92,30 +84,27 @@ func TestModifySSHConfig(t *testing.T) {
 		err := os.MkdirAll(filepath.Dir(fragmentPath), 0o700)
 		require.NoError(t, err)
 
-		existing := "" +
-			"Host board-alias\n" +
-			"  HostName example.com\n" +
-			"  User vscode-user\n" +
-			"  Port 2222\n" +
-			"  IdentityFile /old/key\n" +
-			"  IdentitiesOnly no\n"
+		existing := `Host board-alias
+  HostName example.com
+  User vscode-user
+  Port 2222
+  IdentityFile /old/key
+  IdentitiesOnly no
+`
 		err = os.WriteFile(fragmentPath, []byte(existing), 0o600)
 		require.NoError(t, err)
 
 		err = sshconfig.ModifySSHConfig(targetHost, privKeyPath, targetFileName, false, nil)
 		require.NoError(t, err)
 
-		fragment, err := os.ReadFile(fragmentPath)
-		require.NoError(t, err)
-
-		expected := "" +
-			"Host board-alias\n" +
-			"  HostName example.com\n" +
-			"  User vscode-user\n" +
-			"  Port 2222\n" +
-			fmt.Sprintf("  IdentityFile %s\n", filepath.ToSlash(privKeyPath)) +
-			"  IdentitiesOnly yes\n"
-		require.Equal(t, expected, string(fragment))
+		wantFragmentContents := fmt.Sprintf(`Host board-alias
+  HostName example.com
+  User vscode-user
+  Port 2222
+  IdentityFile %s
+  IdentitiesOnly yes
+`, filepath.ToSlash(privKeyPath))
+		testutil.AssertFileContents(t, wantFragmentContents, fragmentPath)
 	})
 
 	t.Run("deduplicates existing owned key settings", func(t *testing.T) {
@@ -130,30 +119,26 @@ func TestModifySSHConfig(t *testing.T) {
 		err := os.MkdirAll(filepath.Dir(fragmentPath), 0o700)
 		require.NoError(t, err)
 
-		existing := "" +
-			"Host board-alias\n" +
-			"  HostName example.com\n" +
-			"  IdentityFile /old/key1\n" +
-			"  User vscode-user\n" +
-			"  IdentityFile /old/key2\n" +
-			"  IdentitiesOnly no\n" +
-			"  Port 2222\n"
+		existing := `Host board-alias
+  HostName example.com
+  IdentityFile /old/key1
+  User vscode-user
+  IdentityFile /old/key2
+  IdentitiesOnly no
+  Port 2222`
 		err = os.WriteFile(fragmentPath, []byte(existing), 0o600)
 		require.NoError(t, err)
 
 		err = sshconfig.ModifySSHConfig(targetHost, privKeyPath, targetFileName, false, nil)
 		require.NoError(t, err)
 
-		fragment, err := os.ReadFile(fragmentPath)
-		require.NoError(t, err)
-
-		expected := "" +
-			"Host board-alias\n" +
-			"  HostName example.com\n" +
-			"  User vscode-user\n" +
-			"  Port 2222\n" +
-			fmt.Sprintf("  IdentityFile %s\n", filepath.ToSlash(privKeyPath)) +
-			"  IdentitiesOnly yes\n"
-		require.Equal(t, expected, string(fragment))
+		wantFragmentContents := fmt.Sprintf(`Host board-alias
+  HostName example.com
+  User vscode-user
+  Port 2222
+  IdentityFile %s
+  IdentitiesOnly yes
+`, filepath.ToSlash(privKeyPath))
+		testutil.AssertFileContents(t, wantFragmentContents, fragmentPath)
 	})
 }

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -95,3 +95,11 @@ func CmdWithOutput(output string, exitCode int) *exec.Cmd {
 	// #nosec G204 -- ignore as its a test helper
 	return exec.Command("sh", "-c", fmt.Sprintf("printf %%s \"$1\"; exit %d", exitCode), "sh", output)
 }
+
+func AssertFileContents(t *testing.T, wantContents string, path string) {
+	t.Helper()
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Equal(t, wantContents, string(got))
+}


### PR DESCRIPTION
The user may have already written an SSH config fragment based on Topo's directory convention (~/.ssh/topo_config/topo_<target>.conf).

## Changes

- Don't overwrite the config fragments when setting up keys for the target, just overwrite the identity file to be used.
