### PR TITLE
refactor: tighten `Destination` type

### DIFF
--- a/cmd/topo/deploy.go
+++ b/cmd/topo/deploy.go
@@ -87,8 +87,8 @@ Use --dry-run to see what commands would be executed without actually running th
 			return err
 		}
 
-		targetHost := ssh.Destination(resolvedTarget)
-		deployOpts.TargetHost = targetHost
+		cfg := ssh.NewConfig(resolvedTarget)
+		deployOpts.TargetHost = cfg.Destination
 
 		if !skipProjectChecks {
 			if err := checks.EnsureProjectIsLinuxArm64Ready(composeFile); err != nil {
@@ -97,7 +97,7 @@ Use --dry-run to see what commands would be executed without actually running th
 		}
 
 		goos := runtime.GOOS
-		if docker.SupportsRegistry(noRegistry, targetHost) {
+		if docker.SupportsRegistry(noRegistry, cfg.Destination) {
 			deployOpts.Registry = &docker.RegistryConfig{
 				Port:              resolvedPort,
 				UseControlSockets: docker.SupportsSSHControlSockets(goos),

--- a/cmd/topo/deploy.go
+++ b/cmd/topo/deploy.go
@@ -68,7 +68,7 @@ Use --dry-run to see what commands would be executed without actually running th
 			})
 		}
 
-		resolvedTarget, err := requireTarget(cmd)
+		targetArg, err := requireTarget(cmd)
 		if err != nil {
 			return err
 		}
@@ -87,7 +87,7 @@ Use --dry-run to see what commands would be executed without actually running th
 			return err
 		}
 
