### PR TITLE
bug: Warn if args are resolved but not found in both extend and clone

### DIFF
--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -121,8 +121,12 @@ func Extend(targetComposeFile string, src template.Source, argProvider arguments
 	resolvedArgs := argsToMap(resolvedTemplate.Args)
 
 	extendedComposeFilePath := filepath.Join(copiedDirName, template.ComposeFilename)
+	usedArgs := map[string]bool{}
 	for _, service := range resolvedTemplate.Services {
 		serviceArgs := compose.FilterResolvedBuildArgs(service.Data, resolvedArgs)
+		for k := range serviceArgs {
+			usedArgs[k] = true
+		}
 		newSvc := compose.CreateServiceByExtension(extendedComposeFilePath, service.Name, serviceArgs)
 		logs = append(logs, logger.Entry{
 			Level:   logger.Info,
@@ -130,6 +134,14 @@ func Extend(targetComposeFile string, src template.Source, argProvider arguments
 		})
 		if err := compose.InsertService(project, newSvc); err != nil {
 			return logs, err
+		}
+	}
+	for argName := range resolvedArgs {
+		if !usedArgs[argName] {
+			logs = append(logs, logger.Entry{
+				Level:   logger.Warning,
+				Message: fmt.Sprintf("arg %q was resolved but not found in any service build args", argName),
+			})
 		}
 	}
 


### PR DESCRIPTION
## Changes

`topo clone` reports when an arg is resolved but not found. topo extend, before this change, does not.

This change will mean when `topo extend`ing, a arg that is in x-topo but not found in the service args, a warn will be sent out; same as it does in clone.