### PR TITLE
fix!: lack of remoteproc endpoints is an info, not a warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,10 +82,16 @@ Target
 Connectivity: ✅
 Container Engine: ✅ (docker)
 Hardware Info: ✅ (lscpu)
-Subsystem Driver (remoteproc): ⚠️ (no remoteproc devices found)
+Remoteproc Runtime: ⚠️ (remoteproc-runtime not found on path)
+  → run `topo install remoteproc-runtime`
+Remoteproc Shim: ⚠️ (containerd-shim-remoteproc-v1 not found on path)
+  → run `topo install remoteproc-runtime`
+Subsystem Driver (remoteproc): ✅ (m4_0)
 ```
 
-Resolve any ❌ before continuing. A ⚠️ is informational and won't block the core workflow.
+- ❌ must be resolved before continuing.
+- ⚠️ can be resolved to unlock full functionality.
+- ℹ️ are informational and won't block the core workflow.
 
 ### 2. Describe your target hardware
 

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -24,6 +24,7 @@ const (
 	CheckStatusOK      CheckStatus = "ok"
 	CheckStatusWarning CheckStatus = "warning"
 	CheckStatusError   CheckStatus = "error"
+	CheckStatusInfo    CheckStatus = "info"
 )
 
 type HealthCheck struct {
@@ -97,7 +98,7 @@ func GenerateTargetReport(targetStatus Status) TargetReport {
 		report.SubsystemDriver.Status = CheckStatusOK
 		report.SubsystemDriver.Value = strings.Join(names, ", ")
 	} else {
-		report.SubsystemDriver.Status = CheckStatusWarning
+		report.SubsystemDriver.Status = CheckStatusInfo
 		report.SubsystemDriver.Value = "no remoteproc devices found"
 	}
 

--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -24,12 +24,12 @@ func TestGenerateTargetReport(t *testing.T) {
 		return health.GenerateTargetReport(health.Status{Dependencies: statuses}).Dependencies
 	})
 
-	t.Run("when no remoteproc devices are found, SubsystemDriver health check reports error", func(t *testing.T) {
+	t.Run("when no remoteproc devices are found, SubsystemDriver health check an info message", func(t *testing.T) {
 		ts := health.Status{}
 
 		got := health.GenerateTargetReport(ts)
 
-		assert.Equal(t, health.CheckStatusWarning, got.SubsystemDriver.Status)
+		assert.Equal(t, health.CheckStatusInfo, got.SubsystemDriver.Status)
 		assert.Equal(t, "no remoteproc devices found", got.SubsystemDriver.Value)
 	})
 
@@ -44,17 +44,6 @@ func TestGenerateTargetReport(t *testing.T) {
 
 		assert.Equal(t, health.CheckStatusOK, got.SubsystemDriver.Status)
 		assert.Equal(t, "m4_0, m4_1", got.SubsystemDriver.Value)
-	})
-
-	t.Run("when no remoteproc devices are found, SubsystemDriver status reports a warning", func(t *testing.T) {
-		ts := health.Status{
-			Hardware: health.HardwareProfile{RemoteCPU: nil},
-		}
-
-		got := health.GenerateTargetReport(ts)
-
-		assert.Equal(t, health.CheckStatusWarning, got.SubsystemDriver.Status)
-		assert.Equal(t, "no remoteproc devices found", got.SubsystemDriver.Value)
 	})
 
 	t.Run("when the target has a connection error, Connectivity status reports error", func(t *testing.T) {

--- a/internal/output/templates/health.go
+++ b/internal/output/templates/health.go
@@ -53,6 +53,8 @@ func (r PrintableHealthReport) AsPlain(isTTY bool) (string, error) {
 			return " ✅"
 		case health.CheckStatusWarning:
 			return " ⚠️"
+		case health.CheckStatusInfo:
+			return " ℹ️"
 		default:
 			return " ❌"
 		}

--- a/internal/output/templates/health_test.go
+++ b/internal/output/templates/health_test.go
@@ -80,6 +80,29 @@ func TestPrintHealthReport(t *testing.T) {
 			assert.Contains(t, out.String(), "no remoteproc devices found")
 		})
 
+		t.Run("it renders an info icon for info checks", func(t *testing.T) {
+			toPrint := templates.PrintableHealthReport{
+				Target: &health.TargetReport{
+					Connectivity: health.HealthCheck{
+						Name:   "Connected",
+						Status: health.CheckStatusOK,
+					},
+					SubsystemDriver: health.HealthCheck{
+						Name:   "Subsystem Driver (remoteproc)",
+						Status: health.CheckStatusInfo,
+						Value:  "no remoteproc devices found",
+					},
+				},
+			}
+			var out bytes.Buffer
+
+			err := printable.Print(toPrint, &out, term.Plain)
+
+			require.NoError(t, err)
+			assert.Contains(t, out.String(), "ℹ️")
+			assert.Contains(t, out.String(), "no remoteproc devices found")
+		})
+
 		t.Run("it renders connection failures", func(t *testing.T) {
 			toPrint := templates.PrintableHealthReport{
 				Target: &health.TargetReport{


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- Updated lack of remoteproc devices on a target to an info level instead of a warning
- ⚠️ Breaking change: this affects consumers of `health --output json`, as we now have a `status: "info"`

