### PR TITLE
refactor: make login shell explicit per command

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"fmt"
 	"os/exec"
 	"strings"
 
@@ -25,6 +26,21 @@ func SSHKeyGen(keyType string, keyPath string, targetHost string) *exec.Cmd {
 
 func String(cmd *exec.Cmd) string {
 	return strings.Join(cmd.Args, " ")
+}
+
+func WrapInLoginShell(cmd string) string {
+	escaped := shellEscapeForDoubleQuotes(cmd)
+	return fmt.Sprintf(`/bin/sh -c "exec ${SHELL:-/bin/sh} -l -c \"%s\""`, escaped)
+}
+
+func shellEscapeForDoubleQuotes(s string) string {
+	repl := strings.NewReplacer(
+		`\`, `\\`,
+		`"`, `\\\"`,
+		`$`, `\\\$`,
+		"`", `\\\`+"`",
+	)
+	return repl.Replace(s)
 }
 
 func hostToArgs(h ssh.Destination) []string {

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -33,6 +33,18 @@ func WrapInLoginShell(cmd string) string {
 	return fmt.Sprintf(`/bin/sh -c "exec ${SHELL:-/bin/sh} -l -c \"%s\""`, escaped)
 }
 
+func UnsafeBinaryLookupCommand(bin string) string {
+	return WrapInLoginShell(fmt.Sprintf("command -v %s", bin))
+}
+
+func BinaryLookupCommand(bin string) (string, error) {
+	if err := ValidateBinaryName(bin); err != nil {
+		return "", err
+	}
+
+	return UnsafeBinaryLookupCommand(bin), nil
+}
+
 func shellEscapeForDoubleQuotes(s string) string {
 	repl := strings.NewReplacer(
 		`\`, `\\`,

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/arm/topo/internal/command"
 	"github.com/arm/topo/internal/ssh"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestString(t *testing.T) {
@@ -36,5 +37,29 @@ func TestWrapInLoginShell(t *testing.T) {
 
 		want := `/bin/sh -c "exec ${SHELL:-/bin/sh} -l -c \"echo \\\$PATH\""`
 		assert.Equal(t, want, got)
+	})
+}
+
+func TestBinaryLookupCommand(t *testing.T) {
+	t.Run("returns wrapped command for valid binary", func(t *testing.T) {
+		got, err := command.BinaryLookupCommand("docker")
+
+		require.NoError(t, err)
+		assert.Equal(t, command.UnsafeBinaryLookupCommand("docker"), got)
+	})
+
+	t.Run("returns error for invalid binary", func(t *testing.T) {
+		got, err := command.BinaryLookupCommand("bad name")
+
+		assert.Error(t, err)
+		assert.Empty(t, got)
+	})
+}
+
+func TestUnsafeBinaryLookupCommand(t *testing.T) {
+	t.Run("returns wrapped command without validation", func(t *testing.T) {
+		got := command.UnsafeBinaryLookupCommand("docker")
+
+		assert.Equal(t, command.WrapInLoginShell("command -v docker"), got)
 	})
 }

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -29,3 +29,12 @@ func TestString(t *testing.T) {
 		assert.Equal(t, want, got)
 	})
 }
+
+func TestWrapInLoginShell(t *testing.T) {
+	t.Run("wraps command in login shell", func(t *testing.T) {
+		got := command.WrapInLoginShell("echo $PATH")
+
+		want := `/bin/sh -c "exec ${SHELL:-/bin/sh} -l -c \"echo \\\$PATH\""`
+		assert.Equal(t, want, got)
+	})
+}

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -68,7 +68,6 @@ func CheckHost() HostReport {
 func CheckTarget(dest ssh.Destination, probeOpts target.SSHAuthenticationProbeOptions, connectTimeout time.Duration) (TargetReport, error) {
 	opts := target.ConnectionOptions{
 		Multiplex:      true,
-		WithLoginShell: true,
 		ConnectTimeout: connectTimeout,
 	}
 	conn := target.NewConnection(dest, opts)

--- a/internal/health/status.go
+++ b/internal/health/status.go
@@ -1,6 +1,7 @@
 package health
 
 import (
+	"github.com/arm/topo/internal/command"
 	"github.com/arm/topo/internal/ssh"
 	"github.com/arm/topo/internal/target"
 )
@@ -39,7 +40,7 @@ func ProbeHealthStatus(c target.Connection, probeOpts target.SSHAuthenticationPr
 	status.Hardware.RemoteCPU = remoteprocs
 	dependenciesToCheck := FilterByHardware(TargetRequiredDependencies, status.Hardware.Capabilities())
 	status.Dependencies = PerformChecks(dependenciesToCheck, c.BinaryExists, func(fullCmd string) error {
-		_, err := c.Run(ssh.ShellCommand(fullCmd))
+		_, err := c.Run(command.WrapInLoginShell(fullCmd))
 		return err
 	})
 

--- a/internal/health/status.go
+++ b/internal/health/status.go
@@ -39,7 +39,7 @@ func ProbeHealthStatus(c target.Connection, probeOpts target.SSHAuthenticationPr
 	status.Hardware.RemoteCPU = remoteprocs
 	dependenciesToCheck := FilterByHardware(TargetRequiredDependencies, status.Hardware.Capabilities())
 	status.Dependencies = PerformChecks(dependenciesToCheck, c.BinaryExists, func(fullCmd string) error {
-		_, err := c.Run(fullCmd)
+		_, err := c.Run(ssh.ShellCommand(fullCmd))
 		return err
 	})
 

--- a/internal/health/status.go
+++ b/internal/health/status.go
@@ -39,7 +39,14 @@ func ProbeHealthStatus(c target.Connection, probeOpts target.SSHAuthenticationPr
 	remoteprocs, _ := probe.ProbeRemoteproc()
 	status.Hardware.RemoteCPU = remoteprocs
 	dependenciesToCheck := FilterByHardware(TargetRequiredDependencies, status.Hardware.Capabilities())
-	status.Dependencies = PerformChecks(dependenciesToCheck, c.BinaryExists, func(fullCmd string) error {
+	status.Dependencies = PerformChecks(dependenciesToCheck, func(bin string) error {
+		// We can use `UnsafeBinaryLookupCommand`, because the dependencies we're checking are hardcoded in the codebase
+		if _, err := c.Run(command.UnsafeBinaryLookupCommand(bin)); err != nil {
+			return err
+		}
+
+		return nil
+	}, func(fullCmd string) error {
 		_, err := c.Run(command.WrapInLoginShell(fullCmd))
 		return err
 	})

--- a/internal/health/status.go
+++ b/internal/health/status.go
@@ -38,18 +38,20 @@ func ProbeHealthStatus(c target.Connection, probeOpts target.SSHAuthenticationPr
 	probe := target.NewHardwareProbe(&c)
 	remoteprocs, _ := probe.ProbeRemoteproc()
 	status.Hardware.RemoteCPU = remoteprocs
+
 	dependenciesToCheck := FilterByHardware(TargetRequiredDependencies, status.Hardware.Capabilities())
-	status.Dependencies = PerformChecks(dependenciesToCheck, func(bin string) error {
+	binaryExists := func(bin string) error {
 		// We can use `UnsafeBinaryLookupCommand`, because the dependencies we're checking are hardcoded in the codebase
 		if _, err := c.Run(command.UnsafeBinaryLookupCommand(bin)); err != nil {
 			return err
 		}
-
 		return nil
-	}, func(fullCmd string) error {
+	}
+	commandSuccessful := func(fullCmd string) error {
 		_, err := c.Run(command.WrapInLoginShell(fullCmd))
 		return err
-	})
+	}
+	status.Dependencies = PerformChecks(dependenciesToCheck, binaryExists, commandSuccessful)
 
 	return status
 }

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -35,7 +35,7 @@ type PathCandidate struct {
 
 func getPathDirs(targetDest ssh.Destination) ([]string, error) {
 	conn := target.NewConnection(targetDest, target.ConnectionOptions{})
-	output, err := conn.Run(ssh.ShellCommand("echo $PATH"))
+	output, err := conn.Run(command.WrapInLoginShell("echo $PATH"))
 	if err != nil {
 		return nil, err
 	}
@@ -48,7 +48,7 @@ func getPathDirs(targetDest ssh.Destination) ([]string, error) {
 
 func getHomeDir(targetDest ssh.Destination) (string, error) {
 	conn := target.NewConnection(targetDest, target.ConnectionOptions{})
-	output, err := conn.Run(ssh.ShellCommand("echo $HOME"))
+	output, err := conn.Run(command.WrapInLoginShell("echo $HOME"))
 	if err != nil {
 		return "", err
 	}
@@ -57,7 +57,7 @@ func getHomeDir(targetDest ssh.Destination) (string, error) {
 
 func getExistingBinaryDir(targetDest ssh.Destination, binaryName string) (string, error) {
 	conn := target.NewConnection(targetDest, target.ConnectionOptions{})
-	output, err := conn.Run(ssh.ShellCommand(fmt.Sprintf("command -v %s", binaryName)))
+	output, err := conn.Run(command.WrapInLoginShell(fmt.Sprintf("command -v %s", binaryName)))
 	if err != nil {
 		return "", nil
 	}
@@ -282,7 +282,7 @@ func install(installPath string, targetDest ssh.Destination, binaries map[string
 
 		installCmd := fmt.Sprintf("install -D -m %s /dev/stdin %s/%s", mode, installPath, binaryName)
 		conn := target.NewConnection(targetDest, target.ConnectionOptions{WithStdin: binaryData})
-		output, err := conn.Run(ssh.ShellCommand(installCmd))
+		output, err := conn.Run(command.WrapInLoginShell(installCmd))
 		if err != nil {
 			if errors.Is(err, ssh.ErrSSH) {
 				return err

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -34,8 +34,8 @@ type PathCandidate struct {
 }
 
 func getPathDirs(targetDest ssh.Destination) ([]string, error) {
-	conn := target.NewConnection(targetDest, target.ConnectionOptions{WithLoginShell: true})
-	output, err := conn.Run("echo $PATH")
+	conn := target.NewConnection(targetDest, target.ConnectionOptions{})
+	output, err := conn.Run(ssh.ShellCommand("echo $PATH"))
 	if err != nil {
 		return nil, err
 	}
@@ -47,8 +47,8 @@ func getPathDirs(targetDest ssh.Destination) ([]string, error) {
 }
 
 func getHomeDir(targetDest ssh.Destination) (string, error) {
-	conn := target.NewConnection(targetDest, target.ConnectionOptions{WithLoginShell: true})
-	output, err := conn.Run("echo $HOME")
+	conn := target.NewConnection(targetDest, target.ConnectionOptions{})
+	output, err := conn.Run(ssh.ShellCommand("echo $HOME"))
 	if err != nil {
 		return "", err
 	}
@@ -56,8 +56,8 @@ func getHomeDir(targetDest ssh.Destination) (string, error) {
 }
 
 func getExistingBinaryDir(targetDest ssh.Destination, binaryName string) (string, error) {
-	conn := target.NewConnection(targetDest, target.ConnectionOptions{WithLoginShell: true})
-	output, err := conn.Run(fmt.Sprintf("command -v %s", binaryName))
+	conn := target.NewConnection(targetDest, target.ConnectionOptions{})
+	output, err := conn.Run(ssh.ShellCommand(fmt.Sprintf("command -v %s", binaryName)))
 	if err != nil {
 		return "", nil
 	}
@@ -281,8 +281,8 @@ func install(installPath string, targetDest ssh.Destination, binaries map[string
 		}
 
 		installCmd := fmt.Sprintf("install -D -m %s /dev/stdin %s/%s", mode, installPath, binaryName)
-		conn := target.NewConnection(targetDest, target.ConnectionOptions{WithLoginShell: true, WithStdin: binaryData})
-		output, err := conn.Run(installCmd)
+		conn := target.NewConnection(targetDest, target.ConnectionOptions{WithStdin: binaryData})
+		output, err := conn.Run(ssh.ShellCommand(installCmd))
 		if err != nil {
 			if errors.Is(err, ssh.ErrSSH) {
 				return err

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -57,7 +57,12 @@ func getHomeDir(targetDest ssh.Destination) (string, error) {
 
 func getExistingBinaryDir(targetDest ssh.Destination, binaryName string) (string, error) {
 	conn := target.NewConnection(targetDest, target.ConnectionOptions{})
-	output, err := conn.Run(command.WrapInLoginShell(fmt.Sprintf("command -v %s", binaryName)))
+	checkCommand, err := command.BinaryLookupCommand(binaryName)
+	if err != nil {
+		return "", err
+	}
+
+	output, err := conn.Run(checkCommand)
 	if err != nil {
 		return "", nil
 	}

--- a/internal/setupkeys/pubkeytransfer/pub_key_transfer.go
+++ b/internal/setupkeys/pubkeytransfer/pub_key_transfer.go
@@ -31,7 +31,7 @@ func (kt *PubKeyTransfer) Description() string {
 }
 
 func (kt *PubKeyTransfer) buildTransferConnection(stdin []byte) *target.Connection {
-	opts := target.ConnectionOptions{WithLoginShell: true, WithStdin: stdin}
+	opts := target.ConnectionOptions{WithStdin: stdin}
 
 	if kt.opts.WithMockExec != nil {
 		opts.WithMockExec = kt.opts.WithMockExec
@@ -49,7 +49,7 @@ func (kt *PubKeyTransfer) Run(outputWriter io.Writer) error {
 	}
 
 	conn := kt.buildTransferConnection(pubKey)
-	cmdOutput, err := conn.Run(remoteAuthorizedKeysCommand)
+	cmdOutput, err := conn.Run(ssh.ShellCommand(remoteAuthorizedKeysCommand))
 	if err != nil {
 		return fmt.Errorf("failed to transfer public key to target %s: %w", kt.dest, err)
 	}
@@ -59,7 +59,7 @@ func (kt *PubKeyTransfer) Run(outputWriter io.Writer) error {
 
 func (kt *PubKeyTransfer) DryRun(output io.Writer) error {
 	conn := kt.buildTransferConnection(nil)
-	if err := conn.DryRun(remoteAuthorizedKeysCommand, output); err != nil {
+	if err := conn.DryRun(ssh.ShellCommand(remoteAuthorizedKeysCommand), output); err != nil {
 		return fmt.Errorf("failed to write dry-run output for public key transfer to target %s: %w", kt.dest, err)
 	}
 	return nil

--- a/internal/setupkeys/pubkeytransfer/pub_key_transfer.go
+++ b/internal/setupkeys/pubkeytransfer/pub_key_transfer.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 
+	"github.com/arm/topo/internal/command"
 	"github.com/arm/topo/internal/ssh"
 	target "github.com/arm/topo/internal/target"
 )
@@ -49,7 +50,7 @@ func (kt *PubKeyTransfer) Run(outputWriter io.Writer) error {
 	}
 
 	conn := kt.buildTransferConnection(pubKey)
-	cmdOutput, err := conn.Run(ssh.ShellCommand(remoteAuthorizedKeysCommand))
+	cmdOutput, err := conn.Run(command.WrapInLoginShell(remoteAuthorizedKeysCommand))
 	if err != nil {
 		return fmt.Errorf("failed to transfer public key to target %s: %w", kt.dest, err)
 	}
@@ -59,7 +60,7 @@ func (kt *PubKeyTransfer) Run(outputWriter io.Writer) error {
 
 func (kt *PubKeyTransfer) DryRun(output io.Writer) error {
 	conn := kt.buildTransferConnection(nil)
-	if err := conn.DryRun(ssh.ShellCommand(remoteAuthorizedKeysCommand), output); err != nil {
+	if err := conn.DryRun(command.WrapInLoginShell(remoteAuthorizedKeysCommand), output); err != nil {
 		return fmt.Errorf("failed to write dry-run output for public key transfer to target %s: %w", kt.dest, err)
 	}
 	return nil

--- a/internal/ssh/exec.go
+++ b/internal/ssh/exec.go
@@ -2,28 +2,9 @@ package ssh
 
 import (
 	"bytes"
-	"fmt"
 	"os/exec"
 	"slices"
-	"strings"
 )
-
-func shellEscapeForDoubleQuotes(s string) string {
-	// Escape for TWO nested double-quoted shell layers- need three `\\\`.
-	// /bin/sh -c "exec ${SHELL} -l -c \"<command>\""
-	repl := strings.NewReplacer(
-		`\`, `\\\\`,
-		`"`, `\\\"`,
-		`$`, `\\\$`,
-		"`", `\\\`+"`",
-	)
-	return repl.Replace(s)
-}
-
-func ShellCommand(command string) string {
-	escaped := shellEscapeForDoubleQuotes(command)
-	return fmt.Sprintf(`/bin/sh -c "exec ${SHELL:-/bin/sh} -l -c \"%s\""`, escaped)
-}
 
 // ExecCmd builds a command to be executed on the target host. If the target is localhost, it will run locally when executed.
 // Pass stdin data as optional parameter, or nil for no stdin.

--- a/internal/target/connection.go
+++ b/internal/target/connection.go
@@ -88,7 +88,7 @@ func (c *Connection) BinaryExists(bin string) error {
 		return err
 	}
 
-	if _, err := c.Run(ssh.ShellCommand(fmt.Sprintf("command -v %s", bin))); err != nil {
+	if _, err := c.Run(command.WrapInLoginShell(fmt.Sprintf("command -v %s", bin))); err != nil {
 		return fmt.Errorf("%q executable file not found in $PATH", bin)
 	}
 	return nil

--- a/internal/target/connection.go
+++ b/internal/target/connection.go
@@ -22,7 +22,6 @@ type Connection struct {
 }
 
 type ConnectionOptions struct {
-	WithLoginShell bool
 	WithStdin      []byte
 	Multiplex      bool
 	WithMockExec   ExecSSH
@@ -43,10 +42,6 @@ func NewConnection(dest ssh.Destination, opts ConnectionOptions) Connection {
 }
 
 func (c *Connection) Run(cmdStr string) (string, error) {
-	if c.opts.WithLoginShell {
-		cmdStr = ssh.ShellCommand(cmdStr)
-	}
-
 	sshArgs := c.connectTimeoutArgs()
 	if c.opts.Multiplex && runtime.GOOS != "windows" {
 		sshArgs = append(sshArgs, "-o", "ControlMaster=auto", "-o", "ControlPersist=10s", "-o", "ControlPath=~/.ssh/topo-cm-%r@%h:%p")
@@ -83,10 +78,6 @@ func (c *Connection) RunWithArgs(cmdStr string, sshArgs ...string) (string, erro
 }
 
 func (c *Connection) DryRun(cmdStr string, output io.Writer) error {
-	if c.opts.WithLoginShell {
-		cmdStr = ssh.ShellCommand(cmdStr)
-	}
-
 	cmd := c.exec(c.SSHTarget, cmdStr, c.opts.WithStdin)
 	_, err := fmt.Fprintln(output, command.String(cmd))
 	return err
@@ -97,7 +88,7 @@ func (c *Connection) BinaryExists(bin string) error {
 		return err
 	}
 
-	if _, err := c.Run(fmt.Sprintf("command -v %s", bin)); err != nil {
+	if _, err := c.Run(ssh.ShellCommand(fmt.Sprintf("command -v %s", bin))); err != nil {
 		return fmt.Errorf("%q executable file not found in $PATH", bin)
 	}
 	return nil

--- a/internal/target/connection.go
+++ b/internal/target/connection.go
@@ -83,17 +83,6 @@ func (c *Connection) DryRun(cmdStr string, output io.Writer) error {
 	return err
 }
 
-func (c *Connection) BinaryExists(bin string) error {
-	if err := command.ValidateBinaryName(bin); err != nil {
-		return err
-	}
-
-	if _, err := c.Run(command.WrapInLoginShell(fmt.Sprintf("command -v %s", bin))); err != nil {
-		return fmt.Errorf("%q executable file not found in $PATH", bin)
-	}
-	return nil
-}
-
 type ConnectionTimeoutError struct {
 	Timeout time.Duration
 }

--- a/internal/target/connection_test.go
+++ b/internal/target/connection_test.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/arm/topo/internal/command"
 	"github.com/arm/topo/internal/ssh"
 	"github.com/arm/topo/internal/target"
 	"github.com/arm/topo/internal/testutil"
@@ -91,28 +90,5 @@ func TestRun(t *testing.T) {
 		assert.False(t, strings.Contains(capturedArgs, "-o ControlMaster"), "unexpected ControlMaster argument")
 		assert.False(t, strings.Contains(capturedArgs, "-o ControlPersist"), "unexpected ControlPersist argument")
 		assert.False(t, strings.Contains(capturedArgs, "-o ControlPath"), "unexpected ControlPath argument")
-	})
-}
-
-func TestBinaryExists(t *testing.T) {
-	t.Run("when binary found returns nil", func(t *testing.T) {
-		var capturedCmd string
-		mockExec := func(_ ssh.Destination, cmd string, _ []byte, _ ...string) *exec.Cmd {
-			capturedCmd = cmd
-			return testutil.CmdWithOutput("/foo/bar", 0)
-		}
-		conn := target.NewConnection(ssh.NewDestination("hostname"), target.ConnectionOptions{WithMockExec: mockExec})
-
-		assert.NoError(t, conn.BinaryExists("bar"))
-		assert.Equal(t, command.WrapInLoginShell("command -v bar"), capturedCmd)
-	})
-
-	t.Run("invalid format returns an error", func(t *testing.T) {
-		mockExec := func(_ ssh.Destination, _ string, _ []byte, _ ...string) *exec.Cmd {
-			return testutil.CmdWithOutput("/foo/bar", 0)
-		}
-		conn := target.NewConnection(ssh.NewDestination("hostname"), target.ConnectionOptions{WithMockExec: mockExec})
-
-		assert.Error(t, conn.BinaryExists("b a r"))
 	})
 }

--- a/internal/target/connection_test.go
+++ b/internal/target/connection_test.go
@@ -95,12 +95,15 @@ func TestRun(t *testing.T) {
 
 func TestBinaryExists(t *testing.T) {
 	t.Run("when binary found returns nil", func(t *testing.T) {
-		mockExec := func(_ ssh.Destination, _ string, _ []byte, _ ...string) *exec.Cmd {
+		var capturedCmd string
+		mockExec := func(_ ssh.Destination, cmd string, _ []byte, _ ...string) *exec.Cmd {
+			capturedCmd = cmd
 			return testutil.CmdWithOutput("/foo/bar", 0)
 		}
 		conn := target.NewConnection(ssh.NewDestination("hostname"), target.ConnectionOptions{WithMockExec: mockExec})
 
 		assert.NoError(t, conn.BinaryExists("bar"))
+		assert.Equal(t, ssh.ShellCommand("command -v bar"), capturedCmd)
 	})
 
 	t.Run("invalid format returns an error", func(t *testing.T) {

--- a/internal/target/connection_test.go
+++ b/internal/target/connection_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/arm/topo/internal/command"
 	"github.com/arm/topo/internal/ssh"
 	"github.com/arm/topo/internal/target"
 	"github.com/arm/topo/internal/testutil"
@@ -103,7 +104,7 @@ func TestBinaryExists(t *testing.T) {
 		conn := target.NewConnection(ssh.NewDestination("hostname"), target.ConnectionOptions{WithMockExec: mockExec})
 
 		assert.NoError(t, conn.BinaryExists("bar"))
-		assert.Equal(t, ssh.ShellCommand("command -v bar"), capturedCmd)
+		assert.Equal(t, command.WrapInLoginShell("command -v bar"), capturedCmd)
 	})
 
 	t.Run("invalid format returns an error", func(t *testing.T) {

--- a/internal/target/hardware_probe.go
+++ b/internal/target/hardware_probe.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/arm/topo/internal/ssh"
+	"github.com/arm/topo/internal/command"
 )
 
 type HostProcessor struct {
@@ -66,12 +66,12 @@ func (p *HardwareProbe) Probe() (HardwareProfile, error) {
 
 func (p *HardwareProbe) ProbeRemoteproc() ([]RemoteprocCPU, error) {
 	var remoteProcs []RemoteprocCPU
-	out, err := p.runner.Run(ssh.ShellCommand("ls /sys/class/remoteproc"))
+	out, err := p.runner.Run(command.WrapInLoginShell("ls /sys/class/remoteproc"))
 	if err != nil || out == "" {
 		return remoteProcs, nil
 	}
 
-	out, err = p.runner.Run(ssh.ShellCommand("cat /sys/class/remoteproc/*/name"))
+	out, err = p.runner.Run(command.WrapInLoginShell("cat /sys/class/remoteproc/*/name"))
 	if err != nil {
 		return remoteProcs, err
 	}
@@ -88,7 +88,7 @@ func (p *HardwareProbe) collectCPUInfo() ([]HostProcessor, error) {
 		return nil, err
 	}
 
-	out, err := p.runner.Run(ssh.ShellCommand("lscpu --json"))
+	out, err := p.runner.Run(command.WrapInLoginShell("lscpu --json"))
 	if err != nil {
 		return nil, err
 	}
@@ -106,7 +106,7 @@ func (p *HardwareProbe) collectMemInfo() (int64, error) {
 	key := "MemTotal"
 	path := "/proc/meminfo"
 
-	out, err := p.runner.Run(ssh.ShellCommand(fmt.Sprintf("cat %s", path)))
+	out, err := p.runner.Run(command.WrapInLoginShell(fmt.Sprintf("cat %s", path)))
 	if err != nil {
 		return 0, err
 	}

--- a/internal/target/hardware_probe.go
+++ b/internal/target/hardware_probe.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+
+	"github.com/arm/topo/internal/ssh"
 )
 
 type HostProcessor struct {
@@ -64,12 +66,12 @@ func (p *HardwareProbe) Probe() (HardwareProfile, error) {
 
 func (p *HardwareProbe) ProbeRemoteproc() ([]RemoteprocCPU, error) {
 	var remoteProcs []RemoteprocCPU
-	out, err := p.runner.Run("ls /sys/class/remoteproc")
+	out, err := p.runner.Run(ssh.ShellCommand("ls /sys/class/remoteproc"))
 	if err != nil || out == "" {
 		return remoteProcs, nil
 	}
 
-	out, err = p.runner.Run("cat /sys/class/remoteproc/*/name")
+	out, err = p.runner.Run(ssh.ShellCommand("cat /sys/class/remoteproc/*/name"))
 	if err != nil {
 		return remoteProcs, err
 	}
@@ -86,7 +88,7 @@ func (p *HardwareProbe) collectCPUInfo() ([]HostProcessor, error) {
 		return nil, err
 	}
 
-	out, err := p.runner.Run("lscpu --json")
+	out, err := p.runner.Run(ssh.ShellCommand("lscpu --json"))
 	if err != nil {
 		return nil, err
 	}
@@ -104,7 +106,7 @@ func (p *HardwareProbe) collectMemInfo() (int64, error) {
 	key := "MemTotal"
 	path := "/proc/meminfo"
 
-	out, err := p.runner.Run(fmt.Sprintf("cat %s", path))
+	out, err := p.runner.Run(ssh.ShellCommand(fmt.Sprintf("cat %s", path)))
 	if err != nil {
 		return 0, err
 	}

--- a/internal/target/hardware_probe.go
+++ b/internal/target/hardware_probe.go
@@ -29,7 +29,6 @@ type HardwareProfile struct {
 
 type Runner interface {
 	Run(command string) (string, error)
-	BinaryExists(bin string) error
 }
 
 type HardwareProbe struct {
@@ -84,7 +83,7 @@ func (p *HardwareProbe) ProbeRemoteproc() ([]RemoteprocCPU, error) {
 }
 
 func (p *HardwareProbe) collectCPUInfo() ([]HostProcessor, error) {
-	if err := p.runner.BinaryExists("lscpu"); err != nil {
+	if _, err := p.runner.Run(command.UnsafeBinaryLookupCommand("lscpu")); err != nil {
 		return nil, err
 	}
 

--- a/internal/target/hardware_probe_test.go
+++ b/internal/target/hardware_probe_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/arm/topo/internal/ssh"
 	"github.com/arm/topo/internal/target"
 	"github.com/arm/topo/internal/testutil"
 	"github.com/stretchr/testify/assert"
@@ -30,9 +31,9 @@ func TestHardwareProbe(t *testing.T) {
 		t.Run("returns model name and features", func(t *testing.T) {
 			r := new(mockRunner)
 			r.On("BinaryExists", "lscpu").Return(nil)
-			r.On("Run", "lscpu --json").Return(testutil.LsCpuOutputRaw, nil)
-			r.On("Run", "ls /sys/class/remoteproc").Return("", nil)
-			r.On("Run", "cat /proc/meminfo").Return("MemTotal:       16384000 kB", nil)
+			r.On("Run", ssh.ShellCommand("lscpu --json")).Return(testutil.LsCpuOutputRaw, nil)
+			r.On("Run", ssh.ShellCommand("ls /sys/class/remoteproc")).Return("", nil)
+			r.On("Run", ssh.ShellCommand("cat /proc/meminfo")).Return("MemTotal:       16384000 kB", nil)
 			probe := target.NewHardwareProbe(r)
 
 			got, err := probe.Probe()
@@ -66,7 +67,7 @@ func TestHardwareProbe(t *testing.T) {
 		t.Run("returns error when lscpu output is invalid JSON", func(t *testing.T) {
 			r := new(mockRunner)
 			r.On("BinaryExists", "lscpu").Return(nil)
-			r.On("Run", "lscpu --json").Return("not json", nil)
+			r.On("Run", ssh.ShellCommand("lscpu --json")).Return("not json", nil)
 			probe := target.NewHardwareProbe(r)
 
 			_, err := probe.Probe()

--- a/internal/target/hardware_probe_test.go
+++ b/internal/target/hardware_probe_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/arm/topo/internal/ssh"
+	"github.com/arm/topo/internal/command"
 	"github.com/arm/topo/internal/target"
 	"github.com/arm/topo/internal/testutil"
 	"github.com/stretchr/testify/assert"
@@ -31,9 +31,9 @@ func TestHardwareProbe(t *testing.T) {
 		t.Run("returns model name and features", func(t *testing.T) {
 			r := new(mockRunner)
 			r.On("BinaryExists", "lscpu").Return(nil)
-			r.On("Run", ssh.ShellCommand("lscpu --json")).Return(testutil.LsCpuOutputRaw, nil)
-			r.On("Run", ssh.ShellCommand("ls /sys/class/remoteproc")).Return("", nil)
-			r.On("Run", ssh.ShellCommand("cat /proc/meminfo")).Return("MemTotal:       16384000 kB", nil)
+			r.On("Run", command.WrapInLoginShell("lscpu --json")).Return(testutil.LsCpuOutputRaw, nil)
+			r.On("Run", command.WrapInLoginShell("ls /sys/class/remoteproc")).Return("", nil)
+			r.On("Run", command.WrapInLoginShell("cat /proc/meminfo")).Return("MemTotal:       16384000 kB", nil)
 			probe := target.NewHardwareProbe(r)
 
 			got, err := probe.Probe()
@@ -67,7 +67,7 @@ func TestHardwareProbe(t *testing.T) {
 		t.Run("returns error when lscpu output is invalid JSON", func(t *testing.T) {
 			r := new(mockRunner)
 			r.On("BinaryExists", "lscpu").Return(nil)
-			r.On("Run", ssh.ShellCommand("lscpu --json")).Return("not json", nil)
+			r.On("Run", command.WrapInLoginShell("lscpu --json")).Return("not json", nil)
 			probe := target.NewHardwareProbe(r)
 
 			_, err := probe.Probe()

--- a/internal/target/hardware_probe_test.go
+++ b/internal/target/hardware_probe_test.go
@@ -21,16 +21,11 @@ func (m *mockRunner) Run(cmd string) (string, error) {
 	return args.String(0), args.Error(1)
 }
 
-func (m *mockRunner) BinaryExists(bin string) error {
-	args := m.Called(bin)
-	return args.Error(0)
-}
-
 func TestHardwareProbe(t *testing.T) {
 	t.Run("Probe", func(t *testing.T) {
 		t.Run("returns model name and features", func(t *testing.T) {
 			r := new(mockRunner)
-			r.On("BinaryExists", "lscpu").Return(nil)
+			r.On("Run", command.WrapInLoginShell("command -v lscpu")).Return("/usr/bin/lscpu", nil)
 			r.On("Run", command.WrapInLoginShell("lscpu --json")).Return(testutil.LsCpuOutputRaw, nil)
 			r.On("Run", command.WrapInLoginShell("ls /sys/class/remoteproc")).Return("", nil)
 			r.On("Run", command.WrapInLoginShell("cat /proc/meminfo")).Return("MemTotal:       16384000 kB", nil)
@@ -55,7 +50,7 @@ func TestHardwareProbe(t *testing.T) {
 
 		t.Run("returns error when lscpu not found", func(t *testing.T) {
 			r := new(mockRunner)
-			r.On("BinaryExists", "lscpu").Return(fmt.Errorf("%q executable file not found in $PATH", "lscpu"))
+			r.On("Run", command.WrapInLoginShell("command -v lscpu")).Return("", fmt.Errorf("%q executable file not found in $PATH", "lscpu"))
 			probe := target.NewHardwareProbe(r)
 
 			_, err := probe.Probe()
@@ -66,7 +61,7 @@ func TestHardwareProbe(t *testing.T) {
 
 		t.Run("returns error when lscpu output is invalid JSON", func(t *testing.T) {
 			r := new(mockRunner)
-			r.On("BinaryExists", "lscpu").Return(nil)
+			r.On("Run", command.WrapInLoginShell("command -v lscpu")).Return("/usr/bin/lscpu", nil)
 			r.On("Run", command.WrapInLoginShell("lscpu --json")).Return("not json", nil)
 			probe := target.NewHardwareProbe(r)
 


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- Removed connection-level login shell behavior and make login shell usage explicit at each command invocation.
   - Rationale: A reusable connection should not enforce global shell semantics.
- Moved login-shell wrapping out of ssh into command with a clearer API.
- Removed `Connection.BinaryExists`
