### PR TITLE
refactor: decouple `PubKeyTransfer` from `Connection`

### DIFF
--- a/internal/setupkeys/pubkeytransfer/pub_key_transfer.go
+++ b/internal/setupkeys/pubkeytransfer/pub_key_transfer.go
@@ -15,21 +15,19 @@ type runner interface {
 }
 
 type PubKeyTransfer struct {
-	description string
-	pubKeyPath  string
-	runner      runner
+	pubKeyPath string
+	runner     runner
 }
 
-func NewPubKeyTransfer(description string, privKeyPath string, runner runner) *PubKeyTransfer {
+func NewPubKeyTransfer(privKeyPath string, runner runner) *PubKeyTransfer {
 	return &PubKeyTransfer{
-		description: description,
-		pubKeyPath:  privKeyPath + ".pub",
-		runner:      runner,
+		pubKeyPath: privKeyPath + ".pub",
+		runner:     runner,
 	}
 }
 
 func (kt *PubKeyTransfer) Description() string {
-	return kt.description
+	return "Transfer public key to target and set it as an authorized key"
 }
 
 func (kt *PubKeyTransfer) Run(outputWriter io.Writer) error {

--- a/internal/setupkeys/pubkeytransfer/pub_key_transfer.go
+++ b/internal/setupkeys/pubkeytransfer/pub_key_transfer.go
@@ -6,40 +6,30 @@ import (
 	"os"
 
 	"github.com/arm/topo/internal/command"
-	"github.com/arm/topo/internal/ssh"
-	target "github.com/arm/topo/internal/target"
 )
 
 const remoteAuthorizedKeysCommand = "mkdir -p ~/.ssh && chmod 700 ~/.ssh && cat >> ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys"
 
+type runner interface {
+	RunWithStdin(command string, stdin []byte) (string, error)
+}
+
 type PubKeyTransfer struct {
 	description string
-	dest        ssh.Destination
 	pubKeyPath  string
-	opts        PubKeyTransferOptions
+	runner      runner
 }
 
-type PubKeyTransferOptions struct {
-	WithMockExec target.ExecSSH
-}
-
-func NewPubKeyTransfer(description string, dest ssh.Destination, privKeyPath string, opts PubKeyTransferOptions) *PubKeyTransfer {
-	return &PubKeyTransfer{description: description, dest: dest, pubKeyPath: privKeyPath + ".pub", opts: opts}
+func NewPubKeyTransfer(description string, privKeyPath string, runner runner) *PubKeyTransfer {
+	return &PubKeyTransfer{
+		description: description,
+		pubKeyPath:  privKeyPath + ".pub",
+		runner:      runner,
+	}
 }
 
 func (kt *PubKeyTransfer) Description() string {
 	return kt.description
-}
-
-func (kt *PubKeyTransfer) buildTransferConnection() *target.Connection {
-	opts := target.ConnectionOptions{}
-	if kt.opts.WithMockExec != nil {
-		opts.WithMockExec = kt.opts.WithMockExec
-	}
-
-	conn := target.NewConnection(kt.dest, opts)
-
-	return &conn
 }
 
 func (kt *PubKeyTransfer) Run(outputWriter io.Writer) error {
@@ -48,10 +38,9 @@ func (kt *PubKeyTransfer) Run(outputWriter io.Writer) error {
 		return fmt.Errorf("failed to read public key %s: %w", kt.pubKeyPath, err)
 	}
 
-	conn := kt.buildTransferConnection()
-	cmdOutput, err := conn.RunWithStdin(command.WrapInLoginShell(remoteAuthorizedKeysCommand), pubKey)
+	cmdOutput, err := kt.runner.RunWithStdin(command.WrapInLoginShell(remoteAuthorizedKeysCommand), pubKey)
 	if err != nil {
-		return fmt.Errorf("failed to transfer public key to target %s: %w", kt.dest, err)
+		return fmt.Errorf("failed to transfer public key to target: %w", err)
 	}
 	_, err = outputWriter.Write([]byte(cmdOutput))
 	return err

--- a/internal/setupkeys/pubkeytransfer/pub_key_transfer_test.go
+++ b/internal/setupkeys/pubkeytransfer/pub_key_transfer_test.go
@@ -38,7 +38,7 @@ func TestPubKeyTransfer(t *testing.T) {
 				pubKeyContent,
 			).Return("ssh invoked", nil)
 
-			op := pubkeytransfer.NewPubKeyTransfer("Transfer public key", privKeyPath, runner)
+			op := pubkeytransfer.NewPubKeyTransfer(privKeyPath, runner)
 
 			var buf bytes.Buffer
 			require.NoError(t, op.Run(&buf))

--- a/internal/setupkeys/pubkeytransfer/pub_key_transfer_test.go
+++ b/internal/setupkeys/pubkeytransfer/pub_key_transfer_test.go
@@ -3,15 +3,23 @@ package pubkeytransfer_test
 import (
 	"bytes"
 	"os"
-	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/arm/topo/internal/setupkeys/pubkeytransfer"
-	"github.com/arm/topo/internal/ssh"
-	"github.com/arm/topo/internal/testutil"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
+
+type mockRunner struct {
+	mock.Mock
+}
+
+func (m *mockRunner) RunWithStdin(cmd string, stdin []byte) (string, error) {
+	args := m.Called(cmd, stdin)
+	return args.String(0), args.Error(1)
+}
 
 func TestPubKeyTransferRun(t *testing.T) {
 	tmp := t.TempDir()
@@ -20,29 +28,19 @@ func TestPubKeyTransferRun(t *testing.T) {
 	pubKeyContent := []byte("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAItestkey")
 	require.NoError(t, os.WriteFile(pubKeyPath, pubKeyContent, 0o600))
 
-	type call struct {
-		dest  ssh.Destination
-		cmd   string
-		stdin []byte
-		args  []string
-	}
-	var got call
+	runner := &mockRunner{}
+	runner.On(
+		"RunWithStdin",
+		mock.MatchedBy(func(cmd string) bool {
+			return strings.Contains(cmd, "mkdir -p ~/.ssh && chmod 700 ~/.ssh && cat >> ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys")
+		}),
+		pubKeyContent,
+	).Return("ssh invoked", nil)
 
-	opts := pubkeytransfer.PubKeyTransferOptions{WithMockExec: func(d ssh.Destination, command string, stdin []byte, args ...string) *exec.Cmd {
-		got = call{dest: d, cmd: command, stdin: stdin, args: args}
-		cmd := testutil.CmdWithOutput("ssh invoked", 0)
-		if stdin != nil {
-			cmd.Stdin = bytes.NewReader(stdin)
-		}
-		return cmd
-	}}
-	op := pubkeytransfer.NewPubKeyTransfer("Transfer public key", ssh.NewDestination("thing1@thing2.com"), privKeyPath, opts)
+	op := pubkeytransfer.NewPubKeyTransfer("Transfer public key", privKeyPath, runner)
 
 	var buf bytes.Buffer
 	require.NoError(t, op.Run(&buf))
 	require.Contains(t, buf.String(), "ssh invoked")
-	require.Equal(t, ssh.NewDestination("thing1@thing2.com"), got.dest)
-	require.Contains(t, got.cmd, "mkdir -p ~/.ssh && chmod 700 ~/.ssh && cat >> ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys")
-	require.Equal(t, pubKeyContent, got.stdin)
-	require.Empty(t, got.args)
+	runner.AssertExpectations(t)
 }

--- a/internal/setupkeys/pubkeytransfer/pub_key_transfer_test.go
+++ b/internal/setupkeys/pubkeytransfer/pub_key_transfer_test.go
@@ -21,26 +21,29 @@ func (m *mockRunner) RunWithStdin(cmd string, stdin []byte) (string, error) {
 	return args.String(0), args.Error(1)
 }
 
-func TestPubKeyTransferRun(t *testing.T) {
-	tmp := t.TempDir()
-	privKeyPath := filepath.Join(tmp, "id_ed25519_testrun")
-	pubKeyPath := privKeyPath + ".pub"
-	pubKeyContent := []byte("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAItestkey")
-	require.NoError(t, os.WriteFile(pubKeyPath, pubKeyContent, 0o600))
+func TestPubKeyTransfer(t *testing.T) {
+	t.Run("Run", func(t *testing.T) {
+		t.Run("transfers the public key to the target", func(t *testing.T) {
+			tmp := t.TempDir()
+			privKeyPath := filepath.Join(tmp, "id_ed25519_testrun")
+			pubKeyContent := []byte("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAItestkey")
+			require.NoError(t, os.WriteFile(privKeyPath+".pub", pubKeyContent, 0o600))
 
-	runner := &mockRunner{}
-	runner.On(
-		"RunWithStdin",
-		mock.MatchedBy(func(cmd string) bool {
-			return strings.Contains(cmd, "mkdir -p ~/.ssh && chmod 700 ~/.ssh && cat >> ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys")
-		}),
-		pubKeyContent,
-	).Return("ssh invoked", nil)
+			runner := &mockRunner{}
+			runner.On(
+				"RunWithStdin",
+				mock.MatchedBy(func(cmd string) bool {
+					return strings.Contains(cmd, "mkdir -p ~/.ssh && chmod 700 ~/.ssh && cat >> ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys")
+				}),
+				pubKeyContent,
+			).Return("ssh invoked", nil)
 
-	op := pubkeytransfer.NewPubKeyTransfer("Transfer public key", privKeyPath, runner)
+			op := pubkeytransfer.NewPubKeyTransfer("Transfer public key", privKeyPath, runner)
 
-	var buf bytes.Buffer
-	require.NoError(t, op.Run(&buf))
-	require.Contains(t, buf.String(), "ssh invoked")
-	runner.AssertExpectations(t)
+			var buf bytes.Buffer
+			require.NoError(t, op.Run(&buf))
+			require.Contains(t, buf.String(), "ssh invoked")
+			runner.AssertExpectations(t)
+		})
+	})
 }

--- a/internal/setupkeys/setup_keys.go
+++ b/internal/setupkeys/setup_keys.go
@@ -9,6 +9,7 @@ import (
 	"github.com/arm/topo/internal/setupkeys/pubkeytransfer"
 	"github.com/arm/topo/internal/setupkeys/sshkeygen"
 	"github.com/arm/topo/internal/ssh"
+	"github.com/arm/topo/internal/target"
 )
 
 type KeyType string
@@ -18,10 +19,11 @@ const (
 	KeyTypeRSA     KeyType = "rsa"
 )
 
-func NewKeySetup(target ssh.Destination, privKeyPath string, keyType KeyType) (operation.Sequence, error) {
+func NewKeySetup(dest ssh.Destination, privKeyPath string, keyType KeyType) (operation.Sequence, error) {
+	conn := target.NewConnection(dest, target.ConnectionOptions{})
 	ops := []operation.Operation{
-		sshkeygen.NewSSHKeyGen("Generate SSH key pair for target", target, string(keyType), privKeyPath, sshkeygen.SSHKeyGenOptions{}),
-		pubkeytransfer.NewPubKeyTransfer("Transfer public key to target and set it as an authorized key", target, privKeyPath, pubkeytransfer.PubKeyTransferOptions{}),
+		sshkeygen.NewSSHKeyGen("Generate SSH key pair for target", dest, string(keyType), privKeyPath, sshkeygen.SSHKeyGenOptions{}),
+		pubkeytransfer.NewPubKeyTransfer("Transfer public key to target and set it as an authorized key", privKeyPath, &conn),
 	}
 	return operation.NewSequence(ops...), nil
 }

--- a/internal/setupkeys/setup_keys.go
+++ b/internal/setupkeys/setup_keys.go
@@ -23,7 +23,7 @@ func NewKeySetup(dest ssh.Destination, privKeyPath string, keyType KeyType) (ope
 	conn := target.NewConnection(dest, target.ConnectionOptions{})
 	ops := []operation.Operation{
 		sshkeygen.NewSSHKeyGen("Generate SSH key pair for target", dest, string(keyType), privKeyPath, sshkeygen.SSHKeyGenOptions{}),
-		pubkeytransfer.NewPubKeyTransfer("Transfer public key to target and set it as an authorized key", privKeyPath, &conn),
+		pubkeytransfer.NewPubKeyTransfer(privKeyPath, &conn),
 	}
 	return operation.NewSequence(ops...), nil
 }


### PR DESCRIPTION
## Background

Previously, `PubKeyTransfer` built its own `Connection` internally and exposed a `WithMockExec` escape hatch on an options struct to make it testable. This smells, because production code carries testing concerns. Also, the struct tightly coupled to `Connection`.

This PR replaces that with a `runner` interface which `Connection` already satisfies.

## Changes

<!-- List the changes this PR introduces -->

- Introduce local `runner` interface in `pubkeytransfer` package
    - `NewPubKeyTransfer` now accepts `privKeyPath` and a `runner` instead of a destination and options                                                                                                    
- Remove `PubKeyTransferOptions`, `WithMockExec`, and `buildTransferConnection`
- _Unrelated:_ Hardcode `Description()` — it was always a constant in practice
- ⚠️ Minor regression in observability: error message no longer surfaces destination (something I'd like to push to `Connection` eventually)