### PR TITLE
ci: update Linux runners to use ubuntu-24.04-arm

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix: 
-        os: [ ubuntu-24.04-arm, windows-latest ]
+        os: [ ubuntu-latest, ubuntu-24.04-arm, windows-latest ]
         include:
           - os: windows-latest
             docker_host: ssh://test@localhost:2222

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   lint:
-    runs-on: [ ubuntu-latest ]
+    runs-on: [ ubuntu-24.04-arm ]
 
     steps:
       - name: Checkout repository
@@ -37,7 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix: 
-        os: [ ubuntu-latest, windows-latest ]
+        os: [ ubuntu-24.04-arm, windows-latest ]
         include:
           - os: windows-latest
             docker_host: ssh://test@localhost:2222

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- update Linux runners in CI to use ubuntu-24.04-arm
- Windows runners cannot be updated as easily as the WSL action seems to fail when run on ARM (https://github.com/arm/topo/actions/runs/23535780339/job/68510476002#step:2:42)