-		cfg := ssh.NewConfig(resolvedTarget)
+		cfg := ssh.NewConfig(targetArg)
 		deployOpts.TargetHost = cfg.Destination
 
 		if !skipProjectChecks {

--- a/cmd/topo/describe.go
+++ b/cmd/topo/describe.go
@@ -8,6 +8,7 @@ import (
 	"github.com/arm/topo/internal/output/console"
 	"github.com/arm/topo/internal/output/logger"
 	"github.com/arm/topo/internal/output/term"
+	"github.com/arm/topo/internal/ssh"
 	"github.com/arm/topo/internal/target"
 	"github.com/spf13/cobra"
 )
@@ -24,7 +25,7 @@ var describeCmd = &cobra.Command{
 			return err
 		}
 
-		conn := target.NewConnection(sshTarget, target.ConnectionOptions{Multiplex: true, ConnectTimeout: sshConnectTimeout})
+		conn := target.NewConnection(ssh.NewConfig(sshTarget).Destination, target.ConnectionOptions{Multiplex: true, ConnectTimeout: sshConnectTimeout})
 		probe := target.NewHardwareProbe(&conn)
 		hwProfile, err := probe.Probe()
 		if err != nil {

--- a/cmd/topo/describe.go
+++ b/cmd/topo/describe.go
@@ -20,12 +20,12 @@ var describeCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(0),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		sshTarget, err := requireTarget(cmd)
+		targetArg, err := requireTarget(cmd)
 		if err != nil {
 			return err
 		}
 
-		conn := target.NewConnection(ssh.NewConfig(sshTarget).Destination, target.ConnectionOptions{Multiplex: true, ConnectTimeout: sshConnectTimeout})
+		conn := target.NewConnection(ssh.NewConfig(targetArg).Destination, target.ConnectionOptions{Multiplex: true, ConnectTimeout: sshConnectTimeout})
 		probe := target.NewHardwareProbe(&conn)
 		hwProfile, err := probe.Probe()
 		if err != nil {

--- a/cmd/topo/health.go
+++ b/cmd/topo/health.go
@@ -8,6 +8,7 @@ import (
 	"github.com/arm/topo/internal/output/printable"
 	"github.com/arm/topo/internal/output/templates"
 	"github.com/arm/topo/internal/output/term"
+	"github.com/arm/topo/internal/ssh"
 	"github.com/spf13/cobra"
 )
 
@@ -39,7 +40,8 @@ var healthCmd = &cobra.Command{
 		}
 
 		if sshTarget, ok := lookupTarget(cmd); ok {
-			targetReport, err := health.CheckTarget(sshTarget, acceptNewHostKeys, sshConnectTimeout)
+			cfg := ssh.NewConfig(sshTarget)
+			targetReport, err := health.CheckTarget(cfg.Destination, acceptNewHostKeys, sshConnectTimeout)
 			if err != nil {
 				if spinner != nil {
 					spinner.Stop()

--- a/cmd/topo/health.go
+++ b/cmd/topo/health.go
@@ -39,8 +39,8 @@ var healthCmd = &cobra.Command{
 			Host: health.CheckHost(),
 		}
 
-		if sshTarget, ok := lookupTarget(cmd); ok {
-			cfg := ssh.NewConfig(sshTarget)
+		if targetArg, ok := lookupTarget(cmd); ok {
+			cfg := ssh.NewConfig(targetArg)
 			targetReport, err := health.CheckTarget(cfg.Destination, acceptNewHostKeys, sshConnectTimeout)
 			if err != nil {
 				if spinner != nil {

--- a/cmd/topo/install_remoteproc_runtime.go
+++ b/cmd/topo/install_remoteproc_runtime.go
@@ -26,7 +26,7 @@ Falls back to ~/bin if no suitable locations are automatically found.
 	Args: cobra.ExactArgs(0),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		sshTarget, err := requireTarget(cmd)
+		targetArg, err := requireTarget(cmd)
 		if err != nil {
 			return err
 		}
@@ -35,7 +35,7 @@ Falls back to ~/bin if no suitable locations are automatically found.
 		if err != nil {
 			return err
 		}
-		cfg := ssh.NewConfig(sshTarget)
+		cfg := ssh.NewConfig(targetArg)
 		p, err := installRemoteprocRuntime(cfg.Destination)
 		if err != nil {
 			return err

--- a/cmd/topo/install_remoteproc_runtime.go
+++ b/cmd/topo/install_remoteproc_runtime.go
@@ -35,7 +35,8 @@ Falls back to ~/bin if no suitable locations are automatically found.
 		if err != nil {
 			return err
 		}
-		p, err := installRemoteprocRuntime(ssh.Destination(sshTarget))
+		cfg := ssh.NewConfig(sshTarget)
+		p, err := installRemoteprocRuntime(cfg.Destination)
 		if err != nil {
 			return err
 		}

--- a/cmd/topo/setup_keys.go
+++ b/cmd/topo/setup_keys.go
@@ -35,7 +35,7 @@ Use --dry-run to see what commands would be executed without actually running th
 			return err
 		}
 
-		targetSlug := ssh.Destination(resolvedTarget).Slugify()
+		targetSlug := ssh.NewConfig(resolvedTarget).Slugify()
 		if privateKeyPath == "" {
 			privateKeyPath, err = setupkeys.GetDefaultPrivateKeyPath(targetSlug)
 			if err != nil {
@@ -48,7 +48,8 @@ Use --dry-run to see what commands would be executed without actually running th
 			return err
 		}
 
-		seq, err := setupkeys.NewKeySetup(resolvedTarget, privateKeyPath, parsedKeyType)
+		cfg := ssh.NewConfig(resolvedTarget)
+		seq, err := setupkeys.NewKeySetup(cfg.Destination, privateKeyPath, parsedKeyType)
 		if err != nil {
 			return err
 		}

--- a/cmd/topo/setup_keys.go
+++ b/cmd/topo/setup_keys.go
@@ -30,12 +30,12 @@ Use --dry-run to see what commands would be executed without actually running th
 			panic(fmt.Sprintf("internal error: dry-run flag not registered: %v", err))
 		}
 
-		resolvedTarget, err := requireTarget(cmd)
+		targetArg, err := requireTarget(cmd)
 		if err != nil {
 			return err
 		}
 
-		targetSlug := ssh.NewConfig(resolvedTarget).Slugify()
+		targetSlug := ssh.NewConfig(targetArg).Slugify()
 		if privateKeyPath == "" {
 			privateKeyPath, err = setupkeys.GetDefaultPrivateKeyPath(targetSlug)
 			if err != nil {
@@ -48,7 +48,7 @@ Use --dry-run to see what commands would be executed without actually running th
 			return err
 		}
 
-		cfg := ssh.NewConfig(resolvedTarget)
+		cfg := ssh.NewConfig(targetArg)
 		seq, err := setupkeys.NewKeySetup(cfg.Destination, privateKeyPath, parsedKeyType)
 		if err != nil {
 			return err
@@ -64,7 +64,7 @@ Use --dry-run to see what commands would be executed without actually running th
 			return err
 		}
 
-		return sshconfig.ModifySSHConfig(resolvedTarget, privateKeyPath, targetSlug, dryRun, os.Stdout)
+		return sshconfig.ModifySSHConfig(targetArg, privateKeyPath, targetSlug, dryRun, os.Stdout)
 	},
 }
 

--- a/cmd/topo/stop.go
+++ b/cmd/topo/stop.go
@@ -39,9 +39,9 @@ Use --dry-run to see what commands would be executed without actually running th
 			return err
 		}
 
-		targetHost := ssh.NewConfig(targetArg).Destination
+		dest := ssh.NewConfig(targetArg).Destination
 
-		stop := docker.NewDeploymentStop(composeFile, targetHost)
+		stop := docker.NewDeploymentStop(composeFile, dest)
 		if dryRun {
 			return stop.DryRun(os.Stdout)
 		}

--- a/cmd/topo/stop.go
+++ b/cmd/topo/stop.go
@@ -39,7 +39,7 @@ Use --dry-run to see what commands would be executed without actually running th
 			return err
 		}
 
-		targetHost := ssh.Destination(resolvedTarget)
+		targetHost := ssh.NewConfig(resolvedTarget).Destination
 
 		stop := docker.NewDeploymentStop(composeFile, targetHost)
 		if dryRun {

--- a/cmd/topo/stop.go
+++ b/cmd/topo/stop.go
@@ -29,7 +29,7 @@ Use --dry-run to see what commands would be executed without actually running th
 			panic(fmt.Sprintf("internal error: dry-run flag not registered: %v", err))
 		}
 
-		resolvedTarget, err := requireTarget(cmd)
+		targetArg, err := requireTarget(cmd)
 		if err != nil {
 			return err
 		}
@@ -39,7 +39,7 @@ Use --dry-run to see what commands would be executed without actually running th
 			return err
 		}
 
-		targetHost := ssh.NewConfig(resolvedTarget).Destination
+		targetHost := ssh.NewConfig(targetArg).Destination
 
 		stop := docker.NewDeploymentStop(composeFile, targetHost)
 		if dryRun {

--- a/cmd/topo/templates.go
+++ b/cmd/topo/templates.go
@@ -36,9 +36,9 @@ var templatesCmd = &cobra.Command{
 				return err
 			}
 		} else {
-			resolvedTarget, exists := lookupTarget(cmd)
+			targetArg, exists := lookupTarget(cmd)
 			if exists {
-				dest := ssh.NewConfig(resolvedTarget).Destination
+				dest := ssh.NewConfig(targetArg).Destination
 				conn := target.NewConnection(dest, target.ConnectionOptions{Multiplex: true, ConnectTimeout: sshConnectTimeout})
 				probe := target.NewHardwareProbe(&conn)
 				hwProfile, err := probe.Probe()

--- a/cmd/topo/templates.go
+++ b/cmd/topo/templates.go
@@ -7,6 +7,7 @@ import (
 	"github.com/arm/topo/internal/describe"
 	"github.com/arm/topo/internal/output/printable"
 	"github.com/arm/topo/internal/output/templates"
+	"github.com/arm/topo/internal/ssh"
 	"github.com/arm/topo/internal/target"
 	"github.com/spf13/cobra"
 )
@@ -37,7 +38,8 @@ var templatesCmd = &cobra.Command{
 		} else {
 			resolvedTarget, exists := lookupTarget(cmd)
 			if exists {
-				conn := target.NewConnection(resolvedTarget, target.ConnectionOptions{Multiplex: true, ConnectTimeout: sshConnectTimeout})
+				dest := ssh.NewConfig(resolvedTarget).Destination
+				conn := target.NewConnection(dest, target.ConnectionOptions{Multiplex: true, ConnectTimeout: sshConnectTimeout})
 				probe := target.NewHardwareProbe(&conn)
 				hwProfile, err := probe.Probe()
 				if err != nil {

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestString(t *testing.T) {
 	t.Run("converts docker command to string", func(t *testing.T) {
-		h := ssh.Destination("user@remote")
+		h := ssh.MustNewDestination("user@remote")
 		cmd := command.Docker(h, "save", "alpine:latest")
 
 		got := command.String(cmd)
@@ -20,7 +20,7 @@ func TestString(t *testing.T) {
 	})
 
 	t.Run("converts docker compose command to string", func(t *testing.T) {
-		h := ssh.Destination("user@remote")
+		h := ssh.MustNewDestination("user@remote")
 		cmd := command.DockerCompose(h, "/path/to/compose.yaml", "up", "-d")
 
 		got := command.String(cmd)

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -4,13 +4,13 @@ import (
 	"testing"
 
 	"github.com/arm/topo/internal/command"
-	"github.com/arm/topo/internal/ssh"
+	"github.com/arm/topo/internal/testutil"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestString(t *testing.T) {
 	t.Run("converts docker command to string", func(t *testing.T) {
-		h := ssh.MustNewDestination("user@remote")
+		h := testutil.MustNewDestination("user@remote")
 		cmd := command.Docker(h, "save", "alpine:latest")
 
 		got := command.String(cmd)
@@ -20,7 +20,7 @@ func TestString(t *testing.T) {
 	})
 
 	t.Run("converts docker compose command to string", func(t *testing.T) {
-		h := ssh.MustNewDestination("user@remote")
+		h := testutil.MustNewDestination("user@remote")
 		cmd := command.DockerCompose(h, "/path/to/compose.yaml", "up", "-d")
 
 		got := command.String(cmd)

--- a/internal/deploy/docker/deploy.go
+++ b/internal/deploy/docker/deploy.go
@@ -17,16 +17,16 @@ type DeployOptions struct {
 	Registry     *RegistryConfig
 }
 
-func SupportsRegistry(noRegistry bool, targetHost ssh.Destination) bool {
-	return !noRegistry && !targetHost.IsPlainLocalhost()
+func SupportsRegistry(noRegistry bool, dest ssh.Destination) bool {
+	return !noRegistry && !dest.IsPlainLocalhost()
 }
 
 func SupportsSSHControlSockets(goos string) bool {
 	return goos != "windows"
 }
 
-func NewDeploymentStop(composeFile string, targetHost ssh.Destination) goperation.Sequence {
-	return goperation.Sequence{operation.NewDockerComposeStop(composeFile, targetHost)}
+func NewDeploymentStop(composeFile string, dest ssh.Destination) goperation.Sequence {
+	return goperation.Sequence{operation.NewDockerComposeStop(composeFile, dest)}
 }
 
 func NewDeployment(composeFile string, opts DeployOptions) (goperation.Sequence, goperation.Operation) {

--- a/internal/deploy/docker/deploy_test.go
+++ b/internal/deploy/docker/deploy_test.go
@@ -20,7 +20,7 @@ func TestNewDeployment(t *testing.T) {
 	composeFile := "compose.yaml"
 
 	t.Run("includes transfer operation for remote host", func(t *testing.T) {
-		remoteHost := ssh.Destination("user@remote")
+		remoteHost := ssh.MustNewDestination("user@remote")
 		deployOpts := docker.DeployOptions{TargetHost: remoteHost}
 		got, _ := docker.NewDeployment(composeFile, deployOpts)
 
@@ -34,7 +34,7 @@ func TestNewDeployment(t *testing.T) {
 	})
 
 	t.Run("includes registry operations for remote host when enabled", func(t *testing.T) {
-		remoteHost := ssh.Destination("user@remote")
+		remoteHost := ssh.MustNewDestination("user@remote")
 		port := operation.DefaultRegistryPort
 		opts := docker.DeployOptions{TargetHost: remoteHost, Registry: &docker.RegistryConfig{Port: port, UseControlSockets: true}}
 		got, _ := docker.NewDeployment(composeFile, opts)
@@ -94,7 +94,7 @@ func TestNewDeployment(t *testing.T) {
 	})
 
 	t.Run("returns an SSH tunnel cleanup operation for remote host", func(t *testing.T) {
-		remoteHost := ssh.Destination("user@remote")
+		remoteHost := ssh.MustNewDestination("user@remote")
 		deployOpts := docker.DeployOptions{TargetHost: remoteHost, Registry: &docker.RegistryConfig{UseControlSockets: true}}
 		_, cleanup := docker.NewDeployment(composeFile, deployOpts)
 
@@ -112,7 +112,7 @@ func TestNewDeployment(t *testing.T) {
 	})
 
 	t.Run("does not use SSH control sockets when disabled", func(t *testing.T) {
-		remoteHost := ssh.Destination("user@remote")
+		remoteHost := ssh.MustNewDestination("user@remote")
 		port := operation.DefaultRegistryPort
 		opts := docker.DeployOptions{TargetHost: remoteHost, Registry: &docker.RegistryConfig{Port: port, UseControlSockets: false}}
 		got, _ := docker.NewDeployment(composeFile, opts)
@@ -142,7 +142,7 @@ func TestDeployment(t *testing.T) {
 		target := testutil.StartTargetContainer(t)
 
 		t.Run("builds images, transfers them, and starts services", func(t *testing.T) {
-			remoteDockerHost := ssh.Destination(target.SSHDestination)
+			remoteDockerHost := ssh.MustNewDestination(target.SSHDestination)
 			tmpDir := t.TempDir()
 			dockerFilePath := filepath.Join(tmpDir, "Dockerfile")
 			dockerFileContent := `
@@ -186,7 +186,7 @@ services:
     image: busybox
 `
 			testutil.RequireWriteFile(t, composeFilePath, composeFileContent)
-			deployOpts := docker.DeployOptions{TargetHost: ssh.Destination("user@remote")}
+			deployOpts := docker.DeployOptions{TargetHost: ssh.MustNewDestination("user@remote")}
 			d, _ := docker.NewDeployment(composeFilePath, deployOpts)
 
 			err := d.DryRun(&buf)

--- a/internal/deploy/docker/deploy_test.go
+++ b/internal/deploy/docker/deploy_test.go
@@ -20,7 +20,7 @@ func TestNewDeployment(t *testing.T) {
 	composeFile := "compose.yaml"
 
 	t.Run("includes transfer operation for remote host", func(t *testing.T) {
-		remoteHost := ssh.MustNewDestination("user@remote")
+		remoteHost := testutil.MustNewDestination("user@remote")
 		deployOpts := docker.DeployOptions{TargetHost: remoteHost}
 		got, _ := docker.NewDeployment(composeFile, deployOpts)
 
@@ -34,7 +34,7 @@ func TestNewDeployment(t *testing.T) {
 	})
 
 	t.Run("includes registry operations for remote host when enabled", func(t *testing.T) {
-		remoteHost := ssh.MustNewDestination("user@remote")
+		remoteHost := testutil.MustNewDestination("user@remote")
 		port := operation.DefaultRegistryPort
 		opts := docker.DeployOptions{TargetHost: remoteHost, Registry: &docker.RegistryConfig{Port: port, UseControlSockets: true}}
 		got, _ := docker.NewDeployment(composeFile, opts)
@@ -94,7 +94,7 @@ func TestNewDeployment(t *testing.T) {
 	})
 
 	t.Run("returns an SSH tunnel cleanup operation for remote host", func(t *testing.T) {
-		remoteHost := ssh.MustNewDestination("user@remote")
+		remoteHost := testutil.MustNewDestination("user@remote")
 		deployOpts := docker.DeployOptions{TargetHost: remoteHost, Registry: &docker.RegistryConfig{UseControlSockets: true}}
 		_, cleanup := docker.NewDeployment(composeFile, deployOpts)
 
@@ -112,7 +112,7 @@ func TestNewDeployment(t *testing.T) {
 	})
 
 	t.Run("does not use SSH control sockets when disabled", func(t *testing.T) {
-		remoteHost := ssh.MustNewDestination("user@remote")
+		remoteHost := testutil.MustNewDestination("user@remote")
 		port := operation.DefaultRegistryPort
 		opts := docker.DeployOptions{TargetHost: remoteHost, Registry: &docker.RegistryConfig{Port: port, UseControlSockets: false}}
 		got, _ := docker.NewDeployment(composeFile, opts)
@@ -142,7 +142,7 @@ func TestDeployment(t *testing.T) {
 		target := testutil.StartTargetContainer(t)
 
 		t.Run("builds images, transfers them, and starts services", func(t *testing.T) {
-			remoteDockerHost := ssh.MustNewDestination(target.SSHDestination)
+			remoteDockerHost := testutil.MustNewDestination(target.SSHDestination)
 			tmpDir := t.TempDir()
 			dockerFilePath := filepath.Join(tmpDir, "Dockerfile")
 			dockerFileContent := `
@@ -186,7 +186,7 @@ services:
     image: busybox
 `
 			testutil.RequireWriteFile(t, composeFilePath, composeFileContent)
-			deployOpts := docker.DeployOptions{TargetHost: ssh.MustNewDestination("user@remote")}
+			deployOpts := docker.DeployOptions{TargetHost: testutil.MustNewDestination("user@remote")}
 			d, _ := docker.NewDeployment(composeFilePath, deployOpts)
 
 			err := d.DryRun(&buf)

--- a/internal/deploy/docker/operation/docker_compose_test.go
+++ b/internal/deploy/docker/operation/docker_compose_test.go
@@ -41,7 +41,7 @@ services:
 			var buf bytes.Buffer
 			tmpDir := t.TempDir()
 			composeFilePath := filepath.Join(tmpDir, "compose.yaml")
-			remoteHost := ssh.MustNewDestination("user@remote")
+			remoteHost := testutil.MustNewDestination("user@remote")
 			op := operation.NewDockerCompose("", composeFilePath, remoteHost, []string{"up", "-d", "--no-build"})
 
 			err := op.DryRun(&buf)
@@ -56,7 +56,7 @@ services:
 
 func TestNewDockerComposeBuild(t *testing.T) {
 	composeFilePath := "/path/to/compose.yaml"
-	remoteHost := ssh.MustNewDestination("user@remote")
+	remoteHost := testutil.MustNewDestination("user@remote")
 	op := operation.NewDockerComposeBuild(composeFilePath, remoteHost)
 
 	t.Run("Description", func(t *testing.T) {
@@ -78,7 +78,7 @@ func TestNewDockerComposeBuild(t *testing.T) {
 
 func TestNewDockerComposePull(t *testing.T) {
 	composeFilePath := "/path/to/compose.yaml"
-	remoteHost := ssh.MustNewDestination("user@remote")
+	remoteHost := testutil.MustNewDestination("user@remote")
 	op := operation.NewDockerComposePull(composeFilePath, remoteHost)
 
 	t.Run("Description", func(t *testing.T) {
@@ -100,7 +100,7 @@ func TestNewDockerComposePull(t *testing.T) {
 
 func TestNewDockerComposeRun(t *testing.T) {
 	composeFilePath := "/path/to/compose.yaml"
-	remoteHost := ssh.MustNewDestination("user@remote")
+	remoteHost := testutil.MustNewDestination("user@remote")
 	opDefault := operation.NewDockerComposeUp(composeFilePath, remoteHost, operation.RecreateModeDefault)
 
 	t.Run("Description", func(t *testing.T) {

--- a/internal/deploy/docker/operation/docker_compose_test.go
+++ b/internal/deploy/docker/operation/docker_compose_test.go
@@ -41,7 +41,7 @@ services:
 			var buf bytes.Buffer
 			tmpDir := t.TempDir()
 			composeFilePath := filepath.Join(tmpDir, "compose.yaml")
-			remoteHost := ssh.Destination("user@remote")
+			remoteHost := ssh.MustNewDestination("user@remote")
 			op := operation.NewDockerCompose("", composeFilePath, remoteHost, []string{"up", "-d", "--no-build"})
 
 			err := op.DryRun(&buf)
@@ -56,7 +56,7 @@ services:
 
 func TestNewDockerComposeBuild(t *testing.T) {
 	composeFilePath := "/path/to/compose.yaml"
-	remoteHost := ssh.Destination("user@remote")
+	remoteHost := ssh.MustNewDestination("user@remote")
 	op := operation.NewDockerComposeBuild(composeFilePath, remoteHost)
 
 	t.Run("Description", func(t *testing.T) {
@@ -78,7 +78,7 @@ func TestNewDockerComposeBuild(t *testing.T) {
 
 func TestNewDockerComposePull(t *testing.T) {
 	composeFilePath := "/path/to/compose.yaml"
-	remoteHost := ssh.Destination("user@remote")
+	remoteHost := ssh.MustNewDestination("user@remote")
 	op := operation.NewDockerComposePull(composeFilePath, remoteHost)
 
 	t.Run("Description", func(t *testing.T) {
@@ -100,7 +100,7 @@ func TestNewDockerComposePull(t *testing.T) {
 
 func TestNewDockerComposeRun(t *testing.T) {
 	composeFilePath := "/path/to/compose.yaml"
-	remoteHost := ssh.Destination("user@remote")
+	remoteHost := ssh.MustNewDestination("user@remote")
 	opDefault := operation.NewDockerComposeUp(composeFilePath, remoteHost, operation.RecreateModeDefault)
 
 	t.Run("Description", func(t *testing.T) {

--- a/internal/deploy/docker/operation/docker_compose_transfer.go
+++ b/internal/deploy/docker/operation/docker_compose_transfer.go
@@ -14,14 +14,14 @@ import (
 
 type DockerComposePipeTransfer struct {
 	composeFile string
-	sourceHost  ssh.Destination
+	source      ssh.Destination
 	dest        ssh.Destination
 }
 
-func NewDockerComposePipeTransfer(composeFile string, sourceHost, dest ssh.Destination) *DockerComposePipeTransfer {
+func NewDockerComposePipeTransfer(composeFile string, source, dest ssh.Destination) *DockerComposePipeTransfer {
 	return &DockerComposePipeTransfer{
 		composeFile: composeFile,
-		sourceHost:  sourceHost,
+		source:      source,
 		dest:        dest,
 	}
 }
@@ -60,13 +60,13 @@ func (t *DockerComposePipeTransfer) DryRun(output io.Writer) error {
 }
 
 func (t *DockerComposePipeTransfer) buildTransferCommands(imageName string) (*exec.Cmd, *exec.Cmd) {
-	saveCmd := command.Docker(t.sourceHost, "save", imageName)
+	saveCmd := command.Docker(t.source, "save", imageName)
 	loadCmd := command.Docker(t.dest, "load")
 	return saveCmd, loadCmd
 }
 
 func (t *DockerComposePipeTransfer) getImagesFromCompose(cmdOutput io.Writer) ([]string, error) {
-	cmd := command.DockerCompose(t.sourceHost, t.composeFile, "config", "--images")
+	cmd := command.DockerCompose(t.source, t.composeFile, "config", "--images")
 	cmd.Stderr = cmdOutput
 	output, err := cmd.Output()
 	if err != nil {

--- a/internal/deploy/docker/operation/docker_compose_transfer.go
+++ b/internal/deploy/docker/operation/docker_compose_transfer.go
@@ -15,14 +15,14 @@ import (
 type DockerComposePipeTransfer struct {
 	composeFile string
 	sourceHost  ssh.Destination
-	targetHost  ssh.Destination
+	dest  ssh.Destination
 }
 
-func NewDockerComposePipeTransfer(composeFile string, sourceHost, targetHost ssh.Destination) *DockerComposePipeTransfer {
+func NewDockerComposePipeTransfer(composeFile string, sourceHost, dest ssh.Destination) *DockerComposePipeTransfer {
 	return &DockerComposePipeTransfer{
 		composeFile: composeFile,
 		sourceHost:  sourceHost,
-		targetHost:  targetHost,
+		dest:  dest,
 	}
 }
 
@@ -61,7 +61,7 @@ func (t *DockerComposePipeTransfer) DryRun(output io.Writer) error {
 
 func (t *DockerComposePipeTransfer) buildTransferCommands(imageName string) (*exec.Cmd, *exec.Cmd) {
 	saveCmd := command.Docker(t.sourceHost, "save", imageName)
-	loadCmd := command.Docker(t.targetHost, "load")
+	loadCmd := command.Docker(t.dest, "load")
 	return saveCmd, loadCmd
 }
 

--- a/internal/deploy/docker/operation/docker_compose_transfer.go
+++ b/internal/deploy/docker/operation/docker_compose_transfer.go
@@ -15,14 +15,14 @@ import (
 type DockerComposePipeTransfer struct {
 	composeFile string
 	sourceHost  ssh.Destination
-	dest  ssh.Destination
+	dest        ssh.Destination
 }
 
 func NewDockerComposePipeTransfer(composeFile string, sourceHost, dest ssh.Destination) *DockerComposePipeTransfer {
 	return &DockerComposePipeTransfer{
 		composeFile: composeFile,
 		sourceHost:  sourceHost,
-		dest:  dest,
+		dest:        dest,
 	}
 }
 

--- a/internal/deploy/docker/operation/docker_compose_transfer_test.go
+++ b/internal/deploy/docker/operation/docker_compose_transfer_test.go
@@ -80,7 +80,7 @@ services:
     image: nginx:latest
 `
 			testutil.RequireWriteFile(t, composeFilePath, composeFileContent)
-			transfer := operation.NewDockerComposePipeTransfer(composeFilePath, h, ssh.MustNewDestination("user@remote"))
+			transfer := operation.NewDockerComposePipeTransfer(composeFilePath, h, testutil.MustNewDestination("user@remote"))
 
 			err := transfer.DryRun(&buf)
 

--- a/internal/deploy/docker/operation/docker_compose_transfer_test.go
+++ b/internal/deploy/docker/operation/docker_compose_transfer_test.go
@@ -80,7 +80,7 @@ services:
     image: nginx:latest
 `
 			testutil.RequireWriteFile(t, composeFilePath, composeFileContent)
-			transfer := operation.NewDockerComposePipeTransfer(composeFilePath, h, ssh.Destination("user@remote"))
+			transfer := operation.NewDockerComposePipeTransfer(composeFilePath, h, ssh.MustNewDestination("user@remote"))
 
 			err := transfer.DryRun(&buf)
 

--- a/internal/deploy/docker/operation/docker_test.go
+++ b/internal/deploy/docker/operation/docker_test.go
@@ -30,7 +30,7 @@ func TestDocker(t *testing.T) {
 	t.Run("DryRun", func(t *testing.T) {
 		t.Run("prints command with multiple args and remote host", func(t *testing.T) {
 			var buf bytes.Buffer
-			remoteHost := ssh.MustNewDestination("user@remote")
+			remoteHost := testutil.MustNewDestination("user@remote")
 			op := operation.NewDocker("Test operation", remoteHost, []string{"ps", "-a", "--format", "json"})
 
 			err := op.DryRun(&buf)
@@ -68,7 +68,7 @@ func TestDocker(t *testing.T) {
 
 func TestNewDockerPull(t *testing.T) {
 	image := "nginx:latest"
-	remoteHost := ssh.MustNewDestination("user@remote")
+	remoteHost := testutil.MustNewDestination("user@remote")
 	op := operation.NewDockerPull(remoteHost, image)
 
 	t.Run("Description", func(t *testing.T) {
@@ -90,7 +90,7 @@ func TestNewDockerPull(t *testing.T) {
 
 func TestNewDockerStart(t *testing.T) {
 	container := "my-container"
-	remoteHost := ssh.MustNewDestination("user@remote")
+	remoteHost := testutil.MustNewDestination("user@remote")
 	op := operation.NewDockerStart(remoteHost, container)
 
 	t.Run("Description", func(t *testing.T) {
@@ -113,7 +113,7 @@ func TestNewDockerStart(t *testing.T) {
 func TestNewDockerRun(t *testing.T) {
 	image := "alpine:latest"
 	container := "test-container"
-	remoteHost := ssh.MustNewDestination("user@remote")
+	remoteHost := testutil.MustNewDestination("user@remote")
 
 	t.Run("Description", func(t *testing.T) {
 		op := operation.NewDockerRun(remoteHost, image, container, []string{"-d"})

--- a/internal/deploy/docker/operation/docker_test.go
+++ b/internal/deploy/docker/operation/docker_test.go
@@ -30,7 +30,7 @@ func TestDocker(t *testing.T) {
 	t.Run("DryRun", func(t *testing.T) {
 		t.Run("prints command with multiple args and remote host", func(t *testing.T) {
 			var buf bytes.Buffer
-			remoteHost := ssh.Destination("user@remote")
+			remoteHost := ssh.MustNewDestination("user@remote")
 			op := operation.NewDocker("Test operation", remoteHost, []string{"ps", "-a", "--format", "json"})
 
 			err := op.DryRun(&buf)
@@ -68,7 +68,7 @@ func TestDocker(t *testing.T) {
 
 func TestNewDockerPull(t *testing.T) {
 	image := "nginx:latest"
-	remoteHost := ssh.Destination("user@remote")
+	remoteHost := ssh.MustNewDestination("user@remote")
 	op := operation.NewDockerPull(remoteHost, image)
 
 	t.Run("Description", func(t *testing.T) {
@@ -90,7 +90,7 @@ func TestNewDockerPull(t *testing.T) {
 
 func TestNewDockerStart(t *testing.T) {
 	container := "my-container"
-	remoteHost := ssh.Destination("user@remote")
+	remoteHost := ssh.MustNewDestination("user@remote")
 	op := operation.NewDockerStart(remoteHost, container)
 
 	t.Run("Description", func(t *testing.T) {
@@ -113,7 +113,7 @@ func TestNewDockerStart(t *testing.T) {
 func TestNewDockerRun(t *testing.T) {
 	image := "alpine:latest"
 	container := "test-container"
-	remoteHost := ssh.Destination("user@remote")
+	remoteHost := ssh.MustNewDestination("user@remote")
 
 	t.Run("Description", func(t *testing.T) {
 		op := operation.NewDockerRun(remoteHost, image, container, []string{"-d"})

--- a/internal/deploy/docker/operation/registry_transfer.go
+++ b/internal/deploy/docker/operation/registry_transfer.go
@@ -18,7 +18,7 @@ var digestRegexp = regexp.MustCompile(`digest: (sha256:[a-f0-9]+)`)
 type RegistryTransfer struct {
 	composeFile string
 	sourceHost  ssh.Destination
-	dest  ssh.Destination
+	dest        ssh.Destination
 	port        string
 }
 

--- a/internal/deploy/docker/operation/registry_transfer.go
+++ b/internal/deploy/docker/operation/registry_transfer.go
@@ -17,13 +17,13 @@ var digestRegexp = regexp.MustCompile(`digest: (sha256:[a-f0-9]+)`)
 
 type RegistryTransfer struct {
 	composeFile string
-	sourceHost  ssh.Destination
+	source      ssh.Destination
 	dest        ssh.Destination
 	port        string
 }
 
 func NewRegistryTransfer(composeFile string, sourceHost, dest ssh.Destination, port string) *RegistryTransfer {
-	return &RegistryTransfer{composeFile: composeFile, sourceHost: sourceHost, dest: dest, port: port}
+	return &RegistryTransfer{composeFile: composeFile, source: sourceHost, dest: dest, port: port}
 }
 
 func (r *RegistryTransfer) Description() string {
@@ -58,7 +58,7 @@ func (r *RegistryTransfer) DryRun(w io.Writer) error {
 }
 
 func (r *RegistryTransfer) getImagesFromCompose(w io.Writer) ([]string, error) {
-	cmd := command.DockerCompose(r.sourceHost, r.composeFile, "config", "--images")
+	cmd := command.DockerCompose(r.source, r.composeFile, "config", "--images")
 	cmd.Stderr = w
 	out, err := cmd.Output()
 	if err != nil {
@@ -76,8 +76,8 @@ func (r *RegistryTransfer) buildTransferCommands(image string) []*exec.Cmd {
 	tag := fmt.Sprintf("localhost:%s/%s", r.port, image)
 	digestRef := fmt.Sprintf("localhost:%s/%s@<digest>", r.port, image)
 	return []*exec.Cmd{
-		command.Docker(r.sourceHost, "tag", image, tag),
-		command.Docker(r.sourceHost, "push", tag),
+		command.Docker(r.source, "tag", image, tag),
+		command.Docker(r.source, "push", tag),
 		command.Docker(r.dest, "pull", digestRef),
 		command.Docker(r.dest, "tag", digestRef, image),
 	}
@@ -86,12 +86,12 @@ func (r *RegistryTransfer) buildTransferCommands(image string) []*exec.Cmd {
 func (r *RegistryTransfer) transferImage(w io.Writer, image string) error {
 	tag := fmt.Sprintf("localhost:%s/%s", r.port, image)
 
-	tagCmd := command.Docker(r.sourceHost, "tag", image, tag)
+	tagCmd := command.Docker(r.source, "tag", image, tag)
 	if err := runCmd(tagCmd, w); err != nil {
 		return err
 	}
 
-	pushCmd := command.Docker(r.sourceHost, "push", tag)
+	pushCmd := command.Docker(r.source, "push", tag)
 	pushOutput, err := runCmdCaptureOutput(pushCmd, w)
 	if err != nil {
 		if hint := r.checkRegistryPortMismatch(); hint != "" {

--- a/internal/deploy/docker/operation/registry_transfer.go
+++ b/internal/deploy/docker/operation/registry_transfer.go
@@ -18,12 +18,12 @@ var digestRegexp = regexp.MustCompile(`digest: (sha256:[a-f0-9]+)`)
 type RegistryTransfer struct {
 	composeFile string
 	sourceHost  ssh.Destination
-	targetHost  ssh.Destination
+	dest  ssh.Destination
 	port        string
 }
 
-func NewRegistryTransfer(composeFile string, sourceHost, targetHost ssh.Destination, port string) *RegistryTransfer {
-	return &RegistryTransfer{composeFile: composeFile, sourceHost: sourceHost, targetHost: targetHost, port: port}
+func NewRegistryTransfer(composeFile string, sourceHost, dest ssh.Destination, port string) *RegistryTransfer {
+	return &RegistryTransfer{composeFile: composeFile, sourceHost: sourceHost, dest: dest, port: port}
 }
 
 func (r *RegistryTransfer) Description() string {
@@ -78,8 +78,8 @@ func (r *RegistryTransfer) buildTransferCommands(image string) []*exec.Cmd {
 	return []*exec.Cmd{
 		command.Docker(r.sourceHost, "tag", image, tag),
 		command.Docker(r.sourceHost, "push", tag),
-		command.Docker(r.targetHost, "pull", digestRef),
-		command.Docker(r.targetHost, "tag", digestRef, image),
+		command.Docker(r.dest, "pull", digestRef),
+		command.Docker(r.dest, "tag", digestRef, image),
 	}
 }
 
@@ -106,12 +106,12 @@ func (r *RegistryTransfer) transferImage(w io.Writer, image string) error {
 	}
 
 	digestRef := fmt.Sprintf("localhost:%s/%s@%s", r.port, image, digest)
-	pullCmd := command.Docker(r.targetHost, "pull", digestRef)
+	pullCmd := command.Docker(r.dest, "pull", digestRef)
 	if err := runCmd(pullCmd, w); err != nil {
 		return err
 	}
 
-	retagCmd := command.Docker(r.targetHost, "tag", digestRef, image)
+	retagCmd := command.Docker(r.dest, "tag", digestRef, image)
 	if err := runCmd(retagCmd, w); err != nil {
 		return err
 	}

--- a/internal/deploy/docker/operation/registry_transfer_test.go
+++ b/internal/deploy/docker/operation/registry_transfer_test.go
@@ -82,7 +82,7 @@ services:
     image: nginx:latest
 `
 			testutil.RequireWriteFile(t, composeFilePath, composeFileContent)
-			transfer := operation.NewRegistryTransfer(composeFilePath, h, ssh.MustNewDestination("user@remote"), port)
+			transfer := operation.NewRegistryTransfer(composeFilePath, h, testutil.MustNewDestination("user@remote"), port)
 
 			err := transfer.DryRun(&buf)
 

--- a/internal/deploy/docker/operation/registry_transfer_test.go
+++ b/internal/deploy/docker/operation/registry_transfer_test.go
@@ -82,7 +82,7 @@ services:
     image: nginx:latest
 `
 			testutil.RequireWriteFile(t, composeFilePath, composeFileContent)
-			transfer := operation.NewRegistryTransfer(composeFilePath, h, ssh.Destination("user@remote"), port)
+			transfer := operation.NewRegistryTransfer(composeFilePath, h, ssh.MustNewDestination("user@remote"), port)
 
 			err := transfer.DryRun(&buf)
 

--- a/internal/deploy/docker/stop_test.go
+++ b/internal/deploy/docker/stop_test.go
@@ -20,7 +20,7 @@ func TestNewDeploymentStop(t *testing.T) {
 	composeFile := "compose.yaml"
 
 	t.Run("runs stop operation for remote host", func(t *testing.T) {
-		remoteHost := ssh.Destination("user@remote")
+		remoteHost := ssh.MustNewDestination("user@remote")
 
 		got := docker.NewDeploymentStop(composeFile, remoteHost)
 
@@ -47,7 +47,7 @@ func TestDeploymentStop(t *testing.T) {
 		target := testutil.StartTargetContainer(t)
 
 		t.Run("deploys services then confirms stop shuts down containers", func(t *testing.T) {
-			remoteDockerHost := ssh.Destination(target.SSHDestination)
+			remoteDockerHost := ssh.MustNewDestination(target.SSHDestination)
 			tmpDir := t.TempDir()
 			dockerFilePath := filepath.Join(tmpDir, "Dockerfile")
 			dockerFileContent := `
@@ -93,7 +93,7 @@ services:
     image: alpine:latest
 `
 			testutil.RequireWriteFile(t, composeFilePath, composeFileContent)
-			targetHost := ssh.Destination("user@remote")
+			targetHost := ssh.MustNewDestination("user@remote")
 			stop := docker.NewDeploymentStop(composeFilePath, targetHost)
 
 			err := stop.DryRun(&buf)

--- a/internal/deploy/docker/stop_test.go
+++ b/internal/deploy/docker/stop_test.go
@@ -93,8 +93,8 @@ services:
     image: alpine:latest
 `
 			testutil.RequireWriteFile(t, composeFilePath, composeFileContent)
-			targetHost := ssh.MustNewDestination("user@remote")
-			stop := docker.NewDeploymentStop(composeFilePath, targetHost)
+			dest := ssh.MustNewDestination("user@remote")
+			stop := docker.NewDeploymentStop(composeFilePath, dest)
 
 			err := stop.DryRun(&buf)
 

--- a/internal/deploy/docker/stop_test.go
+++ b/internal/deploy/docker/stop_test.go
@@ -20,7 +20,7 @@ func TestNewDeploymentStop(t *testing.T) {
 	composeFile := "compose.yaml"
 
 	t.Run("runs stop operation for remote host", func(t *testing.T) {
-		remoteHost := ssh.MustNewDestination("user@remote")
+		remoteHost := testutil.MustNewDestination("user@remote")
 
 		got := docker.NewDeploymentStop(composeFile, remoteHost)
 
@@ -47,7 +47,7 @@ func TestDeploymentStop(t *testing.T) {
 		target := testutil.StartTargetContainer(t)
 
 		t.Run("deploys services then confirms stop shuts down containers", func(t *testing.T) {
-			remoteDockerHost := ssh.MustNewDestination(target.SSHDestination)
+			remoteDockerHost := testutil.MustNewDestination(target.SSHDestination)
 			tmpDir := t.TempDir()
 			dockerFilePath := filepath.Join(tmpDir, "Dockerfile")
 			dockerFileContent := `
@@ -93,7 +93,7 @@ services:
     image: alpine:latest
 `
 			testutil.RequireWriteFile(t, composeFilePath, composeFileContent)
-			dest := ssh.MustNewDestination("user@remote")
+			dest := testutil.MustNewDestination("user@remote")
 			stop := docker.NewDeploymentStop(composeFilePath, dest)
 
 			err := stop.DryRun(&buf)

--- a/internal/deploy/docker/testutil/testutil.go
+++ b/internal/deploy/docker/testutil/testutil.go
@@ -19,6 +19,7 @@ var (
 	RequireWriteFile         = gtestutil.RequireWriteFile
 	SanitiseTestName         = gtestutil.SanitiseTestName
 	StartTargetContainer     = gtestutil.StartTargetContainer
+	MustNewDestination       = gtestutil.MustNewDestination
 )
 
 func TestImageName(t *testing.T) string {

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/arm/topo/internal/ssh"
 	"github.com/arm/topo/internal/target"
 )
 
@@ -64,14 +65,14 @@ func CheckHost() HostReport {
 	return GenerateHostReport(dependencyStatuses)
 }
 
-func CheckTarget(sshTarget string, acceptNewHostKeys bool, connectTimeout time.Duration) (TargetReport, error) {
+func CheckTarget(dest ssh.Destination, acceptNewHostKeys bool, connectTimeout time.Duration) (TargetReport, error) {
 	opts := target.ConnectionOptions{
 		AcceptNewHostKeys: acceptNewHostKeys,
 		Multiplex:         true,
 		WithLoginShell:    true,
 		ConnectTimeout:    connectTimeout,
 	}
-	conn := target.NewConnection(sshTarget, opts)
+	conn := target.NewConnection(dest, opts)
 	targetStatus := ProbeHealthStatus(conn)
 	return GenerateTargetReport(targetStatus), nil
 }

--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/arm/topo/internal/health"
+	"github.com/arm/topo/internal/ssh"
 	"github.com/arm/topo/internal/target"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -75,14 +76,14 @@ func TestGenerateTargetReport(t *testing.T) {
 
 	t.Run("when password authentication is required, Connectivity includes a setup-keys fix", func(t *testing.T) {
 		ts := health.Status{
-			SSHTarget:       "user@my-target",
+			SSHTarget:       ssh.MustNewDestination("user@my-target"),
 			ConnectionError: target.ErrPasswordAuthentication,
 		}
 
 		got := health.GenerateTargetReport(ts)
 
 		assert.Equal(t, health.CheckStatusError, got.Connectivity.Status)
-		assert.Contains(t, got.Connectivity.Fix, "topo setup-keys --target user@my-target")
+		assert.Contains(t, got.Connectivity.Fix, "topo setup-keys --target ssh://user@my-target")
 	})
 }
 

--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 
 	"github.com/arm/topo/internal/health"
-	"github.com/arm/topo/internal/ssh"
 	"github.com/arm/topo/internal/target"
+	"github.com/arm/topo/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -76,7 +76,7 @@ func TestGenerateTargetReport(t *testing.T) {
 
 	t.Run("when password authentication is required, Connectivity includes a setup-keys fix", func(t *testing.T) {
 		ts := health.Status{
-			SSHTarget:       ssh.MustNewDestination("user@my-target"),
+			SSHTarget:       testutil.MustNewDestination("user@my-target"),
 			ConnectionError: target.ErrPasswordAuthentication,
 		}
 

--- a/internal/health/status_test.go
+++ b/internal/health/status_test.go
@@ -18,7 +18,7 @@ func TestProbeHealthStatus(t *testing.T) {
 			return testutil.CmdWithOutput("connection refused", 1)
 		}
 
-		conn := target.NewConnection("hostname", target.ConnectionOptions{WithMockExec: mockExec})
+		conn := target.NewConnection(ssh.MustNewDestination("hostname"), target.ConnectionOptions{WithMockExec: mockExec})
 		ts := health.ProbeHealthStatus(conn)
 
 		assert.Error(t, ts.ConnectionError)
@@ -39,7 +39,7 @@ func TestProbeHealthStatus(t *testing.T) {
 			}
 		}
 
-		conn := target.NewConnection("hostname", target.ConnectionOptions{WithMockExec: mockExec})
+		conn := target.NewConnection(ssh.MustNewDestination("hostname"), target.ConnectionOptions{WithMockExec: mockExec})
 		ts := health.ProbeHealthStatus(conn)
 
 		want := health.HardwareProfile{RemoteCPU: []target.RemoteprocCPU{{Name: "foo"}, {Name: "bar"}}}
@@ -57,7 +57,7 @@ func TestProbeHealthStatus(t *testing.T) {
 			}
 		}
 
-		conn := target.NewConnection("hostname", target.ConnectionOptions{WithMockExec: mockExec})
+		conn := target.NewConnection(ssh.MustNewDestination("hostname"), target.ConnectionOptions{WithMockExec: mockExec})
 		ts := health.ProbeHealthStatus(conn)
 
 		assert.NoError(t, ts.ConnectionError)

--- a/internal/health/status_test.go
+++ b/internal/health/status_test.go
@@ -18,7 +18,7 @@ func TestProbeHealthStatus(t *testing.T) {
 			return testutil.CmdWithOutput("connection refused", 1)
 		}
 
-		conn := target.NewConnection(ssh.MustNewDestination("hostname"), target.ConnectionOptions{WithMockExec: mockExec})
+		conn := target.NewConnection(testutil.MustNewDestination("hostname"), target.ConnectionOptions{WithMockExec: mockExec})
 		ts := health.ProbeHealthStatus(conn)
 
 		assert.Error(t, ts.ConnectionError)
@@ -39,7 +39,7 @@ func TestProbeHealthStatus(t *testing.T) {
 			}
 		}
 
-		conn := target.NewConnection(ssh.MustNewDestination("hostname"), target.ConnectionOptions{WithMockExec: mockExec})
+		conn := target.NewConnection(testutil.MustNewDestination("hostname"), target.ConnectionOptions{WithMockExec: mockExec})
 		ts := health.ProbeHealthStatus(conn)
 
 		want := health.HardwareProfile{RemoteCPU: []target.RemoteprocCPU{{Name: "foo"}, {Name: "bar"}}}
@@ -57,7 +57,7 @@ func TestProbeHealthStatus(t *testing.T) {
 			}
 		}
 
-		conn := target.NewConnection(ssh.MustNewDestination("hostname"), target.ConnectionOptions{WithMockExec: mockExec})
+		conn := target.NewConnection(testutil.MustNewDestination("hostname"), target.ConnectionOptions{WithMockExec: mockExec})
 		ts := health.ProbeHealthStatus(conn)
 
 		assert.NoError(t, ts.ConnectionError)

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -33,7 +33,7 @@ type PathCandidate struct {
 }
 
 func getPathDirs(targetDest ssh.Destination) ([]string, error) {
-	conn := target.NewConnection(string(targetDest), target.ConnectionOptions{WithLoginShell: true})
+	conn := target.NewConnection(targetDest, target.ConnectionOptions{WithLoginShell: true})
 	output, err := conn.Run("echo $PATH")
 	if err != nil {
 		return nil, err
@@ -46,7 +46,7 @@ func getPathDirs(targetDest ssh.Destination) ([]string, error) {
 }
 
 func getHomeDir(targetDest ssh.Destination) (string, error) {
-	conn := target.NewConnection(string(targetDest), target.ConnectionOptions{WithLoginShell: true})
+	conn := target.NewConnection(targetDest, target.ConnectionOptions{WithLoginShell: true})
 	output, err := conn.Run("echo $HOME")
 	if err != nil {
 		return "", err
@@ -55,7 +55,7 @@ func getHomeDir(targetDest ssh.Destination) (string, error) {
 }
 
 func getExistingBinaryDir(targetDest ssh.Destination, binaryName string) (string, error) {
-	conn := target.NewConnection(string(targetDest), target.ConnectionOptions{WithLoginShell: true})
+	conn := target.NewConnection(targetDest, target.ConnectionOptions{WithLoginShell: true})
 	output, err := conn.Run(fmt.Sprintf("command -v %s", binaryName))
 	if err != nil {
 		return "", nil
@@ -280,7 +280,7 @@ func install(installPath string, targetDest ssh.Destination, binaries map[string
 		}
 
 		installCmd := fmt.Sprintf("install -D -m %s /dev/stdin %s/%s", mode, installPath, binaryName)
-		conn := target.NewConnection(string(targetDest), target.ConnectionOptions{WithLoginShell: true, WithStdin: binaryData})
+		conn := target.NewConnection(targetDest, target.ConnectionOptions{WithLoginShell: true, WithStdin: binaryData})
 		output, err := conn.Run(installCmd)
 		if err != nil {
 			if errors.Is(err, ssh.ErrSSH) {

--- a/internal/setupkeys/pubkeytransfer/pub_key_transfer.go
+++ b/internal/setupkeys/pubkeytransfer/pub_key_transfer.go
@@ -13,7 +13,7 @@ const remoteAuthorizedKeysCommand = "mkdir -p ~/.ssh && chmod 700 ~/.ssh && cat 
 
 type PubKeyTransfer struct {
 	description string
-	targetHost  ssh.Destination
+	dest  ssh.Destination
 	pubKeyPath  string
 	opts        PubKeyTransferOptions
 }
@@ -22,8 +22,8 @@ type PubKeyTransferOptions struct {
 	WithMockExec target.ExecSSH
 }
 
-func NewPubKeyTransfer(description string, targetHost ssh.Destination, privKeyPath string, opts PubKeyTransferOptions) *PubKeyTransfer {
-	return &PubKeyTransfer{description: description, targetHost: targetHost, pubKeyPath: privKeyPath + ".pub", opts: opts}
+func NewPubKeyTransfer(description string, dest ssh.Destination, privKeyPath string, opts PubKeyTransferOptions) *PubKeyTransfer {
+	return &PubKeyTransfer{description: description, dest: dest, pubKeyPath: privKeyPath + ".pub", opts: opts}
 }
 
 func (kt *PubKeyTransfer) Description() string {
@@ -37,7 +37,7 @@ func (kt *PubKeyTransfer) buildTransferConnection(stdin []byte) *target.Connecti
 		opts.WithMockExec = kt.opts.WithMockExec
 	}
 
-	conn := target.NewConnection(kt.targetHost, opts)
+	conn := target.NewConnection(kt.dest, opts)
 
 	return &conn
 }
@@ -51,7 +51,7 @@ func (kt *PubKeyTransfer) Run(outputWriter io.Writer) error {
 	conn := kt.buildTransferConnection(pubKey)
 	cmdOutput, err := conn.Run(remoteAuthorizedKeysCommand)
 	if err != nil {
-		return fmt.Errorf("failed to transfer public key to target %s: %w", kt.targetHost, err)
+		return fmt.Errorf("failed to transfer public key to target %s: %w", kt.dest, err)
 	}
 	_, err = outputWriter.Write([]byte(cmdOutput))
 	return err
@@ -60,7 +60,7 @@ func (kt *PubKeyTransfer) Run(outputWriter io.Writer) error {
 func (kt *PubKeyTransfer) DryRun(output io.Writer) error {
 	conn := kt.buildTransferConnection(nil)
 	if err := conn.DryRun(remoteAuthorizedKeysCommand, output); err != nil {
-		return fmt.Errorf("failed to write dry-run output for public key transfer to target %s: %w", kt.targetHost, err)
+		return fmt.Errorf("failed to write dry-run output for public key transfer to target %s: %w", kt.dest, err)
 	}
 	return nil
 }

--- a/internal/setupkeys/pubkeytransfer/pub_key_transfer.go
+++ b/internal/setupkeys/pubkeytransfer/pub_key_transfer.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 
+	"github.com/arm/topo/internal/ssh"
 	target "github.com/arm/topo/internal/target"
 )
 
@@ -12,7 +13,7 @@ const remoteAuthorizedKeysCommand = "mkdir -p ~/.ssh && chmod 700 ~/.ssh && cat 
 
 type PubKeyTransfer struct {
 	description string
-	targetHost  string
+	targetHost  ssh.Destination
 	pubKeyPath  string
 	opts        PubKeyTransferOptions
 }
@@ -21,7 +22,7 @@ type PubKeyTransferOptions struct {
 	WithMockExec target.ExecSSH
 }
 
-func NewPubKeyTransfer(description string, targetHost string, privKeyPath string, opts PubKeyTransferOptions) *PubKeyTransfer {
+func NewPubKeyTransfer(description string, targetHost ssh.Destination, privKeyPath string, opts PubKeyTransferOptions) *PubKeyTransfer {
 	return &PubKeyTransfer{description: description, targetHost: targetHost, pubKeyPath: privKeyPath + ".pub", opts: opts}
 }
 

--- a/internal/setupkeys/pubkeytransfer/pub_key_transfer.go
+++ b/internal/setupkeys/pubkeytransfer/pub_key_transfer.go
@@ -13,7 +13,7 @@ const remoteAuthorizedKeysCommand = "mkdir -p ~/.ssh && chmod 700 ~/.ssh && cat 
 
 type PubKeyTransfer struct {
 	description string
-	dest  ssh.Destination
+	dest        ssh.Destination
 	pubKeyPath  string
 	opts        PubKeyTransferOptions
 }

--- a/internal/setupkeys/pubkeytransfer/pub_key_transfer_test.go
+++ b/internal/setupkeys/pubkeytransfer/pub_key_transfer_test.go
@@ -16,12 +16,12 @@ import (
 func TestPubKeyTransferDryRun(t *testing.T) {
 	tmp := t.TempDir()
 	privKeyPath := filepath.Join(tmp, "id_ed25519_testrun")
-	op := pubkeytransfer.NewPubKeyTransfer("Transfer public key", "hola@chau", privKeyPath, pubkeytransfer.PubKeyTransferOptions{})
+	op := pubkeytransfer.NewPubKeyTransfer("Transfer public key", ssh.MustNewDestination("hola@chau"), privKeyPath, pubkeytransfer.PubKeyTransferOptions{})
 
 	var buf bytes.Buffer
 	require.NoError(t, op.DryRun(&buf))
 	output := buf.String()
-	require.Contains(t, output, "ssh -- hola@chau")
+	require.Contains(t, output, "ssh -- ssh://hola@chau")
 	require.Contains(t, output, "mkdir -p ~/.ssh && chmod 700 ~/.ssh && cat >> ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys")
 }
 
@@ -48,7 +48,7 @@ func TestPubKeyTransferRun(t *testing.T) {
 		}
 		return cmd
 	}}
-	op := pubkeytransfer.NewPubKeyTransfer("Transfer public key", "thing1@thing2.com", privKeyPath, opts)
+	op := pubkeytransfer.NewPubKeyTransfer("Transfer public key", ssh.MustNewDestination("thing1@thing2.com"), privKeyPath, opts)
 
 	var buf bytes.Buffer
 	require.NoError(t, op.Run(&buf))

--- a/internal/setupkeys/pubkeytransfer/pub_key_transfer_test.go
+++ b/internal/setupkeys/pubkeytransfer/pub_key_transfer_test.go
@@ -53,7 +53,7 @@ func TestPubKeyTransferRun(t *testing.T) {
 	var buf bytes.Buffer
 	require.NoError(t, op.Run(&buf))
 	require.Contains(t, buf.String(), "ssh invoked")
-	require.Equal(t, ssh.Destination("thing1@thing2.com"), got.dest)
+	require.Equal(t, ssh.MustNewDestination("thing1@thing2.com"), got.dest)
 	require.Contains(t, got.cmd, "mkdir -p ~/.ssh && chmod 700 ~/.ssh && cat >> ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys")
 	require.Equal(t, pubKeyContent, got.stdin)
 	require.Empty(t, got.args)

--- a/internal/setupkeys/pubkeytransfer/pub_key_transfer_test.go
+++ b/internal/setupkeys/pubkeytransfer/pub_key_transfer_test.go
@@ -16,7 +16,7 @@ import (
 func TestPubKeyTransferDryRun(t *testing.T) {
 	tmp := t.TempDir()
 	privKeyPath := filepath.Join(tmp, "id_ed25519_testrun")
-	op := pubkeytransfer.NewPubKeyTransfer("Transfer public key", ssh.MustNewDestination("hola@chau"), privKeyPath, pubkeytransfer.PubKeyTransferOptions{})
+	op := pubkeytransfer.NewPubKeyTransfer("Transfer public key", testutil.MustNewDestination("hola@chau"), privKeyPath, pubkeytransfer.PubKeyTransferOptions{})
 
 	var buf bytes.Buffer
 	require.NoError(t, op.DryRun(&buf))
@@ -48,12 +48,12 @@ func TestPubKeyTransferRun(t *testing.T) {
 		}
 		return cmd
 	}}
-	op := pubkeytransfer.NewPubKeyTransfer("Transfer public key", ssh.MustNewDestination("thing1@thing2.com"), privKeyPath, opts)
+	op := pubkeytransfer.NewPubKeyTransfer("Transfer public key", testutil.MustNewDestination("thing1@thing2.com"), privKeyPath, opts)
 
 	var buf bytes.Buffer
 	require.NoError(t, op.Run(&buf))
 	require.Contains(t, buf.String(), "ssh invoked")
-	require.Equal(t, ssh.MustNewDestination("thing1@thing2.com"), got.dest)
+	require.Equal(t, testutil.MustNewDestination("thing1@thing2.com"), got.dest)
 	require.Contains(t, got.cmd, "mkdir -p ~/.ssh && chmod 700 ~/.ssh && cat >> ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys")
 	require.Equal(t, pubKeyContent, got.stdin)
 	require.Empty(t, got.args)

--- a/internal/setupkeys/setup_keys.go
+++ b/internal/setupkeys/setup_keys.go
@@ -8,6 +8,7 @@ import (
 	"github.com/arm/topo/internal/operation"
 	"github.com/arm/topo/internal/setupkeys/pubkeytransfer"
 	"github.com/arm/topo/internal/setupkeys/sshkeygen"
+	"github.com/arm/topo/internal/ssh"
 )
 
 type KeyType string
@@ -17,7 +18,7 @@ const (
 	KeyTypeRSA     KeyType = "rsa"
 )
 
-func NewKeySetup(target string, privKeyPath string, keyType KeyType) (operation.Sequence, error) {
+func NewKeySetup(target ssh.Destination, privKeyPath string, keyType KeyType) (operation.Sequence, error) {
 	ops := []operation.Operation{
 		sshkeygen.NewSSHKeyGen("Generate SSH key pair for target", target, string(keyType), privKeyPath, sshkeygen.SSHKeyGenOptions{}),
 		pubkeytransfer.NewPubKeyTransfer("Transfer public key to target and set it as an authorized key", target, privKeyPath, pubkeytransfer.PubKeyTransferOptions{}),

--- a/internal/setupkeys/setup_keys_test.go
+++ b/internal/setupkeys/setup_keys_test.go
@@ -57,7 +57,7 @@ func TestGetDefaultPrivateKeyPath(t *testing.T) {
 		testutil.SetHomeDir(t, tmp)
 
 		target := "user@some1thing.com"
-		targetSlug := ssh.Destination(target).Slugify()
+		targetSlug := ssh.MustNewDestination(target).Slugify()
 
 		got, err := setupkeys.GetDefaultPrivateKeyPath(targetSlug)
 

--- a/internal/setupkeys/setup_keys_test.go
+++ b/internal/setupkeys/setup_keys_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/arm/topo/internal/setupkeys"
 	"github.com/arm/topo/internal/setupkeys/pubkeytransfer"
 	"github.com/arm/topo/internal/setupkeys/sshkeygen"
-	"github.com/arm/topo/internal/ssh"
 	"github.com/arm/topo/internal/testutil"
 	"github.com/stretchr/testify/require"
 )
@@ -15,7 +14,7 @@ import (
 func TestNewKeySetup(t *testing.T) {
 	t.Run("NewKeySetup returns SSHKeyGen then PubKeyTransfer for supported key types", func(t *testing.T) {
 		t.Run("ed25519 with empty private key path", func(t *testing.T) {
-			got, err := setupkeys.NewKeySetup(ssh.MustNewDestination("user@some1thing.com"), "", setupkeys.KeyTypeED25519)
+			got, err := setupkeys.NewKeySetup(testutil.MustNewDestination("user@some1thing.com"), "", setupkeys.KeyTypeED25519)
 
 			require.NoError(t, err)
 			require.Len(t, got, 2)
@@ -25,7 +24,7 @@ func TestNewKeySetup(t *testing.T) {
 
 		t.Run("ed25519 with custom private key path", func(t *testing.T) {
 			got, err := setupkeys.NewKeySetup(
-				ssh.MustNewDestination("user@some1thing.com"),
+				testutil.MustNewDestination("user@some1thing.com"),
 				filepath.Join(t.TempDir(), "id_ed25519_custom"),
 				setupkeys.KeyTypeED25519,
 			)
@@ -38,7 +37,7 @@ func TestNewKeySetup(t *testing.T) {
 
 		t.Run("rsa with custom private key path", func(t *testing.T) {
 			got, err := setupkeys.NewKeySetup(
-				ssh.MustNewDestination("user@some2thing.com"),
+				testutil.MustNewDestination("user@some2thing.com"),
 				filepath.Join(t.TempDir(), "id_rsa_custom"),
 				setupkeys.KeyTypeRSA,
 			)
@@ -57,7 +56,7 @@ func TestGetDefaultPrivateKeyPath(t *testing.T) {
 		testutil.SetHomeDir(t, tmp)
 
 		target := "user@some1thing.com"
-		targetSlug := ssh.MustNewDestination(target).Slugify()
+		targetSlug := testutil.MustNewDestination(target).Slugify()
 
 		got, err := setupkeys.GetDefaultPrivateKeyPath(targetSlug)
 

--- a/internal/setupkeys/setup_keys_test.go
+++ b/internal/setupkeys/setup_keys_test.go
@@ -15,7 +15,7 @@ import (
 func TestNewKeySetup(t *testing.T) {
 	t.Run("NewKeySetup returns SSHKeyGen then PubKeyTransfer for supported key types", func(t *testing.T) {
 		t.Run("ed25519 with empty private key path", func(t *testing.T) {
-			got, err := setupkeys.NewKeySetup("user@some1thing.com", "", setupkeys.KeyTypeED25519)
+			got, err := setupkeys.NewKeySetup(ssh.MustNewDestination("user@some1thing.com"), "", setupkeys.KeyTypeED25519)
 
 			require.NoError(t, err)
 			require.Len(t, got, 2)
@@ -25,7 +25,7 @@ func TestNewKeySetup(t *testing.T) {
 
 		t.Run("ed25519 with custom private key path", func(t *testing.T) {
 			got, err := setupkeys.NewKeySetup(
-				"user@some1thing.com",
+				ssh.MustNewDestination("user@some1thing.com"),
 				filepath.Join(t.TempDir(), "id_ed25519_custom"),
 				setupkeys.KeyTypeED25519,
 			)
@@ -38,7 +38,7 @@ func TestNewKeySetup(t *testing.T) {
 
 		t.Run("rsa with custom private key path", func(t *testing.T) {
 			got, err := setupkeys.NewKeySetup(
-				"user@some2thing.com",
+				ssh.MustNewDestination("user@some2thing.com"),
 				filepath.Join(t.TempDir(), "id_rsa_custom"),
 				setupkeys.KeyTypeRSA,
 			)

--- a/internal/setupkeys/sshkeygen/ssh_keygen.go
+++ b/internal/setupkeys/sshkeygen/ssh_keygen.go
@@ -15,7 +15,7 @@ type execSSHKeyGen func(keyType string, keyPath string, targetHost string) *exec
 
 type SSHKeyGen struct {
 	description string
-	targetHost  ssh.Destination
+	dest  ssh.Destination
 	keyType     string
 	keyPath     string
 	exec        execSSHKeyGen
@@ -25,7 +25,7 @@ type SSHKeyGenOptions struct {
 	WithMockKeyGen execSSHKeyGen
 }
 
-func NewSSHKeyGen(description string, targetHost ssh.Destination, keyType string, keyPath string, opts SSHKeyGenOptions) *SSHKeyGen {
+func NewSSHKeyGen(description string, dest ssh.Destination, keyType string, keyPath string, opts SSHKeyGenOptions) *SSHKeyGen {
 	execFn := command.SSHKeyGen
 	if opts.WithMockKeyGen != nil {
 		execFn = opts.WithMockKeyGen
@@ -33,7 +33,7 @@ func NewSSHKeyGen(description string, targetHost ssh.Destination, keyType string
 
 	return &SSHKeyGen{
 		description: description,
-		targetHost:  targetHost,
+		dest:  dest,
 		keyType:     keyType,
 		keyPath:     keyPath,
 		exec:        execFn,
@@ -45,7 +45,7 @@ func (kg *SSHKeyGen) Description() string {
 }
 
 func (kg *SSHKeyGen) buildCommand() *exec.Cmd {
-	return kg.exec(kg.keyType, kg.keyPath, kg.targetHost.String())
+	return kg.exec(kg.keyType, kg.keyPath, kg.dest.String())
 }
 
 func (kg *SSHKeyGen) Run(cmdOutput io.Writer) error {

--- a/internal/setupkeys/sshkeygen/ssh_keygen.go
+++ b/internal/setupkeys/sshkeygen/ssh_keygen.go
@@ -8,13 +8,14 @@ import (
 	"path/filepath"
 
 	"github.com/arm/topo/internal/command"
+	"github.com/arm/topo/internal/ssh"
 )
 
 type execSSHKeyGen func(keyType string, keyPath string, targetHost string) *exec.Cmd
 
 type SSHKeyGen struct {
 	description string
-	targetHost  string
+	targetHost  ssh.Destination
 	keyType     string
 	keyPath     string
 	exec        execSSHKeyGen
@@ -24,7 +25,7 @@ type SSHKeyGenOptions struct {
 	WithMockKeyGen execSSHKeyGen
 }
 
-func NewSSHKeyGen(description string, targetHost string, keyType string, keyPath string, opts SSHKeyGenOptions) *SSHKeyGen {
+func NewSSHKeyGen(description string, targetHost ssh.Destination, keyType string, keyPath string, opts SSHKeyGenOptions) *SSHKeyGen {
 	execFn := command.SSHKeyGen
 	if opts.WithMockKeyGen != nil {
 		execFn = opts.WithMockKeyGen
@@ -44,7 +45,7 @@ func (kg *SSHKeyGen) Description() string {
 }
 
 func (kg *SSHKeyGen) buildCommand() *exec.Cmd {
-	return kg.exec(kg.keyType, kg.keyPath, kg.targetHost)
+	return kg.exec(kg.keyType, kg.keyPath, kg.targetHost.String())
 }
 
 func (kg *SSHKeyGen) Run(cmdOutput io.Writer) error {

--- a/internal/setupkeys/sshkeygen/ssh_keygen.go
+++ b/internal/setupkeys/sshkeygen/ssh_keygen.go
@@ -15,7 +15,7 @@ type execSSHKeyGen func(keyType string, keyPath string, targetHost string) *exec
 
 type SSHKeyGen struct {
 	description string
-	dest  ssh.Destination
+	dest        ssh.Destination
 	keyType     string
 	keyPath     string
 	exec        execSSHKeyGen
@@ -33,7 +33,7 @@ func NewSSHKeyGen(description string, dest ssh.Destination, keyType string, keyP
 
 	return &SSHKeyGen{
 		description: description,
-		dest:  dest,
+		dest:        dest,
 		keyType:     keyType,
 		keyPath:     keyPath,
 		exec:        execFn,

--- a/internal/setupkeys/sshkeygen/ssh_keygen_test.go
+++ b/internal/setupkeys/sshkeygen/ssh_keygen_test.go
@@ -8,14 +8,13 @@ import (
 	"testing"
 
 	"github.com/arm/topo/internal/setupkeys/sshkeygen"
-	"github.com/arm/topo/internal/ssh"
 	"github.com/arm/topo/internal/testutil"
 	"github.com/stretchr/testify/require"
 )
 
 func TestSSHKeyGenDryRun(t *testing.T) {
 	keyPath := filepath.Join(t.TempDir(), "keys", "id_ed25519_test")
-	op := sshkeygen.NewSSHKeyGen("Generate SSH key pair", ssh.MustNewDestination("user@example.com"), "ed25519", keyPath, sshkeygen.SSHKeyGenOptions{})
+	op := sshkeygen.NewSSHKeyGen("Generate SSH key pair", testutil.MustNewDestination("user@example.com"), "ed25519", keyPath, sshkeygen.SSHKeyGenOptions{})
 
 	var buf bytes.Buffer
 	require.NoError(t, op.DryRun(&buf))
@@ -29,7 +28,7 @@ func TestSSHKeyGenRun(t *testing.T) {
 			return testutil.CmdWithOutput("ssh-keygen invoked", 0)
 		},
 	}
-	op := sshkeygen.NewSSHKeyGen("Generate SSH key pair", ssh.MustNewDestination("user@example.com"), "ed25519", keyPath, opts)
+	op := sshkeygen.NewSSHKeyGen("Generate SSH key pair", testutil.MustNewDestination("user@example.com"), "ed25519", keyPath, opts)
 	var buf bytes.Buffer
 	require.NoError(t, op.Run(&buf))
 	require.Contains(t, buf.String(), "ssh-keygen invoked")

--- a/internal/setupkeys/sshkeygen/ssh_keygen_test.go
+++ b/internal/setupkeys/sshkeygen/ssh_keygen_test.go
@@ -8,17 +8,18 @@ import (
 	"testing"
 
 	"github.com/arm/topo/internal/setupkeys/sshkeygen"
+	"github.com/arm/topo/internal/ssh"
 	"github.com/arm/topo/internal/testutil"
 	"github.com/stretchr/testify/require"
 )
 
 func TestSSHKeyGenDryRun(t *testing.T) {
 	keyPath := filepath.Join(t.TempDir(), "keys", "id_ed25519_test")
-	op := sshkeygen.NewSSHKeyGen("Generate SSH key pair", "user@example.com", "ed25519", keyPath, sshkeygen.SSHKeyGenOptions{})
+	op := sshkeygen.NewSSHKeyGen("Generate SSH key pair", ssh.MustNewDestination("user@example.com"), "ed25519", keyPath, sshkeygen.SSHKeyGenOptions{})
 
 	var buf bytes.Buffer
 	require.NoError(t, op.DryRun(&buf))
-	require.Contains(t, buf.String(), "ssh-keygen -t ed25519 -f "+keyPath+" -C user@example.com")
+	require.Contains(t, buf.String(), "ssh-keygen -t ed25519 -f "+keyPath+" -C ssh://user@example.com")
 }
 
 func TestSSHKeyGenRun(t *testing.T) {
@@ -28,7 +29,7 @@ func TestSSHKeyGenRun(t *testing.T) {
 			return testutil.CmdWithOutput("ssh-keygen invoked", 0)
 		},
 	}
-	op := sshkeygen.NewSSHKeyGen("Generate SSH key pair", "user@example.com", "ed25519", keyPath, opts)
+	op := sshkeygen.NewSSHKeyGen("Generate SSH key pair", ssh.MustNewDestination("user@example.com"), "ed25519", keyPath, opts)
 	var buf bytes.Buffer
 	require.NoError(t, op.Run(&buf))
 	require.Contains(t, buf.String(), "ssh-keygen invoked")

--- a/internal/ssh/config.go
+++ b/internal/ssh/config.go
@@ -10,9 +10,7 @@ import (
 )
 
 type Config struct {
-	host           string
-	user           string
-	port           string
+	Destination
 	connectTimeout time.Duration
 }
 
@@ -34,11 +32,11 @@ func NewConfigFromBytes(data []byte) Config {
 		}
 		switch strings.ToLower(fields[0]) {
 		case "hostname":
-			config.host = fields[1]
+			config.Host = fields[1]
 		case "user":
-			config.user = fields[1]
+			config.User = fields[1]
 		case "port":
-			config.port = fields[1]
+			config.Port = fields[1]
 		case "connecttimeout":
 			if secs, err := strconv.Atoi(fields[1]); err == nil {
 				config.connectTimeout = time.Duration(secs) * time.Second

--- a/internal/ssh/config_test.go
+++ b/internal/ssh/config_test.go
@@ -16,7 +16,13 @@ port 2222
 
 		got := NewConfigFromBytes(input)
 
-		want := Config{host: "springfield.nuclear.gov", user: "homer", port: "2222"}
+		want := Config{
+			Destination: Destination{
+				Host: "springfield.nuclear.gov",
+				User: "homer",
+				Port: "2222",
+			},
+		}
 		assert.Equal(t, want, got)
 	})
 
@@ -28,7 +34,12 @@ user homer
 
 		got := NewConfigFromBytes(input)
 
-		want := Config{host: "springfield.nuclear.gov", user: "homer"}
+		want := Config{
+			Destination: Destination{
+				Host: "springfield.nuclear.gov",
+				User: "homer",
+			},
+		}
 		assert.Equal(t, want, got)
 	})
 
@@ -47,7 +58,13 @@ Port 22
 
 		got := NewConfigFromBytes(input)
 
-		want := Config{host: "kwik.e.mart", user: "apu", port: "22"}
+		want := Config{
+			Destination: Destination{
+				Host: "kwik.e.mart",
+				User: "apu",
+				Port: "22",
+			},
+		}
 		assert.Equal(t, want, got)
 	})
 

--- a/internal/ssh/dest.go
+++ b/internal/ssh/dest.go
@@ -9,6 +9,10 @@ import (
 
 type Destination string
 
+func MustNewDestination(raw string) Destination {
+	return Destination(raw)
+}
+
 const PlainLocalhost = Destination("localhost")
 
 func (d Destination) IsPlainLocalhost() bool {

--- a/internal/ssh/dest.go
+++ b/internal/ssh/dest.go
@@ -28,16 +28,7 @@ func (d Destination) String() string {
 	return builder.String()
 }
 
-func MustNewDestination(raw string) Destination {
-	user, host, port := SplitUserHostPort(raw)
-	return Destination{
-		User: user,
-		Host: host,
-		Port: port,
-	}
-}
-
-var PlainLocalhost = MustNewDestination("localhost")
+var PlainLocalhost = Destination{Host: "localhost"}
 
 func (d Destination) IsPlainLocalhost() bool {
 	if d.Port != "" || d.User != "" {

--- a/internal/ssh/dest.go
+++ b/internal/ssh/dest.go
@@ -69,6 +69,7 @@ func (d Destination) Slugify() string {
 }
 
 func SplitUserHostPort(raw string) (user, host, port string) {
+	raw = strings.TrimPrefix(raw, "ssh://")
 	hostPart := raw
 	if at := strings.LastIndex(raw, "@"); at != -1 {
 		user = raw[:at]

--- a/internal/ssh/dest.go
+++ b/internal/ssh/dest.go
@@ -7,35 +7,58 @@ import (
 	"unicode"
 )
 
-type Destination string
-
-func MustNewDestination(raw string) Destination {
-	return Destination(raw)
+type Destination struct {
+	User string
+	Host string
+	Port string
 }
 
-const PlainLocalhost = Destination("localhost")
+func (d Destination) String() string {
+	var builder strings.Builder
+	fmt.Fprint(&builder, "ssh://")
+	if d.User != "" {
+		fmt.Fprint(&builder, d.User)
+		fmt.Fprint(&builder, "@")
+	}
+	fmt.Fprint(&builder, d.Host)
+	if d.Port != "" {
+		fmt.Fprint(&builder, ":")
+		fmt.Fprint(&builder, d.Port)
+	}
+	return builder.String()
+}
+
+func MustNewDestination(raw string) Destination {
+	user, host, port := SplitUserHostPort(raw)
+	return Destination{
+		User: user,
+		Host: host,
+		Port: port,
+	}
+}
+
+var PlainLocalhost = MustNewDestination("localhost")
 
 func (d Destination) IsPlainLocalhost() bool {
-	return strings.EqualFold(string(d), "localhost") || d == "127.0.0.1"
+	if d.Port != "" || d.User != "" {
+		return false
+	}
+	return d.IsLocalhost()
 }
 
 func (d Destination) IsLocalhost() bool {
-	if d.IsPlainLocalhost() {
-		return true
-	}
-	_, host, _ := SplitUserHostPort(string(d))
-	return Destination(host).IsPlainLocalhost()
+	return strings.EqualFold(d.Host, "localhost") || d.Host == "127.0.0.1"
 }
 
 func (d Destination) AsURI() string {
-	const scheme = "ssh://"
-	withoutScheme := strings.TrimPrefix(string(d), scheme)
-	return fmt.Sprintf("ssh://%s", withoutScheme)
+	return d.String()
 }
 
 func (d Destination) Slugify() string {
 	var b strings.Builder
-	for _, r := range d {
+	uri := d.AsURI()
+	withoutScheme := strings.TrimPrefix(uri, "ssh://")
+	for _, r := range withoutScheme {
 		toWrite := '_'
 		if unicode.IsLetter(r) || unicode.IsDigit(r) || r == '-' || r == '_' || r == '.' {
 			toWrite = r

--- a/internal/ssh/dest_test.go
+++ b/internal/ssh/dest_test.go
@@ -20,7 +20,7 @@ func TestDestination(t *testing.T) {
 
 			for _, input := range tests {
 				t.Run(input, func(t *testing.T) {
-					d := ssh.Destination(input)
+					d := ssh.MustNewDestination(input)
 
 					assert.True(t, d.IsPlainLocalhost())
 				})
@@ -37,7 +37,7 @@ func TestDestination(t *testing.T) {
 
 			for _, input := range tests {
 				t.Run(input, func(t *testing.T) {
-					d := ssh.Destination(input)
+					d := ssh.MustNewDestination(input)
 
 					assert.False(t, d.IsPlainLocalhost())
 				})
@@ -53,7 +53,7 @@ func TestDestination(t *testing.T) {
 
 			for _, input := range tests {
 				t.Run(input, func(t *testing.T) {
-					d := ssh.Destination(input)
+					d := ssh.MustNewDestination(input)
 
 					assert.False(t, d.IsPlainLocalhost())
 				})
@@ -71,7 +71,7 @@ func TestDestination(t *testing.T) {
 
 			for _, input := range tests {
 				t.Run(input, func(t *testing.T) {
-					d := ssh.Destination(input)
+					d := ssh.MustNewDestination(input)
 
 					assert.True(t, d.IsLocalhost())
 				})
@@ -88,7 +88,7 @@ func TestDestination(t *testing.T) {
 
 			for _, input := range tests {
 				t.Run(input, func(t *testing.T) {
-					d := ssh.Destination(input)
+					d := ssh.MustNewDestination(input)
 
 					assert.True(t, d.IsLocalhost())
 				})
@@ -98,13 +98,13 @@ func TestDestination(t *testing.T) {
 
 	t.Run("AsURI", func(t *testing.T) {
 		t.Run("returns uri form of host string", func(t *testing.T) {
-			d := ssh.Destination("user@host")
+			d := ssh.MustNewDestination("user@host")
 
 			assert.Equal(t, "ssh://user@host", d.AsURI())
 		})
 
 		t.Run("doesn't duplicate ssh:// scheme", func(t *testing.T) {
-			d := ssh.Destination("ssh://user@host:123")
+			d := ssh.MustNewDestination("ssh://user@host:123")
 
 			assert.Equal(t, "ssh://user@host:123", d.AsURI())
 		})
@@ -122,7 +122,7 @@ func TestDestination(t *testing.T) {
 
 		for _, tt := range tests {
 			t.Run(tt.input, func(t *testing.T) {
-				require.Equal(t, tt.want, ssh.Destination(tt.input).Slugify(), "Slugify should replace special characters with underscores and keep allowed characters")
+				require.Equal(t, tt.want, ssh.MustNewDestination(tt.input).Slugify(), "Slugify should replace special characters with underscores and keep allowed characters")
 			})
 		}
 	})

--- a/internal/ssh/dest_test.go
+++ b/internal/ssh/dest_test.go
@@ -150,6 +150,7 @@ func TestDestination(t *testing.T) {
 			{raw: "[2001:db8::1]", wantUser: "", wantHost: "2001:db8::1", wantPort: ""},
 			{raw: "user@[2001:db8::1]:2222", wantUser: "user", wantHost: "2001:db8::1", wantPort: "2222"},
 			{raw: "[2001:db8::1]:2222", wantUser: "", wantHost: "2001:db8::1", wantPort: "2222"},
+			{raw: "ssh://user@example.com:2222", wantUser: "user", wantHost: "example.com", wantPort: "2222"},
 		}
 
 		for _, tc := range cases {

--- a/internal/ssh/dest_test.go
+++ b/internal/ssh/dest_test.go
@@ -9,8 +9,30 @@ import (
 )
 
 func TestDestination(t *testing.T) {
+	t.Run("String", func(t *testing.T) {
+		t.Run("returns the uri form of destination", func(t *testing.T) {
+			tests := []struct {
+				desc string
+				sut  ssh.Destination
+				want string
+			}{
+				{
+					desc: "just host",
+					sut:  ssh.Destination{Host: "localhost"},
+					want: "ssh://localhost",
+				},
+			}
+
+			for _, test := range tests {
+				t.Run(test.desc, func(t *testing.T) {
+					assert.Equal(t, test.want, test.sut.String())
+				})
+			}
+		})
+	})
+
 	t.Run("IsPlainLocalhost", func(t *testing.T) {
-		t.Run("returns true for plain localhost", func(t *testing.T) {
+		t.Run("returns true if host is localhost", func(t *testing.T) {
 			tests := []string{
 				"localhost",
 				"LOCALHOST",
@@ -18,9 +40,9 @@ func TestDestination(t *testing.T) {
 				"127.0.0.1",
 			}
 
-			for _, input := range tests {
-				t.Run(input, func(t *testing.T) {
-					d := ssh.MustNewDestination(input)
+			for _, host := range tests {
+				t.Run(host, func(t *testing.T) {
+					d := ssh.Destination{Host: host}
 
 					assert.True(t, d.IsPlainLocalhost())
 				})
@@ -28,103 +50,90 @@ func TestDestination(t *testing.T) {
 		})
 
 		t.Run("returns false when user or port specified", func(t *testing.T) {
-			tests := []string{
-				"user@localhost",
-				"user@127.0.0.1",
-				"localhost:2222",
-				"user@localhost:2222",
+			tests := []struct {
+				desc string
+				sut  ssh.Destination
+			}{
+				{
+					desc: "user specified",
+					sut:  ssh.Destination{User: "obi-wan", Host: "death-star"},
+				},
+				{
+					desc: "port specified",
+					sut:  ssh.Destination{Host: "death-star", Port: "hole-you-shoot-into"},
+				},
 			}
 
-			for _, input := range tests {
-				t.Run(input, func(t *testing.T) {
-					d := ssh.MustNewDestination(input)
-
-					assert.False(t, d.IsPlainLocalhost())
+			for _, test := range tests {
+				t.Run(test.desc, func(t *testing.T) {
+					assert.False(t, test.sut.IsPlainLocalhost())
 				})
 			}
 		})
 
 		t.Run("returns false for remote hosts", func(t *testing.T) {
-			tests := []string{
-				"remote",
-				"user@remote",
-				"user@remote:2222",
-			}
+			d := ssh.Destination{Host: "remote"}
 
-			for _, input := range tests {
-				t.Run(input, func(t *testing.T) {
-					d := ssh.MustNewDestination(input)
-
-					assert.False(t, d.IsPlainLocalhost())
-				})
-			}
+			assert.False(t, d.IsPlainLocalhost())
 		})
 	})
 
 	t.Run("IsLocalhost", func(t *testing.T) {
-		t.Run("returns true for plain localhost", func(t *testing.T) {
-			tests := []string{
-				"localhost",
-				"LOCALHOST",
-				"LocalHost",
+		t.Run("returns true if host is localhost", func(t *testing.T) {
+			tests := []struct {
+				desc string
+				sut  ssh.Destination
+			}{
+				{
+					desc: "case insensitive",
+					sut:  ssh.Destination{Host: "LoCaLhOsT"},
+				},
+				{
+					desc: "user specified",
+					sut:  ssh.Destination{User: "leet-hacker", Host: "127.0.0.1"},
+				},
+				{
+					desc: "port specified",
+					sut:  ssh.Destination{Host: "localhost", Port: "1337"},
+				},
 			}
 
-			for _, input := range tests {
-				t.Run(input, func(t *testing.T) {
-					d := ssh.MustNewDestination(input)
-
-					assert.True(t, d.IsLocalhost())
-				})
-			}
-		})
-
-		t.Run("returns true when user or port specified", func(t *testing.T) {
-			tests := []string{
-				"user@localhost",
-				"user@127.0.0.1",
-				"localhost:2222",
-				"root@localhost:2222",
-			}
-
-			for _, input := range tests {
-				t.Run(input, func(t *testing.T) {
-					d := ssh.MustNewDestination(input)
-
-					assert.True(t, d.IsLocalhost())
+			for _, test := range tests {
+				t.Run(test.desc, func(t *testing.T) {
+					assert.True(t, test.sut.IsLocalhost())
 				})
 			}
 		})
 	})
 
 	t.Run("AsURI", func(t *testing.T) {
-		t.Run("returns uri form of host string", func(t *testing.T) {
-			d := ssh.MustNewDestination("user@host")
+		t.Run("returns uri form of the destination", func(t *testing.T) {
+			d := ssh.Destination{
+				User: "darth-vader",
+				Host: "death-star",
+				Port: "deep-breath",
+			}
 
-			assert.Equal(t, "ssh://user@host", d.AsURI())
-		})
+			got := d.AsURI()
 
-		t.Run("doesn't duplicate ssh:// scheme", func(t *testing.T) {
-			d := ssh.MustNewDestination("ssh://user@host:123")
-
-			assert.Equal(t, "ssh://user@host:123", d.AsURI())
+			want := "ssh://darth-vader@death-star:deep-breath"
+			assert.Equal(t, want, got)
 		})
 	})
 
 	t.Run("Slugify", func(t *testing.T) {
-		tests := []struct {
-			input string
-			want  string
-		}{
-			{"user@example.com", "user_example.com"},
-			{"Example-Host", "Example-Host"},
-			{"spaces and/tabs", "spaces_and_tabs"},
-		}
+		t.Run("slugifies the uri", func(t *testing.T) {
+			d := ssh.Destination{
+				User: "darth-vader",
+				Host: "death-star",
+				Port: "deep-breath",
+			}
 
-		for _, tt := range tests {
-			t.Run(tt.input, func(t *testing.T) {
-				require.Equal(t, tt.want, ssh.MustNewDestination(tt.input).Slugify(), "Slugify should replace special characters with underscores and keep allowed characters")
-			})
-		}
+			got := d.Slugify()
+
+			want := "darth-vader_death-star_deep-breath"
+			assert.Equal(t, want, got)
+		})
 	})
 
 	t.Run("SplitUserHostPort", func(t *testing.T) {

--- a/internal/ssh/exec.go
+++ b/internal/ssh/exec.go
@@ -43,7 +43,7 @@ func ExecCmd(target Destination, command string, stdin []byte, sshArgs ...string
 		// #nosec G204 -- command should be validated by callers
 		cmd = exec.Command("/bin/sh", "-c", command)
 	} else {
-		args := slices.Concat(sshArgs, []string{"--", string(target), command})
+		args := slices.Concat(sshArgs, []string{"--", target.String(), command})
 		// #nosec G204 -- command should be validated by callers
 		cmd = exec.Command("ssh", args...)
 	}

--- a/internal/ssh/ssh_tunnel.go
+++ b/internal/ssh/ssh_tunnel.go
@@ -21,20 +21,6 @@ func ControlSocketPath(targetHost string) string {
 	return filepath.Join(os.TempDir(), fmt.Sprintf("topo-tunnel-%s", hostHash))
 }
 
-func formatSSHHost(raw string, user string, host string) string {
-	if host == "" {
-		return raw
-	}
-	hostPart := host
-	if strings.Contains(hostPart, ":") {
-		hostPart = "[" + hostPart + "]"
-	}
-	if user == "" {
-		return hostPart
-	}
-	return user + "@" + hostPart
-}
-
 func NewSSHTunnel(targetDest Destination, port string, useControlSockets bool) (operation.Operation, operation.Operation, operation.Operation) {
 	start := NewSSHTunnelStart(targetDest, port, useControlSockets)
 	securityCheck := NewCheckSSHTunnelSecurity(targetDest, port)
@@ -65,21 +51,15 @@ func NewSSHTunnelStart(targetDest Destination, port string, useControlSockets bo
 }
 
 func (s *SSHTunnelStart) Command() *exec.Cmd {
-	rawHost := string(s.TargetDest)
-	user, host, port := SplitUserHostPort(rawHost)
-	hostArg := formatSSHHost(rawHost, user, host)
 	args := []string{"ssh", "-N", "-o", "ExitOnForwardFailure=yes"}
-	if port != "" {
-		args = append(args, "-p", port)
-	}
 	if s.UseControlSockets {
 		args = append(args,
-			"-fMS", ControlSocketPath(string(s.TargetDest)),
+			"-fMS", ControlSocketPath(s.TargetDest.String()),
 		)
 	}
 	args = append(args,
 		"-R", fmt.Sprintf("%s:127.0.0.1:%s", s.Port, s.Port),
-		hostArg,
+		s.TargetDest.String(),
 	)
 	// #nosec -- arguments are validated
 	return exec.Command(args[0], args[1:]...)
@@ -123,7 +103,7 @@ func NewCheckSSHTunnelSecurity(targetDest Destination, port string) *CheckSSHTun
 
 func (ct *CheckSSHTunnelSecurity) Command() *exec.Cmd {
 	if !ct.TargetDest.IsLocalhost() {
-		host := resolveHost(string(ct.TargetDest))
+		host := ct.TargetDest.Host
 		if host == "" {
 			return nil
 		}
@@ -172,24 +152,18 @@ func NewSSHTunnelStop(targetDest Destination) *SSHTunnelStop {
 }
 
 func (s *SSHTunnelStop) Command() *exec.Cmd {
-	rawHost := string(s.TargetDest)
-	user, host, port := SplitUserHostPort(rawHost)
-	hostArg := formatSSHHost(rawHost, user, host)
 	args := []string{"ssh"}
-	if port != "" {
-		args = append(args, "-p", port)
-	}
 	args = append(args,
-		"-S", ControlSocketPath(string(s.TargetDest)),
+		"-S", ControlSocketPath(s.TargetDest.String()),
 		"-O", "exit",
-		hostArg,
+		s.TargetDest.String(),
 	)
 	// #nosec -- arguments are validated
 	return exec.Command(args[0], args[1:]...)
 }
 
 func (s *SSHTunnelStop) Run(w io.Writer) error {
-	if _, err := os.Stat(ControlSocketPath(string(s.TargetDest))); os.IsNotExist(err) {
+	if _, err := os.Stat(ControlSocketPath(s.TargetDest.String())); os.IsNotExist(err) {
 		return nil
 	}
 	cmd := s.Command()
@@ -248,9 +222,4 @@ func (s *SSHTunnelProcessStop) Run(w io.Writer) error {
 func (s *SSHTunnelProcessStop) DryRun(w io.Writer) error {
 	_, _ = fmt.Fprintln(w, strings.Join(s.Command().Args, " "))
 	return nil
-}
-
-func resolveHost(raw string) string {
-	config := NewConfig(raw)
-	return config.host
 }

--- a/internal/ssh/ssh_tunnel_test.go
+++ b/internal/ssh/ssh_tunnel_test.go
@@ -70,7 +70,7 @@ func TestSSHTunnelStart(t *testing.T) {
 			st := ssh.NewSSHTunnelStart(dest, port, true)
 			got := strings.Join(st.Command().Args, " ")
 
-			want := fmt.Sprintf("ssh -N -o ExitOnForwardFailure=yes -fMS %s -R %s:127.0.0.1:%s user@remote", ssh.ControlSocketPath(string(dest)), port, port)
+			want := fmt.Sprintf("ssh -N -o ExitOnForwardFailure=yes -fMS %s -R %s:127.0.0.1:%s ssh://user@remote", ssh.ControlSocketPath(dest.String()), port, port)
 			assert.Equal(t, want, got)
 		})
 
@@ -81,7 +81,7 @@ func TestSSHTunnelStart(t *testing.T) {
 			st := ssh.NewSSHTunnelStart(dest, port, true)
 			got := strings.Join(st.Command().Args, " ")
 
-			want := fmt.Sprintf("ssh -N -o ExitOnForwardFailure=yes -p 2222 -fMS %s -R %s:127.0.0.1:%s user@remote", ssh.ControlSocketPath(string(dest)), port, port)
+			want := fmt.Sprintf("ssh -N -o ExitOnForwardFailure=yes -fMS %s -R %s:127.0.0.1:%s ssh://user@remote:2222", ssh.ControlSocketPath(dest.String()), port, port)
 			assert.Equal(t, want, got)
 		})
 
@@ -92,7 +92,7 @@ func TestSSHTunnelStart(t *testing.T) {
 			st := ssh.NewSSHTunnelStart(dest, port, false)
 			got := strings.Join(st.Command().Args, " ")
 
-			want := fmt.Sprintf("ssh -N -o ExitOnForwardFailure=yes -R %s:127.0.0.1:%s user@remote", port, port)
+			want := fmt.Sprintf("ssh -N -o ExitOnForwardFailure=yes -R %s:127.0.0.1:%s ssh://user@remote", port, port)
 			assert.Equal(t, want, got)
 		})
 	})
@@ -108,22 +108,7 @@ func TestSSHTunnelStart(t *testing.T) {
 			got := strings.TrimSpace(buf.String())
 
 			require.NoError(t, err)
-			wantSuffix := fmt.Sprintf("ssh -N -o ExitOnForwardFailure=yes -fMS %s -R %s:127.0.0.1:%s user@remote", ssh.ControlSocketPath(string(dest)), port, port)
-			assert.True(t, strings.HasSuffix(got, wantSuffix),
-				"DryRun output %q does not end with %q", got, wantSuffix)
-		})
-
-		t.Run("it includes port flag when host has custom port", func(t *testing.T) {
-			var buf bytes.Buffer
-			dest := ssh.MustNewDestination("user@remote:2222")
-			port := operation.DefaultRegistryPort
-
-			st := ssh.NewSSHTunnelStart(dest, port, true)
-			err := st.DryRun(&buf)
-			got := strings.TrimSpace(buf.String())
-
-			require.NoError(t, err)
-			wantSuffix := fmt.Sprintf("ssh -N -o ExitOnForwardFailure=yes -p 2222 -fMS %s -R %s:127.0.0.1:%s user@remote", ssh.ControlSocketPath(string(dest)), port, port)
+			wantSuffix := fmt.Sprintf("ssh -N -o ExitOnForwardFailure=yes -fMS %s -R %s:127.0.0.1:%s ssh://user@remote", ssh.ControlSocketPath(dest.String()), port, port)
 			assert.True(t, strings.HasSuffix(got, wantSuffix),
 				"DryRun output %q does not end with %q", got, wantSuffix)
 		})
@@ -136,54 +121,6 @@ func TestSSHTunnelStart(t *testing.T) {
 			got := st.Description()
 
 			assert.Equal(t, "Open registry SSH tunnel", got)
-		})
-	})
-}
-
-func TestSSHTunnelStartEdgeCases(t *testing.T) {
-	t.Run("Command", func(t *testing.T) {
-		t.Run("it handles host without user", func(t *testing.T) {
-			dest := ssh.MustNewDestination("remote-server")
-			port := operation.DefaultRegistryPort
-
-			st := ssh.NewSSHTunnelStart(dest, port, true)
-			got := strings.Join(st.Command().Args, " ")
-
-			want := fmt.Sprintf("ssh -N -o ExitOnForwardFailure=yes -fMS %s -R %s:127.0.0.1:%s remote-server", ssh.ControlSocketPath(string(dest)), port, port)
-			assert.Equal(t, want, got)
-		})
-
-		t.Run("it handles host without user but with port", func(t *testing.T) {
-			dest := ssh.MustNewDestination("remote-server:2222")
-			port := operation.DefaultRegistryPort
-
-			st := ssh.NewSSHTunnelStart(dest, port, true)
-			got := strings.Join(st.Command().Args, " ")
-
-			want := fmt.Sprintf("ssh -N -o ExitOnForwardFailure=yes -p 2222 -fMS %s -R %s:127.0.0.1:%s remote-server", ssh.ControlSocketPath(string(dest)), port, port)
-			assert.Equal(t, want, got)
-		})
-
-		t.Run("it handles IP address", func(t *testing.T) {
-			dest := ssh.MustNewDestination("user@192.168.1.100")
-			port := operation.DefaultRegistryPort
-
-			st := ssh.NewSSHTunnelStart(dest, port, true)
-			got := strings.Join(st.Command().Args, " ")
-
-			want := fmt.Sprintf("ssh -N -o ExitOnForwardFailure=yes -fMS %s -R %s:127.0.0.1:%s user@192.168.1.100", ssh.ControlSocketPath(string(dest)), port, port)
-			assert.Equal(t, want, got)
-		})
-
-		t.Run("it handles IP address with port", func(t *testing.T) {
-			dest := ssh.MustNewDestination("user@192.168.1.100:2222")
-			port := operation.DefaultRegistryPort
-
-			st := ssh.NewSSHTunnelStart(dest, port, true)
-			got := strings.Join(st.Command().Args, " ")
-
-			want := fmt.Sprintf("ssh -N -o ExitOnForwardFailure=yes -p 2222 -fMS %s -R %s:127.0.0.1:%s user@192.168.1.100", ssh.ControlSocketPath(string(dest)), port, port)
-			assert.Equal(t, want, got)
 		})
 	})
 }
@@ -245,17 +182,7 @@ func TestSSHTunnelStop(t *testing.T) {
 			st := ssh.NewSSHTunnelStop(dest)
 			got := strings.Join(st.Command().Args, " ")
 
-			want := fmt.Sprintf("ssh -S %s -O exit user@remote", ssh.ControlSocketPath(string(dest)))
-			assert.Equal(t, want, got)
-		})
-
-		t.Run("it includes port flag when host has custom port", func(t *testing.T) {
-			dest := ssh.MustNewDestination("user@remote:2222")
-
-			st := ssh.NewSSHTunnelStop(dest)
-			got := strings.Join(st.Command().Args, " ")
-
-			want := fmt.Sprintf("ssh -p 2222 -S %s -O exit user@remote", ssh.ControlSocketPath(string(dest)))
+			want := fmt.Sprintf("ssh -S %s -O exit ssh://user@remote", ssh.ControlSocketPath(dest.String()))
 			assert.Equal(t, want, got)
 		})
 	})
@@ -270,21 +197,7 @@ func TestSSHTunnelStop(t *testing.T) {
 			got := strings.TrimSpace(buf.String())
 
 			require.NoError(t, err)
-			wantSuffix := fmt.Sprintf("ssh -S %s -O exit user@remote", ssh.ControlSocketPath(string(dest)))
-			assert.True(t, strings.HasSuffix(got, wantSuffix),
-				"DryRun output %q does not end with %q", got, wantSuffix)
-		})
-
-		t.Run("it includes port flag when host has custom port", func(t *testing.T) {
-			var buf bytes.Buffer
-			dest := ssh.MustNewDestination("user@remote:2222")
-
-			st := ssh.NewSSHTunnelStop(dest)
-			err := st.DryRun(&buf)
-			got := strings.TrimSpace(buf.String())
-
-			require.NoError(t, err)
-			wantSuffix := fmt.Sprintf("ssh -p 2222 -S %s -O exit user@remote", ssh.ControlSocketPath(string(dest)))
+			wantSuffix := fmt.Sprintf("ssh -S %s -O exit ssh://user@remote", ssh.ControlSocketPath(dest.String()))
 			assert.True(t, strings.HasSuffix(got, wantSuffix),
 				"DryRun output %q does not end with %q", got, wantSuffix)
 		})
@@ -297,50 +210,6 @@ func TestSSHTunnelStop(t *testing.T) {
 			got := st.Description()
 
 			assert.Equal(t, "Close registry SSH tunnel", got)
-		})
-	})
-}
-
-func TestSSHTunnelStopEdgeCases(t *testing.T) {
-	t.Run("Command", func(t *testing.T) {
-		t.Run("handles host without user", func(t *testing.T) {
-			dest := ssh.MustNewDestination("remote-server")
-
-			st := ssh.NewSSHTunnelStop(dest)
-			got := strings.Join(st.Command().Args, " ")
-
-			want := fmt.Sprintf("ssh -S %s -O exit remote-server", ssh.ControlSocketPath(string(dest)))
-			assert.Equal(t, want, got)
-		})
-
-		t.Run("handles host without user but with port", func(t *testing.T) {
-			dest := ssh.MustNewDestination("remote-server:2222")
-
-			st := ssh.NewSSHTunnelStop(dest)
-			got := strings.Join(st.Command().Args, " ")
-
-			want := fmt.Sprintf("ssh -p 2222 -S %s -O exit remote-server", ssh.ControlSocketPath(string(dest)))
-			assert.Equal(t, want, got)
-		})
-
-		t.Run("handles IP address", func(t *testing.T) {
-			dest := ssh.MustNewDestination("user@192.168.1.100")
-
-			st := ssh.NewSSHTunnelStop(dest)
-			got := strings.Join(st.Command().Args, " ")
-
-			want := fmt.Sprintf("ssh -S %s -O exit user@192.168.1.100", ssh.ControlSocketPath(string(dest)))
-			assert.Equal(t, want, got)
-		})
-
-		t.Run("handles IP address with port", func(t *testing.T) {
-			dest := ssh.MustNewDestination("user@192.168.1.100:2222")
-
-			st := ssh.NewSSHTunnelStop(dest)
-			got := strings.Join(st.Command().Args, " ")
-
-			want := fmt.Sprintf("ssh -p 2222 -S %s -O exit user@192.168.1.100", ssh.ControlSocketPath(string(dest)))
-			assert.Equal(t, want, got)
 		})
 	})
 }

--- a/internal/ssh/ssh_tunnel_test.go
+++ b/internal/ssh/ssh_tunnel_test.go
@@ -17,7 +17,7 @@ import (
 func TestSSHTunnel(t *testing.T) {
 	t.Run("NewSSHTunnel", func(t *testing.T) {
 		t.Run("it returns start and stop operations with control sockets", func(t *testing.T) {
-			dest := ssh.Destination("user@remote")
+			dest := ssh.MustNewDestination("user@remote")
 
 			start, _, stop := ssh.NewSSHTunnel(dest, operation.DefaultRegistryPort, true)
 
@@ -28,7 +28,7 @@ func TestSSHTunnel(t *testing.T) {
 		})
 
 		t.Run("it returns start and stop operations without control sockets", func(t *testing.T) {
-			dest := ssh.Destination("user@remote")
+			dest := ssh.MustNewDestination("user@remote")
 
 			start, _, stop := ssh.NewSSHTunnel(dest, operation.DefaultRegistryPort, false)
 
@@ -39,7 +39,7 @@ func TestSSHTunnel(t *testing.T) {
 		})
 
 		t.Run("stop operation has access to start operation process", func(t *testing.T) {
-			dest := ssh.Destination("user@remote")
+			dest := ssh.MustNewDestination("user@remote")
 
 			start, _, stop := ssh.NewSSHTunnel(dest, operation.DefaultRegistryPort, false)
 			startOp, ok := start.(*ssh.SSHTunnelStart)
@@ -51,7 +51,7 @@ func TestSSHTunnel(t *testing.T) {
 		})
 
 		t.Run("it returns security check operation", func(t *testing.T) {
-			dest := ssh.Destination("user@remote")
+			dest := ssh.MustNewDestination("user@remote")
 
 			_, securityCheck, _ := ssh.NewSSHTunnel(dest, operation.DefaultRegistryPort, true)
 
@@ -64,7 +64,7 @@ func TestSSHTunnel(t *testing.T) {
 func TestSSHTunnelStart(t *testing.T) {
 	t.Run("Command", func(t *testing.T) {
 		t.Run("it generates correct ssh command", func(t *testing.T) {
-			dest := ssh.Destination("user@remote")
+			dest := ssh.MustNewDestination("user@remote")
 			port := operation.DefaultRegistryPort
 
 			st := ssh.NewSSHTunnelStart(dest, port, true)
@@ -75,7 +75,7 @@ func TestSSHTunnelStart(t *testing.T) {
 		})
 
 		t.Run("it includes port flag when host has custom port", func(t *testing.T) {
-			dest := ssh.Destination("user@remote:2222")
+			dest := ssh.MustNewDestination("user@remote:2222")
 			port := operation.DefaultRegistryPort
 
 			st := ssh.NewSSHTunnelStart(dest, port, true)
@@ -86,7 +86,7 @@ func TestSSHTunnelStart(t *testing.T) {
 		})
 
 		t.Run("it does not include control socket flag when disabled", func(t *testing.T) {
-			dest := ssh.Destination("user@remote")
+			dest := ssh.MustNewDestination("user@remote")
 			port := operation.DefaultRegistryPort
 
 			st := ssh.NewSSHTunnelStart(dest, port, false)
@@ -100,7 +100,7 @@ func TestSSHTunnelStart(t *testing.T) {
 	t.Run("DryRun", func(t *testing.T) {
 		t.Run("it outputs the ssh command", func(t *testing.T) {
 			var buf bytes.Buffer
-			dest := ssh.Destination("user@remote")
+			dest := ssh.MustNewDestination("user@remote")
 			port := operation.DefaultRegistryPort
 
 			st := ssh.NewSSHTunnelStart(dest, port, true)
@@ -115,7 +115,7 @@ func TestSSHTunnelStart(t *testing.T) {
 
 		t.Run("it includes port flag when host has custom port", func(t *testing.T) {
 			var buf bytes.Buffer
-			dest := ssh.Destination("user@remote:2222")
+			dest := ssh.MustNewDestination("user@remote:2222")
 			port := operation.DefaultRegistryPort
 
 			st := ssh.NewSSHTunnelStart(dest, port, true)
@@ -131,7 +131,7 @@ func TestSSHTunnelStart(t *testing.T) {
 
 	t.Run("Description", func(t *testing.T) {
 		t.Run("it returns expected string", func(t *testing.T) {
-			st := ssh.NewSSHTunnelStart(ssh.Destination("user@remote"), operation.DefaultRegistryPort, true)
+			st := ssh.NewSSHTunnelStart(ssh.MustNewDestination("user@remote"), operation.DefaultRegistryPort, true)
 
 			got := st.Description()
 
@@ -143,7 +143,7 @@ func TestSSHTunnelStart(t *testing.T) {
 func TestSSHTunnelStartEdgeCases(t *testing.T) {
 	t.Run("Command", func(t *testing.T) {
 		t.Run("it handles host without user", func(t *testing.T) {
-			dest := ssh.Destination("remote-server")
+			dest := ssh.MustNewDestination("remote-server")
 			port := operation.DefaultRegistryPort
 
 			st := ssh.NewSSHTunnelStart(dest, port, true)
@@ -154,7 +154,7 @@ func TestSSHTunnelStartEdgeCases(t *testing.T) {
 		})
 
 		t.Run("it handles host without user but with port", func(t *testing.T) {
-			dest := ssh.Destination("remote-server:2222")
+			dest := ssh.MustNewDestination("remote-server:2222")
 			port := operation.DefaultRegistryPort
 
 			st := ssh.NewSSHTunnelStart(dest, port, true)
@@ -165,7 +165,7 @@ func TestSSHTunnelStartEdgeCases(t *testing.T) {
 		})
 
 		t.Run("it handles IP address", func(t *testing.T) {
-			dest := ssh.Destination("user@192.168.1.100")
+			dest := ssh.MustNewDestination("user@192.168.1.100")
 			port := operation.DefaultRegistryPort
 
 			st := ssh.NewSSHTunnelStart(dest, port, true)
@@ -176,7 +176,7 @@ func TestSSHTunnelStartEdgeCases(t *testing.T) {
 		})
 
 		t.Run("it handles IP address with port", func(t *testing.T) {
-			dest := ssh.Destination("user@192.168.1.100:2222")
+			dest := ssh.MustNewDestination("user@192.168.1.100:2222")
 			port := operation.DefaultRegistryPort
 
 			st := ssh.NewSSHTunnelStart(dest, port, true)
@@ -191,7 +191,7 @@ func TestSSHTunnelStartEdgeCases(t *testing.T) {
 func TestCheckSSHTunnelSecurity(t *testing.T) {
 	t.Run("Command", func(t *testing.T) {
 		t.Run("it generates correct curl command", func(t *testing.T) {
-			dest := ssh.Destination("user@remote")
+			dest := ssh.MustNewDestination("user@remote")
 			port := operation.DefaultRegistryPort
 
 			cs := ssh.NewCheckSSHTunnelSecurity(dest, port)
@@ -202,7 +202,7 @@ func TestCheckSSHTunnelSecurity(t *testing.T) {
 		})
 
 		t.Run("it returns nil when target is localhost", func(t *testing.T) {
-			dest := ssh.Destination("root@localhost")
+			dest := ssh.MustNewDestination("root@localhost")
 			port := operation.DefaultRegistryPort
 
 			cs := ssh.NewCheckSSHTunnelSecurity(dest, port)
@@ -214,7 +214,7 @@ func TestCheckSSHTunnelSecurity(t *testing.T) {
 	t.Run("DryRun", func(t *testing.T) {
 		t.Run("it outputs the curl command", func(t *testing.T) {
 			var buf bytes.Buffer
-			dest := ssh.Destination("user@remote")
+			dest := ssh.MustNewDestination("user@remote")
 			port := operation.DefaultRegistryPort
 
 			cs := ssh.NewCheckSSHTunnelSecurity(dest, port)
@@ -228,7 +228,7 @@ func TestCheckSSHTunnelSecurity(t *testing.T) {
 
 	t.Run("Description", func(t *testing.T) {
 		t.Run("it returns the expected string", func(t *testing.T) {
-			cs := ssh.NewCheckSSHTunnelSecurity(ssh.Destination("user@remote"), operation.DefaultRegistryPort)
+			cs := ssh.NewCheckSSHTunnelSecurity(ssh.MustNewDestination("user@remote"), operation.DefaultRegistryPort)
 
 			got := cs.Description()
 
@@ -240,7 +240,7 @@ func TestCheckSSHTunnelSecurity(t *testing.T) {
 func TestSSHTunnelStop(t *testing.T) {
 	t.Run("Command", func(t *testing.T) {
 		t.Run("it generates correct ssh command", func(t *testing.T) {
-			dest := ssh.Destination("user@remote")
+			dest := ssh.MustNewDestination("user@remote")
 
 			st := ssh.NewSSHTunnelStop(dest)
 			got := strings.Join(st.Command().Args, " ")
@@ -250,7 +250,7 @@ func TestSSHTunnelStop(t *testing.T) {
 		})
 
 		t.Run("it includes port flag when host has custom port", func(t *testing.T) {
-			dest := ssh.Destination("user@remote:2222")
+			dest := ssh.MustNewDestination("user@remote:2222")
 
 			st := ssh.NewSSHTunnelStop(dest)
 			got := strings.Join(st.Command().Args, " ")
@@ -263,7 +263,7 @@ func TestSSHTunnelStop(t *testing.T) {
 	t.Run("DryRun", func(t *testing.T) {
 		t.Run("generates the correct ssh command", func(t *testing.T) {
 			var buf bytes.Buffer
-			dest := ssh.Destination("user@remote")
+			dest := ssh.MustNewDestination("user@remote")
 
 			st := ssh.NewSSHTunnelStop(dest)
 			err := st.DryRun(&buf)
@@ -277,7 +277,7 @@ func TestSSHTunnelStop(t *testing.T) {
 
 		t.Run("it includes port flag when host has custom port", func(t *testing.T) {
 			var buf bytes.Buffer
-			dest := ssh.Destination("user@remote:2222")
+			dest := ssh.MustNewDestination("user@remote:2222")
 
 			st := ssh.NewSSHTunnelStop(dest)
 			err := st.DryRun(&buf)
@@ -292,7 +292,7 @@ func TestSSHTunnelStop(t *testing.T) {
 
 	t.Run("Description", func(t *testing.T) {
 		t.Run("it returns expected string", func(t *testing.T) {
-			st := ssh.NewSSHTunnelStop(ssh.Destination("user@remote"))
+			st := ssh.NewSSHTunnelStop(ssh.MustNewDestination("user@remote"))
 
 			got := st.Description()
 
@@ -304,7 +304,7 @@ func TestSSHTunnelStop(t *testing.T) {
 func TestSSHTunnelStopEdgeCases(t *testing.T) {
 	t.Run("Command", func(t *testing.T) {
 		t.Run("handles host without user", func(t *testing.T) {
-			dest := ssh.Destination("remote-server")
+			dest := ssh.MustNewDestination("remote-server")
 
 			st := ssh.NewSSHTunnelStop(dest)
 			got := strings.Join(st.Command().Args, " ")
@@ -314,7 +314,7 @@ func TestSSHTunnelStopEdgeCases(t *testing.T) {
 		})
 
 		t.Run("handles host without user but with port", func(t *testing.T) {
-			dest := ssh.Destination("remote-server:2222")
+			dest := ssh.MustNewDestination("remote-server:2222")
 
 			st := ssh.NewSSHTunnelStop(dest)
 			got := strings.Join(st.Command().Args, " ")
@@ -324,7 +324,7 @@ func TestSSHTunnelStopEdgeCases(t *testing.T) {
 		})
 
 		t.Run("handles IP address", func(t *testing.T) {
-			dest := ssh.Destination("user@192.168.1.100")
+			dest := ssh.MustNewDestination("user@192.168.1.100")
 
 			st := ssh.NewSSHTunnelStop(dest)
 			got := strings.Join(st.Command().Args, " ")
@@ -334,7 +334,7 @@ func TestSSHTunnelStopEdgeCases(t *testing.T) {
 		})
 
 		t.Run("handles IP address with port", func(t *testing.T) {
-			dest := ssh.Destination("user@192.168.1.100:2222")
+			dest := ssh.MustNewDestination("user@192.168.1.100:2222")
 
 			st := ssh.NewSSHTunnelStop(dest)
 			got := strings.Join(st.Command().Args, " ")

--- a/internal/ssh/ssh_tunnel_test.go
+++ b/internal/ssh/ssh_tunnel_test.go
@@ -17,7 +17,7 @@ import (
 func TestSSHTunnel(t *testing.T) {
 	t.Run("NewSSHTunnel", func(t *testing.T) {
 		t.Run("it returns start and stop operations with control sockets", func(t *testing.T) {
-			dest := ssh.MustNewDestination("user@remote")
+			dest := testutil.MustNewDestination("user@remote")
 
 			start, _, stop := ssh.NewSSHTunnel(dest, operation.DefaultRegistryPort, true)
 
@@ -28,7 +28,7 @@ func TestSSHTunnel(t *testing.T) {
 		})
 
 		t.Run("it returns start and stop operations without control sockets", func(t *testing.T) {
-			dest := ssh.MustNewDestination("user@remote")
+			dest := testutil.MustNewDestination("user@remote")
 
 			start, _, stop := ssh.NewSSHTunnel(dest, operation.DefaultRegistryPort, false)
 
@@ -39,7 +39,7 @@ func TestSSHTunnel(t *testing.T) {
 		})
 
 		t.Run("stop operation has access to start operation process", func(t *testing.T) {
-			dest := ssh.MustNewDestination("user@remote")
+			dest := testutil.MustNewDestination("user@remote")
 
 			start, _, stop := ssh.NewSSHTunnel(dest, operation.DefaultRegistryPort, false)
 			startOp, ok := start.(*ssh.SSHTunnelStart)
@@ -51,7 +51,7 @@ func TestSSHTunnel(t *testing.T) {
 		})
 
 		t.Run("it returns security check operation", func(t *testing.T) {
-			dest := ssh.MustNewDestination("user@remote")
+			dest := testutil.MustNewDestination("user@remote")
 
 			_, securityCheck, _ := ssh.NewSSHTunnel(dest, operation.DefaultRegistryPort, true)
 
@@ -64,7 +64,7 @@ func TestSSHTunnel(t *testing.T) {
 func TestSSHTunnelStart(t *testing.T) {
 	t.Run("Command", func(t *testing.T) {
 		t.Run("it generates correct ssh command", func(t *testing.T) {
-			dest := ssh.MustNewDestination("user@remote")
+			dest := testutil.MustNewDestination("user@remote")
 			port := operation.DefaultRegistryPort
 
 			st := ssh.NewSSHTunnelStart(dest, port, true)
@@ -75,7 +75,7 @@ func TestSSHTunnelStart(t *testing.T) {
 		})
 
 		t.Run("it includes port flag when host has custom port", func(t *testing.T) {
-			dest := ssh.MustNewDestination("user@remote:2222")
+			dest := testutil.MustNewDestination("user@remote:2222")
 			port := operation.DefaultRegistryPort
 
 			st := ssh.NewSSHTunnelStart(dest, port, true)
@@ -86,7 +86,7 @@ func TestSSHTunnelStart(t *testing.T) {
 		})
 
 		t.Run("it does not include control socket flag when disabled", func(t *testing.T) {
-			dest := ssh.MustNewDestination("user@remote")
+			dest := testutil.MustNewDestination("user@remote")
 			port := operation.DefaultRegistryPort
 
 			st := ssh.NewSSHTunnelStart(dest, port, false)
@@ -100,7 +100,7 @@ func TestSSHTunnelStart(t *testing.T) {
 	t.Run("DryRun", func(t *testing.T) {
 		t.Run("it outputs the ssh command", func(t *testing.T) {
 			var buf bytes.Buffer
-			dest := ssh.MustNewDestination("user@remote")
+			dest := testutil.MustNewDestination("user@remote")
 			port := operation.DefaultRegistryPort
 
 			st := ssh.NewSSHTunnelStart(dest, port, true)
@@ -116,7 +116,7 @@ func TestSSHTunnelStart(t *testing.T) {
 
 	t.Run("Description", func(t *testing.T) {
 		t.Run("it returns expected string", func(t *testing.T) {
-			st := ssh.NewSSHTunnelStart(ssh.MustNewDestination("user@remote"), operation.DefaultRegistryPort, true)
+			st := ssh.NewSSHTunnelStart(testutil.MustNewDestination("user@remote"), operation.DefaultRegistryPort, true)
 
 			got := st.Description()
 
@@ -128,7 +128,7 @@ func TestSSHTunnelStart(t *testing.T) {
 func TestCheckSSHTunnelSecurity(t *testing.T) {
 	t.Run("Command", func(t *testing.T) {
 		t.Run("it generates correct curl command", func(t *testing.T) {
-			dest := ssh.MustNewDestination("user@remote")
+			dest := testutil.MustNewDestination("user@remote")
 			port := operation.DefaultRegistryPort
 
 			cs := ssh.NewCheckSSHTunnelSecurity(dest, port)
@@ -139,7 +139,7 @@ func TestCheckSSHTunnelSecurity(t *testing.T) {
 		})
 
 		t.Run("it returns nil when target is localhost", func(t *testing.T) {
-			dest := ssh.MustNewDestination("root@localhost")
+			dest := testutil.MustNewDestination("root@localhost")
 			port := operation.DefaultRegistryPort
 
 			cs := ssh.NewCheckSSHTunnelSecurity(dest, port)
@@ -151,7 +151,7 @@ func TestCheckSSHTunnelSecurity(t *testing.T) {
 	t.Run("DryRun", func(t *testing.T) {
 		t.Run("it outputs the curl command", func(t *testing.T) {
 			var buf bytes.Buffer
-			dest := ssh.MustNewDestination("user@remote")
+			dest := testutil.MustNewDestination("user@remote")
 			port := operation.DefaultRegistryPort
 
 			cs := ssh.NewCheckSSHTunnelSecurity(dest, port)
@@ -165,7 +165,7 @@ func TestCheckSSHTunnelSecurity(t *testing.T) {
 
 	t.Run("Description", func(t *testing.T) {
 		t.Run("it returns the expected string", func(t *testing.T) {
-			cs := ssh.NewCheckSSHTunnelSecurity(ssh.MustNewDestination("user@remote"), operation.DefaultRegistryPort)
+			cs := ssh.NewCheckSSHTunnelSecurity(testutil.MustNewDestination("user@remote"), operation.DefaultRegistryPort)
 
 			got := cs.Description()
 
@@ -177,7 +177,7 @@ func TestCheckSSHTunnelSecurity(t *testing.T) {
 func TestSSHTunnelStop(t *testing.T) {
 	t.Run("Command", func(t *testing.T) {
 		t.Run("it generates correct ssh command", func(t *testing.T) {
-			dest := ssh.MustNewDestination("user@remote")
+			dest := testutil.MustNewDestination("user@remote")
 
 			st := ssh.NewSSHTunnelStop(dest)
 			got := strings.Join(st.Command().Args, " ")
@@ -190,7 +190,7 @@ func TestSSHTunnelStop(t *testing.T) {
 	t.Run("DryRun", func(t *testing.T) {
 		t.Run("generates the correct ssh command", func(t *testing.T) {
 			var buf bytes.Buffer
-			dest := ssh.MustNewDestination("user@remote")
+			dest := testutil.MustNewDestination("user@remote")
 
 			st := ssh.NewSSHTunnelStop(dest)
 			err := st.DryRun(&buf)
@@ -205,7 +205,7 @@ func TestSSHTunnelStop(t *testing.T) {
 
 	t.Run("Description", func(t *testing.T) {
 		t.Run("it returns expected string", func(t *testing.T) {
-			st := ssh.NewSSHTunnelStop(ssh.MustNewDestination("user@remote"))
+			st := ssh.NewSSHTunnelStop(testutil.MustNewDestination("user@remote"))
 
 			got := st.Description()
 

--- a/internal/target/connection.go
+++ b/internal/target/connection.go
@@ -54,14 +54,15 @@ type ConnectionOptions struct {
 
 var ErrPasswordAuthentication = errors.New("key-based SSH authentication is not setup")
 
-func NewConnection(sshTarget string, opts ConnectionOptions) Connection {
+func NewConnection(dest ssh.Destination, opts ConnectionOptions) Connection {
 	execFn := ssh.ExecCmd
 	if opts.WithMockExec != nil {
 		execFn = opts.WithMockExec
 	}
-	opts.ConnectTimeout = ssh.NewConfig(sshTarget).ConnectTimeout(opts.ConnectTimeout)
+	// We know this is sub-optimal, but acceptable tradeoff for now (refactor in progress)
+	opts.ConnectTimeout = ssh.NewConfig(dest.String()).ConnectTimeout(opts.ConnectTimeout)
 	return Connection{
-		SSHTarget: ssh.Destination(sshTarget),
+		SSHTarget: dest,
 		exec:      execFn,
 		opts:      opts,
 	}
@@ -88,7 +89,7 @@ func (c *Connection) Run(command string) (string, error) {
 		if classified := ssh.ClassifyStderr(stderr); classified != nil {
 			err = classified
 		}
-		return stdoutBuf.String() + stderr, fmt.Errorf("ssh command to %s failed: %w | stderr: %s", string(c.SSHTarget), err, stderr)
+		return stdoutBuf.String() + stderr, fmt.Errorf("ssh command to %s failed: %w | stderr: %s", c.SSHTarget, err, stderr)
 	}
 	return stdoutBuf.String(), nil
 }

--- a/internal/target/connection_auth_test.go
+++ b/internal/target/connection_auth_test.go
@@ -64,7 +64,7 @@ func TestProbeAuthentication(t *testing.T) {
 			"public": {stdout: "", err: nil},
 		}, &calls)
 		opts := target.ConnectionOptions{AcceptNewHostKeys: true, WithMockExec: mockExec}
-		conn := target.NewConnection("user@host", opts)
+		conn := target.NewConnection(ssh.MustNewDestination("user@host"), opts)
 		err := conn.ProbeAuthentication()
 		require.NoError(t, err)
 
@@ -79,7 +79,7 @@ func TestProbeAuthentication(t *testing.T) {
 			"public": {stdout: "Host key verification failed", err: errSSH},
 		}, &calls)
 		opts := target.ConnectionOptions{AcceptNewHostKeys: true, WithMockExec: mockExec}
-		conn := target.NewConnection("user@host", opts)
+		conn := target.NewConnection(ssh.MustNewDestination("user@host"), opts)
 		err := conn.ProbeAuthentication()
 		require.ErrorIs(t, err, target.ErrHostKeyVerification)
 		require.Len(t, calls, 1)
@@ -92,7 +92,7 @@ func TestProbeAuthentication(t *testing.T) {
 			"password": {stdout: "Host key verification failed", err: errSSH},
 		}, &calls)
 		opts := target.ConnectionOptions{AcceptNewHostKeys: true, WithMockExec: mockExec}
-		conn := target.NewConnection("user@host", opts)
+		conn := target.NewConnection(ssh.MustNewDestination("user@host"), opts)
 		err := conn.ProbeAuthentication()
 		require.ErrorIs(t, err, target.ErrHostKeyVerification)
 		require.Len(t, calls, 2)
@@ -106,7 +106,7 @@ func TestProbeAuthentication(t *testing.T) {
 			"password": {stdout: "Authentication failed", err: errSSH},
 		}, &calls)
 		opts := target.ConnectionOptions{AcceptNewHostKeys: true, WithMockExec: mockExec}
-		conn := target.NewConnection("user@host", opts)
+		conn := target.NewConnection(ssh.MustNewDestination("user@host"), opts)
 		err := conn.ProbeAuthentication()
 		require.ErrorIs(t, err, target.ErrPasswordAuthentication)
 	})
@@ -118,7 +118,7 @@ func TestProbeAuthentication(t *testing.T) {
 			"password": {stdout: "ok", err: nil},
 		}, &calls)
 		opts := target.ConnectionOptions{AcceptNewHostKeys: true, WithMockExec: mockExec}
-		conn := target.NewConnection("user@host", opts)
+		conn := target.NewConnection(ssh.MustNewDestination("user@host"), opts)
 		err := conn.ProbeAuthentication()
 		require.NoError(t, err)
 		require.Len(t, calls, 2)
@@ -132,7 +132,7 @@ func TestProbeAuthentication(t *testing.T) {
 			"password": {stdout: "Some other error", err: errSSH},
 		}, &calls)
 		opts := target.ConnectionOptions{AcceptNewHostKeys: true, WithMockExec: mockExec}
-		conn := target.NewConnection("user@host", opts)
+		conn := target.NewConnection(ssh.MustNewDestination("user@host"), opts)
 		err := conn.ProbeAuthentication()
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "ssh probe failed")
@@ -145,7 +145,7 @@ func TestProbeAuthentication(t *testing.T) {
 			"public":    {stdout: "", err: nil},
 		}, &calls)
 		opts := target.ConnectionOptions{AcceptNewHostKeys: false, WithMockExec: mockExec}
-		conn := target.NewConnection("user@host", opts)
+		conn := target.NewConnection(ssh.MustNewDestination("user@host"), opts)
 		err := conn.ProbeAuthentication()
 		require.NoError(t, err)
 
@@ -159,7 +159,7 @@ func TestProbeAuthentication(t *testing.T) {
 			"knownhost": {stdout: "HOST KEY VERIFICATION FAILED", err: errSSH},
 		}, &calls)
 		opts := target.ConnectionOptions{AcceptNewHostKeys: false, WithMockExec: mockExec}
-		conn := target.NewConnection("user@host", opts)
+		conn := target.NewConnection(ssh.MustNewDestination("user@host"), opts)
 		err := conn.ProbeAuthentication()
 		require.ErrorIs(t, err, target.ErrHostKeyVerification)
 		require.Len(t, calls, 1)
@@ -171,7 +171,7 @@ func TestProbeAuthentication(t *testing.T) {
 			"knownhost": {stdout: "dial tcp: lookup host: no such host", err: errSSH},
 		}, &calls)
 		opts := target.ConnectionOptions{AcceptNewHostKeys: false, WithMockExec: mockExec}
-		conn := target.NewConnection("user@host", opts)
+		conn := target.NewConnection(ssh.MustNewDestination("user@host"), opts)
 		err := conn.ProbeAuthentication()
 		require.Error(t, err)
 		require.Len(t, calls, 1)

--- a/internal/target/connection_auth_test.go
+++ b/internal/target/connection_auth_test.go
@@ -64,7 +64,7 @@ func TestProbeAuthentication(t *testing.T) {
 			"public": {stdout: "", err: nil},
 		}, &calls)
 		opts := target.ConnectionOptions{AcceptNewHostKeys: true, WithMockExec: mockExec}
-		conn := target.NewConnection(ssh.MustNewDestination("user@host"), opts)
+		conn := target.NewConnection(testutil.MustNewDestination("user@host"), opts)
 		err := conn.ProbeAuthentication()
 		require.NoError(t, err)
 
@@ -79,7 +79,7 @@ func TestProbeAuthentication(t *testing.T) {
 			"public": {stdout: "Host key verification failed", err: errSSH},
 		}, &calls)
 		opts := target.ConnectionOptions{AcceptNewHostKeys: true, WithMockExec: mockExec}
-		conn := target.NewConnection(ssh.MustNewDestination("user@host"), opts)
+		conn := target.NewConnection(testutil.MustNewDestination("user@host"), opts)
 		err := conn.ProbeAuthentication()
 		require.ErrorIs(t, err, target.ErrHostKeyVerification)
 		require.Len(t, calls, 1)
@@ -92,7 +92,7 @@ func TestProbeAuthentication(t *testing.T) {
 			"password": {stdout: "Host key verification failed", err: errSSH},
 		}, &calls)
 		opts := target.ConnectionOptions{AcceptNewHostKeys: true, WithMockExec: mockExec}
-		conn := target.NewConnection(ssh.MustNewDestination("user@host"), opts)
+		conn := target.NewConnection(testutil.MustNewDestination("user@host"), opts)
 		err := conn.ProbeAuthentication()
 		require.ErrorIs(t, err, target.ErrHostKeyVerification)
 		require.Len(t, calls, 2)
@@ -106,7 +106,7 @@ func TestProbeAuthentication(t *testing.T) {
 			"password": {stdout: "Authentication failed", err: errSSH},
 		}, &calls)
 		opts := target.ConnectionOptions{AcceptNewHostKeys: true, WithMockExec: mockExec}
-		conn := target.NewConnection(ssh.MustNewDestination("user@host"), opts)
+		conn := target.NewConnection(testutil.MustNewDestination("user@host"), opts)
 		err := conn.ProbeAuthentication()
 		require.ErrorIs(t, err, target.ErrPasswordAuthentication)
 	})
@@ -118,7 +118,7 @@ func TestProbeAuthentication(t *testing.T) {
 			"password": {stdout: "ok", err: nil},
 		}, &calls)
 		opts := target.ConnectionOptions{AcceptNewHostKeys: true, WithMockExec: mockExec}
-		conn := target.NewConnection(ssh.MustNewDestination("user@host"), opts)
+		conn := target.NewConnection(testutil.MustNewDestination("user@host"), opts)
 		err := conn.ProbeAuthentication()
 		require.NoError(t, err)
 		require.Len(t, calls, 2)
@@ -132,7 +132,7 @@ func TestProbeAuthentication(t *testing.T) {
 			"password": {stdout: "Some other error", err: errSSH},
 		}, &calls)
 		opts := target.ConnectionOptions{AcceptNewHostKeys: true, WithMockExec: mockExec}
-		conn := target.NewConnection(ssh.MustNewDestination("user@host"), opts)
+		conn := target.NewConnection(testutil.MustNewDestination("user@host"), opts)
 		err := conn.ProbeAuthentication()
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "ssh probe failed")
@@ -145,7 +145,7 @@ func TestProbeAuthentication(t *testing.T) {
 			"public":    {stdout: "", err: nil},
 		}, &calls)
 		opts := target.ConnectionOptions{AcceptNewHostKeys: false, WithMockExec: mockExec}
-		conn := target.NewConnection(ssh.MustNewDestination("user@host"), opts)
+		conn := target.NewConnection(testutil.MustNewDestination("user@host"), opts)
 		err := conn.ProbeAuthentication()
 		require.NoError(t, err)
 
@@ -159,7 +159,7 @@ func TestProbeAuthentication(t *testing.T) {
 			"knownhost": {stdout: "HOST KEY VERIFICATION FAILED", err: errSSH},
 		}, &calls)
 		opts := target.ConnectionOptions{AcceptNewHostKeys: false, WithMockExec: mockExec}
-		conn := target.NewConnection(ssh.MustNewDestination("user@host"), opts)
+		conn := target.NewConnection(testutil.MustNewDestination("user@host"), opts)
 		err := conn.ProbeAuthentication()
 		require.ErrorIs(t, err, target.ErrHostKeyVerification)
 		require.Len(t, calls, 1)
@@ -171,7 +171,7 @@ func TestProbeAuthentication(t *testing.T) {
 			"knownhost": {stdout: "dial tcp: lookup host: no such host", err: errSSH},
 		}, &calls)
 		opts := target.ConnectionOptions{AcceptNewHostKeys: false, WithMockExec: mockExec}
-		conn := target.NewConnection(ssh.MustNewDestination("user@host"), opts)
+		conn := target.NewConnection(testutil.MustNewDestination("user@host"), opts)
 		err := conn.ProbeAuthentication()
 		require.Error(t, err)
 		require.Len(t, calls, 1)

--- a/internal/target/connection_test.go
+++ b/internal/target/connection_test.go
@@ -16,7 +16,7 @@ func TestRun(t *testing.T) {
 		mockExec := func(_ ssh.Destination, _ string, _ []byte, _ ...string) *exec.Cmd {
 			return testutil.CmdWithOutput("success", 0)
 		}
-		conn := target.NewConnection("hostname", target.ConnectionOptions{WithMockExec: mockExec})
+		conn := target.NewConnection(ssh.MustNewDestination("hostname"), target.ConnectionOptions{WithMockExec: mockExec})
 
 		out, err := conn.Run("ls")
 
@@ -28,7 +28,7 @@ func TestRun(t *testing.T) {
 		mockExec := func(_ ssh.Destination, _ string, _ []byte, _ ...string) *exec.Cmd {
 			return testutil.CmdWithOutput("", 1)
 		}
-		conn := target.NewConnection("hostname", target.ConnectionOptions{WithMockExec: mockExec})
+		conn := target.NewConnection(ssh.MustNewDestination("hostname"), target.ConnectionOptions{WithMockExec: mockExec})
 
 		out, err := conn.Run("ls")
 
@@ -40,7 +40,7 @@ func TestRun(t *testing.T) {
 		mockExec := func(_ ssh.Destination, _ string, _ []byte, _ ...string) *exec.Cmd {
 			return testutil.CmdWithStderr("Permission denied (publickey)", 1)
 		}
-		conn := target.NewConnection("hostname", target.ConnectionOptions{WithMockExec: mockExec})
+		conn := target.NewConnection(ssh.MustNewDestination("hostname"), target.ConnectionOptions{WithMockExec: mockExec})
 
 		_, err := conn.Run("ls")
 
@@ -51,7 +51,7 @@ func TestRun(t *testing.T) {
 		mockExec := func(_ ssh.Destination, _ string, _ []byte, _ ...string) *exec.Cmd {
 			return testutil.CmdWithStderr("ssh: connect to host foo port 22: Connection refused", 1)
 		}
-		conn := target.NewConnection("hostname", target.ConnectionOptions{WithMockExec: mockExec})
+		conn := target.NewConnection(ssh.MustNewDestination("hostname"), target.ConnectionOptions{WithMockExec: mockExec})
 
 		_, err := conn.Run("ls")
 
@@ -65,7 +65,7 @@ func TestRun(t *testing.T) {
 			capturedArgs = strings.Join(sshArgs, " ")
 			return testutil.CmdWithOutput("success", 0)
 		}
-		conn := target.NewConnection("hostname", target.ConnectionOptions{Multiplex: true, WithMockExec: mockExec})
+		conn := target.NewConnection(ssh.MustNewDestination("hostname"), target.ConnectionOptions{Multiplex: true, WithMockExec: mockExec})
 
 		_, err := conn.Run("ls")
 
@@ -82,7 +82,7 @@ func TestRun(t *testing.T) {
 			capturedArgs = strings.Join(sshArgs, " ")
 			return testutil.CmdWithOutput("success", 0)
 		}
-		conn := target.NewConnection("hostname", target.ConnectionOptions{Multiplex: true, WithMockExec: mockExec})
+		conn := target.NewConnection(ssh.MustNewDestination("hostname"), target.ConnectionOptions{Multiplex: true, WithMockExec: mockExec})
 
 		_, err := conn.Run("ls")
 
@@ -98,7 +98,7 @@ func TestBinaryExists(t *testing.T) {
 		mockExec := func(_ ssh.Destination, _ string, _ []byte, _ ...string) *exec.Cmd {
 			return testutil.CmdWithOutput("/foo/bar", 0)
 		}
-		conn := target.NewConnection("hostname", target.ConnectionOptions{WithMockExec: mockExec})
+		conn := target.NewConnection(ssh.MustNewDestination("hostname"), target.ConnectionOptions{WithMockExec: mockExec})
 
 		assert.NoError(t, conn.BinaryExists("bar"))
 	})
@@ -107,7 +107,7 @@ func TestBinaryExists(t *testing.T) {
 		mockExec := func(_ ssh.Destination, _ string, _ []byte, _ ...string) *exec.Cmd {
 			return testutil.CmdWithOutput("/foo/bar", 0)
 		}
-		conn := target.NewConnection("hostname", target.ConnectionOptions{WithMockExec: mockExec})
+		conn := target.NewConnection(ssh.MustNewDestination("hostname"), target.ConnectionOptions{WithMockExec: mockExec})
 
 		assert.Error(t, conn.BinaryExists("b a r"))
 	})

--- a/internal/target/connection_test.go
+++ b/internal/target/connection_test.go
@@ -16,7 +16,7 @@ func TestRun(t *testing.T) {
 		mockExec := func(_ ssh.Destination, _ string, _ []byte, _ ...string) *exec.Cmd {
 			return testutil.CmdWithOutput("success", 0)
 		}
-		conn := target.NewConnection(ssh.MustNewDestination("hostname"), target.ConnectionOptions{WithMockExec: mockExec})
+		conn := target.NewConnection(testutil.MustNewDestination("hostname"), target.ConnectionOptions{WithMockExec: mockExec})
 
 		out, err := conn.Run("ls")
 
@@ -28,7 +28,7 @@ func TestRun(t *testing.T) {
 		mockExec := func(_ ssh.Destination, _ string, _ []byte, _ ...string) *exec.Cmd {
 			return testutil.CmdWithOutput("", 1)
 		}
-		conn := target.NewConnection(ssh.MustNewDestination("hostname"), target.ConnectionOptions{WithMockExec: mockExec})
+		conn := target.NewConnection(testutil.MustNewDestination("hostname"), target.ConnectionOptions{WithMockExec: mockExec})
 
 		out, err := conn.Run("ls")
 
@@ -40,7 +40,7 @@ func TestRun(t *testing.T) {
 		mockExec := func(_ ssh.Destination, _ string, _ []byte, _ ...string) *exec.Cmd {
 			return testutil.CmdWithStderr("Permission denied (publickey)", 1)
 		}
-		conn := target.NewConnection(ssh.MustNewDestination("hostname"), target.ConnectionOptions{WithMockExec: mockExec})
+		conn := target.NewConnection(testutil.MustNewDestination("hostname"), target.ConnectionOptions{WithMockExec: mockExec})
 
 		_, err := conn.Run("ls")
 
@@ -51,7 +51,7 @@ func TestRun(t *testing.T) {
 		mockExec := func(_ ssh.Destination, _ string, _ []byte, _ ...string) *exec.Cmd {
 			return testutil.CmdWithStderr("ssh: connect to host foo port 22: Connection refused", 1)
 		}
-		conn := target.NewConnection(ssh.MustNewDestination("hostname"), target.ConnectionOptions{WithMockExec: mockExec})
+		conn := target.NewConnection(testutil.MustNewDestination("hostname"), target.ConnectionOptions{WithMockExec: mockExec})
 
 		_, err := conn.Run("ls")
 
@@ -65,7 +65,7 @@ func TestRun(t *testing.T) {
 			capturedArgs = strings.Join(sshArgs, " ")
 			return testutil.CmdWithOutput("success", 0)
 		}
-		conn := target.NewConnection(ssh.MustNewDestination("hostname"), target.ConnectionOptions{Multiplex: true, WithMockExec: mockExec})
+		conn := target.NewConnection(testutil.MustNewDestination("hostname"), target.ConnectionOptions{Multiplex: true, WithMockExec: mockExec})
 
 		_, err := conn.Run("ls")
 
@@ -82,7 +82,7 @@ func TestRun(t *testing.T) {
 			capturedArgs = strings.Join(sshArgs, " ")
 			return testutil.CmdWithOutput("success", 0)
 		}
-		conn := target.NewConnection(ssh.MustNewDestination("hostname"), target.ConnectionOptions{Multiplex: true, WithMockExec: mockExec})
+		conn := target.NewConnection(testutil.MustNewDestination("hostname"), target.ConnectionOptions{Multiplex: true, WithMockExec: mockExec})
 
 		_, err := conn.Run("ls")
 
@@ -98,7 +98,7 @@ func TestBinaryExists(t *testing.T) {
 		mockExec := func(_ ssh.Destination, _ string, _ []byte, _ ...string) *exec.Cmd {
 			return testutil.CmdWithOutput("/foo/bar", 0)
 		}
-		conn := target.NewConnection(ssh.MustNewDestination("hostname"), target.ConnectionOptions{WithMockExec: mockExec})
+		conn := target.NewConnection(testutil.MustNewDestination("hostname"), target.ConnectionOptions{WithMockExec: mockExec})
 
 		assert.NoError(t, conn.BinaryExists("bar"))
 	})
@@ -107,7 +107,7 @@ func TestBinaryExists(t *testing.T) {
 		mockExec := func(_ ssh.Destination, _ string, _ []byte, _ ...string) *exec.Cmd {
 			return testutil.CmdWithOutput("/foo/bar", 0)
 		}
-		conn := target.NewConnection(ssh.MustNewDestination("hostname"), target.ConnectionOptions{WithMockExec: mockExec})
+		conn := target.NewConnection(testutil.MustNewDestination("hostname"), target.ConnectionOptions{WithMockExec: mockExec})
 
 		assert.Error(t, conn.BinaryExists("b a r"))
 	})

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/arm/topo/internal/ssh"
 	"github.com/arm/topo/internal/template"
 	"github.com/stretchr/testify/require"
 )
@@ -102,4 +103,9 @@ func AssertFileContents(t *testing.T, wantContents string, path string) {
 	got, err := os.ReadFile(path)
 	require.NoError(t, err)
 	require.Equal(t, wantContents, string(got))
+}
+
+func MustNewDestination(raw string) ssh.Destination {
+	user, host, port := ssh.SplitUserHostPort(raw)
+	return ssh.Destination{User: user, Host: host, Port: port}
 }


### PR DESCRIPTION
## Background

`Destination` was previously a plain string type alias, which allowed it to be constructed anywhere by casting. This PR converts it to a struct with explicit `User`, `Host`, and `Port` fields, making the type self-contained and eliminating the need to parse the string in multiple places.

## Changes

- `Destination` is now a struct; construction goes through `MustNewDestination(raw string)` (for tests only!) or direct field assignment
- `String()` returns the canonical `ssh://user@host:port` URI form (previously done by `AsURI()`, which now delegates to `String()`)
- `Config` embeds `Destination` directly, replacing its private `host`/`user`/`port` fields
- `NewConfig(target)` is used at command boundaries to parse the raw string; inner packages receive a typed `Destination`
- All call sites updated: `ssh.Destination("...")` casts replaced with `ssh.MustNewDestination("...")`
- `target.NewConnection` now accepts `ssh.Destination` instead of `string`


