### PR TITLE
fix: prevent SSH host key prompt from overlapping with spinner

### DIFF
--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -146,8 +146,11 @@ func connectivityCheck(status ConnectionStatus) HealthCheck {
 	}
 
 	check.Value = status.Error.Error()
-	if errors.Is(status.Error, target.ErrPasswordAuthentication) {
-		check.Fix = fmt.Sprintf("run `topo setup-keys --target %s` or manually setup SSH keys for the target", status.Destination)
+	switch {
+	case errors.Is(status.Error, target.ErrPasswordAuthentication):
+		check.Fix = fmt.Sprintf("run `topo setup-keys --target %s` to configure SSH keys", status.Destination)
+	case errors.Is(status.Error, target.ErrHostKeyVerification):
+		check.Fix = fmt.Sprintf("run `topo health --target %s --accept-new-host-keys` to trust the target's identity", status.Destination)
 	}
 	return check
 }

--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -76,6 +76,20 @@ func TestGenerateTargetReport(t *testing.T) {
 		assert.Equal(t, health.CheckStatusError, got.Connectivity.Status)
 		assert.Contains(t, got.Connectivity.Fix, "topo setup-keys --target ssh://user@my-target")
 	})
+
+	t.Run("when host key verification fails, Connectivity includes an accept-new-host-keys fix", func(t *testing.T) {
+		ts := health.Status{
+			Connection: health.ConnectionStatus{
+				Destination: ssh.NewDestination("user@my-target"),
+				Error:       target.ErrHostKeyVerification,
+			},
+		}
+
+		got := health.GenerateTargetReport(ts)
+
+		assert.Equal(t, health.CheckStatusError, got.Connectivity.Status)
+		assert.Equal(t, "run `topo health --target ssh://user@my-target --accept-new-host-keys` to trust the target's identity", got.Connectivity.Fix)
+	})
 }
 
 func TestHostReport(t *testing.T) {

--- a/internal/target/ssh_authentication_probe.go
+++ b/internal/target/ssh_authentication_probe.go
@@ -17,6 +17,7 @@ var (
 		"-o", "NumberOfPasswordPrompts=0",
 	}
 	knownHostProbeArgs = []string{
+		"-o", "StrictHostKeyChecking=yes",
 		"-o", "PreferredAuthentications=publickey",
 		"-o", "PasswordAuthentication=no",
 		"-o", "NumberOfPasswordPrompts=0",


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

Use `StrictHostKeyChecking=yes` in the known host probe so SSH fails immediately when the host key is unknown, rather than prompting interactively and racing with the spinner output. We already provide an escape hatch with `--accept-new-host-keys` arg.
