### PR TITLE
feat: Only allow one user per Host/alias when setting up keys

### DIFF
--- a/internal/ssh/config.go
+++ b/internal/ssh/config.go
@@ -10,12 +10,14 @@ import (
 )
 
 type Config struct {
-	HostName       string
-	connectTimeout time.Duration
+	HostName            string
+	User                string
+	connectTimeout      time.Duration
+	matchedHostPatterns []string
 }
 
 func NewConfig(dest Destination) Config {
-	output, err := exec.Command("ssh", "-G", dest.String()).Output()
+	output, err := exec.Command("ssh", "-v", "-G", dest.String()).CombinedOutput()
 	if err != nil {
 		return Config{}
 	}
@@ -26,13 +28,20 @@ func NewConfigFromBytes(data []byte) Config {
 	var config Config
 	scanner := bufio.NewScanner(bytes.NewReader(data))
 	for scanner.Scan() {
-		fields := strings.Fields(scanner.Text())
+		line := scanner.Text()
+		if matchedPatterns := extractMatchedHostPatterns(line); len(matchedPatterns) > 0 {
+			config.matchedHostPatterns = append(config.matchedHostPatterns, matchedPatterns...)
+		}
+
+		fields := strings.Fields(line)
 		if len(fields) < 2 {
 			continue
 		}
 		switch strings.ToLower(fields[0]) {
 		case "hostname":
 			config.HostName = fields[1]
+		case "user":
+			config.User = fields[1]
 		case "connecttimeout":
 			if secs, err := strconv.Atoi(fields[1]); err == nil {
 				config.connectTimeout = time.Duration(secs) * time.Second
@@ -48,4 +57,29 @@ func (c Config) ConnectTimeout(fallback time.Duration) time.Duration {
 		return c.connectTimeout
 	}
 	return fallback
+}
+
+func (c Config) HasExactHostMatch(host string) bool {
+	for _, pattern := range c.matchedHostPatterns {
+		if pattern == "" || strings.HasPrefix(pattern, "!") {
+			continue
+		}
+		if strings.EqualFold(pattern, host) {
+			return true
+		}
+	}
+	return false
+}
+
+func extractMatchedHostPatterns(line string) []string {
+	const marker = ": Applying options for "
+
+	idx := strings.Index(line, marker)
+	if idx == -1 {
+		return nil
+	}
+
+	return strings.FieldsFunc(strings.TrimSpace(line[idx+len(marker):]), func(r rune) bool {
+		return r == ',' || r == ' ' || r == '\t'
+	})
 }

--- a/internal/ssh/config_test.go
+++ b/internal/ssh/config_test.go
@@ -20,6 +20,18 @@ func TestNewConfigFromBytes(t *testing.T) {
 		assert.Equal(t, want, got)
 	})
 
+	t.Run("parses user", func(t *testing.T) {
+		input := []byte(`user homer
+`)
+
+		got := NewConfigFromBytes(input)
+
+		want := Config{
+			User: "homer",
+		}
+		assert.Equal(t, want, got)
+	})
+
 	t.Run("ignores unrecognised keys", func(t *testing.T) {
 		input := []byte(`hostname springfield.nuclear.gov
 identityfile ~/.ssh/id_ed25519
@@ -30,6 +42,7 @@ user homer
 
 		want := Config{
 			HostName: "springfield.nuclear.gov",
+			User:     "homer",
 		}
 		assert.Equal(t, want, got)
 	})
@@ -70,6 +83,30 @@ connecttimeout none
 		got := NewConfigFromBytes(input)
 
 		assert.Equal(t, time.Duration(0), got.connectTimeout)
+	})
+
+	t.Run("records exact host matches from verbose ssh output", func(t *testing.T) {
+		input := []byte(`debug1: /tmp/config line 1: Applying options for board
+debug1: /tmp/config line 5: Applying options for *
+hostname springfield.nuclear.gov
+user homer
+`)
+
+		got := NewConfigFromBytes(input)
+
+		assert.True(t, got.HasExactHostMatch("board"))
+		assert.False(t, got.HasExactHostMatch("other-board"))
+	})
+
+	t.Run("splits matched host patterns while ignoring negations", func(t *testing.T) {
+		input := []byte(`debug1: /tmp/config line 1: Applying options for board,!skip,board-alt
+`)
+
+		got := NewConfigFromBytes(input)
+
+		assert.True(t, got.HasExactHostMatch("board"))
+		assert.True(t, got.HasExactHostMatch("board-alt"))
+		assert.False(t, got.HasExactHostMatch("skip"))
 	})
 }
 

--- a/internal/ssh/sshconfig/ssh_config.go
+++ b/internal/ssh/sshconfig/ssh_config.go
@@ -69,7 +69,10 @@ func CreateOrModifySSHConfig(dest ssh.Destination, targetSlug string, directives
 
 	var fragmentToWrite []byte
 	if len(existingTopoContent) == 0 {
-		fragmentToWrite = buildSSHConfigFragment(dest, directives)
+		fragmentToWrite, err = buildSSHConfigFragment(dest, directives)
+		if err != nil {
+			return err
+		}
 	} else {
 		fragmentToWrite = mergeOwnedSSHConfigDirectives(existingTopoContent, directives)
 	}
@@ -112,11 +115,25 @@ func hasIncludeLine(data []byte, includeLine string) bool {
 	return false
 }
 
-func buildSSHConfigFragment(dest ssh.Destination, directives []SSHConfigDirective) []byte {
+func buildSSHConfigFragment(dest ssh.Destination, directives []SSHConfigDirective) ([]byte, error) {
+	effectiveDest := dest
+	effectiveDest.User = ""
+	effectiveConfig := ssh.NewConfig(effectiveDest)
+	hasExactHostMatch := effectiveConfig.HasExactHostMatch(dest.Host)
+
+	if dest.User != "" && hasExactHostMatch && effectiveConfig.User != "" && effectiveConfig.User != dest.User {
+		return nil, fmt.Errorf("ssh host/alias %q is already associated with user %q; the same host/alias cannot be used for multiple users", dest.Host, effectiveConfig.User)
+	}
+
+	hostName := dest.Host
+	if !hasExactHostMatch && effectiveConfig.HostName != "" {
+		hostName = effectiveConfig.HostName
+	}
+
 	var b strings.Builder
 	fmt.Fprintf(&b, "Host %s\n", dest.Host)
-	if dest.Host != "" && (dest.User != "" || net.ParseIP(dest.Host) != nil) {
-		fmt.Fprintf(&b, "  HostName %s\n", dest.Host)
+	if !hasExactHostMatch && hostName != "" && (hostName != dest.Host || dest.User != "" || net.ParseIP(dest.Host) != nil) {
+		fmt.Fprintf(&b, "  HostName %s\n", hostName)
 	}
 	if dest.User != "" {
 		fmt.Fprintf(&b, "  User %s\n", dest.User)
@@ -128,7 +145,7 @@ func buildSSHConfigFragment(dest ssh.Destination, directives []SSHConfigDirectiv
 	for _, directive := range directives {
 		fmt.Fprintf(&b, "  %s\n", directive.String())
 	}
-	return []byte(b.String())
+	return []byte(b.String()), nil
 }
 
 func mergeOwnedSSHConfigDirectives(existing []byte, directives []SSHConfigDirective) []byte {


### PR DESCRIPTION
When we use `topo setup-keys --target <target>`, we parse the user's effective SSH config, and create an SSH config fragment under `~/.ssh/topo_config` that sets up the key path (Identity File) for that target.

However, if we later on do `topo setup-keys --target newuser@<target>`, this will create a HostName collision. SSH configs should not have multiple users defind for the same target Host/alias as this would effectively overwrite the user with the one defined last.

 * Error out when the requested Host/alias is already defined in the effective SSH config but for a different user.