### PR TITLE
refactor: Remove `SplitUserHostPort()`

### DIFF
--- a/internal/setupkeys/sshconfig/ssh_config.go
+++ b/internal/setupkeys/sshconfig/ssh_config.go
@@ -100,22 +100,19 @@ func hasIncludeLine(data []byte, includeLine string) bool {
 }
 
 func buildSSHConfigFragment(targetHost string, privKeyPath string) string {
-	user, host, port := ssh.SplitUserHostPort(targetHost)
-	hostAlias := host
-	if hostAlias == "" {
-		hostAlias = targetHost
-	}
+	config := ssh.NewConfig(targetHost)
+	hostAlias := config.Host
 
 	var b strings.Builder
 	fmt.Fprintf(&b, "Host %s\n", hostAlias)
-	if host != "" && (strings.Contains(targetHost, "@") || strings.Contains(targetHost, ":")) {
-		fmt.Fprintf(&b, "  HostName %s\n", host)
+	if config.Host != "" && (strings.Contains(targetHost, "@") || strings.Contains(targetHost, ":")) {
+		fmt.Fprintf(&b, "  HostName %s\n", config.Host)
 	}
-	if user != "" {
-		fmt.Fprintf(&b, "  User %s\n", user)
+	if config.User != "" {
+		fmt.Fprintf(&b, "  User %s\n", config.User)
 	}
-	if port != "" {
-		fmt.Fprintf(&b, "  Port %s\n", port)
+	if config.Port != "" {
+		fmt.Fprintf(&b, "  Port %s\n", config.Port)
 	}
 
 	// needs to be this way even on Windows to work with ssh config parsing, which generally accepts forward slashes

--- a/internal/setupkeys/sshconfig/ssh_config_test.go
+++ b/internal/setupkeys/sshconfig/ssh_config_test.go
@@ -23,7 +23,7 @@ func TestModifySSHConfigWritesIncludeAndFragment(t *testing.T) {
 		}
 	}
 
-	targetHost := "user@example.com:2222"
+	targetHost := "ssh://user@example.com:2222"
 	targetFileName := "user_example_com_2222"
 	privKeyPath := filepath.Join(tmp, ".ssh", fmt.Sprintf("id_ed25519_topo_%s", targetFileName))
 

--- a/internal/ssh/config.go
+++ b/internal/ssh/config.go
@@ -3,6 +3,7 @@ package ssh
 import (
 	"bufio"
 	"bytes"
+	"fmt"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -10,9 +11,10 @@ import (
 )
 
 type Config struct {
-	host           string
-	user           string
-	port           string
+	HostName       string
+	Host           string
+	User           string
+	Port           string
 	connectTimeout time.Duration
 }
 
@@ -22,6 +24,10 @@ func NewConfig(destination string) Config {
 		return Config{}
 	}
 	return NewConfigFromBytes(output)
+}
+
+func (c Config) ConnectionString() string {
+	return fmt.Sprintf("%s@%s", c.User, c.Host)
 }
 
 func NewConfigFromBytes(data []byte) Config {
@@ -34,11 +40,13 @@ func NewConfigFromBytes(data []byte) Config {
 		}
 		switch strings.ToLower(fields[0]) {
 		case "hostname":
-			config.host = fields[1]
+			config.HostName = fields[1]
+		case "host":
+			config.Host = fields[1]
 		case "user":
-			config.user = fields[1]
+			config.User = fields[1]
 		case "port":
-			config.port = fields[1]
+			config.Port = fields[1]
 		case "connecttimeout":
 			if secs, err := strconv.Atoi(fields[1]); err == nil {
 				config.connectTimeout = time.Duration(secs) * time.Second

--- a/internal/ssh/config_test.go
+++ b/internal/ssh/config_test.go
@@ -16,7 +16,7 @@ port 2222
 
 		got := NewConfigFromBytes(input)
 
-		want := Config{host: "springfield.nuclear.gov", user: "homer", port: "2222"}
+		want := Config{HostName: "springfield.nuclear.gov", User: "homer", Port: "2222"}
 		assert.Equal(t, want, got)
 	})
 
@@ -28,7 +28,7 @@ user homer
 
 		got := NewConfigFromBytes(input)
 
-		want := Config{host: "springfield.nuclear.gov", user: "homer"}
+		want := Config{HostName: "springfield.nuclear.gov", User: "homer"}
 		assert.Equal(t, want, got)
 	})
 
@@ -47,7 +47,7 @@ Port 22
 
 		got := NewConfigFromBytes(input)
 
-		want := Config{host: "kwik.e.mart", user: "apu", port: "22"}
+		want := Config{HostName: "kwik.e.mart", User: "apu", Port: "22"}
 		assert.Equal(t, want, got)
 	})
 

