### PR TITLE
fix: scope template build args per service

### DIFF
--- a/internal/compose/compose.go
+++ b/internal/compose/compose.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/compose-spec/compose-go/v2/cli"
 	"github.com/compose-spec/compose-go/v2/loader"
@@ -58,6 +59,85 @@ func CreateServiceByExtension(referencedComposeFilePath string, serviceName stri
 	}
 
 	return svc
+}
+
+func FilterResolvedBuildArgs(service map[string]any, resolvedArgs map[string]string) map[string]string {
+	if len(resolvedArgs) == 0 {
+		return nil
+	}
+
+	buildDefinition, hasBuild := service["build"]
+	if !hasBuild {
+		return nil
+	}
+
+	buildMap, ok := buildDefinition.(map[string]any)
+	if !ok {
+		return nil
+	}
+
+	argsDefinition, hasArgs := buildMap["args"]
+	if !hasArgs {
+		return nil
+	}
+
+	usedArgNames := extractBuildArgNames(argsDefinition)
+	if len(usedArgNames) == 0 {
+		return nil
+	}
+
+	filteredArgs := make(map[string]string)
+	for _, argName := range usedArgNames {
+		if value, exists := resolvedArgs[argName]; exists {
+			filteredArgs[argName] = value
+		}
+	}
+
+	if len(filteredArgs) == 0 {
+		return nil
+	}
+
+	return filteredArgs
+}
+
+func extractBuildArgNames(argsDefinition any) []string {
+	argNames := make(map[string]struct{})
+
+	switch args := argsDefinition.(type) {
+	case map[string]any:
+		for argName := range args {
+			argNames[argName] = struct{}{}
+		}
+	case []any:
+		for _, entry := range args {
+			argName, ok := parseBuildArgName(entry)
+			if ok {
+				argNames[argName] = struct{}{}
+			}
+		}
+	}
+
+	result := make([]string, 0, len(argNames))
+	for argName := range argNames {
+		result = append(result, argName)
+	}
+
+	return result
+}
+
+func parseBuildArgName(entry any) (string, bool) {
+	argText, ok := entry.(string)
+	if !ok {
+		return "", false
+	}
+
+	argName, _, _ := strings.Cut(argText, "=")
+	argName = strings.TrimSpace(argName)
+	if argName == "" {
+		return "", false
+	}
+
+	return argName, true
 }
 
 func convertArgs(resolvedArgs map[string]string) types.MappingWithEquals {

--- a/internal/compose/compose_test.go
+++ b/internal/compose/compose_test.go
@@ -107,6 +107,54 @@ func TestCreateServiceByExtension(t *testing.T) {
 	})
 }
 
