### PR TITLE
fix: avoid overwriting HostName for SSH aliases in setup-keys

### DIFF
--- a/internal/ssh/sshconfig/ssh_config.go
+++ b/internal/ssh/sshconfig/ssh_config.go
@@ -3,7 +3,6 @@ package sshconfig
 import (
 	"bytes"
 	"fmt"
-	"net"
 	"os"
 	"path/filepath"
 	"slices"
@@ -115,7 +114,8 @@ func hasIncludeLine(data []byte, includeLine string) bool {
 func buildSSHConfigFragment(dest ssh.Destination, directives []SSHConfigDirective) []byte {
 	var b strings.Builder
 	fmt.Fprintf(&b, "Host %s\n", dest.Host)
-	if dest.Host != "" && (dest.User != "" || net.ParseIP(dest.Host) != nil) {
+	sshConfig := ssh.NewConfig(dest)
+	if dest.Host != "" && (sshConfig.HostName == "" || strings.EqualFold(sshConfig.HostName, dest.Host)) {
 		fmt.Fprintf(&b, "  HostName %s\n", dest.Host)
 	}
 	if dest.User != "" {


### PR DESCRIPTION
Currently, setup-keys writes a HostName line on the Topo SSH config fragment it generates. This line is written only when @ or : are present in the target definition.

If the user's SSH config is, for example:

```
Host some-board
  HostName <ip>
  User root
```

and we call `topo setup-keys --target otheruser@some-board`, this will create an SSH config fragment like the following:

```
Host some-board
  HostName some-board
  User otheruser
  IdentityFile ...
  IdentitiesOnly yes
```

Which creates a HostName conflict, and we get the following error:

$ ssh some-board
ssh: Could not resolve hostname some-board: nodename nor servname provided, or not known

Fix:

 * Don't write HostName in the fragment in those cases where we are passing down a target thath uses an alias already defined in our effective SSH config.
