### PR TITLE
fix: use password-based auth for Public Key transfer operation

### DIFF
--- a/internal/runner/mock.go
+++ b/internal/runner/mock.go
@@ -17,3 +17,12 @@ func (m *Mock) RunWithStdin(command string, stdin []byte) (string, error) {
 	args := m.Called(command, stdin)
 	return args.String(0), args.Error(1)
 }
+
+func (m *Mock) RunWithStdinAndArgs(command string, stdin []byte, sshArgs ...string) (string, error) {
+	callArgs := []any{command, stdin}
+	for _, arg := range sshArgs {
+		callArgs = append(callArgs, arg)
+	}
+	args := m.Called(callArgs...)
+	return args.String(0), args.Error(1)
+}

--- a/internal/runner/ssh.go
+++ b/internal/runner/ssh.go
@@ -47,6 +47,11 @@ func (r *SSH) RunWithArgs(cmdStr string, args ...string) (string, error) {
 	return ssh.RunCommand(r.dest, cmdStr, nil, args...)
 }
 
+func (r *SSH) RunWithStdinAndArgs(cmdStr string, stdin []byte, args ...string) (string, error) {
+	args = append(args, r.opts.SSHArgs()...)
+	return ssh.RunCommand(r.dest, cmdStr, stdin, args...)
+}
+
 func (r *SSH) exec(cmdStr string, stdin []byte, extraSSHArgs []string) (string, error) {
 	return ssh.RunCommand(r.dest, cmdStr, stdin, extraSSHArgs...)
 }

--- a/internal/setupkeys/pubkeytransfer/pub_key_transfer.go
+++ b/internal/setupkeys/pubkeytransfer/pub_key_transfer.go
@@ -6,17 +6,24 @@ import (
 	"os"
 
 	"github.com/arm/topo/internal/command"
-	"github.com/arm/topo/internal/runner"
 )
 
 const remoteAuthorizedKeysCommand = "mkdir -p ~/.ssh && chmod 700 ~/.ssh && cat >> ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys"
 
-type PubKeyTransfer struct {
-	pubKeyPath string
-	r          runner.Runner
+var passwordAuthArgs = []string{
+	"-o", "PreferredAuthentications=password",
 }
 
-func NewPubKeyTransfer(privKeyPath string, r runner.Runner) *PubKeyTransfer {
+type sshRunnerWithExtraArgs interface {
+	RunWithStdinAndArgs(command string, stdin []byte, sshArgs ...string) (string, error)
+}
+
+type PubKeyTransfer struct {
+	pubKeyPath string
+	r          sshRunnerWithExtraArgs
+}
+
+func NewPubKeyTransfer(privKeyPath string, r sshRunnerWithExtraArgs) *PubKeyTransfer {
 	return &PubKeyTransfer{
 		pubKeyPath: privKeyPath + ".pub",
 		r:          r,
@@ -33,7 +40,7 @@ func (kt *PubKeyTransfer) Run(outputWriter io.Writer) error {
 		return fmt.Errorf("failed to read public key %s: %w", kt.pubKeyPath, err)
 	}
 
-	cmdOutput, err := kt.r.RunWithStdin(command.WrapInLoginShell(remoteAuthorizedKeysCommand), pubKey)
+	cmdOutput, err := kt.r.RunWithStdinAndArgs(command.WrapInLoginShell(remoteAuthorizedKeysCommand), pubKey, passwordAuthArgs...)
 	if err != nil {
 		return fmt.Errorf("failed to transfer public key to target: %w", err)
 	}

--- a/internal/setupkeys/pubkeytransfer/pub_key_transfer_test.go
+++ b/internal/setupkeys/pubkeytransfer/pub_key_transfer_test.go
@@ -23,11 +23,13 @@ func TestPubKeyTransfer(t *testing.T) {
 
 			r := &runner.Mock{}
 			r.On(
-				"RunWithStdin",
+				"RunWithStdinAndArgs",
 				mock.MatchedBy(func(cmd string) bool {
 					return strings.Contains(cmd, "mkdir -p ~/.ssh && chmod 700 ~/.ssh && cat >> ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys")
 				}),
 				pubKeyContent,
+				"-o",
+				"PreferredAuthentications=password",
 			).Return("ssh invoked", nil)
 
 			op := pubkeytransfer.NewPubKeyTransfer(privKeyPath, r)


### PR DESCRIPTION
If not explicitly specified, the public key transfer operation will
attempt to SSH by using default SSH keys.
    
```
(...)
debug1: Will attempt key: /home/tomgon01/.ssh/id_rsa
debug1: Will attempt key: /home/tomgon01/.ssh/id_ecdsa
debug1: Will attempt key: /home/tomgon01/.ssh/id_ecdsa_sk
debug1: Will attempt key: /home/tomgon01/.ssh/id_ed25519_sk
debug1: Will attempt key: /home/tomgon01/.ssh/id_xmss
debug1: Will attempt key: /home/tomgon01/.ssh/id_dsa
```

It will iterate over multiple identity files and then fail as it
has tried too many options.

## Changes
 - Use password-based authentication when transferring the newly created SSH key onto the target.