### PR TITLE
test: add e2e tests for JSON output

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -33,3 +33,11 @@ docker build -t topo-e2e-target:latest ./internal/testutil/test-container
 ```
 
 > Note that if either of these test dependencies are missing, the dependent tests will just be skipped as opposed to failing.
+
+### Golden Files
+
+A subset of our e2e tests rely on "golden files" to assert CLI output against a known good state. These tests will fail when breaking changes are made and can be updated in place with the `UPDATE_GOLDEN` environment variable when running the tests.
+
+```
+UPDATE_GOLDEN=1 go test ./e2e/...
+```

--- a/e2e/health_test.go
+++ b/e2e/health_test.go
@@ -1,11 +1,9 @@
 package e2e
 
 import (
-	"encoding/json"
 	"os/exec"
 	"testing"
 
-	"github.com/arm/topo/internal/health"
 	"github.com/arm/topo/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -44,9 +42,7 @@ func TestHealthCheck(t *testing.T) {
 		out, err := runCheckHealth(topo, target, "--output", "json")
 
 		assert.NoError(t, err)
-		var entry health.TargetReport
-		err = json.Unmarshal([]byte(out), &entry)
-		assert.NoError(t, err)
+		testutil.AssertGoldenFile(t, out, "testdata/TestHealthCheckJson.golden")
 	})
 }
 

--- a/e2e/health_test.go
+++ b/e2e/health_test.go
@@ -1,9 +1,11 @@
 package e2e
 
 import (
+	"encoding/json"
 	"os/exec"
 	"testing"
 
+	"github.com/arm/topo/internal/health"
 	"github.com/arm/topo/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -37,10 +39,19 @@ func TestHealthCheck(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Contains(t, out, "Connectivity: ❌")
 	})
+
+	t.Run("outputs JSON when specified", func(t *testing.T) {
+		out, err := runCheckHealth(topo, target, "--output", "json")
+
+		assert.NoError(t, err)
+		var entry health.TargetReport
+		err = json.Unmarshal([]byte(out), &entry)
+		assert.NoError(t, err)
+	})
 }
 
-func runCheckHealth(topo string, target *testutil.TargetContainer) (string, error) {
-	args := []string{"health", "--target", target.SSHDestination}
+func runCheckHealth(topo string, target *testutil.TargetContainer, args ...string) (string, error) {
+	args = append([]string{"health", "--target", target.SSHDestination}, args...)
 	healthCmd := exec.Command(topo, args...)
 
 	out, err := healthCmd.CombinedOutput()

--- a/e2e/health_test.go
+++ b/e2e/health_test.go
@@ -42,7 +42,7 @@ func TestHealthCheck(t *testing.T) {
 		out, err := runCheckHealth(topo, target, "--output", "json")
 
 		assert.NoError(t, err)
-		testutil.AssertGoldenFile(t, out, "testdata/TestHealthCheckJson.golden")
+		testutil.AssertJsonGoldenFile(t, out, "testdata/TestHealthCheckJson.golden")
 	})
 }
 

--- a/e2e/templates_test.go
+++ b/e2e/templates_test.go
@@ -73,6 +73,20 @@ totalmemory_kb: 4194304
 		err = json.Unmarshal(out, &entry)
 		assert.NoError(t, err)
 	})
+
+	t.Run("outputs errors as JSON when specified", func(t *testing.T) {
+		cmd := exec.Command(bin, "templates", "--output", "json", "--target", "invalid-target")
+		out, err := cmd.CombinedOutput()
+		require.Error(t, err)
+
+		var entry map[string]interface{}
+		err = json.Unmarshal(out, &entry)
+		assert.NoError(t, err)
+		assert.Equal(t, "ERROR", entry["level"])
+		_, ok := entry["msg"].(string)
+		assert.True(t, ok, "msg field should be a string")
+		assert.NotNil(t, entry["time"])
+	})
 }
 
 func writeTargetDescription(t *testing.T, content string) string {

--- a/e2e/templates_test.go
+++ b/e2e/templates_test.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/arm/topo/internal/output/templates"
 	"github.com/arm/topo/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -68,10 +67,7 @@ totalmemory_kb: 4194304
 		out, err := cmd.CombinedOutput()
 		require.NoError(t, err)
 
-		assert.NoError(t, err)
-		var entry templates.RepoCollection
-		err = json.Unmarshal(out, &entry)
-		assert.NoError(t, err)
+		testutil.AssertGoldenFile(t, string(out), "testdata/TestTemplatesJson.golden")
 	})
 
 	t.Run("outputs errors as JSON when specified", func(t *testing.T) {

--- a/e2e/templates_test.go
+++ b/e2e/templates_test.go
@@ -67,7 +67,7 @@ totalmemory_kb: 4194304
 		out, err := cmd.CombinedOutput()
 		require.NoError(t, err)
 
-		testutil.AssertGoldenFile(t, string(out), "testdata/TestTemplatesJson.golden")
+		testutil.AssertJsonGoldenFile(t, string(out), "testdata/TestTemplatesJson.golden")
 	})
 
 	t.Run("outputs errors as JSON when specified", func(t *testing.T) {

--- a/e2e/templates_test.go
+++ b/e2e/templates_test.go
@@ -1,11 +1,13 @@
 package e2e
 
 import (
+	"encoding/json"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"
 
+	"github.com/arm/topo/internal/output/templates"
 	"github.com/arm/topo/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -59,6 +61,17 @@ totalmemory_kb: 4194304
 			require.NoError(t, err, output)
 			assert.Contains(t, output, "✅ topo-welcome")
 		})
+	})
+
+	t.Run("outputs JSON when specified", func(t *testing.T) {
+		cmd := exec.Command(bin, "templates", "--output", "json")
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err)
+
+		assert.NoError(t, err)
+		var entry templates.RepoCollection
+		err = json.Unmarshal(out, &entry)
+		assert.NoError(t, err)
 	})
 }
 

--- a/e2e/testdata/TestHealthCheckJson.golden
+++ b/e2e/testdata/TestHealthCheckJson.golden
@@ -1,0 +1,41 @@
+{
+  "host": {
+    "dependencies": [
+      {
+        "name": "SSH",
+        "status": "ok",
+        "value": "ssh"
+      },
+      {
+        "name": "Container Engine",
+        "status": "ok",
+        "value": "docker"
+      }
+    ]
+  },
+  "target": {
+    "isLocalhost": false,
+    "connectivity": {
+      "name": "Connectivity",
+      "status": "ok",
+      "value": ""
+    },
+    "dependencies": [
+      {
+        "name": "Container Engine",
+        "status": "ok",
+        "value": "docker"
+      },
+      {
+        "name": "Hardware Info",
+        "status": "ok",
+        "value": "lscpu"
+      }
+    ],
+    "subsystemDriver": {
+      "name": "Subsystem Driver (remoteproc)",
+      "status": "info",
+      "value": "no remoteproc devices found"
+    }
+  }
+}

--- a/e2e/testdata/TestTemplatesJson.golden
+++ b/e2e/testdata/TestTemplatesJson.golden
@@ -1,0 +1,38 @@
+[
+  {
+    "name": "topo-welcome",
+    "description": "A minimal \"Hello, World\" web app for validating a Topo setup and deployment.\nIt runs a single service that exposes a web page on the target,\nwith the greeting text customizable via the GREETING_NAME parameter.\n",
+    "features": null,
+    "url": "https://github.com/Arm-Examples/topo-welcome.git",
+    "ref": "main"
+  },
+  {
+    "name": "topo-lightbulb-moment",
+    "description": "Reads a switch over GPIO pins on an M class cpu, reports switch state over Remoteproc Message, then a web application on the A class reads this and displays a lightbulb in either the on or off state. The lightbulb state is described by an LLM in any user-specified style.",
+    "features": [
+      "remoteproc-runtime"
+    ],
+    "url": "https://github.com/Arm-Examples/topo-lightbulb-moment.git",
+    "ref": "main"
+  },
+  {
+    "name": "topo-v9-cpu-chat",
+    "description": "Complete LLM chat application optimized for Arm CPU inference.\n\nThis project demonstrates running large language models on CPU\nusing llama.cpp compiled with Arm baseline optimizations and \naccelerated using NEON SIMD and SVE (when supported and enabled).\n\nThe stack includes:\n- llama.cpp server with Arm NEON optimizations (SVE optional)\n- Quantized Qwen2.5-1.5B-Instruct model bundled in the image (~1.12 GB)\n- Simple web-based chat interface\n- No GPU required - pure CPU inference\n\nPerfect for demos and testing! The bundled Qwen2.5-1.5B model allows the\nproject to run immediately without downloading additional models.\n\nIdeal for testing LLM workloads on Arm hardware without GPU dependencies,\nshowcasing how far you can push NEON acceleration. Rebuild with SVE enabled\nwhen wider vectors are available.\n",
+    "features": [
+      "SVE",
+      "NEON"
+    ],
+    "url": "https://github.com/Arm-Examples/topo-v9-cpu-chat.git",
+    "ref": "main"
+  },
+  {
+    "name": "topo-simd-visual-benchmark",
+    "description": "Visual demonstration of SIMD performance benefits on Arm processors.\nCompare scalar (no SIMD), NEON (128-bit), and SVE (scalable vector)\nimplementations running identical image processing workloads side-by-side.\n\nThis demo shows real hardware acceleration through three C++ services\ncompiled with different architecture flags, processing the same box blur\nalgorithm on images. Performance differences are measured in real-time\nand displayed in an interactive web dashboard.\n\nPerfect for demonstrating to non-technical audiences the concrete benefits\nof SIMD optimizations, with visual results and quantified speedups.\n",
+    "features": [
+      "NEON",
+      "SVE"
+    ],
+    "url": "https://github.com/Arm-Examples/topo-simd-visual-benchmark.git",
+    "ref": "main"
+  }
+]

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -107,6 +107,12 @@ func AssertFileContents(t *testing.T, wantContents string, path string) {
 func AssertGoldenFile(t *testing.T, got string, goldenPath string) {
 	t.Helper()
 
+	if os.Getenv("UPDATE_GOLDEN") == "1" {
+		err := os.WriteFile(goldenPath, []byte(got), 0o644)
+		require.NoError(t, err)
+		return
+	}
+
 	wantBytes, err := os.ReadFile(goldenPath)
 	require.NoError(t, err)
 	want := string(wantBytes)

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -103,3 +103,13 @@ func AssertFileContents(t *testing.T, wantContents string, path string) {
 	require.NoError(t, err)
 	require.Equal(t, wantContents, string(got))
 }
+
+func AssertGoldenFile(t *testing.T, got string, goldenPath string) {
+	t.Helper()
+
+	wantBytes, err := os.ReadFile(goldenPath)
+	require.NoError(t, err)
+	want := string(wantBytes)
+
+	require.Equal(t, want, got, "output did not match golden file %s", goldenPath)
+}

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -104,7 +104,7 @@ func AssertFileContents(t *testing.T, wantContents string, path string) {
 	require.Equal(t, wantContents, string(got))
 }
 
-func AssertGoldenFile(t *testing.T, got string, goldenPath string) {
+func AssertJsonGoldenFile(t *testing.T, got string, goldenPath string) {
 	t.Helper()
 
 	if os.Getenv("UPDATE_GOLDEN") == "1" {
@@ -117,5 +117,5 @@ func AssertGoldenFile(t *testing.T, got string, goldenPath string) {
 	require.NoError(t, err)
 	want := string(wantBytes)
 
-	require.Equal(t, want, got, "output did not match golden file %s", goldenPath)
+	require.JSONEq(t, want, got, "output did not match golden file %s", goldenPath)
 }


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- Adds a couple of small e2e tests for health and templates to ensure `--output json` produces valid JSON in the expected form
  - This introduces slight coupling between the tests and the JSON output format but I think this is a positive as it will force us to detect breaking changes in this format.
- Add an e2e test to templates to ensure errors are also written in JSON form when specified w/ the expected fields
