### PR TITLE
docs: fix references to old template names

### DIFF
--- a/cmd/topo/clone.go
+++ b/cmd/topo/clone.go
@@ -21,7 +21,7 @@ The project-source argument uses scheme prefixes to specify the source type.
 The git: prefix is optional for git@host and https:// URLs.
 
 Template Name (from built-in catalog):
-  topo clone template:Hello-World
+  topo clone template:topo-welcome
 
 Git repository:
   topo clone git@github.com:user/repo.git
@@ -38,11 +38,11 @@ Local directory (must contain a Topo template):
 Some projects require build arguments. Supply them on the command line or answer prompts:
 
   # Will prompt for required args
-  topo clone template:Hello-World
+  topo clone template:topo-welcome
   # Provide args explicitly
-  topo clone template:Hello-World GREETING_NAME="World"
+  topo clone template:topo-welcome GREETING_NAME="World"
   # With an explicit path
-  topo clone template:Hello-World my-demo GREETING_NAME="World"
+  topo clone template:topo-welcome my-demo GREETING_NAME="World"
 `,
 	Args: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/topo/extend.go
+++ b/cmd/topo/extend.go
@@ -19,7 +19,7 @@ var extendCmd = &cobra.Command{
 The source argument uses scheme prefixes to specify the source type:
 
 Template Name (from built-in templates):
-  topo extend compose.yaml template:Hello-World
+  topo extend compose.yaml template:topo-welcome
 
 Git repository (git: prefix is optional for git@host and https:// URLs):
   topo extend compose.yaml git:https://github.com/user/repo.git


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- Hello-World is now topo-welcome