### PR TITLE
fix: suggest correct fix for auth failure

### DIFF
--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -149,8 +149,10 @@ func connectivityCheck(status ConnectionStatus) HealthCheck {
 	switch {
 	case errors.Is(status.Error, target.ErrPasswordAuthentication):
 		check.Fix = fmt.Sprintf("run `topo setup-keys --target %s` to configure SSH keys", status.Destination)
-	case errors.Is(status.Error, target.ErrHostKeyVerification):
+	case errors.Is(status.Error, target.ErrHostKeyNew):
 		check.Fix = fmt.Sprintf("run `topo health --target %s --accept-new-host-keys` to trust the target's identity", status.Destination)
+	case errors.Is(status.Error, target.ErrHostKeyChanged):
+		check.Fix = fmt.Sprintf("run `ssh-keygen -R %s` to remove the old host key, then retry", status.Destination.Host)
 	}
 	return check
 }

--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -77,11 +77,11 @@ func TestGenerateTargetReport(t *testing.T) {
 		assert.Contains(t, got.Connectivity.Fix, "topo setup-keys --target ssh://user@my-target")
 	})
 
-	t.Run("when host key verification fails, Connectivity includes an accept-new-host-keys fix", func(t *testing.T) {
+	t.Run("when host key is new, Connectivity includes an accept-new-host-keys fix", func(t *testing.T) {
 		ts := health.Status{
 			Connection: health.ConnectionStatus{
 				Destination: ssh.NewDestination("user@my-target"),
-				Error:       target.ErrHostKeyVerification,
+				Error:       target.ErrHostKeyNew,
 			},
 		}
 
@@ -89,6 +89,20 @@ func TestGenerateTargetReport(t *testing.T) {
 
 		assert.Equal(t, health.CheckStatusError, got.Connectivity.Status)
 		assert.Equal(t, "run `topo health --target ssh://user@my-target --accept-new-host-keys` to trust the target's identity", got.Connectivity.Fix)
+	})
+
+	t.Run("when host key has changed, Connectivity includes a known_hosts fix", func(t *testing.T) {
+		ts := health.Status{
+			Connection: health.ConnectionStatus{
+				Destination: ssh.NewDestination("user@my-target"),
+				Error:       target.ErrHostKeyChanged,
+			},
+		}
+
+		got := health.GenerateTargetReport(ts)
+
+		assert.Equal(t, health.CheckStatusError, got.Connectivity.Status)
+		assert.Equal(t, "run `ssh-keygen -R my-target` to remove the old host key, then retry", got.Connectivity.Fix)
 	})
 }
 

--- a/internal/target/ssh_authentication_probe.go
+++ b/internal/target/ssh_authentication_probe.go
@@ -29,7 +29,8 @@ var (
 
 var (
 	ErrPasswordAuthentication = errors.New("key-based SSH authentication is not setup")
-	ErrHostKeyVerification    = errors.New("ssh host key verification failed")
+	ErrHostKeyNew             = errors.New("ssh host key is not known")
+	ErrHostKeyChanged         = errors.New("ssh host key has changed")
 	ErrAuthenticationFailure  = errors.New("ssh authentication failed")
 )
 
@@ -110,7 +111,10 @@ func (p SSHAuthenticationProbe) runAuthenticationProbe(sshArgs []string) error {
 	}
 	output := strings.ToLower(out)
 	if strings.Contains(output, "host key verification failed") {
-		return ErrHostKeyVerification
+		if strings.Contains(output, "has changed") {
+			return ErrHostKeyChanged
+		}
+		return ErrHostKeyNew
 	}
 	if strings.Contains(output, "permission denied") || strings.Contains(output, "authentication failed") || strings.Contains(output, "password") {
 		return ErrAuthenticationFailure

--- a/internal/target/ssh_authentication_probe_test.go
+++ b/internal/target/ssh_authentication_probe_test.go
@@ -21,6 +21,13 @@ func (m *mockSSHRunnerWithExtraArgs) RunWithArgs(command string, sshArgs ...stri
 }
 
 var (
+	newHostKeyOutput = `No ED25519 host key is known for 10.2.4.68 and you have requested strict checking.
+Host key verification failed.`
+	changedHostKeyOutput = `Host key for 10.2.4.68 has changed and you have requested strict checking.
+Host key verification failed.`
+)
+
+var (
 	publicKeyMode = mock.MatchedBy(func(args []string) bool {
 		return slices.Contains(args, "PreferredAuthentications=publickey") &&
 			!slices.Contains(args, "PasswordAuthentication=no")
@@ -49,26 +56,48 @@ func TestSSHAuthenticationProbe(t *testing.T) {
 		assert.Contains(t, call.Arguments[1], "StrictHostKeyChecking=accept-new")
 	})
 
-	t.Run("returns host key verification error for public key probe", func(t *testing.T) {
+	t.Run("returns new host key error when host key is unknown", func(t *testing.T) {
+		r := &mockSSHRunnerWithExtraArgs{}
+		r.On("RunWithArgs", "true", publicKeyMode).Return(newHostKeyOutput, errSSH)
+
+		probe := target.NewSSHAuthenticationProbe(r, target.SSHAuthenticationProbeOptions{AcceptNewHostKeys: true})
+		err := probe.Probe()
+
+		require.ErrorIs(t, err, target.ErrHostKeyNew)
+		r.AssertNumberOfCalls(t, "RunWithArgs", 1)
+	})
+
+	t.Run("returns changed host key error when host key has changed", func(t *testing.T) {
+		r := &mockSSHRunnerWithExtraArgs{}
+		r.On("RunWithArgs", "true", publicKeyMode).Return(changedHostKeyOutput, errSSH)
+
+		probe := target.NewSSHAuthenticationProbe(r, target.SSHAuthenticationProbeOptions{AcceptNewHostKeys: true})
+		err := probe.Probe()
+
+		require.ErrorIs(t, err, target.ErrHostKeyChanged)
+		r.AssertNumberOfCalls(t, "RunWithArgs", 1)
+	})
+
+	t.Run("returns new host key error for generic host key verification failure", func(t *testing.T) {
 		r := &mockSSHRunnerWithExtraArgs{}
 		r.On("RunWithArgs", "true", publicKeyMode).Return("Host key verification failed", errSSH)
 
 		probe := target.NewSSHAuthenticationProbe(r, target.SSHAuthenticationProbeOptions{AcceptNewHostKeys: true})
 		err := probe.Probe()
 
-		require.ErrorIs(t, err, target.ErrHostKeyVerification)
+		require.ErrorIs(t, err, target.ErrHostKeyNew)
 		r.AssertNumberOfCalls(t, "RunWithArgs", 1)
 	})
 
-	t.Run("returns host key verification error for password probe", func(t *testing.T) {
+	t.Run("returns changed host key error for password probe", func(t *testing.T) {
 		r := &mockSSHRunnerWithExtraArgs{}
 		r.On("RunWithArgs", "true", publicKeyMode).Return("Permission denied", errSSH)
-		r.On("RunWithArgs", "true", passwordMode).Return("Host key verification failed", errSSH)
+		r.On("RunWithArgs", "true", passwordMode).Return(changedHostKeyOutput, errSSH)
 
 		probe := target.NewSSHAuthenticationProbe(r, target.SSHAuthenticationProbeOptions{AcceptNewHostKeys: true})
 		err := probe.Probe()
 
-		require.ErrorIs(t, err, target.ErrHostKeyVerification)
+		require.ErrorIs(t, err, target.ErrHostKeyChanged)
 		r.AssertNumberOfCalls(t, "RunWithArgs", 2)
 	})
 
@@ -119,14 +148,25 @@ func TestSSHAuthenticationProbe(t *testing.T) {
 		assert.Contains(t, r.Calls[0].Arguments[1], "PasswordAuthentication=no")
 	})
 
-	t.Run("returns host key verification error when known host fails", func(t *testing.T) {
+	t.Run("returns new host key error when known host check fails", func(t *testing.T) {
 		r := &mockSSHRunnerWithExtraArgs{}
 		r.On("RunWithArgs", "true", knownHostMode).Return("HOST KEY VERIFICATION FAILED", errSSH)
 
 		probe := target.NewSSHAuthenticationProbe(r, target.SSHAuthenticationProbeOptions{})
 		err := probe.Probe()
 
-		require.ErrorIs(t, err, target.ErrHostKeyVerification)
+		require.ErrorIs(t, err, target.ErrHostKeyNew)
+		r.AssertNumberOfCalls(t, "RunWithArgs", 1)
+	})
+
+	t.Run("returns changed host key error when known host check detects changed key", func(t *testing.T) {
+		r := &mockSSHRunnerWithExtraArgs{}
+		r.On("RunWithArgs", "true", knownHostMode).Return(changedHostKeyOutput, errSSH)
+
+		probe := target.NewSSHAuthenticationProbe(r, target.SSHAuthenticationProbeOptions{})
+		err := probe.Probe()
+
+		require.ErrorIs(t, err, target.ErrHostKeyChanged)
 		r.AssertNumberOfCalls(t, "RunWithArgs", 1)
 	})
 


### PR DESCRIPTION
## Changes

- Split `ErrHostKeyVerification` into `ErrHostKeyNew` and `ErrHostKeyChanged` to distinguish between unknown and changed SSH host keys
- Detect "has changed" in SSH output to classify the error type
- Suggest `--accept-new-host-keys` only for new hosts; suggest `ssh-keygen -R` for changed hosts