### PR TITLE
feat: only allow one user per Host/alias when setting up keys

### DIFF
--- a/cmd/topo/setup_keys.go
+++ b/cmd/topo/setup_keys.go
@@ -41,6 +41,11 @@ var setupKeysCmd = &cobra.Command{
 			return err
 		}
 
+		err = ssh.IsDestinationAlreadyConfiguredWithAnotherUser(dest)
+		if err != nil {
+			return fmt.Errorf("%w; note: a per user SSH config entry should be created  when setting up keys", err)
+		}
+
 		seq, err := setupkeys.NewKeySetup(dest, privateKeyPath, parsedKeyType)
 		if err != nil {
 			return err

--- a/internal/ssh/config.go
+++ b/internal/ssh/config.go
@@ -3,6 +3,7 @@ package ssh
 import (
 	"bufio"
 	"bytes"
+	"fmt"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -11,11 +12,16 @@ import (
 
 type Config struct {
 	HostName       string
+	User           string
 	connectTimeout time.Duration
 }
 
+func readConfig(dest Destination) ([]byte, error) {
+	return exec.Command("ssh", "-v", "-G", dest.String()).CombinedOutput()
+}
+
 func NewConfig(dest Destination) Config {
-	output, err := exec.Command("ssh", "-G", dest.String()).Output()
+	output, err := readConfig(dest)
 	if err != nil {
 		return Config{}
 	}
@@ -26,13 +32,17 @@ func NewConfigFromBytes(data []byte) Config {
 	var config Config
 	scanner := bufio.NewScanner(bytes.NewReader(data))
 	for scanner.Scan() {
-		fields := strings.Fields(scanner.Text())
+		line := scanner.Text()
+
+		fields := strings.Fields(line)
 		if len(fields) < 2 {
 			continue
 		}
 		switch strings.ToLower(fields[0]) {
 		case "hostname":
 			config.HostName = fields[1]
+		case "user":
+			config.User = fields[1]
 		case "connecttimeout":
 			if secs, err := strconv.Atoi(fields[1]); err == nil {
 				config.connectTimeout = time.Duration(secs) * time.Second
@@ -48,4 +58,59 @@ func (c Config) ConnectTimeout(fallback time.Duration) time.Duration {
 		return c.connectTimeout
 	}
 	return fallback
+}
+
+func IsDestinationAlreadyConfiguredWithAnotherUser(dest Destination) error {
+	hostConfig, err := LookupExplicitHostConfig(dest.Host, dest.Port)
+	if err != nil {
+		return err
+	}
+
+	if dest.User != "" && hostConfig.User != dest.User {
+		return fmt.Errorf("ssh host/alias %q is already associated with user %q", dest.Host, hostConfig.User)
+	}
+	return nil
+}
+
+// LookupExplicitHostConfig returns configuration, only if there's an explicit entry for the given host/port
+func LookupExplicitHostConfig(host, port string) (Config, error) {
+	dest := Destination{Host: host, Port: port}
+	output, err := readConfig(dest)
+	if err != nil {
+		return Config{}, err
+	}
+
+	if !isExplicitHostConfig(host, output) {
+		return Config{}, fmt.Errorf("no explicit host config found for %s", host)
+	}
+
+	return NewConfigFromBytes(output), nil
+}
+
+func isExplicitHostConfig(host string, config []byte) bool {
+	const marker = ": Applying options for "
+
+	scanner := bufio.NewScanner(bytes.NewReader(config))
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		if !strings.Contains(line, marker) {
+			continue
+		}
+
+		hostCandidates := strings.FieldsFunc(strings.TrimSpace(line[strings.Index(line, marker)+len(marker):]), func(r rune) bool {
+			return r == ',' || r == ' ' || r == '\t'
+		})
+
+		for _, hostCandidate := range hostCandidates {
+			if hostCandidate == "" || strings.HasPrefix(hostCandidate, "!") || strings.ContainsAny(hostCandidate, "*?") {
+				continue
+			}
+			if strings.EqualFold(hostCandidate, host) {
+				return true
+			}
+		}
+	}
+
+	return false
 }

--- a/internal/ssh/config_test.go
+++ b/internal/ssh/config_test.go
@@ -8,14 +8,16 @@ import (
 )
 
 func TestNewConfigFromBytes(t *testing.T) {
-	t.Run("parses hostname", func(t *testing.T) {
+	t.Run("parses basic config fields", func(t *testing.T) {
 		input := []byte(`hostname springfield.nuclear.gov
+user homer
 `)
 
 		got := NewConfigFromBytes(input)
 
 		want := Config{
 			HostName: "springfield.nuclear.gov",
+			User:     "homer",
 		}
 		assert.Equal(t, want, got)
 	})
@@ -30,6 +32,7 @@ user homer
 
 		want := Config{
 			HostName: "springfield.nuclear.gov",
+			User:     "homer",
 		}
 		assert.Equal(t, want, got)
 	})
@@ -86,5 +89,45 @@ func TestConfigConnectTimeout(t *testing.T) {
 		config := Config{}
 
 		assert.Equal(t, fallback, config.ConnectTimeout(fallback))
+	})
+}
+
+func TestIsExplicitHostConfig(t *testing.T) {
+	t.Run("returns true for exact host matches in verbose ssh output", func(t *testing.T) {
+		config := []byte(`debug1: /tmp/config line 1: Applying options for Board,board-alt
+debug1: /tmp/config line 5: Applying options for *
+hostname springfield.nuclear.gov
+`)
+
+		got := isExplicitHostConfig("board", config)
+		assert.True(t, got)
+	})
+
+	t.Run("ignores negated host patterns", func(t *testing.T) {
+		config := []byte(`debug1: /tmp/config line 1: Applying options for Board,!skip,*.corp,te?t
+hostname springfield.nuclear.gov
+`)
+
+		got := isExplicitHostConfig("skip", config)
+		assert.False(t, got)
+	})
+
+	t.Run("returns false when the host is not in the effective host list", func(t *testing.T) {
+		config := []byte(`debug1: /tmp/config line 1: Applying options for board,board-alt
+hostname springfield.nuclear.gov
+`)
+
+		got := isExplicitHostConfig("other-board", config)
+		assert.False(t, got)
+	})
+
+	t.Run("ignores lines without an applying options marker", func(t *testing.T) {
+		config := []byte(`hostname springfield.nuclear.gov
+user homer
+debug1: /tmp/config line 5: Applying options for *
+`)
+
+		got := isExplicitHostConfig("board", config)
+		assert.False(t, got)
 	})
 }


### PR DESCRIPTION
When we use `topo setup-keys --target <target>`, we parse the user's effective SSH config, and create an SSH config fragment under `~/.ssh/topo_config` that sets up the key path (Identity File) for that target.

However, if we later on do `topo setup-keys --target newuser@<target>`, this will create a HostName collision. SSH configs should not have multiple users defined for the same target Host/alias as this would effectively overwrite the user with the one defined last.

 * Error out when the requested Host/alias is already defined in the effective SSH config but for a different user.