### PR TITLE
chore: Use https git urls for templates

### DIFF
--- a/e2e/templates_test.go
+++ b/e2e/templates_test.go
@@ -22,7 +22,7 @@ func TestTemplates(t *testing.T) {
 		output := string(out)
 
 		assert.Contains(t, output, "topo-welcome")
-		assert.Contains(t, output, "git@github.com:")
+		assert.Contains(t, output, "https://github.com/")
 		assert.Contains(t, output, "Features:")
 	})
 

--- a/internal/catalog/catalog_test.go
+++ b/internal/catalog/catalog_test.go
@@ -17,7 +17,7 @@ func TestGetTemplateRepo(t *testing.T) {
 			Name:        "topo-lightbulb-moment",
 			Description: "Reads a switch over GPIO pins on an M class cpu, reports switch state over Remoteproc Message, then a web application on the A class reads this and displays a lightbulb in either the on or off state. The lightbulb state is described by an LLM in any user-specified style.",
 			Features:    []string{"remoteproc-runtime"},
-			URL:         "git@github.com:Arm-Examples/topo-lightbulb-moment.git",
+			URL:         "https://github.com/Arm-Examples/topo-lightbulb-moment.git",
 			Ref:         "main",
 		}, template)
 	})

--- a/internal/catalog/data/templates.json
+++ b/internal/catalog/data/templates.json
@@ -3,28 +3,28 @@
     "name": "topo-welcome",
     "description": "A minimal \"Hello, World\" web app for validating a Topo setup and deployment.\nIt runs a single service that exposes a web page on the target,\nwith the greeting text customizable via the GREETING_NAME parameter.\n",
     "features": null,
-    "url": "git@github.com:Arm-Examples/topo-welcome.git",
+    "url": "https://github.com/Arm-Examples/topo-welcome.git",
     "ref": "main"
   },
   {
     "name": "topo-lightbulb-moment",
     "description": "Reads a switch over GPIO pins on an M class cpu, reports switch state over Remoteproc Message, then a web application on the A class reads this and displays a lightbulb in either the on or off state. The lightbulb state is described by an LLM in any user-specified style.",
     "features": ["remoteproc-runtime"],
-    "url": "git@github.com:Arm-Examples/topo-lightbulb-moment.git",
+    "url": "https://github.com/Arm-Examples/topo-lightbulb-moment.git",
     "ref": "main"
   },
   {
     "name": "topo-v9-cpu-chat",
     "description": "Complete LLM chat application optimized for Arm CPU inference.\n\nThis project demonstrates running large language models on CPU\nusing llama.cpp compiled with Arm baseline optimizations and \naccelerated using NEON SIMD and SVE (when supported and enabled).\n\nThe stack includes:\n- llama.cpp server with Arm NEON optimizations (SVE optional)\n- Quantized Qwen2.5-1.5B-Instruct model bundled in the image (~1.12 GB)\n- Simple web-based chat interface\n- No GPU required - pure CPU inference\n\nPerfect for demos and testing! The bundled Qwen2.5-1.5B model allows the\nproject to run immediately without downloading additional models.\n\nIdeal for testing LLM workloads on Arm hardware without GPU dependencies,\nshowcasing how far you can push NEON acceleration. Rebuild with SVE enabled\nwhen wider vectors are available.\n",
     "features": ["SVE", "NEON"],
-    "url": "git@github.com:Arm-Examples/topo-v9-cpu-chat.git",
+    "url": "https://github.com/Arm-Examples/topo-v9-cpu-chat.git",
     "ref": "main"
   },
   {
     "name": "topo-simd-visual-benchmark",
     "description": "Visual demonstration of SIMD performance benefits on Arm processors.\nCompare scalar (no SIMD), NEON (128-bit), and SVE (scalable vector)\nimplementations running identical image processing workloads side-by-side.\n\nThis demo shows real hardware acceleration through three C++ services\ncompiled with different architecture flags, processing the same box blur\nalgorithm on images. Performance differences are measured in real-time\nand displayed in an interactive web dashboard.\n\nPerfect for demonstrating to non-technical audiences the concrete benefits\nof SIMD optimizations, with visual results and quantified speedups.\n",
     "features": ["NEON", "SVE"],
-    "url": "git@github.com:Arm-Examples/topo-simd-visual-benchmark.git",
+    "url": "https://github.com/Arm-Examples/topo-simd-visual-benchmark.git",
     "ref": "main"
   }
 ]


### PR DESCRIPTION
Use https urls for cloning templates to increase reliability