--- a/internal/ssh/dest.go
+++ b/internal/ssh/dest.go
@@ -2,7 +2,6 @@ package ssh
 
 import (
 	"fmt"
-	"net"
 	"strings"
 	"unicode"
 )
@@ -19,8 +18,8 @@ func (d Destination) IsLocalhost() bool {
 	if d.IsPlainLocalhost() {
 		return true
 	}
-	_, host, _ := SplitUserHostPort(string(d))
-	return Destination(host).IsPlainLocalhost()
+	config := NewConfig(string(d))
+	return Destination(config.Host).IsPlainLocalhost()
 }
 
 func (d Destination) AsURI() string {
@@ -39,22 +38,4 @@ func (d Destination) Slugify() string {
 		b.WriteRune(toWrite)
 	}
 	return b.String()
-}
-
-func SplitUserHostPort(raw string) (user, host, port string) {
-	hostPart := raw
-	if at := strings.LastIndex(raw, "@"); at != -1 {
-		user = raw[:at]
-		hostPart = raw[at+1:]
-	}
-
-	if strings.HasPrefix(hostPart, "[") && strings.HasSuffix(hostPart, "]") {
-		host = strings.TrimSuffix(strings.TrimPrefix(hostPart, "["), "]")
-		return user, host, port
-	}
-
-	if h, p, err := net.SplitHostPort(hostPart); err == nil {
-		return user, h, p
-	}
-	return user, hostPart, port
 }

--- a/internal/ssh/dest_test.go
+++ b/internal/ssh/dest_test.go
@@ -126,30 +126,4 @@ func TestDestination(t *testing.T) {
 			})
 		}
 	})
-
-	t.Run("SplitUserHostPort", func(t *testing.T) {
-		cases := []struct {
-			raw      string
-			wantUser string
-			wantHost string
-			wantPort string
-		}{
-			{raw: "user@example.com:2222", wantUser: "user", wantHost: "example.com", wantPort: "2222"},
-			{raw: "example.com:2222", wantUser: "", wantHost: "example.com", wantPort: "2222"},
-			{raw: "example.com", wantUser: "", wantHost: "example.com", wantPort: ""},
-			{raw: "user@example.com", wantUser: "user", wantHost: "example.com", wantPort: ""},
-			{raw: "[2001:db8::1]", wantUser: "", wantHost: "2001:db8::1", wantPort: ""},
-			{raw: "user@[2001:db8::1]:2222", wantUser: "user", wantHost: "2001:db8::1", wantPort: "2222"},
-			{raw: "[2001:db8::1]:2222", wantUser: "", wantHost: "2001:db8::1", wantPort: "2222"},
-		}
-
-		for _, tc := range cases {
-			t.Run(tc.raw, func(t *testing.T) {
-				user, host, port := ssh.SplitUserHostPort(tc.raw)
-				require.Equal(t, tc.wantUser, user, "user for %q", tc.raw)
-				require.Equal(t, tc.wantHost, host, "host for %q", tc.raw)
-				require.Equal(t, tc.wantPort, port, "port for %q", tc.raw)
-			})
-		}
-	})
 }

