### PR TITLE
feat: linter - enable funcorder and reorder Go methods

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -8,6 +8,7 @@ formatters:
 linters:
   enable:
     - gosec
+    - funcorder
 
   settings:
     gosec:
@@ -15,6 +16,12 @@ linters:
         - G304
       severity: high
       confidence: medium
+
+    funcorder:
+      constructor: true
+      struct-method: true
+      alphabetical: false
+
   exclusions:
     rules:
       - path: (.+)_test.go

--- a/internal/deploy/docker/operation/docker.go
+++ b/internal/deploy/docker/operation/docker.go
@@ -22,21 +22,6 @@ func NewDocker(description string, h command.Host, args []string) *Docker {
 	}
 }
 
-func (d *Docker) Description() string {
-	return d.description
-}
-
-func (d *Docker) Run(cmdOutput io.Writer) error {
-	cmd := d.buildCommand()
-	cmd.Stdout = cmdOutput
-	cmd.Stderr = cmdOutput
-	return cmd.Run()
-}
-
-func (d *Docker) buildCommand() *exec.Cmd {
-	return command.Docker(d.host, d.args...)
-}
-
 func NewDockerPull(host command.Host, image string) *Docker {
 	description := fmt.Sprintf("Pull image %s", image)
 	return NewDocker(description, host, []string{"pull", image})
@@ -54,4 +39,19 @@ func NewDockerRun(host command.Host, image string, container string, dockerArgs 
 	allArgs = append(allArgs, "--name", container)
 	allArgs = append(allArgs, image)
 	return NewDocker(description, host, allArgs)
+}
+
+func (d *Docker) Description() string {
+	return d.description
+}
+
+func (d *Docker) Run(cmdOutput io.Writer) error {
+	cmd := d.buildCommand()
+	cmd.Stdout = cmdOutput
+	cmd.Stderr = cmdOutput
+	return cmd.Run()
+}
+
+func (d *Docker) buildCommand() *exec.Cmd {
+	return command.Docker(d.host, d.args...)
 }

--- a/internal/deploy/docker/operation/docker_compose.go
+++ b/internal/deploy/docker/operation/docker_compose.go
@@ -23,6 +23,29 @@ func NewDockerCompose(description string, composeFile string, h command.Host, ar
 	}
 }
 
+func NewDockerComposeBuild(composeFile string, h command.Host) *DockerCompose {
+	return NewDockerCompose("Build images", composeFile, h, []string{"build"})
+}
+
+func NewDockerComposePull(composeFile string, h command.Host) *DockerCompose {
+	return NewDockerCompose("Pull images", composeFile, h, []string{"pull"})
+}
+
+func NewDockerComposeStop(composeFile string, h command.Host) *DockerCompose {
+	return NewDockerCompose("Stop services", composeFile, h, []string{"stop"})
+}
+
+func NewDockerComposeUp(composeFile string, h command.Host, mode RecreateMode) *DockerCompose {
+	args := []string{"up", "-d", "--no-build", "--pull", "never"}
+	switch mode {
+	case RecreateModeForce:
+		args = append(args, "--force-recreate")
+	case RecreateModeNone:
+		args = append(args, "--no-recreate")
+	}
+	return NewDockerCompose("Start services", composeFile, h, args)
+}
+
 func (dc *DockerCompose) Description() string {
 	return dc.description
 }
@@ -38,18 +61,6 @@ func (dc *DockerCompose) buildCommand() *exec.Cmd {
 	return command.DockerCompose(dc.host, dc.composeFile, dc.args...)
 }
 