+func TestFilterResolvedBuildArgs(t *testing.T) {
+	t.Run("returns only args referenced by build args mapping", func(t *testing.T) {
+		service := map[string]any{
+			"build": map[string]any{
+				"args": map[string]any{
+					"GREETING": "${GREETING:-hello}",
+				},
+			},
+		}
+
+		resolved := map[string]string{
+			"GREETING": "Hello",
+			"PORT":     "8080",
+		}
+
+		got := compose.FilterResolvedBuildArgs(service, resolved)
+
+		assert.Equal(t, map[string]string{"GREETING": "Hello"}, got)
+	})
+
+	t.Run("returns only args referenced by build args sequence", func(t *testing.T) {
+		service := map[string]any{
+			"build": map[string]any{
+				"args": []any{"GREETING", "PORT=80"},
+			},
+		}
+
+		resolved := map[string]string{
+			"GREETING": "Hello",
+			"PORT":     "8080",
+			"UNUSED":   "value",
+		}
+
+		got := compose.FilterResolvedBuildArgs(service, resolved)
+
+		assert.Equal(t, map[string]string{"GREETING": "Hello", "PORT": "8080"}, got)
+	})
+
+	t.Run("returns empty when service has no build args", func(t *testing.T) {
+		service := map[string]any{"image": "nginx:alpine"}
+		resolved := map[string]string{"GREETING": "Hello"}
+
+		got := compose.FilterResolvedBuildArgs(service, resolved)
+
+		assert.Empty(t, got)
+	})
+}
+
 func TestRegisterVolumes(t *testing.T) {
 	t.Run("registers volumes", func(t *testing.T) {
 		project := &types.Project{

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -118,10 +118,12 @@ func Extend(targetComposeFile string, src template.Source, argProvider arguments
 	if err != nil {
 		return logs, err
 	}
+	resolvedArgs := argsToMap(resolvedTemplate.Args)
 
 	extendedComposeFilePath := filepath.Join(copiedDirName, template.ComposeFilename)
 	for _, service := range resolvedTemplate.Services {
-		newSvc := compose.CreateServiceByExtension(extendedComposeFilePath, service.Name, argsToMap(resolvedTemplate.Args))
+		serviceArgs := compose.FilterResolvedBuildArgs(service.Data, resolvedArgs)
+		newSvc := compose.CreateServiceByExtension(extendedComposeFilePath, service.Name, serviceArgs)
 		logs = append(logs, logger.Entry{
 			Level:   logger.Info,
 			Message: fmt.Sprintf("adding service %q to project", newSvc.Name),

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -180,6 +180,9 @@ volumes:
 services:
   app:
     image: nginx:alpine
+    build:
+      args:
+        GREETING: ${GREETING:-Hello}
 
 x-topo:
   name: "piggy-service"
@@ -211,6 +214,65 @@ services:
 		assert.YAMLEq(t, want, string(got))
 	})
 
+	t.Run("injects arguments only into services that declare them", func(t *testing.T) {
+		dir := t.TempDir()
+		targetProjectFile := testutil.WriteComposeFile(t, dir, emptyComposeProject)
+		sourceName := "service-args-scope"
+		mockSource := mockTemplateSourceWithContent(t, `
+services:
+  app:
+    image: nginx:alpine
+    build:
+      args:
+        GREETING: ${GREETING:-Hello}
+  worker:
+    image: redis:alpine
+    build:
+      args:
+        PORT: ${PORT:-8080}
+
+x-topo:
+  name: "service-args-scope"
+  args:
+    GREETING:
+      description: "Greeting message"
+      required: true
+    PORT:
+      description: "Worker port"
+      required: true
+`, sourceName)
+		provider := arguments.NewStaticProvider(
+			arguments.ResolvedArg{Name: "GREETING", Value: "Hello, World"},
+			arguments.ResolvedArg{Name: "PORT", Value: "9090"},
+		)
+
+		_, err := project.Extend(targetProjectFile, mockSource, provider)
+		require.NoError(t, err)
+
+		got, err := os.ReadFile(targetProjectFile)
+		require.NoError(t, err)
+		sourcePath := filepath.Join(sourceName, "compose.yaml")
+		want := fmt.Sprintf(`
+name: example-project
+services:
+  app:
+    extends:
+      file: %s
+      service: app
+    build:
+      args:
+        GREETING: "Hello, World"
+  worker:
+    extends:
+      file: %s
+      service: worker
+    build:
+      args:
+        PORT: "9090"
+`, sourcePath, sourcePath)
+		assert.YAMLEq(t, want, string(got))
+	})
+
 	t.Run("does not collect optional arguments into x-topo", func(t *testing.T) {
 		dir := t.TempDir()
 		targetProjectFile := testutil.WriteComposeFile(t, dir, emptyComposeProject)
@@ -219,6 +281,9 @@ services:
 services:
   app:
     image: nginx:alpine
+    build:
+      args:
+        GREETING: ${GREETING:-Hello}
 
 x-topo:
   name: "oyster-service"


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- Filter resolved template arguments against each service's declared `build.args` during `extend` so unrelated args are not duplicated across all generated service stubs.
