### PR TITLE
chore: build config fragments from parsed destinations

### DIFF
--- a/cmd/topo/setup_keys.go
+++ b/cmd/topo/setup_keys.go
@@ -56,7 +56,7 @@ var setupKeysCmd = &cobra.Command{
 			sshconfig.NewDirective("IdentitiesOnly", "yes"),
 		}
 
-		return sshconfig.CreateOrModifySSHConfig(targetArg, targetSlug, directives)
+		return sshconfig.CreateOrModifySSHConfig(dest, targetSlug, directives)
 	},
 }
 

--- a/cmd/topo/vscode.go
+++ b/cmd/topo/vscode.go
@@ -44,7 +44,7 @@ This will also update the main SSH config (~/.ssh/config) to include the topo-ma
 			return err
 		}
 
-		return sshconfig.CreateSSHConfig(targetArg, targetSlug)
+		return sshconfig.CreateSSHConfig(dest, targetSlug)
 	},
 }
 

--- a/internal/ssh/destination.go
+++ b/internal/ssh/destination.go
@@ -14,7 +14,7 @@ type Destination struct {
 }
 
 func NewDestination(destStr string) Destination {
-	user, host, port := SplitUserHostPort(destStr)
+	user, host, port := splitUserHostPort(destStr)
 	return Destination{User: user, Host: host, Port: port}
 }
 
@@ -64,7 +64,7 @@ func (d Destination) Slugify() string {
 	return b.String()
 }
 
-func SplitUserHostPort(raw string) (user, host, port string) {
+func splitUserHostPort(raw string) (user, host, port string) {
 	raw = strings.TrimPrefix(raw, "ssh://")
 	hostPart := raw
 	if at := strings.LastIndex(raw, "@"); at != -1 {

--- a/internal/ssh/destination_test.go
+++ b/internal/ssh/destination_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/arm/topo/internal/ssh"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestNewDestination(t *testing.T) {
@@ -214,32 +213,5 @@ func TestDestination(t *testing.T) {
 			want := "darth-vader_death-star_deep-breath"
 			assert.Equal(t, want, got)
 		})
-	})
-
-	t.Run("SplitUserHostPort", func(t *testing.T) {
-		cases := []struct {
-			raw      string
-			wantUser string
-			wantHost string
-			wantPort string
-		}{
-			{raw: "user@example.com:2222", wantUser: "user", wantHost: "example.com", wantPort: "2222"},
-			{raw: "example.com:2222", wantUser: "", wantHost: "example.com", wantPort: "2222"},
-			{raw: "example.com", wantUser: "", wantHost: "example.com", wantPort: ""},
-			{raw: "user@example.com", wantUser: "user", wantHost: "example.com", wantPort: ""},
-			{raw: "[2001:db8::1]", wantUser: "", wantHost: "2001:db8::1", wantPort: ""},
-			{raw: "user@[2001:db8::1]:2222", wantUser: "user", wantHost: "2001:db8::1", wantPort: "2222"},
-			{raw: "[2001:db8::1]:2222", wantUser: "", wantHost: "2001:db8::1", wantPort: "2222"},
-			{raw: "ssh://user@example.com:2222", wantUser: "user", wantHost: "example.com", wantPort: "2222"},
-		}
-
-		for _, tc := range cases {
-			t.Run(tc.raw, func(t *testing.T) {
-				user, host, port := ssh.SplitUserHostPort(tc.raw)
-				require.Equal(t, tc.wantUser, user, "user for %q", tc.raw)
-				require.Equal(t, tc.wantHost, host, "host for %q", tc.raw)
-				require.Equal(t, tc.wantPort, port, "port for %q", tc.raw)
-			})
-		}
 	})
 }

--- a/internal/ssh/sshconfig/ssh_config.go
+++ b/internal/ssh/sshconfig/ssh_config.go
@@ -3,6 +3,7 @@ package sshconfig
 import (
 	"bytes"
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"slices"
@@ -34,11 +35,11 @@ func NewDirective(key, value string) SSHConfigDirective {
 	}
 }
 
