### PR TITLE
refactor: logger options + fix JSON output

### DIFF
--- a/cmd/topo/main.go
+++ b/cmd/topo/main.go
@@ -8,7 +8,7 @@ import (
 
 func main() {
 	outputFormat := resolveOutput(rootCmd)
-	logger.SetOutputFormat(outputFormat)
+	logger.SetOptions(logger.Options{Format: outputFormat})
 
 	if err := rootCmd.Execute(); err != nil {
 		logger.Error(err.Error())

--- a/cmd/topo/main.go
+++ b/cmd/topo/main.go
@@ -7,9 +7,6 @@ import (
 )
 
 func main() {
-	outputFormat := resolveOutput(rootCmd)
-	logger.SetOptions(logger.Options{Format: outputFormat})
-
 	if err := rootCmd.Execute(); err != nil {
 		logger.Error(err.Error())
 		os.Exit(1)

--- a/cmd/topo/root.go
+++ b/cmd/topo/root.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/arm/topo/internal/output/logger"
 	"github.com/arm/topo/internal/output/term"
 	"github.com/arm/topo/internal/version"
 	"github.com/spf13/cobra"
@@ -17,6 +18,10 @@ var rootCmd = &cobra.Command{
 	Version:       fmt.Sprintf("%s (commit: %s)", version.Version, version.GitCommit),
 	SilenceErrors: true,
 	SilenceUsage:  true,
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		outputFormat := resolveOutput(cmd)
+		logger.SetOptions(logger.Options{Format: outputFormat})
+	},
 }
 
 func init() {

--- a/internal/output/logger/logger.go
+++ b/internal/output/logger/logger.go
@@ -10,30 +10,32 @@ import (
 	"github.com/lmittmann/tint"
 )
 
-var (
-	output = io.Writer(os.Stderr)
-	logger = newPlainLogger()
-)
-
-func newPlainLogger() *slog.Logger {
-	return slog.New(tint.NewHandler(output, &tint.Options{
-		TimeFormat: time.TimeOnly,
-		NoColor:    !term.IsTTY(output),
-	}))
+type Options struct {
+	Output io.Writer
+	Format term.Format
 }
 
-func SetOutput(w io.Writer) {
-	output = w
-	logger = newPlainLogger()
+var logger = new(Options{})
+
+func SetOptions(o Options) {
+	logger = new(o)
 }
 
-func SetOutputFormat(format term.Format) {
-	switch format {
-	case term.Plain:
-		logger = newPlainLogger()
-	case term.JSON:
-		logger = slog.New(slog.NewJSONHandler(output, nil))
+func new(o Options) *slog.Logger {
+	if o.Output == nil {
+		o.Output = io.Writer(os.Stderr)
 	}
+
+	switch o.Format {
+	case term.JSON:
+		return slog.New(slog.NewJSONHandler(o.Output, nil))
+	default:
+		return slog.New(tint.NewHandler(o.Output, &tint.Options{
+			TimeFormat: time.TimeOnly,
+			NoColor:    !term.IsTTY(o.Output),
+		}))
+	}
+
 }
 
 func Debug(msg string, args ...any) {

--- a/internal/output/logger/logger.go
+++ b/internal/output/logger/logger.go
@@ -35,7 +35,6 @@ func new(o Options) *slog.Logger {
 			NoColor:    !term.IsTTY(o.Output),
 		}))
 	}
-
 }
 
 func Debug(msg string, args ...any) {

--- a/internal/output/logger/logger_test.go
+++ b/internal/output/logger/logger_test.go
@@ -3,7 +3,6 @@ package logger_test
 import (
 	"bytes"
 	"encoding/json"
-	"os"
 	"testing"
 
 	"github.com/arm/topo/internal/output/logger"
@@ -14,11 +13,9 @@ import (
 func setupTestLogOutputBuffer(t *testing.T, format term.Format) *bytes.Buffer {
 	t.Helper()
 	var buf bytes.Buffer
-	logger.SetOutput(&buf)
-	logger.SetOutputFormat(format)
+	logger.SetOptions(logger.Options{Output: &buf, Format: format})
 	t.Cleanup(func() {
-		logger.SetOutput(os.Stderr)
-		logger.SetOutputFormat(term.Plain)
+		logger.SetOptions(logger.Options{})
 	})
 	return &buf
 }


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- `--output json` was broken by a refactor made after review in the slog PR (#161) without manual re-testing (this is my bad, will hold my hands up) - I'll make a follow-up to add a proper test for this as it's a pretty big hole in our e2e tests atm.
- Refactors logger options to be a bit neater and improve extensibility (`--log-level` coming soon tm)
