### PR TITLE
refactor: decouple `ProbeHealthStatus` from `Connection` 

### DIFF
--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -65,6 +65,17 @@ func CheckHost() HostReport {
 	return GenerateHostReport(dependencyStatuses)
 }
 
+type ConnectionStatus struct {
+	Destination ssh.Destination
+	Error       error
+}
+
+type Status struct {
+	Connection   ConnectionStatus
+	Dependencies []DependencyStatus
+	Hardware     HardwareProfile
+}
+
 func CheckTarget(dest ssh.Destination, probeOpts target.SSHAuthenticationProbeOptions, connectTimeout time.Duration) (TargetReport, error) {
 	opts := target.ConnectionOptions{
 		Multiplex:      true,
@@ -75,13 +86,17 @@ func CheckTarget(dest ssh.Destination, probeOpts target.SSHAuthenticationProbeOp
 	if !dest.IsPlainLocalhost() {
 		authProbe := target.NewSSHAuthenticationProbe(&conn, probeOpts)
 		if err := authProbe.Probe(); err != nil {
-			status := Status{SSHTarget: dest, ConnectionError: err}
+			status := Status{Connection: ConnectionStatus{Destination: dest, Error: err}}
 			return GenerateTargetReport(status), nil
 		}
 	}
 
-	status := ProbeHealthStatus(&conn)
-	status.SSHTarget = dest
+	hs := ProbeHealthStatus(&conn)
+	status := Status{
+		Connection:   ConnectionStatus{Destination: dest},
+		Dependencies: hs.Dependencies,
+		Hardware:     hs.Hardware,
+	}
 	return GenerateTargetReport(status), nil
 }
 
@@ -94,7 +109,7 @@ func GenerateHostReport(statuses []DependencyStatus) HostReport {
 
 func GenerateTargetReport(targetStatus Status) TargetReport {
 	report := TargetReport{}
-	report.IsLocalhost = targetStatus.SSHTarget.IsPlainLocalhost()
+	report.IsLocalhost = targetStatus.Connection.Destination.IsPlainLocalhost()
 	report.Connectivity = connectivityCheck(targetStatus)
 
 	report.SubsystemDriver.Name = "Subsystem Driver (remoteproc)"
@@ -119,15 +134,15 @@ func GenerateTargetReport(targetStatus Status) TargetReport {
 func connectivityCheck(targetStatus Status) HealthCheck {
 	check := HealthCheck{
 		Name:   "Connectivity",
-		Status: NewCheckStatusFromError(targetStatus.ConnectionError),
+		Status: NewCheckStatusFromError(targetStatus.Connection.Error),
 	}
-	if targetStatus.ConnectionError == nil {
+	if targetStatus.Connection.Error == nil {
 		return check
 	}
 
-	check.Value = targetStatus.ConnectionError.Error()
-	if errors.Is(targetStatus.ConnectionError, target.ErrPasswordAuthentication) {
-		check.Fix = fmt.Sprintf("run `topo setup-keys --target %s` or manually setup SSH keys for the target", targetStatus.SSHTarget)
+	check.Value = targetStatus.Connection.Error.Error()
+	if errors.Is(targetStatus.Connection.Error, target.ErrPasswordAuthentication) {
+		check.Fix = fmt.Sprintf("run `topo setup-keys --target %s` or manually setup SSH keys for the target", targetStatus.Connection.Destination)
 	}
 	return check
 }

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -70,6 +70,10 @@ type ConnectionStatus struct {
 	Error       error
 }
 
+func (c ConnectionStatus) IsPlainLocalhost() bool {
+	return c.Destination.IsPlainLocalhost()
+}
+
 type Status struct {
 	Connection   ConnectionStatus
 	Dependencies []DependencyStatus
@@ -109,8 +113,8 @@ func GenerateHostReport(statuses []DependencyStatus) HostReport {
 
 func GenerateTargetReport(targetStatus Status) TargetReport {
 	report := TargetReport{}
-	report.IsLocalhost = targetStatus.Connection.Destination.IsPlainLocalhost()
-	report.Connectivity = connectivityCheck(targetStatus)
+	report.IsLocalhost = targetStatus.Connection.IsPlainLocalhost()
+	report.Connectivity = connectivityCheck(targetStatus.Connection)
 
 	report.SubsystemDriver.Name = "Subsystem Driver (remoteproc)"
 	remoteCPUs := targetStatus.Hardware.RemoteCPU
@@ -131,18 +135,18 @@ func GenerateTargetReport(targetStatus Status) TargetReport {
 	return report
 }
 
-func connectivityCheck(targetStatus Status) HealthCheck {
+func connectivityCheck(status ConnectionStatus) HealthCheck {
 	check := HealthCheck{
 		Name:   "Connectivity",
-		Status: NewCheckStatusFromError(targetStatus.Connection.Error),
+		Status: NewCheckStatusFromError(status.Error),
 	}
-	if targetStatus.Connection.Error == nil {
+	if status.Error == nil {
 		return check
 	}
 
-	check.Value = targetStatus.Connection.Error.Error()
-	if errors.Is(targetStatus.Connection.Error, target.ErrPasswordAuthentication) {
-		check.Fix = fmt.Sprintf("run `topo setup-keys --target %s` or manually setup SSH keys for the target", targetStatus.Connection.Destination)
+	check.Value = status.Error.Error()
+	if errors.Is(status.Error, target.ErrPasswordAuthentication) {
+		check.Fix = fmt.Sprintf("run `topo setup-keys --target %s` or manually setup SSH keys for the target", status.Destination)
 	}
 	return check
 }

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -71,8 +71,18 @@ func CheckTarget(dest ssh.Destination, probeOpts target.SSHAuthenticationProbeOp
 		ConnectTimeout: connectTimeout,
 	}
 	conn := target.NewConnection(dest, opts)
-	targetStatus := ProbeHealthStatus(conn, probeOpts)
-	return GenerateTargetReport(targetStatus), nil
+
+	if !dest.IsPlainLocalhost() {
+		authProbe := target.NewSSHAuthenticationProbe(&conn, probeOpts)
+		if err := authProbe.Probe(); err != nil {
+			status := Status{SSHTarget: dest, ConnectionError: err}
+			return GenerateTargetReport(status), nil
+		}
+	}
+
+	status := ProbeHealthStatus(&conn)
+	status.SSHTarget = dest
+	return GenerateTargetReport(status), nil
 }
 
 func GenerateHostReport(statuses []DependencyStatus) HostReport {

--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -58,7 +58,7 @@ func TestGenerateTargetReport(t *testing.T) {
 	})
 
 	t.Run("when the target has a connection error, Connectivity status reports error", func(t *testing.T) {
-		ts := health.Status{ConnectionError: assert.AnError}
+		ts := health.Status{Connection: health.ConnectionStatus{Error: assert.AnError}}
 
 		got := health.GenerateTargetReport(ts)
 
@@ -76,8 +76,10 @@ func TestGenerateTargetReport(t *testing.T) {
 
 	t.Run("when password authentication is required, Connectivity includes a setup-keys fix", func(t *testing.T) {
 		ts := health.Status{
-			SSHTarget:       ssh.NewDestination("user@my-target"),
-			ConnectionError: target.ErrPasswordAuthentication,
+			Connection: health.ConnectionStatus{
+				Destination: ssh.NewDestination("user@my-target"),
+				Error:       target.ErrPasswordAuthentication,
+			},
 		}
 
 		got := health.GenerateTargetReport(ts)

--- a/internal/health/status.go
+++ b/internal/health/status.go
@@ -2,7 +2,6 @@ package health
 
 import (
 	"github.com/arm/topo/internal/command"
-	"github.com/arm/topo/internal/ssh"
 	"github.com/arm/topo/internal/target"
 )
 
@@ -22,21 +21,19 @@ func (h HardwareProfile) Capabilities() map[HardwareCapability]struct{} {
 	return capabilities
 }
 
-type Status struct {
-	SSHTarget       ssh.Destination
-	ConnectionError error
-	Dependencies    []DependencyStatus
-	Hardware        HardwareProfile
+type HealthStatus struct {
+	Dependencies []DependencyStatus
+	Hardware     HardwareProfile
 }
 
-func ProbeHealthStatus(r runner) Status {
-	var status Status
+func ProbeHealthStatus(r runner) HealthStatus {
+	var hs HealthStatus
 
 	probe := target.NewHardwareProbe(r)
 	remoteprocs, _ := probe.ProbeRemoteproc()
-	status.Hardware.RemoteCPU = remoteprocs
+	hs.Hardware.RemoteCPU = remoteprocs
 
-	dependenciesToCheck := FilterByHardware(TargetRequiredDependencies, status.Hardware.Capabilities())
+	dependenciesToCheck := FilterByHardware(TargetRequiredDependencies, hs.Hardware.Capabilities())
 	binaryExists := func(bin string) error {
 		// We can use `UnsafeBinaryLookupCommand`, because the dependencies we're checking are hardcoded in the codebase
 		if _, err := r.Run(command.UnsafeBinaryLookupCommand(bin)); err != nil {
@@ -48,7 +45,7 @@ func ProbeHealthStatus(r runner) Status {
 		_, err := r.Run(command.WrapInLoginShell(fullCmd))
 		return err
 	}
-	status.Dependencies = PerformChecks(dependenciesToCheck, binaryExists, commandSuccessful)
+	hs.Dependencies = PerformChecks(dependenciesToCheck, binaryExists, commandSuccessful)
 
-	return status
+	return hs
 }

--- a/internal/health/status.go
+++ b/internal/health/status.go
@@ -6,6 +6,10 @@ import (
 	"github.com/arm/topo/internal/target"
 )
 
+type runner interface {
+	Run(command string) (string, error)
+}
+
 type HardwareProfile struct {
 	RemoteCPU []target.RemoteprocCPU
 }
@@ -25,30 +29,23 @@ type Status struct {
 	Hardware        HardwareProfile
 }
 
-func ProbeHealthStatus(c target.Connection, probeOpts target.SSHAuthenticationProbeOptions) Status {
+func ProbeHealthStatus(r runner) Status {
 	var status Status
-	status.SSHTarget = c.SSHTarget
 
-	authProbe := target.NewSSHAuthenticationProbe(&c, probeOpts)
-	if err := authProbe.Probe(); err != nil {
-		status.ConnectionError = err
-		return status
-	}
-
-	probe := target.NewHardwareProbe(&c)
+	probe := target.NewHardwareProbe(r)
 	remoteprocs, _ := probe.ProbeRemoteproc()
 	status.Hardware.RemoteCPU = remoteprocs
 
 	dependenciesToCheck := FilterByHardware(TargetRequiredDependencies, status.Hardware.Capabilities())
 	binaryExists := func(bin string) error {
 		// We can use `UnsafeBinaryLookupCommand`, because the dependencies we're checking are hardcoded in the codebase
-		if _, err := c.Run(command.UnsafeBinaryLookupCommand(bin)); err != nil {
+		if _, err := r.Run(command.UnsafeBinaryLookupCommand(bin)); err != nil {
 			return err
 		}
 		return nil
 	}
 	commandSuccessful := func(fullCmd string) error {
-		_, err := c.Run(command.WrapInLoginShell(fullCmd))
+		_, err := r.Run(command.WrapInLoginShell(fullCmd))
 		return err
 	}
 	status.Dependencies = PerformChecks(dependenciesToCheck, binaryExists, commandSuccessful)

--- a/internal/health/status_test.go
+++ b/internal/health/status_test.go
@@ -21,28 +21,26 @@ func (m *mockRunner) Run(cmd string) (string, error) {
 }
 
 func TestProbeHealthStatus(t *testing.T) {
-	t.Run("ProbeHealthStatus", func(t *testing.T) {
-		t.Run("finds remote CPUs", func(t *testing.T) {
-			r := new(mockRunner)
-			r.On("Run", command.WrapInLoginShell("ls /sys/class/remoteproc")).Return("remoteproc0\nremoteproc1", nil)
-			r.On("Run", command.WrapInLoginShell("cat /sys/class/remoteproc/*/name")).Return("foo\nbar", nil)
-			r.On("Run", mock.AnythingOfType("string")).Maybe().Return("", fmt.Errorf("not found"))
+	t.Run("finds remote CPUs", func(t *testing.T) {
+		r := new(mockRunner)
+		r.On("Run", command.WrapInLoginShell("ls /sys/class/remoteproc")).Return("remoteproc0\nremoteproc1", nil)
+		r.On("Run", command.WrapInLoginShell("cat /sys/class/remoteproc/*/name")).Return("foo\nbar", nil)
+		r.On("Run", mock.AnythingOfType("string")).Maybe().Return("", fmt.Errorf("not found"))
 
-			ts := health.ProbeHealthStatus(r)
+		ts := health.ProbeHealthStatus(r)
 
-			want := health.HardwareProfile{RemoteCPU: []target.RemoteprocCPU{{Name: "foo"}, {Name: "bar"}}}
-			assert.Equal(t, want, ts.Hardware)
-			r.AssertExpectations(t)
-		})
+		want := health.HardwareProfile{RemoteCPU: []target.RemoteprocCPU{{Name: "foo"}, {Name: "bar"}}}
+		assert.Equal(t, want, ts.Hardware)
+		r.AssertExpectations(t)
+	})
 
-		t.Run("succeeds when no remoteproc support", func(t *testing.T) {
-			r := new(mockRunner)
-			r.On("Run", mock.AnythingOfType("string")).Return("", fmt.Errorf("no such directory"))
+	t.Run("succeeds when no remoteproc support", func(t *testing.T) {
+		r := new(mockRunner)
+		r.On("Run", mock.AnythingOfType("string")).Return("", fmt.Errorf("no such directory"))
 
-			ts := health.ProbeHealthStatus(r)
+		ts := health.ProbeHealthStatus(r)
 
-			assert.Len(t, ts.Hardware.RemoteCPU, 0)
-			r.AssertExpectations(t)
-		})
+		assert.Len(t, ts.Hardware.RemoteCPU, 0)
+		r.AssertExpectations(t)
 	})
 }

--- a/internal/health/status_test.go
+++ b/internal/health/status_test.go
@@ -2,50 +2,47 @@ package health_test
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
+	"github.com/arm/topo/internal/command"
 	"github.com/arm/topo/internal/health"
 	"github.com/arm/topo/internal/target"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
-type fakeRunner struct {
-	run func(command string) (string, error)
+type mockRunner struct {
+	mock.Mock
 }
 
-func (f fakeRunner) Run(command string) (string, error) {
-	return f.run(command)
+func (m *mockRunner) Run(cmd string) (string, error) {
+	args := m.Called(cmd)
+	return args.String(0), args.Error(1)
 }
 
 func TestProbeHealthStatus(t *testing.T) {
 	t.Run("ProbeHealthStatus", func(t *testing.T) {
 		t.Run("finds remote CPUs", func(t *testing.T) {
-			r := fakeRunner{run: func(command string) (string, error) {
-				switch {
-				case strings.Contains(command, "ls /sys/class/remoteproc"):
-					return "remoteproc0\nremoteproc1", nil
-				case strings.Contains(command, "cat /sys/class/remoteproc"):
-					return "foo\nbar", nil
-				default:
-					return "", fmt.Errorf("unexpected command: %s", command)
-				}
-			}}
+			r := new(mockRunner)
+			r.On("Run", command.WrapInLoginShell("ls /sys/class/remoteproc")).Return("remoteproc0\nremoteproc1", nil)
+			r.On("Run", command.WrapInLoginShell("cat /sys/class/remoteproc/*/name")).Return("foo\nbar", nil)
+			r.On("Run", mock.AnythingOfType("string")).Maybe().Return("", fmt.Errorf("not found"))
 
 			ts := health.ProbeHealthStatus(r)
 
 			want := health.HardwareProfile{RemoteCPU: []target.RemoteprocCPU{{Name: "foo"}, {Name: "bar"}}}
 			assert.Equal(t, want, ts.Hardware)
+			r.AssertExpectations(t)
 		})
 
 		t.Run("succeeds when no remoteproc support", func(t *testing.T) {
-			r := fakeRunner{run: func(command string) (string, error) {
-				return "", fmt.Errorf("no such directory")
-			}}
+			r := new(mockRunner)
+			r.On("Run", mock.AnythingOfType("string")).Return("", fmt.Errorf("no such directory"))
 
 			ts := health.ProbeHealthStatus(r)
 
 			assert.Len(t, ts.Hardware.RemoteCPU, 0)
+			r.AssertExpectations(t)
 		})
 	})
 }

--- a/internal/health/status_test.go
+++ b/internal/health/status_test.go
@@ -1,61 +1,51 @@
 package health_test
 
 import (
-	"os/exec"
+	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/arm/topo/internal/health"
-	"github.com/arm/topo/internal/ssh"
 	"github.com/arm/topo/internal/target"
-	"github.com/arm/topo/internal/testutil"
 	"github.com/stretchr/testify/assert"
 )
 
+type fakeRunner struct {
+	run func(command string) (string, error)
+}
+
+func (f fakeRunner) Run(command string) (string, error) {
+	return f.run(command)
+}
+
 func TestProbeHealthStatus(t *testing.T) {
-	t.Run("probe fails connection", func(t *testing.T) {
-		mockExec := func(_ ssh.Destination, _ string, _ []byte, _ ...string) *exec.Cmd {
-			return testutil.CmdWithOutput("connection refused", 1)
-		}
-		conn := target.NewConnection(ssh.NewDestination("hostname"), target.ConnectionOptions{WithMockExec: mockExec})
-		ts := health.ProbeHealthStatus(conn, target.SSHAuthenticationProbeOptions{AcceptNewHostKeys: true})
+	t.Run("ProbeHealthStatus", func(t *testing.T) {
+		t.Run("finds remote CPUs", func(t *testing.T) {
+			r := fakeRunner{run: func(command string) (string, error) {
+				switch {
+				case strings.Contains(command, "ls /sys/class/remoteproc"):
+					return "remoteproc0\nremoteproc1", nil
+				case strings.Contains(command, "cat /sys/class/remoteproc"):
+					return "foo\nbar", nil
+				default:
+					return "", fmt.Errorf("unexpected command: %s", command)
+				}
+			}}
 
-		assert.Error(t, ts.ConnectionError)
-		assert.ErrorContains(t, ts.ConnectionError, "exit status")
-	})
+			ts := health.ProbeHealthStatus(r)
 
-	t.Run("probe finds remote CPUs", func(t *testing.T) {
-		mockExec := func(_ ssh.Destination, command string, _ []byte, _ ...string) *exec.Cmd {
-			switch {
-			case command == "true":
-				return testutil.CmdWithOutput("", 0)
-			case strings.Contains(command, "ls /sys/class/remoteproc"):
-				return testutil.CmdWithOutput("remoteproc0\nremoteproc1", 0)
-			case strings.Contains(command, "cat /sys/class/remoteproc"):
-				return testutil.CmdWithOutput("foo\nbar", 0)
-			default:
-				return testutil.CmdWithOutput("unexpected command: "+command, 1)
-			}
-		}
-		conn := target.NewConnection(ssh.NewDestination("hostname"), target.ConnectionOptions{WithMockExec: mockExec})
-		ts := health.ProbeHealthStatus(conn, target.SSHAuthenticationProbeOptions{AcceptNewHostKeys: true})
+			want := health.HardwareProfile{RemoteCPU: []target.RemoteprocCPU{{Name: "foo"}, {Name: "bar"}}}
+			assert.Equal(t, want, ts.Hardware)
+		})
 
-		want := health.HardwareProfile{RemoteCPU: []target.RemoteprocCPU{{Name: "foo"}, {Name: "bar"}}}
-		assert.NoError(t, ts.ConnectionError)
-		assert.Equal(t, want, ts.Hardware)
-	})
+		t.Run("succeeds when no remoteproc support", func(t *testing.T) {
+			r := fakeRunner{run: func(command string) (string, error) {
+				return "", fmt.Errorf("no such directory")
+			}}
 
-	t.Run("probe succeeds when no remoteproc support", func(t *testing.T) {
-		mockExec := func(_ ssh.Destination, command string, _ []byte, _ ...string) *exec.Cmd {
-			if command == "true" {
-				return testutil.CmdWithOutput("", 0)
-			}
-			return testutil.CmdWithOutput("no such directory", 1)
-		}
-		conn := target.NewConnection(ssh.NewDestination("hostname"), target.ConnectionOptions{WithMockExec: mockExec})
-		ts := health.ProbeHealthStatus(conn, target.SSHAuthenticationProbeOptions{AcceptNewHostKeys: true})
+			ts := health.ProbeHealthStatus(r)
 
-		assert.NoError(t, ts.ConnectionError)
-		assert.Len(t, ts.Hardware.RemoteCPU, 0)
+			assert.Len(t, ts.Hardware.RemoteCPU, 0)
+		})
 	})
 }


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- `ProbeHealthStatus` now accepts a `runner` interface instead of `target.Connection`, returning `HealthStatus` (hardware + dependencies only) — it owns what it discovers, nothing more               
- Auth probe moves into `CheckTarget`, gated on `!dest.IsPlainLocalhost()`, laying the groundwork for localhost targets skipping SSH auth entirely                                                     
- `ConnectionStatus` groups destination and connection error; `CheckTarget` assembles the full `Status` from ConnectionStatus` + `HealthStatus`                                                       
- Tests switch from `WithMockExec` to `testify/mock` 
