### PR TITLE
refactor: remove `WithMockExec` and `ExecSSH`

### DIFF
--- a/internal/target/connection.go
+++ b/internal/target/connection.go
@@ -3,7 +3,6 @@ package target
 import (
 	"bytes"
 	"fmt"
-	"os/exec"
 	"runtime"
 	"strings"
 	"time"
@@ -11,29 +10,20 @@ import (
 	"github.com/arm/topo/internal/ssh"
 )
 
-type ExecSSH func(target ssh.Destination, cmdStr string, stdin []byte, sshArgs ...string) *exec.Cmd
-
 type Connection struct {
 	SSHTarget ssh.Destination
-	exec      ExecSSH
 	opts      ConnectionOptions
 }
 
 type ConnectionOptions struct {
 	Multiplex      bool
-	WithMockExec   ExecSSH
 	ConnectTimeout time.Duration
 }
 
 func NewConnection(dest ssh.Destination, opts ConnectionOptions) Connection {
-	execFn := ssh.ExecCmd
-	if opts.WithMockExec != nil {
-		execFn = opts.WithMockExec
-	}
 	opts.ConnectTimeout = ssh.NewConfig(dest).ConnectTimeout(opts.ConnectTimeout)
 	return Connection{
 		SSHTarget: dest,
-		exec:      execFn,
 		opts:      opts,
 	}
 }
@@ -47,7 +37,7 @@ func (c *Connection) RunWithStdin(cmdStr string, stdin []byte) (string, error) {
 }
 
 func (c *Connection) run(cmdStr string, stdin []byte) (string, error) {
-	cmd := c.exec(c.SSHTarget, cmdStr, stdin, c.opts.SSHArgs()...)
+	cmd := ssh.ExecCmd(c.SSHTarget, cmdStr, stdin, c.opts.SSHArgs()...)
 	var stdoutBuf, stderrBuf bytes.Buffer
 	cmd.Stdout = &stdoutBuf
 	cmd.Stderr = &stderrBuf
@@ -65,7 +55,7 @@ func (c *Connection) run(cmdStr string, stdin []byte) (string, error) {
 
 func (c *Connection) RunWithArgs(cmdStr string, sshArgs ...string) (string, error) {
 	allArgs := append(c.opts.SSHArgs(), sshArgs...)
-	cmd := c.exec(c.SSHTarget, cmdStr, nil, allArgs...)
+	cmd := ssh.ExecCmd(c.SSHTarget, cmdStr, nil, allArgs...)
 	out, err := cmd.CombinedOutput()
 	if err == nil {
 		return string(out), nil

--- a/internal/target/connection.go
+++ b/internal/target/connection.go
@@ -47,12 +47,7 @@ func (c *Connection) RunWithStdin(cmdStr string, stdin []byte) (string, error) {
 }
 
 func (c *Connection) run(cmdStr string, stdin []byte) (string, error) {
-	sshArgs := c.connectTimeoutArgs()
-	if c.opts.Multiplex && runtime.GOOS != "windows" {
-		sshArgs = append(sshArgs, "-o", "ControlMaster=auto", "-o", "ControlPersist=10s", "-o", "ControlPath=~/.ssh/topo-cm-%r@%h:%p")
-	}
-
-	cmd := c.exec(c.SSHTarget, cmdStr, stdin, sshArgs...)
+	cmd := c.exec(c.SSHTarget, cmdStr, stdin, c.opts.SSHArgs()...)
 	var stdoutBuf, stderrBuf bytes.Buffer
 	cmd.Stdout = &stdoutBuf
 	cmd.Stderr = &stderrBuf
@@ -69,7 +64,7 @@ func (c *Connection) run(cmdStr string, stdin []byte) (string, error) {
 }
 
 func (c *Connection) RunWithArgs(cmdStr string, sshArgs ...string) (string, error) {
-	allArgs := append(c.connectTimeoutArgs(), sshArgs...)
+	allArgs := append(c.opts.SSHArgs(), sshArgs...)
 	cmd := c.exec(c.SSHTarget, cmdStr, nil, allArgs...)
 	out, err := cmd.CombinedOutput()
 	if err == nil {
@@ -93,9 +88,13 @@ func (e ConnectionTimeoutError) Error() string {
 	return "ssh connection timed out"
 }
 
-func (c *Connection) connectTimeoutArgs() []string {
-	if c.opts.ConnectTimeout <= 0 {
-		return nil
+func (opts ConnectionOptions) SSHArgs() []string {
+	var args []string
+	if opts.ConnectTimeout > 0 {
+		args = append(args, "-o", fmt.Sprintf("ConnectTimeout=%d", int(opts.ConnectTimeout.Seconds())))
 	}
-	return []string{"-o", fmt.Sprintf("ConnectTimeout=%d", int(c.opts.ConnectTimeout.Seconds()))}
+	if opts.Multiplex && runtime.GOOS != "windows" {
+		args = append(args, "-o", "ControlMaster=auto", "-o", "ControlPersist=10s", "-o", "ControlPath=~/.ssh/topo-cm-%r@%h:%p")
+	}
+	return args
 }

--- a/internal/target/connection_test.go
+++ b/internal/target/connection_test.go
@@ -1,109 +1,50 @@
 package target_test
 
 import (
-	"os/exec"
-	"strings"
 	"testing"
+	"time"
 
-	"github.com/arm/topo/internal/ssh"
 	"github.com/arm/topo/internal/target"
 	"github.com/arm/topo/internal/testutil"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestRun(t *testing.T) {
-	t.Run("run executes command successfully", func(t *testing.T) {
-		mockExec := func(_ ssh.Destination, _ string, _ []byte, _ ...string) *exec.Cmd {
-			return testutil.CmdWithOutput("success", 0)
-		}
-		conn := target.NewConnection(ssh.NewDestination("hostname"), target.ConnectionOptions{WithMockExec: mockExec})
+func TestConnectionOptions(t *testing.T) {
+	t.Run("SSHArgs", func(t *testing.T) {
+		t.Run("with multiplexing enabled on non-windows includes Control args", func(t *testing.T) {
+			testutil.RequireOS(t, "linux")
+			opts := target.ConnectionOptions{Multiplex: true}
 
-		out, err := conn.Run("ls")
+			assert.Equal(t, []string{
+				"-o", "ControlMaster=auto",
+				"-o", "ControlPersist=10s",
+				"-o", "ControlPath=~/.ssh/topo-cm-%r@%h:%p",
+			}, opts.SSHArgs())
+		})
 
-		assert.NoError(t, err)
-		assert.Equal(t, "success", out)
-	})
+		t.Run("with multiplexing enabled on windows includes no Control args", func(t *testing.T) {
+			testutil.RequireOS(t, "windows")
+			opts := target.ConnectionOptions{Multiplex: true}
 
-	t.Run("run returns error", func(t *testing.T) {
-		mockExec := func(_ ssh.Destination, _ string, _ []byte, _ ...string) *exec.Cmd {
-			return testutil.CmdWithOutput("", 1)
-		}
-		conn := target.NewConnection(ssh.NewDestination("hostname"), target.ConnectionOptions{WithMockExec: mockExec})
+			assert.Nil(t, opts.SSHArgs())
+		})
 
-		out, err := conn.Run("ls")
+		t.Run("with multiplexing disabled includes no Control args", func(t *testing.T) {
+			opts := target.ConnectionOptions{Multiplex: false}
 
-		assert.Error(t, err)
-		assert.Empty(t, out)
-	})
+			assert.Nil(t, opts.SSHArgs())
+		})
 
-	t.Run("returns ErrAuthFailed when stderr contains auth failure", func(t *testing.T) {
-		mockExec := func(_ ssh.Destination, _ string, _ []byte, _ ...string) *exec.Cmd {
-			return testutil.CmdWithStderr("Permission denied (publickey)", 1)
-		}
-		conn := target.NewConnection(ssh.NewDestination("hostname"), target.ConnectionOptions{WithMockExec: mockExec})
+		t.Run("with connect timeout includes ConnectTimeout arg", func(t *testing.T) {
+			opts := target.ConnectionOptions{ConnectTimeout: 10 * time.Second}
 
-		_, err := conn.Run("ls")
+			assert.Equal(t, []string{"-o", "ConnectTimeout=10"}, opts.SSHArgs())
+		})
 
-		assert.ErrorIs(t, err, ssh.ErrAuthFailed)
-	})
+		t.Run("with no timeout includes no ConnectTimeout arg", func(t *testing.T) {
+			opts := target.ConnectionOptions{}
 
-	t.Run("returns ErrConnectionFailed when stderr contains connection refused", func(t *testing.T) {
-		mockExec := func(_ ssh.Destination, _ string, _ []byte, _ ...string) *exec.Cmd {
-			return testutil.CmdWithStderr("ssh: connect to host foo port 22: Connection refused", 1)
-		}
-		conn := target.NewConnection(ssh.NewDestination("hostname"), target.ConnectionOptions{WithMockExec: mockExec})
-
-		_, err := conn.Run("ls")
-
-		assert.ErrorIs(t, err, ssh.ErrConnectionFailed)
-	})
-
-	t.Run("run with stdin passes stdin to command", func(t *testing.T) {
-		var gotStdin []byte
-		mockExec := func(_ ssh.Destination, _ string, stdin []byte, _ ...string) *exec.Cmd {
-			gotStdin = stdin
-			return testutil.CmdWithOutput("success", 0)
-		}
-		conn := target.NewConnection(ssh.NewDestination("hostname"), target.ConnectionOptions{WithMockExec: mockExec})
-
-		out, err := conn.RunWithStdin("cat", []byte("payload"))
-
-		assert.NoError(t, err)
-		assert.Equal(t, "success", out)
-		assert.Equal(t, []byte("payload"), gotStdin)
-	})
-
-	t.Run("run with mutliplexing enabled includes Control args", func(t *testing.T) {
-		testutil.RequireOS(t, "linux")
-		var capturedArgs string
-		mockExec := func(_ ssh.Destination, _ string, _ []byte, sshArgs ...string) *exec.Cmd {
-			capturedArgs = strings.Join(sshArgs, " ")
-			return testutil.CmdWithOutput("success", 0)
-		}
-		conn := target.NewConnection(ssh.NewDestination("hostname"), target.ConnectionOptions{Multiplex: true, WithMockExec: mockExec})
-
-		_, err := conn.Run("ls")
-
-		assert.NoError(t, err)
-		assert.True(t, strings.Contains(capturedArgs, "-o ControlMaster"), "missing ControlMaster argument")
-		assert.True(t, strings.Contains(capturedArgs, "-o ControlPersist"), "missing ControlPersist argument")
-		assert.True(t, strings.Contains(capturedArgs, "-o ControlPath"), "missing ControlPath argument")
-	})
-
-	t.Run("run with mutliplexing enabled does not include Control args on windows", func(t *testing.T) {
-		testutil.RequireOS(t, "windows")
-		var capturedArgs string
-		mockExec := func(_ ssh.Destination, _ string, _ []byte, sshArgs ...string) *exec.Cmd {
-			capturedArgs = strings.Join(sshArgs, " ")
-			return testutil.CmdWithOutput("success", 0)
-		}
-		conn := target.NewConnection(ssh.NewDestination("hostname"), target.ConnectionOptions{Multiplex: true, WithMockExec: mockExec})
-
-		_, err := conn.Run("ls")
-
-		assert.NoError(t, err)
-		assert.False(t, strings.Contains(capturedArgs, "-o ControlMaster"), "unexpected ControlMaster argument")
-		assert.False(t, strings.Contains(capturedArgs, "-o ControlPersist"), "unexpected ControlPersist argument")
-		assert.False(t, strings.Contains(capturedArgs, "-o ControlPath"), "unexpected ControlPath argument")
+			assert.Nil(t, opts.SSHArgs())
+		})
 	})
 }


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- Removed `ExecSSH` along with related fields on `Connection` and `ConnectionOptions`. We now call `ssh.ExecCmd` directly.
- `ConnectionOptions.SSHArgs() []string` — new method that converts options to SSH arguments. Pure function, replaces the scattered arg-building logic.
