### PR TITLE
Do not show failed curl command in logs where failed curl command is wanted behaviour

### DIFF
--- a/internal/ssh/ssh_tunnel.go
+++ b/internal/ssh/ssh_tunnel.go
@@ -128,7 +128,7 @@ func (ct *CheckSSHTunnelSecurity) Run(w io.Writer) error {
 		return fmt.Errorf("SSH tunnel to %s is not secure: able to access registry port without authentication", ct.TargetDest)
 	}
 
-	_, _ = fmt.Fprintf(w, "Port %s is not exposed to local network\n", ct.Port)
+	_, _ = fmt.Fprintf(w, "Port %s is not exposed on remote to local network\n", ct.Port)
 	return nil
 }
 

--- a/internal/ssh/ssh_tunnel.go
+++ b/internal/ssh/ssh_tunnel.go
@@ -128,7 +128,7 @@ func (ct *CheckSSHTunnelSecurity) Run(w io.Writer) error {
 		return fmt.Errorf("SSH tunnel to %s is not secure: able to access registry port without authentication", ct.TargetDest)
 	}
 
-	_, _ = fmt.Fprintf(w, "Port %s is not exposed on remote\n", ct.Port)
+	_, _ = fmt.Fprintf(w, "Port %s is not exposed to local network\n", ct.Port)
 	return nil
 }
 

--- a/internal/ssh/ssh_tunnel.go
+++ b/internal/ssh/ssh_tunnel.go
@@ -128,7 +128,7 @@ func (ct *CheckSSHTunnelSecurity) Run(w io.Writer) error {
 		return fmt.Errorf("SSH tunnel to %s is not secure: able to access registry port without authentication", ct.TargetDest)
 	}
 
-	_, _ = fmt.Fprintf(w, "Port %s is not exposed on remote to local network\n", ct.Port)
+	_, _ = fmt.Fprintf(w, "Port %s is not exposed on target to local network\n", ct.Port)
 	return nil
 }
 

--- a/internal/ssh/ssh_tunnel.go
+++ b/internal/ssh/ssh_tunnel.go
@@ -117,14 +117,18 @@ func (ct *CheckSSHTunnelSecurity) Run(w io.Writer) error {
 	if cmd == nil {
 		panic(fmt.Sprintf("BUG: security check called for unresolvable host %q; caller must validate host before invoking", ct.TargetDest))
 	}
-	cmd.Stdout = w
-	cmd.Stderr = w
+
+	var buf strings.Builder
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
 
 	err := cmd.Run()
 	if err == nil {
+		_, _ = fmt.Fprint(w, buf.String())
 		return fmt.Errorf("SSH tunnel to %s is not secure: able to access registry port without authentication", ct.TargetDest)
 	}
 
+	_, _ = fmt.Fprintf(w, "Port %s is not exposed on remote\n", ct.Port)
 	return nil
 }
 


### PR DESCRIPTION
I ran topo deploy and got:
```
┌─ Check SSH tunnel security ───────────────────────────
curl: (7) Failed to connect to 10.2.2.39 port 12737 after 5 ms: Couldn't connect to server
```

Even though this is the correct path, it looks like an error.

This PR changes it so that error message is hidden, and instead we just tell the user that their port is secure.
```
Port %s is not exposed on remote\n
```