### PR TITLE
feat: delete setup-ssh

### DIFF
--- a/cmd/topo/vscode.go
+++ b/cmd/topo/vscode.go
@@ -3,7 +3,6 @@ package main
 import (
 	"os"
 
-	"github.com/arm/topo/internal/ssh"
 	"github.com/arm/topo/internal/vscode"
 	"github.com/spf13/cobra"
 )
@@ -20,35 +19,6 @@ var getProjectCmd = &cobra.Command{
 	},
 }
 
-var setupSSHCommand = &cobra.Command{
-	Use:   "setup-ssh",
-	Short: "Create a topo-managed SSH config entry for the target",
-	Long: `Create a topo-managed SSH config entry for the target in ~/.ssh/topo_config.
-	
-This will also update the main SSH config (~/.ssh/config) to include the topo-managed configs, if not already included.`,
-	Hidden: true,
-	Args:   cobra.ExactArgs(0),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		cmd.SilenceUsage = true
-
-		targetArg, err := requireTarget(cmd)
-		if err != nil {
-			return err
-		}
-
-		dest := ssh.NewDestination(targetArg)
-		targetSlug := dest.Slugify()
-
-		if err != nil {
-			return err
-		}
-
-		return ssh.CreateConfigFile(dest, targetSlug)
-	},
-}
-
 func init() {
 	rootCmd.AddCommand(getProjectCmd)
-	addTargetFlag(setupSSHCommand)
-	rootCmd.AddCommand(setupSSHCommand)
 }

--- a/internal/ssh/config.go
+++ b/internal/ssh/config.go
@@ -138,10 +138,6 @@ func (d ConfigDirective) String() string {
 	return fmt.Sprintf("%s %s", d.Key, d.Value)
 }
 
-func CreateConfigFile(dest Destination, targetSlug string) error {
-	return CreateOrModifyConfigFile(dest, targetSlug, nil)
-}
-
 func CreateOrModifyConfigFile(dest Destination, targetSlug string, directives []ConfigDirective) error {
 	home, err := os.UserHomeDir()
 	if err != nil {

--- a/internal/ssh/config_test.go
+++ b/internal/ssh/config_test.go
@@ -141,26 +141,6 @@ debug1: /tmp/config line 5: Applying options for *
 	})
 }
 
-func TestCreateConfigFile(t *testing.T) {
-	t.Run("handles creation of new ssh config file", func(t *testing.T) {
-		tmp := t.TempDir()
-		testutil.SetHomeDir(t, tmp)
-		targetHost := ssh.NewDestination("user@example.com:2222")
-		targetFileName := "user_example_com_2222"
-		fragmentPath := filepath.Join(tmp, ".ssh", "topo_config", fmt.Sprintf("topo_%s.conf", targetFileName))
-		mainConfigPath := filepath.Join(tmp, ".ssh", "config")
-
-		err := ssh.CreateConfigFile(targetHost, targetFileName)
-
-		require.NoError(t, err)
-		wantFragmentContents := "Host example.com\n  HostName example.com\n  User user\n  Port 2222\n"
-		wantIncludedFragmentPath := filepath.ToSlash(filepath.Join(tmp, ".ssh", "topo_config", "*.conf"))
-		wantConfigContents := fmt.Sprintf("Include %s\n\n", wantIncludedFragmentPath)
-		testutil.AssertFileContents(t, wantFragmentContents, fragmentPath)
-		testutil.AssertFileContents(t, wantConfigContents, mainConfigPath)
-	})
-}
-
 func TestCreateOrModifyConfigFile(t *testing.T) {
 	t.Run("writes include and fragment", func(t *testing.T) {
 		tmp := t.TempDir()


### PR DESCRIPTION
## Background

Given we're pursuing a slightly different approach to target management in the vscode extension this command no longer has any utility

## Changes

<!-- List the changes this PR introduces -->

- Deletes the `setup-ssh` command and corresponding internals/tests


