### PR TITLE
feat!: remove `--dry-run` support

### DIFF
--- a/cmd/topo/deploy.go
+++ b/cmd/topo/deploy.go
@@ -39,9 +39,7 @@ This command performs the following operations in sequence:
   3. Transfer - Transfers built and pulled images and compose file to the target host
   4. Run - Runs docker compose up on the target host
 
-The compose file (compose.yaml) must be in the current working directory, as this is used to select the containers to be deployed.
-
-Use --dry-run to see what commands would be executed without actually running them.`,
+The compose file (compose.yaml) must be in the current working directory, as this is used to select the containers to be deployed.`,
 	Args: cobra.ExactArgs(0),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true

--- a/cmd/topo/deploy.go
+++ b/cmd/topo/deploy.go
@@ -46,11 +46,6 @@ Use --dry-run to see what commands would be executed without actually running th
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 
-		dryRun, err := cmd.Flags().GetBool("dry-run")
-		if err != nil {
-			panic(fmt.Sprintf("internal error: dry-run flag not registered: %v", err))
-		}
-
 		outputFormat, err := resolveOutput(cmd)
 		if err != nil {
 			return err
@@ -124,9 +119,6 @@ Use --dry-run to see what commands would be executed without actually running th
 			c.Log(entries...)
 		}()
 
-		if dryRun {
-			return deployment.DryRun(os.Stdout)
-		}
 		return deployment.Run(os.Stdout)
 	},
 }
@@ -166,7 +158,6 @@ func resolvePort(cmd *cobra.Command, flagValue string) (string, error) {
 
 func init() {
 	addTargetFlag(deployCmd)
-	addDryRunFlag(deployCmd)
 	deployCmd.Flags().StringVarP(&registryPort, "registry-port", "p", operation.DefaultRegistryPort, fmt.Sprintf("Registry and SSH tunnel port (can also be set via %s env var)", portEnvVar))
 	deployCmd.Flags().BoolVar(&noRegistry, "no-registry", false, "Disable private registry flow; use direct save/load transfer")
 	deployCmd.Flags().BoolVar(&forceRecreate, "force-recreate", false, "Force recreation of containers even if their configuration and image haven't changed")

--- a/cmd/topo/root.go
+++ b/cmd/topo/root.go
@@ -39,10 +39,6 @@ func addTargetFlag(cmd *cobra.Command) {
 	)
 }
 
-func addDryRunFlag(cmd *cobra.Command) {
-	cmd.Flags().Bool("dry-run", false, "Show what commands would be executed without actually running them")
-}
-
 func lookupTarget(cmd *cobra.Command) (string, bool) {
 	flagValue, err := cmd.Flags().GetString("target")
 	if err != nil {

--- a/cmd/topo/stop.go
+++ b/cmd/topo/stop.go
@@ -16,9 +16,7 @@ var topoStopCmd = &cobra.Command{
 
 Executing this command does not remove the containers.
 
-The compose file (compose.yaml) must be in the current working directory, as this is used to select the containers to be stopped.
-
-Use --dry-run to see what commands would be executed without actually running them.`,
+The compose file (compose.yaml) must be in the current working directory, as this is used to select the containers to be stopped.`,
 	Args: cobra.ExactArgs(0),
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		cmd.SilenceUsage = true

--- a/cmd/topo/stop.go
+++ b/cmd/topo/stop.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/arm/topo/internal/deploy/docker"
@@ -24,11 +23,6 @@ Use --dry-run to see what commands would be executed without actually running th
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		cmd.SilenceUsage = true
 
-		dryRun, err := cmd.Flags().GetBool("dry-run")
-		if err != nil {
-			panic(fmt.Sprintf("internal error: dry-run flag not registered: %v", err))
-		}
-
 		targetArg, err := requireTarget(cmd)
 		if err != nil {
 			return err
@@ -42,9 +36,6 @@ Use --dry-run to see what commands would be executed without actually running th
 		dest := ssh.NewDestination(targetArg)
 
 		stop := docker.NewDeploymentStop(composeFile, dest)
-		if dryRun {
-			return stop.DryRun(os.Stdout)
-		}
 
 		return stop.Run(os.Stdout)
 	},
@@ -52,6 +43,5 @@ Use --dry-run to see what commands would be executed without actually running th
 
 func init() {
 	addTargetFlag(topoStopCmd)
-	addDryRunFlag(topoStopCmd)
 	rootCmd.AddCommand(topoStopCmd)
 }


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- Removes the `--dry-run` flag from stop/deploy + updates relevant help strings
- Does not clean up any internals, that will come in a later refactor PR
