### PR TITLE
refactor: move stdin from connection to command execution

### DIFF
--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -286,8 +286,8 @@ func install(installPath string, targetDest ssh.Destination, binaries map[string
 		}
 
 		installCmd := fmt.Sprintf("install -D -m %s /dev/stdin %s/%s", mode, installPath, binaryName)
-		conn := target.NewConnection(targetDest, target.ConnectionOptions{WithStdin: binaryData})
-		output, err := conn.Run(command.WrapInLoginShell(installCmd))
+		conn := target.NewConnection(targetDest, target.ConnectionOptions{})
+		output, err := conn.RunWithStdin(command.WrapInLoginShell(installCmd), binaryData)
 		if err != nil {
 			if errors.Is(err, ssh.ErrSSH) {
 				return err

--- a/internal/setupkeys/pubkeytransfer/pub_key_transfer.go
+++ b/internal/setupkeys/pubkeytransfer/pub_key_transfer.go
@@ -31,9 +31,8 @@ func (kt *PubKeyTransfer) Description() string {
 	return kt.description
 }
 
-func (kt *PubKeyTransfer) buildTransferConnection(stdin []byte) *target.Connection {
-	opts := target.ConnectionOptions{WithStdin: stdin}
-
+func (kt *PubKeyTransfer) buildTransferConnection() *target.Connection {
+	opts := target.ConnectionOptions{}
 	if kt.opts.WithMockExec != nil {
 		opts.WithMockExec = kt.opts.WithMockExec
 	}
@@ -49,8 +48,8 @@ func (kt *PubKeyTransfer) Run(outputWriter io.Writer) error {
 		return fmt.Errorf("failed to read public key %s: %w", kt.pubKeyPath, err)
 	}
 
-	conn := kt.buildTransferConnection(pubKey)
-	cmdOutput, err := conn.Run(command.WrapInLoginShell(remoteAuthorizedKeysCommand))
+	conn := kt.buildTransferConnection()
+	cmdOutput, err := conn.RunWithStdin(command.WrapInLoginShell(remoteAuthorizedKeysCommand), pubKey)
 	if err != nil {
 		return fmt.Errorf("failed to transfer public key to target %s: %w", kt.dest, err)
 	}

--- a/internal/target/connection.go
+++ b/internal/target/connection.go
@@ -20,7 +20,6 @@ type Connection struct {
 }
 
 type ConnectionOptions struct {
-	WithStdin      []byte
 	Multiplex      bool
 	WithMockExec   ExecSSH
 	ConnectTimeout time.Duration
@@ -40,12 +39,20 @@ func NewConnection(dest ssh.Destination, opts ConnectionOptions) Connection {
 }
 
 func (c *Connection) Run(cmdStr string) (string, error) {
+	return c.run(cmdStr, nil)
+}
+
+func (c *Connection) RunWithStdin(cmdStr string, stdin []byte) (string, error) {
+	return c.run(cmdStr, stdin)
+}
+
+func (c *Connection) run(cmdStr string, stdin []byte) (string, error) {
 	sshArgs := c.connectTimeoutArgs()
 	if c.opts.Multiplex && runtime.GOOS != "windows" {
 		sshArgs = append(sshArgs, "-o", "ControlMaster=auto", "-o", "ControlPersist=10s", "-o", "ControlPath=~/.ssh/topo-cm-%r@%h:%p")
 	}
 
-	cmd := c.exec(c.SSHTarget, cmdStr, c.opts.WithStdin, sshArgs...)
+	cmd := c.exec(c.SSHTarget, cmdStr, stdin, sshArgs...)
 	var stdoutBuf, stderrBuf bytes.Buffer
 	cmd.Stdout = &stdoutBuf
 	cmd.Stderr = &stderrBuf

--- a/internal/target/connection_test.go
+++ b/internal/target/connection_test.go
@@ -58,6 +58,21 @@ func TestRun(t *testing.T) {
 		assert.ErrorIs(t, err, ssh.ErrConnectionFailed)
 	})
 
+	t.Run("run with stdin passes stdin to command", func(t *testing.T) {
+		var gotStdin []byte
+		mockExec := func(_ ssh.Destination, _ string, stdin []byte, _ ...string) *exec.Cmd {
+			gotStdin = stdin
+			return testutil.CmdWithOutput("success", 0)
+		}
+		conn := target.NewConnection(ssh.NewDestination("hostname"), target.ConnectionOptions{WithMockExec: mockExec})
+
+		out, err := conn.RunWithStdin("cat", []byte("payload"))
+
+		assert.NoError(t, err)
+		assert.Equal(t, "success", out)
+		assert.Equal(t, []byte("payload"), gotStdin)
+	})
+
 	t.Run("run with mutliplexing enabled includes Control args", func(t *testing.T) {
 		testutil.RequireOS(t, "linux")
 		var capturedArgs string


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- Removed `WithStdin` from `target.ConnectionOptions`
- Added per-command stdin support via `Connection.RunWithStdin(...)`

## Rationale

`Connection` is reusable transport/configuration. Stdin is command-specific input.

Keeping stdin on the connection made the API surprising and easy to misuse, because one command’s input could implicitly affect other commands executed through the same connection. This change makes the data flow explicit at the call site and narrows the responsibility of `Connection`.