-func CreateSSHConfig(targetHost string, targetSlug string) error {
-	return CreateOrModifySSHConfig(targetHost, targetSlug, nil)
+func CreateSSHConfig(dest ssh.Destination, targetSlug string) error {
+	return CreateOrModifySSHConfig(dest, targetSlug, nil)
 }
 
-func CreateOrModifySSHConfig(targetHost string, targetSlug string, directives []SSHConfigDirective) error {
+func CreateOrModifySSHConfig(dest ssh.Destination, targetSlug string, directives []SSHConfigDirective) error {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return fmt.Errorf("failed to determine home directory for SSH config: %w", err)
@@ -68,7 +69,7 @@ func CreateOrModifySSHConfig(targetHost string, targetSlug string, directives []
 
 	var fragmentToWrite []byte
 	if len(existingTopoContent) == 0 {
-		fragmentToWrite = buildSSHConfigFragment(targetHost, directives)
+		fragmentToWrite = buildSSHConfigFragment(dest, directives)
 	} else {
 		fragmentToWrite = mergeOwnedSSHConfigDirectives(existingTopoContent, directives)
 	}
@@ -111,23 +112,17 @@ func hasIncludeLine(data []byte, includeLine string) bool {
 	return false
 }
 
-func buildSSHConfigFragment(targetHost string, directives []SSHConfigDirective) []byte {
-	user, host, port := ssh.SplitUserHostPort(targetHost)
-	hostAlias := host
-	if hostAlias == "" {
-		hostAlias = targetHost
-	}
-
+func buildSSHConfigFragment(dest ssh.Destination, directives []SSHConfigDirective) []byte {
 	var b strings.Builder
-	fmt.Fprintf(&b, "Host %s\n", hostAlias)
-	if host != "" && (strings.Contains(targetHost, "@") || strings.Contains(targetHost, ":")) {
-		fmt.Fprintf(&b, "  HostName %s\n", host)
+	fmt.Fprintf(&b, "Host %s\n", dest.Host)
+	if dest.Host != "" && (dest.User != "" || net.ParseIP(dest.Host) != nil) {
+		fmt.Fprintf(&b, "  HostName %s\n", dest.Host)
 	}
-	if user != "" {
-		fmt.Fprintf(&b, "  User %s\n", user)
+	if dest.User != "" {
+		fmt.Fprintf(&b, "  User %s\n", dest.User)
 	}
-	if port != "" {
-		fmt.Fprintf(&b, "  Port %s\n", port)
+	if dest.Port != "" {
+		fmt.Fprintf(&b, "  Port %s\n", dest.Port)
 	}
 
 	for _, directive := range directives {

--- a/internal/ssh/sshconfig/ssh_config_test.go
+++ b/internal/ssh/sshconfig/ssh_config_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/arm/topo/internal/ssh"
 	"github.com/arm/topo/internal/ssh/sshconfig"
 	"github.com/arm/topo/internal/testutil"
 	"github.com/stretchr/testify/require"
@@ -16,7 +17,7 @@ func TestModifySSHConfig(t *testing.T) {
 		tmp := t.TempDir()
 		testutil.SetHomeDir(t, tmp)
 
-		targetHost := "user@example.com:2222"
+		targetHost := ssh.NewDestination("user@example.com:2222")
 		targetFileName := "user_example_com_2222"
 		privKeyPath := filepath.Join(tmp, ".ssh", fmt.Sprintf("id_ed25519_topo_%s", targetFileName))
 
@@ -46,7 +47,7 @@ func TestModifySSHConfig(t *testing.T) {
 		tmp := t.TempDir()
 		testutil.SetHomeDir(t, tmp)
 
-		targetHost := "user@example.com:2222"
+		targetHost := ssh.NewDestination("user@example.com:2222")
 		targetFileName := "user_example_com_2222"
 		privKeyPath := filepath.Join(tmp, ".ssh", fmt.Sprintf("id_ed25519_topo_%s", targetFileName))
 		fragmentPath := filepath.Join(tmp, ".ssh", "topo_config", fmt.Sprintf("topo_%s.conf", targetFileName))
@@ -82,7 +83,7 @@ func TestModifySSHConfig(t *testing.T) {
 		tmp := t.TempDir()
 		testutil.SetHomeDir(t, tmp)
 
-		targetHost := "user@example.com:2222"
+		targetHost := ssh.NewDestination("user@example.com:2222")
 		targetFileName := "user_example_com_2222"
 		privKeyPath := filepath.Join(tmp, ".ssh", fmt.Sprintf("id_ed25519_topo_%s", targetFileName))
 		fragmentPath := filepath.Join(tmp, ".ssh", "topo_config", fmt.Sprintf("topo_%s.conf", targetFileName))
@@ -120,7 +121,7 @@ func TestModifySSHConfig(t *testing.T) {
 		tmp := t.TempDir()
 		testutil.SetHomeDir(t, tmp)
 
-		targetHost := "user@example.com:2222"
+		targetHost := ssh.NewDestination("user@example.com:2222")
 		targetFileName := "user_example_com_2222"
 		privKeyPath := filepath.Join(tmp, ".ssh", fmt.Sprintf("id_ed25519_topo_%s", targetFileName))
 		fragmentPath := filepath.Join(tmp, ".ssh", "topo_config", fmt.Sprintf("topo_%s.conf", targetFileName))
@@ -159,7 +160,7 @@ func TestCreateSSHConfig(t *testing.T) {
 	t.Run("handles creation of new ssh config file", func(t *testing.T) {
 		tmp := t.TempDir()
 		testutil.SetHomeDir(t, tmp)
-		targetHost := "user@example.com:2222"
+		targetHost := ssh.NewDestination("user@example.com:2222")
 		targetFileName := "user_example_com_2222"
 		fragmentPath := filepath.Join(tmp, ".ssh", "topo_config", fmt.Sprintf("topo_%s.conf", targetFileName))
 		mainConfigPath := filepath.Join(tmp, ".ssh", "config")


### PR DESCRIPTION
Pass ssh.Destination through SSH config creation instead of reparsing the raw target string inside sshconfig.
This reuses functionality used elsewhere and avoids code duplication.
