### PR TITLE
feat: add `--timeout` flag to `health`, `describe` and `templates`

### DIFF
--- a/cmd/topo/describe.go
+++ b/cmd/topo/describe.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"os"
 
@@ -27,7 +26,9 @@ var describeCmd = &cobra.Command{
 
 		r := runner.For(ssh.NewDestination(targetArg), runner.SSHOptions{Multiplex: true})
 		probe := target.NewHardwareProbe(r)
-		hwProfile, err := probe.Probe(context.Background())
+		ctx, cancel := contextWithTimeout(cmd)
+		defer cancel()
+		hwProfile, err := probe.Probe(ctx)
 		if err != nil {
 			return err
 		}
@@ -50,5 +51,6 @@ var describeCmd = &cobra.Command{
 
 func init() {
 	addTargetFlag(describeCmd)
+	addTimeoutFlag(describeCmd, defaultTimeout)
 	rootCmd.AddCommand(describeCmd)
 }

--- a/cmd/topo/describe.go
+++ b/cmd/topo/describe.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -24,9 +25,9 @@ var describeCmd = &cobra.Command{
 			return err
 		}
 
-		r := runner.For(ssh.NewDestination(targetArg), runner.SSHOptions{Multiplex: true, ConnectTimeout: sshConnectTimeout})
+		r := runner.For(ssh.NewDestination(targetArg), runner.SSHOptions{Multiplex: true})
 		probe := target.NewHardwareProbe(r)
-		hwProfile, err := probe.Probe()
+		hwProfile, err := probe.Probe(context.Background())
 		if err != nil {
 			return err
 		}

--- a/cmd/topo/health.go
+++ b/cmd/topo/health.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -39,7 +40,7 @@ var healthCmd = &cobra.Command{
 		}
 
 		if targetArg, ok := lookupTarget(cmd); ok {
-			targetReport, err := health.CheckTarget(ssh.NewDestination(targetArg), probeOpts, sshConnectTimeout)
+			targetReport, err := health.CheckTarget(context.Background(), ssh.NewDestination(targetArg), probeOpts)
 			if err != nil {
 				if spinner != nil {
 					spinner.Stop()

--- a/cmd/topo/health.go
+++ b/cmd/topo/health.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"os"
 
@@ -40,7 +39,9 @@ var healthCmd = &cobra.Command{
 		}
 
 		if targetArg, ok := lookupTarget(cmd); ok {
-			targetReport, err := health.CheckTarget(context.Background(), ssh.NewDestination(targetArg), probeOpts)
+			ctx, cancel := contextWithTimeout(cmd)
+			defer cancel()
+			targetReport, err := health.CheckTarget(ctx, ssh.NewDestination(targetArg), probeOpts)
 			if err != nil {
 				if spinner != nil {
 					spinner.Stop()
@@ -62,6 +63,7 @@ var healthCmd = &cobra.Command{
 
 func init() {
 	addTargetFlag(healthCmd)
+	addTimeoutFlag(healthCmd, defaultTimeout)
 	healthCmd.Flags().Bool(acceptNewHostFlag, false, "Automatically trust and add new SSH host keys for the target")
 	rootCmd.AddCommand(healthCmd)
 }

--- a/cmd/topo/root.go
+++ b/cmd/topo/root.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -35,7 +36,6 @@ func init() {
 
 const targetEnvVar = "TOPO_TARGET"
 
-const sshConnectTimeout = 5 * time.Second
 
 func addTargetFlag(cmd *cobra.Command) {
 	cmd.Flags().StringP(
@@ -68,6 +68,21 @@ func requireTarget(cmd *cobra.Command) (string, error) {
 		return "", fmt.Errorf("target not specified: provide --target or set TOPO_TARGET env var")
 	}
 	return t, nil
+}
+
+func addTimeoutFlag(cmd *cobra.Command, defaultTimeout time.Duration) {
+	cmd.Flags().Duration("timeout", defaultTimeout, "Maximum time to wait for the command to complete (0 to disable)")
+}
+
+func contextWithTimeout(cmd *cobra.Command) (context.Context, context.CancelFunc) {
+	timeout, err := cmd.Flags().GetDuration("timeout")
+	if err != nil {
+		panic(fmt.Sprintf("internal error: timeout flag not registered: %v", err))
+	}
+	if timeout == 0 {
+		return context.Background(), func() {}
+	}
+	return context.WithTimeout(context.Background(), timeout)
 }
 
 func resolveOutput(cmd *cobra.Command) term.Format {

--- a/cmd/topo/root.go
+++ b/cmd/topo/root.go
@@ -72,7 +72,7 @@ func requireTarget(cmd *cobra.Command) (string, error) {
 const defaultTimeout = 5 * time.Second
 
 func addTimeoutFlag(cmd *cobra.Command, defaultTimeout time.Duration) {
-	cmd.Flags().Duration("timeout", defaultTimeout, "Maximum time to wait for the command to complete (0 to disable)")
+	cmd.Flags().Duration("timeout", defaultTimeout, "Maximum time to wait for the command to complete (0 to disable timeout)")
 }
 
 func contextWithTimeout(cmd *cobra.Command) (context.Context, context.CancelFunc) {

--- a/cmd/topo/root.go
+++ b/cmd/topo/root.go
@@ -69,7 +69,7 @@ func requireTarget(cmd *cobra.Command) (string, error) {
 	return t, nil
 }
 
-const defaultTimeout = 30 * time.Second
+const defaultTimeout = 5 * time.Second
 
 func addTimeoutFlag(cmd *cobra.Command, defaultTimeout time.Duration) {
 	cmd.Flags().Duration("timeout", defaultTimeout, "Maximum time to wait for the command to complete (0 to disable)")

--- a/cmd/topo/root.go
+++ b/cmd/topo/root.go
@@ -36,7 +36,6 @@ func init() {
 
 const targetEnvVar = "TOPO_TARGET"
 
-
 func addTargetFlag(cmd *cobra.Command) {
 	cmd.Flags().StringP(
 		"target", "t", "",
@@ -69,6 +68,8 @@ func requireTarget(cmd *cobra.Command) (string, error) {
 	}
 	return t, nil
 }
+
+const defaultTimeout = 30 * time.Second
 
 func addTimeoutFlag(cmd *cobra.Command, defaultTimeout time.Duration) {
 	cmd.Flags().Duration("timeout", defaultTimeout, "Maximum time to wait for the command to complete (0 to disable)")

--- a/cmd/topo/templates.go
+++ b/cmd/topo/templates.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"os"
 
 	"github.com/arm/topo/internal/catalog"
@@ -39,7 +38,9 @@ var templatesCmd = &cobra.Command{
 			if exists {
 				r := runner.For(ssh.NewDestination(targetArg), runner.SSHOptions{Multiplex: true})
 				probe := target.NewHardwareProbe(r)
-				hwProfile, err := probe.Probe(context.Background())
+				ctx, cancel := contextWithTimeout(cmd)
+				defer cancel()
+				hwProfile, err := probe.Probe(ctx)
 				if err != nil {
 					return err
 				}
@@ -54,6 +55,7 @@ var templatesCmd = &cobra.Command{
 
 func init() {
 	addTargetFlag(templatesCmd)
+	addTimeoutFlag(templatesCmd, defaultTimeout)
 	templatesCmd.Flags().StringVar(
 		&targetDescriptionPath,
 		"target-description",

--- a/cmd/topo/templates.go
+++ b/cmd/topo/templates.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"os"
 
 	"github.com/arm/topo/internal/catalog"
@@ -36,9 +37,9 @@ var templatesCmd = &cobra.Command{
 		} else {
 			targetArg, exists := lookupTarget(cmd)
 			if exists {
-				r := runner.For(ssh.NewDestination(targetArg), runner.SSHOptions{Multiplex: true, ConnectTimeout: sshConnectTimeout})
+				r := runner.For(ssh.NewDestination(targetArg), runner.SSHOptions{Multiplex: true})
 				probe := target.NewHardwareProbe(r)
-				hwProfile, err := probe.Probe()
+				hwProfile, err := probe.Probe(context.Background())
 				if err != nil {
 					return err
 				}

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -1,11 +1,11 @@
 package health
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/arm/topo/internal/runner"
 	"github.com/arm/topo/internal/ssh"
@@ -82,24 +82,24 @@ type Status struct {
 	Hardware     HardwareProfile
 }
 
-func CheckTarget(dest ssh.Destination, probeOpts target.SSHAuthenticationProbeOptions, connectTimeout time.Duration) (TargetReport, error) {
-	r, connErr := prepareRunner(dest, probeOpts, connectTimeout)
+func CheckTarget(ctx context.Context, dest ssh.Destination, probeOpts target.SSHAuthenticationProbeOptions) (TargetReport, error) {
+	r, connErr := prepareRunner(ctx, dest, probeOpts)
 	status := Status{Connection: ConnectionStatus{Destination: dest, Error: connErr}}
 	if connErr == nil {
-		hs := ProbeHealthStatus(r)
+		hs := ProbeHealthStatus(ctx, r)
 		status.Dependencies = hs.Dependencies
 		status.Hardware = hs.Hardware
 	}
 	return GenerateTargetReport(status), nil
 }
 
-func prepareRunner(dest ssh.Destination, probeOpts target.SSHAuthenticationProbeOptions, connectTimeout time.Duration) (runner.Runner, error) {
+func prepareRunner(ctx context.Context, dest ssh.Destination, probeOpts target.SSHAuthenticationProbeOptions) (runner.Runner, error) {
 	if dest.IsPlainLocalhost() {
 		return runner.NewLocal(), nil
 	}
-	sshOpts := runner.SSHOptions{Multiplex: true, ConnectTimeout: connectTimeout}
+	sshOpts := runner.SSHOptions{Multiplex: true}
 	authProbe := target.NewSSHAuthenticationProbe(runner.NewSSH(dest, sshOpts), probeOpts)
-	if err := authProbe.Probe(); err != nil {
+	if err := authProbe.Probe(ctx); err != nil {
 		return nil, err
 	}
 	return runner.NewSSH(dest, sshOpts), nil

--- a/internal/health/status.go
+++ b/internal/health/status.go
@@ -1,6 +1,8 @@
 package health
 
 import (
+	"context"
+
 	"github.com/arm/topo/internal/command"
 	"github.com/arm/topo/internal/runner"
 	"github.com/arm/topo/internal/target"
@@ -23,23 +25,23 @@ type HealthStatus struct {
 	Hardware     HardwareProfile
 }
 
-func ProbeHealthStatus(r runner.Runner) HealthStatus {
+func ProbeHealthStatus(ctx context.Context, r runner.Runner) HealthStatus {
 	var hs HealthStatus
 
 	probe := target.NewHardwareProbe(r)
-	remoteprocs, _ := probe.ProbeRemoteproc()
+	remoteprocs, _ := probe.ProbeRemoteproc(ctx)
 	hs.Hardware.RemoteCPU = remoteprocs
 
 	dependenciesToCheck := FilterByHardware(TargetRequiredDependencies, hs.Hardware.Capabilities())
 	binaryExists := func(bin string) error {
 		// We can use `UnsafeBinaryLookupCommand`, because the dependencies we're checking are hardcoded in the codebase
-		if _, err := r.Run(command.UnsafeBinaryLookupCommand(bin)); err != nil {
+		if _, err := r.Run(ctx, command.UnsafeBinaryLookupCommand(bin)); err != nil {
 			return err
 		}
 		return nil
 	}
 	commandSuccessful := func(fullCmd string) error {
-		_, err := r.Run(command.WrapInLoginShell(fullCmd))
+		_, err := r.Run(ctx, command.WrapInLoginShell(fullCmd))
 		return err
 	}
 	hs.Dependencies = PerformChecks(dependenciesToCheck, binaryExists, commandSuccessful)

--- a/internal/health/status_test.go
+++ b/internal/health/status_test.go
@@ -1,6 +1,7 @@
 package health_test
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -15,11 +16,11 @@ import (
 func TestProbeHealthStatus(t *testing.T) {
 	t.Run("finds remote CPUs", func(t *testing.T) {
 		r := &runner.Mock{}
-		r.On("Run", command.WrapInLoginShell("ls /sys/class/remoteproc")).Return("remoteproc0\nremoteproc1", nil)
-		r.On("Run", command.WrapInLoginShell("cat /sys/class/remoteproc/*/name")).Return("foo\nbar", nil)
-		r.On("Run", mock.AnythingOfType("string")).Maybe().Return("", fmt.Errorf("not found"))
+		r.On("Run", context.Background(), command.WrapInLoginShell("ls /sys/class/remoteproc")).Return("remoteproc0\nremoteproc1", nil)
+		r.On("Run", context.Background(), command.WrapInLoginShell("cat /sys/class/remoteproc/*/name")).Return("foo\nbar", nil)
+		r.On("Run", context.Background(), mock.AnythingOfType("string")).Maybe().Return("", fmt.Errorf("not found"))
 
-		ts := health.ProbeHealthStatus(r)
+		ts := health.ProbeHealthStatus(context.Background(), r)
 
 		want := health.HardwareProfile{RemoteCPU: []target.RemoteprocCPU{{Name: "foo"}, {Name: "bar"}}}
 		assert.Equal(t, want, ts.Hardware)
@@ -28,9 +29,9 @@ func TestProbeHealthStatus(t *testing.T) {
 
 	t.Run("succeeds when no remoteproc support", func(t *testing.T) {
 		r := &runner.Mock{}
-		r.On("Run", mock.AnythingOfType("string")).Return("", fmt.Errorf("no such directory"))
+		r.On("Run", context.Background(), mock.AnythingOfType("string")).Return("", fmt.Errorf("no such directory"))
 
-		ts := health.ProbeHealthStatus(r)
+		ts := health.ProbeHealthStatus(context.Background(), r)
 
 		assert.Len(t, ts.Hardware.RemoteCPU, 0)
 		r.AssertExpectations(t)

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -34,7 +34,7 @@ type PathCandidate struct {
 }
 
 func getPathDirs(r runner.Runner) ([]string, error) {
-	output, err := r.Run(command.WrapInLoginShell("echo $PATH"))
+	output, err := r.Run(context.TODO(), command.WrapInLoginShell("echo $PATH"))
 	if err != nil {
 		return nil, err
 	}
@@ -46,7 +46,7 @@ func getPathDirs(r runner.Runner) ([]string, error) {
 }
 
 func getHomeDir(r runner.Runner) (string, error) {
-	output, err := r.Run(command.WrapInLoginShell("echo $HOME"))
+	output, err := r.Run(context.TODO(), command.WrapInLoginShell("echo $HOME"))
 	if err != nil {
 		return "", err
 	}
@@ -59,7 +59,7 @@ func getExistingBinaryDir(r runner.Runner, binaryName string) (string, error) {
 		return "", err
 	}
 
-	output, err := r.Run(checkCommand)
+	output, err := r.Run(context.TODO(), checkCommand)
 	if err != nil {
 		return "", nil
 	}
@@ -283,7 +283,7 @@ func install(installPath string, r runner.Runner, binaries map[string][]byte) er
 		}
 
 		installCmd := fmt.Sprintf("install -D -m %s /dev/stdin %s/%s", mode, installPath, binaryName)
-		output, err := r.RunWithStdin(command.WrapInLoginShell(installCmd), binaryData)
+		output, err := r.RunWithStdin(context.TODO(), command.WrapInLoginShell(installCmd), binaryData)
 		if err != nil {
 			if errors.Is(err, ssh.ErrSSH) {
 				return err

--- a/internal/runner/local.go
+++ b/internal/runner/local.go
@@ -2,6 +2,7 @@ package runner
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os/exec"
 )
@@ -12,17 +13,17 @@ func NewLocal() *Local {
 	return &Local{}
 }
 
-func (r *Local) Run(cmdStr string) (string, error) {
-	return r.exec(cmdStr, nil)
+func (r *Local) Run(ctx context.Context, cmdStr string) (string, error) {
+	return r.exec(ctx, cmdStr, nil)
 }
 
-func (r *Local) RunWithStdin(cmdStr string, stdin []byte) (string, error) {
-	return r.exec(cmdStr, stdin)
+func (r *Local) RunWithStdin(ctx context.Context, cmdStr string, stdin []byte) (string, error) {
+	return r.exec(ctx, cmdStr, stdin)
 }
 
-func (r *Local) exec(cmdStr string, stdin []byte) (string, error) {
+func (r *Local) exec(ctx context.Context, cmdStr string, stdin []byte) (string, error) {
 	// #nosec G204 -- command should be validated by callers
-	cmd := exec.Command("/bin/sh", "-c", cmdStr)
+	cmd := exec.CommandContext(ctx, "/bin/sh", "-c", cmdStr)
 	if stdin != nil {
 		cmd.Stdin = bytes.NewReader(stdin)
 	}
@@ -32,6 +33,9 @@ func (r *Local) exec(cmdStr string, stdin []byte) (string, error) {
 
 	err := cmd.Run()
 	if err != nil {
+		if ctx.Err() != nil {
+			return "", ErrTimeout
+		}
 		stderr := stderrBuf.String()
 		return stdoutBuf.String() + stderr, fmt.Errorf("local command failed: %w | stderr: %s", err, stderr)
 	}

--- a/internal/runner/local_test.go
+++ b/internal/runner/local_test.go
@@ -1,0 +1,33 @@
+package runner_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/arm/topo/internal/runner"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLocal(t *testing.T) {
+	t.Run("cancelled context returns timeout error", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		r := runner.NewLocal()
+
+		_, err := r.Run(ctx, "sleep 10")
+
+		require.ErrorIs(t, err, runner.ErrTimeout)
+	})
+
+	t.Run("expired deadline returns timeout error", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
+		defer cancel()
+		time.Sleep(5 * time.Millisecond)
+		r := runner.NewLocal()
+
+		_, err := r.Run(ctx, "sleep 10")
+
+		require.ErrorIs(t, err, runner.ErrTimeout)
+	})
+}

--- a/internal/runner/mock.go
+++ b/internal/runner/mock.go
@@ -1,6 +1,10 @@
 package runner
 
-import "github.com/stretchr/testify/mock"
+import (
+	"context"
+
+	"github.com/stretchr/testify/mock"
+)
 
 // Mock implements Runner.
 // Use it in tests to stub runner behaviour without rolling a custom fake.
@@ -8,18 +12,18 @@ type Mock struct {
 	mock.Mock
 }
 
-func (m *Mock) Run(command string) (string, error) {
-	args := m.Called(command)
+func (m *Mock) Run(ctx context.Context, command string) (string, error) {
+	args := m.Called(ctx, command)
 	return args.String(0), args.Error(1)
 }
 
-func (m *Mock) RunWithStdin(command string, stdin []byte) (string, error) {
-	args := m.Called(command, stdin)
+func (m *Mock) RunWithStdin(ctx context.Context, command string, stdin []byte) (string, error) {
+	args := m.Called(ctx, command, stdin)
 	return args.String(0), args.Error(1)
 }
 
-func (m *Mock) RunWithStdinAndArgs(command string, stdin []byte, sshArgs ...string) (string, error) {
-	callArgs := []any{command, stdin}
+func (m *Mock) RunWithStdinAndArgs(ctx context.Context, command string, stdin []byte, sshArgs ...string) (string, error) {
+	callArgs := []any{ctx, command, stdin}
 	for _, arg := range sshArgs {
 		callArgs = append(callArgs, arg)
 	}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -1,10 +1,18 @@
 package runner
 
-import "github.com/arm/topo/internal/ssh"
+import (
+	"context"
+	"errors"
+
+	"github.com/arm/topo/internal/ssh"
+)
+
+// ErrTimeout is returned when a command fails due to context cancellation or deadline.
+var ErrTimeout = errors.New("command timed out")
 
 type Runner interface {
-	Run(command string) (string, error)
-	RunWithStdin(command string, stdin []byte) (string, error)
+	Run(ctx context.Context, command string) (string, error)
+	RunWithStdin(ctx context.Context, command string, stdin []byte) (string, error)
 }
 
 func For(dest ssh.Destination, opts SSHOptions) Runner {

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -8,7 +8,7 @@ import (
 )
 
 // ErrTimeout is returned when a command fails due to context cancellation or deadline.
-var ErrTimeout = errors.New("command timed out")
+var ErrTimeout = errors.New("timed out")
 
 type Runner interface {
 	Run(ctx context.Context, command string) (string, error)

--- a/internal/runner/ssh.go
+++ b/internal/runner/ssh.go
@@ -1,23 +1,18 @@
 package runner
 
 import (
-	"fmt"
+	"context"
 	"runtime"
-	"time"
 
 	"github.com/arm/topo/internal/ssh"
 )
 
 type SSHOptions struct {
-	Multiplex      bool
-	ConnectTimeout time.Duration
+	Multiplex bool
 }
 
 func (opts SSHOptions) SSHArgs() []string {
 	var args []string
-	if opts.ConnectTimeout > 0 {
-		args = append(args, "-o", fmt.Sprintf("ConnectTimeout=%d", int(opts.ConnectTimeout.Seconds())))
-	}
 	if opts.Multiplex && runtime.GOOS != "windows" {
 		args = append(args, "-o", "ControlMaster=auto", "-o", "ControlPersist=10s", "-o", "ControlPath=~/.ssh/topo-cm-%r@%h:%p")
 	}
@@ -30,28 +25,39 @@ type SSH struct {
 }
 
 func NewSSH(dest ssh.Destination, opts SSHOptions) *SSH {
-	opts.ConnectTimeout = ssh.NewConfig(dest).ConnectTimeout(opts.ConnectTimeout)
 	return &SSH{dest: dest, opts: opts}
 }
 
-func (r *SSH) Run(cmdStr string) (string, error) {
-	return r.exec(cmdStr, nil, nil)
+func (r *SSH) Run(ctx context.Context, cmdStr string) (string, error) {
+	return r.exec(ctx, cmdStr, nil, nil)
 }
 
-func (r *SSH) RunWithStdin(cmdStr string, stdin []byte) (string, error) {
-	return r.exec(cmdStr, stdin, nil)
+func (r *SSH) RunWithStdin(ctx context.Context, cmdStr string, stdin []byte) (string, error) {
+	return r.exec(ctx, cmdStr, stdin, nil)
 }
 
-func (r *SSH) RunWithArgs(cmdStr string, args ...string) (string, error) {
+func (r *SSH) RunWithArgs(ctx context.Context, cmdStr string, args ...string) (string, error) {
 	args = append(args, r.opts.SSHArgs()...)
-	return ssh.RunCommand(r.dest, cmdStr, nil, args...)
+	out, err := ssh.RunCommand(ctx, r.dest, cmdStr, nil, args...)
+	if err != nil && ctx.Err() != nil {
+		return "", ErrTimeout
+	}
+	return out, err
 }
 
-func (r *SSH) RunWithStdinAndArgs(cmdStr string, stdin []byte, args ...string) (string, error) {
+func (r *SSH) RunWithStdinAndArgs(ctx context.Context, cmdStr string, stdin []byte, args ...string) (string, error) {
 	args = append(args, r.opts.SSHArgs()...)
-	return ssh.RunCommand(r.dest, cmdStr, stdin, args...)
+	out, err := ssh.RunCommand(ctx, r.dest, cmdStr, stdin, args...)
+	if err != nil && ctx.Err() != nil {
+		return "", ErrTimeout
+	}
+	return out, err
 }
 
-func (r *SSH) exec(cmdStr string, stdin []byte, extraSSHArgs []string) (string, error) {
-	return ssh.RunCommand(r.dest, cmdStr, stdin, extraSSHArgs...)
+func (r *SSH) exec(ctx context.Context, cmdStr string, stdin []byte, extraSSHArgs []string) (string, error) {
+	out, err := ssh.RunCommand(ctx, r.dest, cmdStr, stdin, extraSSHArgs...)
+	if err != nil && ctx.Err() != nil {
+		return "", ErrTimeout
+	}
+	return out, err
 }

--- a/internal/runner/ssh_test.go
+++ b/internal/runner/ssh_test.go
@@ -2,7 +2,6 @@ package runner_test
 
 import (
 	"testing"
-	"time"
 
 	"github.com/arm/topo/internal/runner"
 	"github.com/arm/topo/internal/testutil"
@@ -33,13 +32,7 @@ func TestSSHOptions(t *testing.T) {
 			assert.Nil(t, runner.SSHOptions{Multiplex: false}.SSHArgs())
 		})
 
-		t.Run("with connect timeout includes ConnectTimeout arg", func(t *testing.T) {
-			opts := runner.SSHOptions{ConnectTimeout: 10 * time.Second}
-
-			assert.Equal(t, []string{"-o", "ConnectTimeout=10"}, opts.SSHArgs())
-		})
-
-		t.Run("with no timeout includes no ConnectTimeout arg", func(t *testing.T) {
+		t.Run("without multiplexing returns nil", func(t *testing.T) {
 			assert.Nil(t, runner.SSHOptions{}.SSHArgs())
 		})
 	})

--- a/internal/setupkeys/pubkeytransfer/pub_key_transfer.go
+++ b/internal/setupkeys/pubkeytransfer/pub_key_transfer.go
@@ -1,6 +1,7 @@
 package pubkeytransfer
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -15,7 +16,7 @@ var passwordAuthArgs = []string{
 }
 
 type sshRunnerWithExtraArgs interface {
-	RunWithStdinAndArgs(command string, stdin []byte, sshArgs ...string) (string, error)
+	RunWithStdinAndArgs(ctx context.Context, command string, stdin []byte, sshArgs ...string) (string, error)
 }
 
 type PubKeyTransfer struct {
@@ -40,7 +41,7 @@ func (kt *PubKeyTransfer) Run(outputWriter io.Writer) error {
 		return fmt.Errorf("failed to read public key %s: %w", kt.pubKeyPath, err)
 	}
 
-	cmdOutput, err := kt.r.RunWithStdinAndArgs(command.WrapInLoginShell(remoteAuthorizedKeysCommand), pubKey, passwordAuthArgs...)
+	cmdOutput, err := kt.r.RunWithStdinAndArgs(context.TODO(), command.WrapInLoginShell(remoteAuthorizedKeysCommand), pubKey, passwordAuthArgs...)
 	if err != nil {
 		return fmt.Errorf("failed to transfer public key to target: %w", err)
 	}

--- a/internal/setupkeys/pubkeytransfer/pub_key_transfer_test.go
+++ b/internal/setupkeys/pubkeytransfer/pub_key_transfer_test.go
@@ -24,6 +24,7 @@ func TestPubKeyTransfer(t *testing.T) {
 			r := &runner.Mock{}
 			r.On(
 				"RunWithStdinAndArgs",
+				mock.Anything,
 				mock.MatchedBy(func(cmd string) bool {
 					return strings.Contains(cmd, "mkdir -p ~/.ssh && chmod 700 ~/.ssh && cat >> ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys")
 				}),

--- a/internal/ssh/config.go
+++ b/internal/ssh/config.go
@@ -5,15 +5,12 @@ import (
 	"bytes"
 	"fmt"
 	"os/exec"
-	"strconv"
 	"strings"
-	"time"
 )
 
 type Config struct {
-	HostName       string
-	User           string
-	connectTimeout time.Duration
+	HostName string
+	User     string
 }
 
 func NewConfig(dest Destination) Config {
@@ -39,21 +36,9 @@ func NewConfigFromBytes(data []byte) Config {
 			config.HostName = fields[1]
 		case "user":
 			config.User = fields[1]
-		case "connecttimeout":
-			if secs, err := strconv.Atoi(fields[1]); err == nil {
-				config.connectTimeout = time.Duration(secs) * time.Second
-			}
 		}
 	}
 	return config
-}
-
-// ConnectTimeout returns the user's configured ConnectTimeout if set, otherwise the fallback.
-func (c Config) ConnectTimeout(fallback time.Duration) time.Duration {
-	if c.connectTimeout > 0 {
-		return c.connectTimeout
-	}
-	return fallback
 }
 
 func IsDestinationAlreadyConfiguredWithAnotherUser(dest Destination) error {

--- a/internal/ssh/config_test.go
+++ b/internal/ssh/config_test.go
@@ -54,7 +54,6 @@ user homer
 		}
 		assert.Equal(t, want, got)
 	})
-
 }
 
 func TestIsExplicitHostConfig(t *testing.T) {

--- a/internal/ssh/config_test.go
+++ b/internal/ssh/config_test.go
@@ -2,7 +2,6 @@ package ssh_test
 
 import (
 	"testing"
-	"time"
 
 	"github.com/arm/topo/internal/ssh"
 	"github.com/stretchr/testify/assert"
@@ -56,44 +55,6 @@ user homer
 		assert.Equal(t, want, got)
 	})
 
-	t.Run("parses connecttimeout as duration", func(t *testing.T) {
-		input := []byte(`hostname springfield.nuclear.gov
-connecttimeout 30
-`)
-
-		got := ssh.NewConfigFromBytes(input)
-
-		assert.Equal(t, 30*time.Second, got.ConnectTimeout(0))
-	})
-
-	t.Run("ignores non-numeric connecttimeout", func(t *testing.T) {
-		input := []byte(`hostname springfield.nuclear.gov
-connecttimeout none
-`)
-
-		got := ssh.NewConfigFromBytes(input)
-
-		assert.Equal(t, time.Duration(0), got.ConnectTimeout(0))
-	})
-}
-
-func TestConfigConnectTimeout(t *testing.T) {
-	const fallback = 5 * time.Second
-
-	t.Run("returns user config value when set", func(t *testing.T) {
-		configContent := []byte(`connecttimeout 30
-hostname springfield.nuclear.gov
-`)
-		config := ssh.NewConfigFromBytes(configContent)
-
-		assert.Equal(t, 30*time.Second, config.ConnectTimeout(fallback))
-	})
-
-	t.Run("returns fallback when not set in config", func(t *testing.T) {
-		config := ssh.Config{}
-
-		assert.Equal(t, fallback, config.ConnectTimeout(fallback))
-	})
 }
 
 func TestIsExplicitHostConfig(t *testing.T) {

--- a/internal/ssh/exec.go
+++ b/internal/ssh/exec.go
@@ -2,6 +2,7 @@ package ssh
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os/exec"
 	"slices"
@@ -10,10 +11,10 @@ import (
 // RunCommand executes a command on dest over SSH and returns stdout.
 // stderr is classified into a typed error when a known failure pattern is detected.
 // Pass stdin data as optional parameter, or nil for no stdin.
-func RunCommand(dest Destination, command string, stdin []byte, sshArgs ...string) (string, error) {
+func RunCommand(ctx context.Context, dest Destination, command string, stdin []byte, sshArgs ...string) (string, error) {
 	args := slices.Concat(sshArgs, []string{"--", dest.String(), command})
 	// #nosec G204 -- command should be validated by callers
-	cmd := exec.Command("ssh", args...)
+	cmd := exec.CommandContext(ctx, "ssh", args...)
 	if stdin != nil {
 		cmd.Stdin = bytes.NewReader(stdin)
 	}
@@ -23,6 +24,9 @@ func RunCommand(dest Destination, command string, stdin []byte, sshArgs ...strin
 
 	err := cmd.Run()
 	if err != nil {
+		if ctx.Err() != nil {
+			return "", ctx.Err()
+		}
 		stderr := stderrBuf.String()
 		if classified := ClassifyStderr(stderr); classified != nil {
 			err = classified

--- a/internal/target/hardware_probe.go
+++ b/internal/target/hardware_probe.go
@@ -2,6 +2,7 @@ package target
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -36,22 +37,22 @@ func NewHardwareProbe(r runner.Runner) HardwareProbe {
 	return HardwareProbe{runner: r}
 }
 
-func (p *HardwareProbe) Probe() (HardwareProfile, error) {
+func (p *HardwareProbe) Probe(ctx context.Context) (HardwareProfile, error) {
 	var hp HardwareProfile
 
-	cpuProfile, err := p.collectCPUInfo()
+	cpuProfile, err := p.collectCPUInfo(ctx)
 	if err != nil {
 		return hp, fmt.Errorf("collecting CPU info: %w", err)
 	}
 	hp.HostProcessor = cpuProfile
 
-	cpus, err := p.ProbeRemoteproc()
+	cpus, err := p.ProbeRemoteproc(ctx)
 	if err != nil {
 		return hp, fmt.Errorf("collecting remote CPUs: %w", err)
 	}
 	hp.RemoteCPU = cpus
 
-	memTotal, err := p.collectMemInfo()
+	memTotal, err := p.collectMemInfo(ctx)
 	if err != nil {
 		return hp, fmt.Errorf("collecting memory info: %w", err)
 	}
@@ -60,14 +61,14 @@ func (p *HardwareProbe) Probe() (HardwareProfile, error) {
 	return hp, nil
 }
 
-func (p *HardwareProbe) ProbeRemoteproc() ([]RemoteprocCPU, error) {
+func (p *HardwareProbe) ProbeRemoteproc(ctx context.Context) ([]RemoteprocCPU, error) {
 	var remoteProcs []RemoteprocCPU
-	out, err := p.runner.Run(command.WrapInLoginShell("ls /sys/class/remoteproc"))
+	out, err := p.runner.Run(ctx, command.WrapInLoginShell("ls /sys/class/remoteproc"))
 	if err != nil || out == "" {
 		return remoteProcs, nil
 	}
 
-	out, err = p.runner.Run(command.WrapInLoginShell("cat /sys/class/remoteproc/*/name"))
+	out, err = p.runner.Run(ctx, command.WrapInLoginShell("cat /sys/class/remoteproc/*/name"))
 	if err != nil {
 		return remoteProcs, err
 	}
@@ -79,12 +80,12 @@ func (p *HardwareProbe) ProbeRemoteproc() ([]RemoteprocCPU, error) {
 	return remoteProcs, nil
 }
 
-func (p *HardwareProbe) collectCPUInfo() ([]HostProcessor, error) {
-	if _, err := p.runner.Run(command.UnsafeBinaryLookupCommand("lscpu")); err != nil {
+func (p *HardwareProbe) collectCPUInfo(ctx context.Context) ([]HostProcessor, error) {
+	if _, err := p.runner.Run(ctx, command.UnsafeBinaryLookupCommand("lscpu")); err != nil {
 		return nil, err
 	}
 
-	out, err := p.runner.Run(command.WrapInLoginShell("lscpu --json"))
+	out, err := p.runner.Run(ctx, command.WrapInLoginShell("lscpu --json"))
 	if err != nil {
 		return nil, err
 	}
@@ -98,11 +99,11 @@ func (p *HardwareProbe) collectCPUInfo() ([]HostProcessor, error) {
 	return CreateCPUProfile(lscpuOutput.Lscpu)
 }
 
-func (p *HardwareProbe) collectMemInfo() (int64, error) {
+func (p *HardwareProbe) collectMemInfo(ctx context.Context) (int64, error) {
 	key := "MemTotal"
 	path := "/proc/meminfo"
 
-	out, err := p.runner.Run(command.WrapInLoginShell(fmt.Sprintf("cat %s", path)))
+	out, err := p.runner.Run(ctx, command.WrapInLoginShell(fmt.Sprintf("cat %s", path)))
 	if err != nil {
 		return 0, err
 	}

--- a/internal/target/hardware_probe_test.go
+++ b/internal/target/hardware_probe_test.go
@@ -1,6 +1,7 @@
 package target_test
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -16,13 +17,13 @@ func TestHardwareProbe(t *testing.T) {
 	t.Run("Probe", func(t *testing.T) {
 		t.Run("returns model name and features", func(t *testing.T) {
 			r := &runner.Mock{}
-			r.On("Run", command.WrapInLoginShell("command -v lscpu")).Return("/usr/bin/lscpu", nil)
-			r.On("Run", command.WrapInLoginShell("lscpu --json")).Return(testutil.LsCpuOutputRaw, nil)
-			r.On("Run", command.WrapInLoginShell("ls /sys/class/remoteproc")).Return("", nil)
-			r.On("Run", command.WrapInLoginShell("cat /proc/meminfo")).Return("MemTotal:       16384000 kB", nil)
+			r.On("Run", context.Background(), command.WrapInLoginShell("command -v lscpu")).Return("/usr/bin/lscpu", nil)
+			r.On("Run", context.Background(), command.WrapInLoginShell("lscpu --json")).Return(testutil.LsCpuOutputRaw, nil)
+			r.On("Run", context.Background(), command.WrapInLoginShell("ls /sys/class/remoteproc")).Return("", nil)
+			r.On("Run", context.Background(), command.WrapInLoginShell("cat /proc/meminfo")).Return("MemTotal:       16384000 kB", nil)
 			probe := target.NewHardwareProbe(r)
 
-			got, err := probe.Probe()
+			got, err := probe.Probe(context.Background())
 
 			require.NoError(t, err)
 			want := target.HardwareProfile{
@@ -41,10 +42,10 @@ func TestHardwareProbe(t *testing.T) {
 
 		t.Run("returns error when lscpu not found", func(t *testing.T) {
 			r := &runner.Mock{}
-			r.On("Run", command.WrapInLoginShell("command -v lscpu")).Return("", fmt.Errorf("%q executable file not found in $PATH", "lscpu"))
+			r.On("Run", context.Background(), command.WrapInLoginShell("command -v lscpu")).Return("", fmt.Errorf("%q executable file not found in $PATH", "lscpu"))
 			probe := target.NewHardwareProbe(r)
 
-			_, err := probe.Probe()
+			_, err := probe.Probe(context.Background())
 
 			assert.ErrorContains(t, err, `"lscpu" executable file not found in $PATH`)
 			r.AssertExpectations(t)
@@ -52,11 +53,11 @@ func TestHardwareProbe(t *testing.T) {
 
 		t.Run("returns error when lscpu output is invalid JSON", func(t *testing.T) {
 			r := &runner.Mock{}
-			r.On("Run", command.WrapInLoginShell("command -v lscpu")).Return("/usr/bin/lscpu", nil)
-			r.On("Run", command.WrapInLoginShell("lscpu --json")).Return("not json", nil)
+			r.On("Run", context.Background(), command.WrapInLoginShell("command -v lscpu")).Return("/usr/bin/lscpu", nil)
+			r.On("Run", context.Background(), command.WrapInLoginShell("lscpu --json")).Return("not json", nil)
 			probe := target.NewHardwareProbe(r)
 
-			_, err := probe.Probe()
+			_, err := probe.Probe(context.Background())
 
 			assert.ErrorContains(t, err, "collecting CPU info")
 			r.AssertExpectations(t)

--- a/internal/target/ssh_authentication_probe.go
+++ b/internal/target/ssh_authentication_probe.go
@@ -1,6 +1,7 @@
 package target
 
 import (
+	"context"
 	"errors"
 	"slices"
 	"strings"
@@ -35,7 +36,7 @@ var (
 )
 
 type sshRunnerWithExtraArgs interface {
-	RunWithArgs(command string, sshArgs ...string) (string, error)
+	RunWithArgs(ctx context.Context, command string, sshArgs ...string) (string, error)
 }
 
 type SSHAuthenticationProbeOptions struct {
@@ -51,18 +52,18 @@ func NewSSHAuthenticationProbe(r sshRunnerWithExtraArgs, opts SSHAuthenticationP
 	return SSHAuthenticationProbe{runner: r, opts: opts}
 }
 
-func (p SSHAuthenticationProbe) Probe() error {
-	if err := p.verifyKnownHost(); err != nil {
+func (p SSHAuthenticationProbe) Probe(ctx context.Context) error {
+	if err := p.verifyKnownHost(ctx); err != nil {
 		return err
 	}
 
-	if err := p.authenticateUsingPublicKey(); err == nil {
+	if err := p.authenticateUsingPublicKey(ctx); err == nil {
 		return nil
 	} else if !errors.Is(err, ErrAuthenticationFailure) {
 		return err
 	}
 
-	if err := p.authenticateUsingPassword(); err == nil {
+	if err := p.authenticateUsingPassword(ctx); err == nil {
 		return nil
 	} else if errors.Is(err, ErrAuthenticationFailure) {
 		return ErrPasswordAuthentication
@@ -71,12 +72,12 @@ func (p SSHAuthenticationProbe) Probe() error {
 	}
 }
 
-func (p SSHAuthenticationProbe) verifyKnownHost() error {
+func (p SSHAuthenticationProbe) verifyKnownHost(ctx context.Context) error {
 	if p.opts.AcceptNewHostKeys {
 		return nil
 	}
 
-	err := p.runAuthenticationProbe(knownHostProbeArgs)
+	err := p.runAuthenticationProbe(ctx, knownHostProbeArgs)
 	if err == nil || errors.Is(err, ErrAuthenticationFailure) {
 		return nil
 	}
@@ -84,28 +85,28 @@ func (p SSHAuthenticationProbe) verifyKnownHost() error {
 	return err
 }
 
-func (p SSHAuthenticationProbe) authenticateUsingPublicKey() error {
+func (p SSHAuthenticationProbe) authenticateUsingPublicKey(ctx context.Context) error {
 	publicKeyArgs := slices.Clone(publicKeyProbeArgs)
 	if p.opts.AcceptNewHostKeys {
 		publicKeyArgs = slices.Concat(publicKeyArgs, acceptNewHostKeyArgs)
 	}
 
-	return p.runAuthenticationProbe(publicKeyArgs)
+	return p.runAuthenticationProbe(ctx, publicKeyArgs)
 }
 
-func (p SSHAuthenticationProbe) authenticateUsingPassword() error {
+func (p SSHAuthenticationProbe) authenticateUsingPassword(ctx context.Context) error {
 	passwordArgs := slices.Clone(passwordProbeArgs)
 	if p.opts.AcceptNewHostKeys {
 		passwordArgs = slices.Concat(passwordArgs, acceptNewHostKeyArgs)
 	}
 
-	return p.runAuthenticationProbe(passwordArgs)
+	return p.runAuthenticationProbe(ctx, passwordArgs)
 }
 
 // All SSH authentication probes run the command "true" to check if the authentication method works.
 // All sshArgs should be hardcoded SSH options, not user-provided arguments.
-func (p SSHAuthenticationProbe) runAuthenticationProbe(sshArgs []string) error {
-	out, err := p.runner.RunWithArgs("true", sshArgs...)
+func (p SSHAuthenticationProbe) runAuthenticationProbe(ctx context.Context, sshArgs []string) error {
+	out, err := p.runner.RunWithArgs(ctx, "true", sshArgs...)
 	if err == nil {
 		return nil
 	}

--- a/internal/target/ssh_authentication_probe_test.go
+++ b/internal/target/ssh_authentication_probe_test.go
@@ -1,6 +1,7 @@
 package target_test
 
 import (
+	"context"
 	"errors"
 	"slices"
 	"testing"
@@ -15,8 +16,8 @@ type mockSSHRunnerWithExtraArgs struct {
 	mock.Mock
 }
 
-func (m *mockSSHRunnerWithExtraArgs) RunWithArgs(command string, sshArgs ...string) (string, error) {
-	ret := m.Called(command, sshArgs)
+func (m *mockSSHRunnerWithExtraArgs) RunWithArgs(ctx context.Context, command string, sshArgs ...string) (string, error) {
+	ret := m.Called(ctx, command, sshArgs)
 	return ret.String(0), ret.Error(1)
 }
 
@@ -45,23 +46,23 @@ func TestSSHAuthenticationProbe(t *testing.T) {
 
 	t.Run("does not require password when public key succeeds", func(t *testing.T) {
 		r := &mockSSHRunnerWithExtraArgs{}
-		r.On("RunWithArgs", "true", publicKeyMode).Return("", nil)
+		r.On("RunWithArgs", context.Background(), "true", publicKeyMode).Return("", nil)
 
 		probe := target.NewSSHAuthenticationProbe(r, target.SSHAuthenticationProbeOptions{AcceptNewHostKeys: true})
-		err := probe.Probe()
+		err := probe.Probe(context.Background())
 
 		require.NoError(t, err)
 		r.AssertExpectations(t)
 		call := r.Calls[0]
-		assert.Contains(t, call.Arguments[1], "StrictHostKeyChecking=accept-new")
+		assert.Contains(t, call.Arguments[2], "StrictHostKeyChecking=accept-new")
 	})
 
 	t.Run("returns new host key error when host key is unknown", func(t *testing.T) {
 		r := &mockSSHRunnerWithExtraArgs{}
-		r.On("RunWithArgs", "true", publicKeyMode).Return(newHostKeyOutput, errSSH)
+		r.On("RunWithArgs", context.Background(), "true", publicKeyMode).Return(newHostKeyOutput, errSSH)
 
 		probe := target.NewSSHAuthenticationProbe(r, target.SSHAuthenticationProbeOptions{AcceptNewHostKeys: true})
-		err := probe.Probe()
+		err := probe.Probe(context.Background())
 
 		require.ErrorIs(t, err, target.ErrHostKeyNew)
 		r.AssertNumberOfCalls(t, "RunWithArgs", 1)
@@ -69,10 +70,10 @@ func TestSSHAuthenticationProbe(t *testing.T) {
 
 	t.Run("returns changed host key error when host key has changed", func(t *testing.T) {
 		r := &mockSSHRunnerWithExtraArgs{}
-		r.On("RunWithArgs", "true", publicKeyMode).Return(changedHostKeyOutput, errSSH)
+		r.On("RunWithArgs", context.Background(), "true", publicKeyMode).Return(changedHostKeyOutput, errSSH)
 
 		probe := target.NewSSHAuthenticationProbe(r, target.SSHAuthenticationProbeOptions{AcceptNewHostKeys: true})
-		err := probe.Probe()
+		err := probe.Probe(context.Background())
 
 		require.ErrorIs(t, err, target.ErrHostKeyChanged)
 		r.AssertNumberOfCalls(t, "RunWithArgs", 1)
@@ -80,10 +81,10 @@ func TestSSHAuthenticationProbe(t *testing.T) {
 
 	t.Run("returns new host key error for generic host key verification failure", func(t *testing.T) {
 		r := &mockSSHRunnerWithExtraArgs{}
-		r.On("RunWithArgs", "true", publicKeyMode).Return("Host key verification failed", errSSH)
+		r.On("RunWithArgs", context.Background(), "true", publicKeyMode).Return("Host key verification failed", errSSH)
 
 		probe := target.NewSSHAuthenticationProbe(r, target.SSHAuthenticationProbeOptions{AcceptNewHostKeys: true})
-		err := probe.Probe()
+		err := probe.Probe(context.Background())
 
 		require.ErrorIs(t, err, target.ErrHostKeyNew)
 		r.AssertNumberOfCalls(t, "RunWithArgs", 1)
@@ -91,11 +92,11 @@ func TestSSHAuthenticationProbe(t *testing.T) {
 
 	t.Run("returns changed host key error for password probe", func(t *testing.T) {
 		r := &mockSSHRunnerWithExtraArgs{}
-		r.On("RunWithArgs", "true", publicKeyMode).Return("Permission denied", errSSH)
-		r.On("RunWithArgs", "true", passwordMode).Return(changedHostKeyOutput, errSSH)
+		r.On("RunWithArgs", context.Background(), "true", publicKeyMode).Return("Permission denied", errSSH)
+		r.On("RunWithArgs", context.Background(), "true", passwordMode).Return(changedHostKeyOutput, errSSH)
 
 		probe := target.NewSSHAuthenticationProbe(r, target.SSHAuthenticationProbeOptions{AcceptNewHostKeys: true})
-		err := probe.Probe()
+		err := probe.Probe(context.Background())
 
 		require.ErrorIs(t, err, target.ErrHostKeyChanged)
 		r.AssertNumberOfCalls(t, "RunWithArgs", 2)
@@ -103,22 +104,22 @@ func TestSSHAuthenticationProbe(t *testing.T) {
 
 	t.Run("returns password-only auth error when auth fails", func(t *testing.T) {
 		r := &mockSSHRunnerWithExtraArgs{}
-		r.On("RunWithArgs", "true", publicKeyMode).Return("Permission denied", errSSH)
-		r.On("RunWithArgs", "true", passwordMode).Return("Authentication failed", errSSH)
+		r.On("RunWithArgs", context.Background(), "true", publicKeyMode).Return("Permission denied", errSSH)
+		r.On("RunWithArgs", context.Background(), "true", passwordMode).Return("Authentication failed", errSSH)
 
 		probe := target.NewSSHAuthenticationProbe(r, target.SSHAuthenticationProbeOptions{AcceptNewHostKeys: true})
-		err := probe.Probe()
+		err := probe.Probe(context.Background())
 
 		require.ErrorIs(t, err, target.ErrPasswordAuthentication)
 	})
 
 	t.Run("does not require password when password probe succeeds", func(t *testing.T) {
 		r := &mockSSHRunnerWithExtraArgs{}
-		r.On("RunWithArgs", "true", publicKeyMode).Return("Permission denied", errSSH)
-		r.On("RunWithArgs", "true", passwordMode).Return("", nil)
+		r.On("RunWithArgs", context.Background(), "true", publicKeyMode).Return("Permission denied", errSSH)
+		r.On("RunWithArgs", context.Background(), "true", passwordMode).Return("", nil)
 
 		probe := target.NewSSHAuthenticationProbe(r, target.SSHAuthenticationProbeOptions{AcceptNewHostKeys: true})
-		err := probe.Probe()
+		err := probe.Probe(context.Background())
 
 		require.NoError(t, err)
 		r.AssertExpectations(t)
@@ -126,34 +127,34 @@ func TestSSHAuthenticationProbe(t *testing.T) {
 
 	t.Run("returns error on non-auth failure for password probe", func(t *testing.T) {
 		r := &mockSSHRunnerWithExtraArgs{}
-		r.On("RunWithArgs", "true", publicKeyMode).Return("Permission denied", errSSH)
-		r.On("RunWithArgs", "true", passwordMode).Return("Some other error", errSSH)
+		r.On("RunWithArgs", context.Background(), "true", publicKeyMode).Return("Permission denied", errSSH)
+		r.On("RunWithArgs", context.Background(), "true", passwordMode).Return("Some other error", errSSH)
 
 		probe := target.NewSSHAuthenticationProbe(r, target.SSHAuthenticationProbeOptions{AcceptNewHostKeys: true})
-		err := probe.Probe()
+		err := probe.Probe(context.Background())
 
 		require.ErrorIs(t, err, errSSH)
 	})
 
 	t.Run("ensures known host when not accepting new host keys", func(t *testing.T) {
 		r := &mockSSHRunnerWithExtraArgs{}
-		r.On("RunWithArgs", "true", knownHostMode).Return("Permission denied", errSSH)
-		r.On("RunWithArgs", "true", publicKeyMode).Return("", nil)
+		r.On("RunWithArgs", context.Background(), "true", knownHostMode).Return("Permission denied", errSSH)
+		r.On("RunWithArgs", context.Background(), "true", publicKeyMode).Return("", nil)
 
 		probe := target.NewSSHAuthenticationProbe(r, target.SSHAuthenticationProbeOptions{})
-		err := probe.Probe()
+		err := probe.Probe(context.Background())
 
 		require.NoError(t, err)
 		r.AssertExpectations(t)
-		assert.Contains(t, r.Calls[0].Arguments[1], "PasswordAuthentication=no")
+		assert.Contains(t, r.Calls[0].Arguments[2], "PasswordAuthentication=no")
 	})
 
 	t.Run("returns new host key error when known host check fails", func(t *testing.T) {
 		r := &mockSSHRunnerWithExtraArgs{}
-		r.On("RunWithArgs", "true", knownHostMode).Return("HOST KEY VERIFICATION FAILED", errSSH)
+		r.On("RunWithArgs", context.Background(), "true", knownHostMode).Return("HOST KEY VERIFICATION FAILED", errSSH)
 
 		probe := target.NewSSHAuthenticationProbe(r, target.SSHAuthenticationProbeOptions{})
-		err := probe.Probe()
+		err := probe.Probe(context.Background())
 
 		require.ErrorIs(t, err, target.ErrHostKeyNew)
 		r.AssertNumberOfCalls(t, "RunWithArgs", 1)
@@ -161,10 +162,10 @@ func TestSSHAuthenticationProbe(t *testing.T) {
 
 	t.Run("returns changed host key error when known host check detects changed key", func(t *testing.T) {
 		r := &mockSSHRunnerWithExtraArgs{}
-		r.On("RunWithArgs", "true", knownHostMode).Return(changedHostKeyOutput, errSSH)
+		r.On("RunWithArgs", context.Background(), "true", knownHostMode).Return(changedHostKeyOutput, errSSH)
 
 		probe := target.NewSSHAuthenticationProbe(r, target.SSHAuthenticationProbeOptions{})
-		err := probe.Probe()
+		err := probe.Probe(context.Background())
 
 		require.ErrorIs(t, err, target.ErrHostKeyChanged)
 		r.AssertNumberOfCalls(t, "RunWithArgs", 1)
@@ -172,10 +173,10 @@ func TestSSHAuthenticationProbe(t *testing.T) {
 
 	t.Run("returns error when known host fails with other error", func(t *testing.T) {
 		r := &mockSSHRunnerWithExtraArgs{}
-		r.On("RunWithArgs", "true", knownHostMode).Return("dial tcp: lookup host: no such host", errSSH)
+		r.On("RunWithArgs", context.Background(), "true", knownHostMode).Return("dial tcp: lookup host: no such host", errSSH)
 
 		probe := target.NewSSHAuthenticationProbe(r, target.SSHAuthenticationProbeOptions{})
-		err := probe.Probe()
+		err := probe.Probe(context.Background())
 
 		require.ErrorIs(t, err, errSSH)
 		r.AssertNumberOfCalls(t, "RunWithArgs", 1)


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- Thread `context.Context` through `Runner` interface, `ssh.RunCommand`, probes, and health checks
- Replace SSH `ConnectTimeout` (`-o ConnectTimeout=N`) with context-based timeout via `exec.CommandContext`
- Add `--timeout` flag to relevant commands (default 5s)
- Return `runner.ErrTimeout` on context cancellation or deadline
- Call sites not yet wired to a real context use `context.TODO()` at the `Run()` call (`install`, `pubkeytransfer`)

### How it looks

```
❱ topo health --target <target> --timeout 1ms
Host
----
SSH: ✅ (ssh)
Container Engine: ✅ (docker)

Target
------
Connectivity: ❌ (timed out)
```