-func NewDockerComposeBuild(composeFile string, h command.Host) *DockerCompose {
-	return NewDockerCompose("Build images", composeFile, h, []string{"build"})
-}
-
-func NewDockerComposePull(composeFile string, h command.Host) *DockerCompose {
-	return NewDockerCompose("Pull images", composeFile, h, []string{"pull"})
-}
-
-func NewDockerComposeStop(composeFile string, h command.Host) *DockerCompose {
-	return NewDockerCompose("Stop services", composeFile, h, []string{"stop"})
-}
-
 type RecreateMode int
 
 const (
@@ -57,14 +68,3 @@ const (
 	RecreateModeForce
 	RecreateModeNone
 )
-
-func NewDockerComposeUp(composeFile string, h command.Host, mode RecreateMode) *DockerCompose {
-	args := []string{"up", "-d", "--no-build", "--pull", "never"}
-	switch mode {
-	case RecreateModeForce:
-		args = append(args, "--force-recreate")
-	case RecreateModeNone:
-		args = append(args, "--no-recreate")
-	}
-	return NewDockerCompose("Start services", composeFile, h, args)
-}

--- a/internal/setupkeys/sshkeygen/ssh_keygen.go
+++ b/internal/setupkeys/sshkeygen/ssh_keygen.go
@@ -44,10 +44,6 @@ func (kg *SSHKeyGen) Description() string {
 	return kg.description
 }
 
-func (kg *SSHKeyGen) buildCommand() *exec.Cmd {
-	return kg.exec(kg.keyType, kg.keyPath, kg.dest.String())
-}
-
 func (kg *SSHKeyGen) Run(cmdOutput io.Writer) error {
 	dir := filepath.Dir(kg.keyPath)
 	if err := os.MkdirAll(dir, 0o700); err != nil {
@@ -59,4 +55,8 @@ func (kg *SSHKeyGen) Run(cmdOutput io.Writer) error {
 	cmd.Stdout = cmdOutput
 	cmd.Stderr = cmdOutput
 	return cmd.Run()
+}
+
+func (kg *SSHKeyGen) buildCommand() *exec.Cmd {
+	return kg.exec(kg.keyType, kg.keyPath, kg.dest.String())
 }

--- a/internal/ssh/ssh_tunnel.go
+++ b/internal/ssh/ssh_tunnel.go
@@ -42,12 +42,12 @@ type SSHTunnelStart struct {
 	Process           *os.Process
 }
 
-func (s *SSHTunnelStart) Description() string {
-	return "Open registry SSH tunnel"
-}
-
 func NewSSHTunnelStart(targetDest Destination, port string, useControlSockets bool) *SSHTunnelStart {
 	return &SSHTunnelStart{TargetDest: targetDest, Port: port, UseControlSockets: useControlSockets}
+}
+
+func (s *SSHTunnelStart) Description() string {
+	return "Open registry SSH tunnel"
 }
 
 func (s *SSHTunnelStart) Command() *exec.Cmd {
@@ -88,12 +88,12 @@ type CheckSSHTunnelSecurity struct {
 	Port       string
 }
 
-func (ct *CheckSSHTunnelSecurity) Description() string {
-	return "Check SSH tunnel security"
-}
-
 func NewCheckSSHTunnelSecurity(targetDest Destination, port string) *CheckSSHTunnelSecurity {
 	return &CheckSSHTunnelSecurity{TargetDest: targetDest, Port: port}
+}
+
+func (ct *CheckSSHTunnelSecurity) Description() string {
+	return "Check SSH tunnel security"
 }
 
 func (ct *CheckSSHTunnelSecurity) Command() *exec.Cmd {
@@ -131,12 +131,12 @@ type SSHTunnelStop struct {
 	TargetDest Destination
 }
 
-func (s *SSHTunnelStop) Description() string {
-	return "Close registry SSH tunnel"
-}
-
 func NewSSHTunnelStop(targetDest Destination) *SSHTunnelStop {
 	return &SSHTunnelStop{TargetDest: targetDest}
+}
+
+func (s *SSHTunnelStop) Description() string {
+	return "Close registry SSH tunnel"
 }
 
 func (s *SSHTunnelStop) Command() *exec.Cmd {
@@ -167,12 +167,12 @@ type SSHTunnelProcessStop struct {
 	Start *SSHTunnelStart
 }
 
-func (s *SSHTunnelProcessStop) Description() string {
-	return "Close registry SSH tunnel"
-}
-
 func NewSSHTunnelProcessStop(start *SSHTunnelStart) *SSHTunnelProcessStop {
 	return &SSHTunnelProcessStop{Start: start}
+}
+
+func (s *SSHTunnelProcessStop) Description() string {
+	return "Close registry SSH tunnel"
 }
 
 func (s *SSHTunnelProcessStop) Command() *exec.Cmd {

--- a/internal/ssh/sshconfig/ssh_config.go
+++ b/internal/ssh/sshconfig/ssh_config.go
@@ -17,10 +17,6 @@ type SSHConfigDirective struct {
 	Value string
 }
 
-func (d SSHConfigDirective) String() string {
-	return fmt.Sprintf("%s %s", d.Key, d.Value)
-}
-
 func NewDirectiveIdentityFile(path string) SSHConfigDirective {
 	return SSHConfigDirective{
 		Key:   "IdentityFile",
@@ -33,6 +29,10 @@ func NewDirective(key, value string) SSHConfigDirective {
 		Key:   key,
 		Value: value,
 	}
+}
+
+func (d SSHConfigDirective) String() string {
+	return fmt.Sprintf("%s %s", d.Key, d.Value)
 }
 
 func CreateSSHConfig(dest ssh.Destination, targetSlug string) error {

--- a/internal/target/connection.go
+++ b/internal/target/connection.go
@@ -36,6 +36,20 @@ func (c *Connection) RunWithStdin(cmdStr string, stdin []byte) (string, error) {
 	return c.run(cmdStr, stdin)
 }
 
+func (c *Connection) RunWithArgs(cmdStr string, sshArgs ...string) (string, error) {
+	allArgs := append(c.opts.SSHArgs(), sshArgs...)
+	cmd := ssh.ExecCmd(c.SSHTarget, cmdStr, nil, allArgs...)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		return string(out), nil
+	}
+	output := strings.ToLower(string(out))
+	if strings.Contains(output, "timed out") || strings.Contains(output, "connection timeout") || strings.Contains(output, "did not properly respond after a period of time") {
+		return string(out), ConnectionTimeoutError{Timeout: c.opts.ConnectTimeout}
+	}
+	return string(out), err
+}
+
 func (c *Connection) run(cmdStr string, stdin []byte) (string, error) {
 	cmd := ssh.ExecCmd(c.SSHTarget, cmdStr, stdin, c.opts.SSHArgs()...)
 	var stdoutBuf, stderrBuf bytes.Buffer
@@ -51,20 +65,6 @@ func (c *Connection) run(cmdStr string, stdin []byte) (string, error) {
 		return stdoutBuf.String() + stderr, fmt.Errorf("ssh command to %s failed: %w | stderr: %s", c.SSHTarget, err, stderr)
 	}
 	return stdoutBuf.String(), nil
-}
-
-func (c *Connection) RunWithArgs(cmdStr string, sshArgs ...string) (string, error) {
-	allArgs := append(c.opts.SSHArgs(), sshArgs...)
-	cmd := ssh.ExecCmd(c.SSHTarget, cmdStr, nil, allArgs...)
-	out, err := cmd.CombinedOutput()
-	if err == nil {
-		return string(out), nil
-	}
-	output := strings.ToLower(string(out))
-	if strings.Contains(output, "timed out") || strings.Contains(output, "connection timeout") || strings.Contains(output, "did not properly respond after a period of time") {
-		return string(out), ConnectionTimeoutError{Timeout: c.opts.ConnectTimeout}
-	}
-	return string(out), err
 }
 
 type ConnectionTimeoutError struct {


### PR DESCRIPTION
Enable the golangci-lint `funcorder` checker and configure it to enforce constructor and struct-method ordering.

No functional behavior change intended.