--- a/internal/ssh/dest_test.go
+++ b/internal/ssh/dest_test.go
@@ -82,8 +82,8 @@ func TestDestination(t *testing.T) {
 			tests := []string{
 				"user@localhost",
 				"user@127.0.0.1",
-				"localhost:2222",
-				"root@localhost:2222",
+				"ssh://localhost:2222",
+				"ssh://root@localhost:2222",
 			}
 
 			for _, input := range tests {

--- a/internal/ssh/ssh_tunnel.go
+++ b/internal/ssh/ssh_tunnel.go
@@ -66,11 +66,11 @@ func NewSSHTunnelStart(targetDest Destination, port string, useControlSockets bo
 
 func (s *SSHTunnelStart) Command() *exec.Cmd {
 	rawHost := string(s.TargetDest)
-	user, host, port := SplitUserHostPort(rawHost)
-	hostArg := formatSSHHost(rawHost, user, host)
+	config := NewConfig(rawHost)
+	hostArg := config.ConnectionString()
 	args := []string{"ssh", "-N", "-o", "ExitOnForwardFailure=yes"}
-	if port != "" {
-		args = append(args, "-p", port)
+	if s.Port != "" && config.Port != "22" {
+		args = append(args, "-p", s.Port)
 	}
 	if s.UseControlSockets {
 		args = append(args,
@@ -123,7 +123,7 @@ func NewCheckSSHTunnelSecurity(targetDest Destination, port string) *CheckSSHTun
 
 func (ct *CheckSSHTunnelSecurity) Command() *exec.Cmd {
 	if !ct.TargetDest.IsLocalhost() {
-		host := resolveHost(string(ct.TargetDest))
+		host := resolveHostName(string(ct.TargetDest))
 		if host == "" {
 			return nil
 		}
@@ -173,11 +173,11 @@ func NewSSHTunnelStop(targetDest Destination) *SSHTunnelStop {
 
 func (s *SSHTunnelStop) Command() *exec.Cmd {
 	rawHost := string(s.TargetDest)
-	user, host, port := SplitUserHostPort(rawHost)
-	hostArg := formatSSHHost(rawHost, user, host)
+	config := NewConfig(rawHost)
+	hostArg := config.ConnectionString()
 	args := []string{"ssh"}
-	if port != "" {
-		args = append(args, "-p", port)
+	if config.Port != "" {
+		args = append(args, "-p", config.Port)
 	}
 	args = append(args,
 		"-S", ControlSocketPath(string(s.TargetDest)),
@@ -250,7 +250,7 @@ func (s *SSHTunnelProcessStop) DryRun(w io.Writer) error {
 	return nil
 }
 
-func resolveHost(raw string) string {
+func resolveHostName(raw string) string {
 	config := NewConfig(raw)
-	return config.host
+	return config.HostName
 }

--- a/internal/ssh/ssh_tunnel.go
+++ b/internal/ssh/ssh_tunnel.go
@@ -21,20 +21,6 @@ func ControlSocketPath(targetHost string) string {
 	return filepath.Join(os.TempDir(), fmt.Sprintf("topo-tunnel-%s", hostHash))
 }
 
-func formatSSHHost(raw string, user string, host string) string {
-	if host == "" {
-		return raw
-	}
-	hostPart := host
-	if strings.Contains(hostPart, ":") {
-		hostPart = "[" + hostPart + "]"
-	}
-	if user == "" {
-		return hostPart
-	}
-	return user + "@" + hostPart
-}
-
 func NewSSHTunnel(targetDest Destination, port string, useControlSockets bool) (operation.Operation, operation.Operation, operation.Operation) {
 	start := NewSSHTunnelStart(targetDest, port, useControlSockets)
 	securityCheck := NewCheckSSHTunnelSecurity(targetDest, port)

--- a/internal/ssh/ssh_tunnel.go
+++ b/internal/ssh/ssh_tunnel.go
@@ -69,8 +69,8 @@ func (s *SSHTunnelStart) Command() *exec.Cmd {
 	config := NewConfig(rawHost)
 	hostArg := config.ConnectionString()
 	args := []string{"ssh", "-N", "-o", "ExitOnForwardFailure=yes"}
-	if s.Port != "" && config.Port != "22" {
-		args = append(args, "-p", s.Port)
+	if config.Port != "" && config.Port != "22" {
+		args = append(args, "-p", config.Port)
 	}
 	if s.UseControlSockets {
 		args = append(args,
@@ -176,7 +176,7 @@ func (s *SSHTunnelStop) Command() *exec.Cmd {
 	config := NewConfig(rawHost)
 	hostArg := config.ConnectionString()
 	args := []string{"ssh"}
-	if config.Port != "" {
+	if config.Port != "" && config.Port != "22" {
 		args = append(args, "-p", config.Port)
 	}
 	args = append(args,

--- a/internal/ssh/ssh_tunnel_test.go
+++ b/internal/ssh/ssh_tunnel_test.go
@@ -75,7 +75,7 @@ func TestSSHTunnelStart(t *testing.T) {
 		})
 
 		t.Run("it includes port flag when host has custom port", func(t *testing.T) {
-			dest := ssh.Destination("user@remote:2222")
+			dest := ssh.Destination("ssh://user@remote:2222")
 			port := operation.DefaultRegistryPort
 
 			st := ssh.NewSSHTunnelStart(dest, port, true)
@@ -115,7 +115,7 @@ func TestSSHTunnelStart(t *testing.T) {
 
 		t.Run("it includes port flag when host has custom port", func(t *testing.T) {
 			var buf bytes.Buffer
-			dest := ssh.Destination("user@remote:2222")
+			dest := ssh.Destination("ssh://user@remote:2222")
 			port := operation.DefaultRegistryPort
 
 			st := ssh.NewSSHTunnelStart(dest, port, true)
@@ -149,19 +149,19 @@ func TestSSHTunnelStartEdgeCases(t *testing.T) {
 			st := ssh.NewSSHTunnelStart(dest, port, true)
 			got := strings.Join(st.Command().Args, " ")
 
-			want := fmt.Sprintf("ssh -N -o ExitOnForwardFailure=yes -fMS %s -R %s:127.0.0.1:%s remote-server", ssh.ControlSocketPath(string(dest)), port, port)
-			assert.Equal(t, want, got)
+			wantPattern := fmt.Sprintf("ssh -N -o ExitOnForwardFailure=yes -fMS %s -R %s:127.0.0.1:%s [^@]+@remote-server", ssh.ControlSocketPath(string(dest)), port, port)
+			assert.Regexp(t, wantPattern, got)
 		})
 
 		t.Run("it handles host without user but with port", func(t *testing.T) {
-			dest := ssh.Destination("remote-server:2222")
+			dest := ssh.Destination("ssh://remote-server:2222")
 			port := operation.DefaultRegistryPort
 
 			st := ssh.NewSSHTunnelStart(dest, port, true)
 			got := strings.Join(st.Command().Args, " ")
 
-			want := fmt.Sprintf("ssh -N -o ExitOnForwardFailure=yes -p 2222 -fMS %s -R %s:127.0.0.1:%s remote-server", ssh.ControlSocketPath(string(dest)), port, port)
-			assert.Equal(t, want, got)
+			wantPattern := fmt.Sprintf("ssh -N -o ExitOnForwardFailure=yes -p 2222 -fMS %s -R %s:127.0.0.1:%s [^@]+@remote-server", ssh.ControlSocketPath(string(dest)), port, port)
+			assert.Regexp(t, wantPattern, got)
 		})
 
 		t.Run("it handles IP address", func(t *testing.T) {
@@ -176,7 +176,7 @@ func TestSSHTunnelStartEdgeCases(t *testing.T) {
 		})
 
 		t.Run("it handles IP address with port", func(t *testing.T) {
-			dest := ssh.Destination("user@192.168.1.100:2222")
+			dest := ssh.Destination("ssh://user@192.168.1.100:2222")
 			port := operation.DefaultRegistryPort
 
 			st := ssh.NewSSHTunnelStart(dest, port, true)
@@ -250,7 +250,7 @@ func TestSSHTunnelStop(t *testing.T) {
 		})
 
 		t.Run("it includes port flag when host has custom port", func(t *testing.T) {
-			dest := ssh.Destination("user@remote:2222")
+			dest := ssh.Destination("ssh://user@remote:2222")
 
 			st := ssh.NewSSHTunnelStop(dest)
 			got := strings.Join(st.Command().Args, " ")
@@ -277,7 +277,7 @@ func TestSSHTunnelStop(t *testing.T) {
 
 		t.Run("it includes port flag when host has custom port", func(t *testing.T) {
 			var buf bytes.Buffer
-			dest := ssh.Destination("user@remote:2222")
+			dest := ssh.Destination("ssh://user@remote:2222")
 
 			st := ssh.NewSSHTunnelStop(dest)
 			err := st.DryRun(&buf)
@@ -309,18 +309,18 @@ func TestSSHTunnelStopEdgeCases(t *testing.T) {
 			st := ssh.NewSSHTunnelStop(dest)
 			got := strings.Join(st.Command().Args, " ")
 
-			want := fmt.Sprintf("ssh -S %s -O exit remote-server", ssh.ControlSocketPath(string(dest)))
-			assert.Equal(t, want, got)
+			wantPattern := fmt.Sprintf("ssh -S %s -O exit [^@]+@remote-server", ssh.ControlSocketPath(string(dest)))
+			assert.Regexp(t, wantPattern, got)
 		})
 
 		t.Run("handles host without user but with port", func(t *testing.T) {
-			dest := ssh.Destination("remote-server:2222")
+			dest := ssh.Destination("ssh://remote-server:2222")
 
 			st := ssh.NewSSHTunnelStop(dest)
 			got := strings.Join(st.Command().Args, " ")
 
-			want := fmt.Sprintf("ssh -p 2222 -S %s -O exit remote-server", ssh.ControlSocketPath(string(dest)))
-			assert.Equal(t, want, got)
+			wantPattern := fmt.Sprintf("ssh -p 2222 -S %s -O exit [^@]+@remote-server", ssh.ControlSocketPath(string(dest)))
+			assert.Regexp(t, wantPattern, got)
 		})
 
 		t.Run("handles IP address", func(t *testing.T) {
@@ -334,7 +334,7 @@ func TestSSHTunnelStopEdgeCases(t *testing.T) {
 		})
 
 		t.Run("handles IP address with port", func(t *testing.T) {
-			dest := ssh.Destination("user@192.168.1.100:2222")
+			dest := ssh.Destination("ssh://user@192.168.1.100:2222")
 
 			st := ssh.NewSSHTunnelStop(dest)
 			got := strings.Join(st.Command().Args, " ")


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- Remove usage of `SplitUserHostPort()` function
- Use `Config`'s Host, `User`, `Port` instead after making them public
- fix tests so that it uses `ssh://` prefix when specifying the port to comply with ssh target input from `man ssh`
