### PR TITLE
fix: show binary name in health check failure instead of raw runner error

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -16,16 +16,12 @@ func WrapInLoginShell(cmd string) string {
 	return fmt.Sprintf(`/bin/sh -c "exec ${SHELL:-/bin/sh} -l -c \"%s\""`, escaped)
 }
 
-func UnsafeBinaryLookupCommand(bin string) string {
-	return WrapInLoginShell(fmt.Sprintf("command -v %s", bin))
-}
-
 func BinaryLookupCommand(bin string) (string, error) {
 	if err := ValidateBinaryName(bin); err != nil {
 		return "", err
 	}
 
-	return UnsafeBinaryLookupCommand(bin), nil
+	return WrapInLoginShell(fmt.Sprintf("command -v %s", bin)), nil
 }
 
 func shellEscapeForDoubleQuotes(s string) string {

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -22,7 +22,7 @@ func TestBinaryLookupCommand(t *testing.T) {
 		got, err := command.BinaryLookupCommand("docker")
 
 		require.NoError(t, err)
-		assert.Equal(t, command.UnsafeBinaryLookupCommand("docker"), got)
+		assert.Equal(t, command.WrapInLoginShell("command -v docker"), got)
 	})
 
 	t.Run("returns error for invalid binary", func(t *testing.T) {
@@ -30,13 +30,5 @@ func TestBinaryLookupCommand(t *testing.T) {
 
 		assert.Error(t, err)
 		assert.Empty(t, got)
-	})
-}
-
-func TestUnsafeBinaryLookupCommand(t *testing.T) {
-	t.Run("returns wrapped command without validation", func(t *testing.T) {
-		got := command.UnsafeBinaryLookupCommand("docker")
-
-		assert.Equal(t, command.WrapInLoginShell("command -v docker"), got)
 	})
 }

--- a/internal/health/dependencies.go
+++ b/internal/health/dependencies.go
@@ -1,5 +1,7 @@
 package health
 
+import "context"
+
 type CheckKind int
 
 const (
@@ -147,11 +149,11 @@ func hardwareCapabilityMatches(required []HardwareCapability, available map[Hard
 }
 
 type (
-	BinaryExistsFn      = func(bin string) error
+	BinaryExistsFn      = func(ctx context.Context, bin string) error
 	CommandSuccessfulFn = func(fullCmd string) error
 )
 
-func PerformChecks(dependencies []Dependency, binaryExists BinaryExistsFn, commandSuccessful CommandSuccessfulFn) []DependencyStatus {
+func PerformChecks(ctx context.Context, dependencies []Dependency, binaryExists BinaryExistsFn, commandSuccessful CommandSuccessfulFn) []DependencyStatus {
 	installed := make(map[SoftwareDependency]struct{})
 	result := make([]DependencyStatus, 0, len(dependencies))
 
@@ -165,7 +167,7 @@ func PerformChecks(dependencies []Dependency, binaryExists BinaryExistsFn, comma
 		for _, check := range dep.Checks {
 			switch check.Kind {
 			case CheckBinaryExists:
-				err = binaryExists(dep.Binary)
+				err = binaryExists(ctx, dep.Binary)
 				if err == nil && dep.SoftwareEnumID != UnsetSoftwareDependency {
 					installed[dep.SoftwareEnumID] = struct{}{}
 				}

--- a/internal/health/dependencies.go
+++ b/internal/health/dependencies.go
@@ -1,12 +1,5 @@
 package health
 
-import (
-	"fmt"
-	"os/exec"
-	"strings"
-
-	"github.com/arm/topo/internal/command"
-)
 
 type CheckKind int
 
@@ -207,21 +200,3 @@ func hasAnyInstalledPrerequisite(required []SoftwareDependency, installed map[So
 	return false
 }
 
-func BinaryExistsLocally(bin string) error {
-	if err := command.ValidateBinaryName(bin); err != nil {
-		return err
-	}
-	if _, err := exec.LookPath(bin); err != nil {
-		return fmt.Errorf("%q executable file not found in $PATH", bin)
-	}
-	return nil
-}
-
-func CommandSuccessfulLocally(fullCmd string) error {
-	cmdParts := strings.Fields(fullCmd)
-	execCmd := exec.Command(cmdParts[0], cmdParts[1:]...)
-	if err := execCmd.Run(); err != nil {
-		return fmt.Errorf("failed to run `%s`: %w", fullCmd, err)
-	}
-	return nil
-}

--- a/internal/health/dependencies.go
+++ b/internal/health/dependencies.go
@@ -1,6 +1,5 @@
 package health
 
-
 type CheckKind int
 
 const (
@@ -199,4 +198,3 @@ func hasAnyInstalledPrerequisite(required []SoftwareDependency, installed map[So
 	}
 	return false
 }
-

--- a/internal/health/dependencies_test.go
+++ b/internal/health/dependencies_test.go
@@ -1,6 +1,7 @@
 package health_test
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -55,21 +56,21 @@ func TestPerformChecks(t *testing.T) {
 			{Binary: "foo", Label: "bar", Checks: []health.Check{health.BinaryExists()}},
 			{Binary: "baz", Label: "qux", Checks: []health.Check{health.BinaryExists()}},
 		}
-		mockBinaryExists := func(bin string) error {
+		mockBinaryExists := func(_ context.Context, bin string) error {
 			return fmt.Errorf("%q executable file not found in $PATH", bin)
 		}
 		mockCommandSuccessful := func(string) error { return nil }
 
-		got := health.PerformChecks(deps, mockBinaryExists, mockCommandSuccessful)
+		got := health.PerformChecks(context.Background(), deps, mockBinaryExists, mockCommandSuccessful)
 
 		want := []health.DependencyStatus{
 			{
 				Dependency: health.Dependency{Binary: "foo", Label: "bar", Checks: []health.Check{health.BinaryExists()}},
-				Error:      mockBinaryExists("foo"),
+				Error:      mockBinaryExists(context.Background(), "foo"),
 			},
 			{
 				Dependency: health.Dependency{Binary: "baz", Label: "qux", Checks: []health.Check{health.BinaryExists()}},
-				Error:      mockBinaryExists("baz"),
+				Error:      mockBinaryExists(context.Background(), "baz"),
 			},
 		}
 		assert.Equal(t, want, got)
@@ -78,18 +79,18 @@ func TestPerformChecks(t *testing.T) {
 	t.Run("wraps error as WarningError when binary exists check severity is warning", func(t *testing.T) {
 		missingBin := health.Dependency{Binary: "missing-bin", Label: "Missing", Checks: []health.Check{health.BinaryExistsWarning()}}
 		deps := []health.Dependency{missingBin}
-		mockBinaryExists := func(bin string) error {
+		mockBinaryExists := func(_ context.Context, bin string) error {
 			return fmt.Errorf("%q executable file not found in $PATH", bin)
 		}
 		mockCommandSuccessful := func(string) error { return nil }
 
-		got := health.PerformChecks(deps, mockBinaryExists, mockCommandSuccessful)
+		got := health.PerformChecks(context.Background(), deps, mockBinaryExists, mockCommandSuccessful)
 
 		assert.Len(t, got, 1)
 		want := []health.DependencyStatus{
 			{
 				Dependency: missingBin,
-				Error:      health.WarningError{Err: mockBinaryExists("missing-bin")},
+				Error:      health.WarningError{Err: mockBinaryExists(context.Background(), "missing-bin")},
 			},
 		}
 		assert.Equal(t, want, got)
@@ -99,7 +100,7 @@ func TestPerformChecks(t *testing.T) {
 		deps := []health.Dependency{
 			{Binary: "baz", Label: "qux", Checks: []health.Check{health.BinaryExists()}},
 		}
-		mockBinaryExists := func(bin string) error {
+		mockBinaryExists := func(_ context.Context, bin string) error {
 			if bin == "baz" {
 				return nil
 			}
@@ -107,7 +108,7 @@ func TestPerformChecks(t *testing.T) {
 		}
 		mockCommandSuccessful := func(string) error { return nil }
 
-		got := health.PerformChecks(deps, mockBinaryExists, mockCommandSuccessful)
+		got := health.PerformChecks(context.Background(), deps, mockBinaryExists, mockCommandSuccessful)
 
 		want := []health.DependencyStatus{
 			{
@@ -123,7 +124,7 @@ func TestPerformChecks(t *testing.T) {
 			{Binary: "docker", Label: "Container Engine", Checks: []health.Check{health.BinaryExists()}},
 			{Binary: "runtime", Label: "Runtime", SoftwarePrerequisites: []health.SoftwareDependency{health.Docker}, Checks: []health.Check{health.BinaryExists()}},
 		}
-		mockBinaryExists := func(bin string) error {
+		mockBinaryExists := func(_ context.Context, bin string) error {
 			if bin == "runtime" {
 				return nil
 			}
@@ -131,10 +132,10 @@ func TestPerformChecks(t *testing.T) {
 		}
 		mockCommandSuccessful := func(string) error { return nil }
 
-		got := health.PerformChecks(deps, mockBinaryExists, mockCommandSuccessful)
+		got := health.PerformChecks(context.Background(), deps, mockBinaryExists, mockCommandSuccessful)
 
 		want := []health.DependencyStatus{
-			{Dependency: health.Dependency{Binary: "docker", Label: "Container Engine", Checks: []health.Check{health.BinaryExists()}}, Error: mockBinaryExists("docker")},
+			{Dependency: health.Dependency{Binary: "docker", Label: "Container Engine", Checks: []health.Check{health.BinaryExists()}}, Error: mockBinaryExists(context.Background(), "docker")},
 		}
 		assert.Equal(t, want, got)
 	})
@@ -144,12 +145,12 @@ func TestPerformChecks(t *testing.T) {
 			{Binary: "docker", Label: "Container Engine", SoftwareEnumID: health.Docker, Checks: []health.Check{health.BinaryExists()}},
 			{Binary: "runtime", Label: "Runtime", SoftwarePrerequisites: []health.SoftwareDependency{health.Docker}, Checks: []health.Check{health.BinaryExists()}},
 		}
-		mockBinaryExists := func(bin string) error {
+		mockBinaryExists := func(_ context.Context, bin string) error {
 			return nil
 		}
 		mockCommandSuccessful := func(string) error { return nil }
 
-		got := health.PerformChecks(deps, mockBinaryExists, mockCommandSuccessful)
+		got := health.PerformChecks(context.Background(), deps, mockBinaryExists, mockCommandSuccessful)
 
 		want := []health.DependencyStatus{
 			{Dependency: health.Dependency{Binary: "docker", Label: "Container Engine", SoftwareEnumID: health.Docker, Checks: []health.Check{health.BinaryExists()}}, Error: nil},
@@ -164,12 +165,12 @@ func TestPerformChecks(t *testing.T) {
 			Label:  "Sith",
 			Checks: []health.Check{{Kind: health.CheckBinaryExists, Severity: health.SeverityWarning, Fix: "turn Anakin into a bad man"}},
 		}
-		mockBinaryExists := func(bin string) error {
+		mockBinaryExists := func(_ context.Context, bin string) error {
 			return errors.New("vader not found")
 		}
 		mockCommandSuccessful := func(string) error { return nil }
 
-		got := health.PerformChecks([]health.Dependency{dep}, mockBinaryExists, mockCommandSuccessful)
+		got := health.PerformChecks(context.Background(), []health.Dependency{dep}, mockBinaryExists, mockCommandSuccessful)
 
 		assert.Len(t, got, 1)
 		assert.Equal(t, "turn Anakin into a bad man", got[0].Fix)
@@ -179,12 +180,12 @@ func TestPerformChecks(t *testing.T) {
 		deps := []health.Dependency{
 			{Binary: "standalone", Label: "Tools", Checks: []health.Check{health.BinaryExists()}},
 		}
-		mockBinaryExists := func(bin string) error {
+		mockBinaryExists := func(_ context.Context, bin string) error {
 			return nil
 		}
 		mockCommandSuccessful := func(string) error { return nil }
 
-		got := health.PerformChecks(deps, mockBinaryExists, mockCommandSuccessful)
+		got := health.PerformChecks(context.Background(), deps, mockBinaryExists, mockCommandSuccessful)
 
 		want := []health.DependencyStatus{
 			{Dependency: health.Dependency{Binary: "standalone", Label: "Tools", Checks: []health.Check{health.BinaryExists()}}, Error: nil},
@@ -203,7 +204,7 @@ func TestPerformChecks(t *testing.T) {
 				Fix:      "Ensure current user can run the potatoe cooker",
 			}},
 		}
-		mockBinaryExists := func(string) error { return nil }
+		mockBinaryExists := func(context.Context, string) error { return nil }
 		mockCommandSuccessful := func(cmd string) error {
 			if cmd == "potatoes --cook-well" {
 				return errors.New("permission denied")
@@ -211,7 +212,7 @@ func TestPerformChecks(t *testing.T) {
 			return nil
 		}
 
-		got := health.PerformChecks([]health.Dependency{dep}, mockBinaryExists, mockCommandSuccessful)
+		got := health.PerformChecks(context.Background(), []health.Dependency{dep}, mockBinaryExists, mockCommandSuccessful)
 
 		want := []health.DependencyStatus{
 			{

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -68,7 +68,7 @@ func CheckHost() HostReport {
 		_, err := r.Run(context.Background(), fullCmd)
 		return err
 	}
-	dependencyStatuses := PerformChecks(HostRequiredDependencies, r.BinaryExists, commandSuccessful)
+	dependencyStatuses := PerformChecks(context.Background(), HostRequiredDependencies, r.BinaryExists, commandSuccessful)
 	return GenerateHostReport(dependencyStatuses)
 }
 

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/arm/topo/internal/command"
 	"github.com/arm/topo/internal/runner"
 	"github.com/arm/topo/internal/ssh"
 	"github.com/arm/topo/internal/target"
@@ -66,7 +65,7 @@ func (r TargetReport) MarshalJSON() ([]byte, error) {
 func CheckHost() HostReport {
 	r := runner.NewLocal()
 	commandSuccessful := func(fullCmd string) error {
-		_, err := r.Run(context.Background(), command.WrapInLoginShell(fullCmd))
+		_, err := r.Run(context.Background(), fullCmd)
 		return err
 	}
 	dependencyStatuses := PerformChecks(HostRequiredDependencies, r.BinaryExists, commandSuccessful)

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/arm/topo/internal/command"
 	"github.com/arm/topo/internal/runner"
 	"github.com/arm/topo/internal/ssh"
 	"github.com/arm/topo/internal/target"
@@ -63,7 +64,12 @@ func (r TargetReport) MarshalJSON() ([]byte, error) {
 }
 
 func CheckHost() HostReport {
-	dependencyStatuses := PerformChecks(HostRequiredDependencies, BinaryExistsLocally, CommandSuccessfulLocally)
+	r := runner.NewLocal()
+	commandSuccessful := func(fullCmd string) error {
+		_, err := r.Run(command.WrapInLoginShell(fullCmd))
+		return err
+	}
+	dependencyStatuses := PerformChecks(HostRequiredDependencies, r.BinaryExists, commandSuccessful)
 	return GenerateHostReport(dependencyStatuses)
 }
 

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -66,7 +66,7 @@ func (r TargetReport) MarshalJSON() ([]byte, error) {
 func CheckHost() HostReport {
 	r := runner.NewLocal()
 	commandSuccessful := func(fullCmd string) error {
-		_, err := r.Run(command.WrapInLoginShell(fullCmd))
+		_, err := r.Run(context.Background(), command.WrapInLoginShell(fullCmd))
 		return err
 	}
 	dependencyStatuses := PerformChecks(HostRequiredDependencies, r.BinaryExists, commandSuccessful)

--- a/internal/health/status.go
+++ b/internal/health/status.go
@@ -2,6 +2,7 @@ package health
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/arm/topo/internal/command"
 	"github.com/arm/topo/internal/runner"
@@ -36,7 +37,7 @@ func ProbeHealthStatus(ctx context.Context, r runner.Runner) HealthStatus {
 	binaryExists := func(bin string) error {
 		// We can use `UnsafeBinaryLookupCommand`, because the dependencies we're checking are hardcoded in the codebase
 		if _, err := r.Run(ctx, command.UnsafeBinaryLookupCommand(bin)); err != nil {
-			return err
+			return fmt.Errorf("%q not found in $PATH", bin)
 		}
 		return nil
 	}

--- a/internal/health/status.go
+++ b/internal/health/status.go
@@ -2,7 +2,6 @@ package health
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/arm/topo/internal/command"
 	"github.com/arm/topo/internal/runner"
@@ -35,11 +34,7 @@ func ProbeHealthStatus(ctx context.Context, r runner.Runner) HealthStatus {
 
 	dependenciesToCheck := FilterByHardware(TargetRequiredDependencies, hs.Hardware.Capabilities())
 	binaryExists := func(bin string) error {
-		// We can use `UnsafeBinaryLookupCommand`, because the dependencies we're checking are hardcoded in the codebase
-		if _, err := r.Run(ctx, command.UnsafeBinaryLookupCommand(bin)); err != nil {
-			return fmt.Errorf("%q not found in $PATH", bin)
-		}
-		return nil
+		return r.BinaryExists(bin)
 	}
 	commandSuccessful := func(fullCmd string) error {
 		_, err := r.Run(ctx, command.WrapInLoginShell(fullCmd))

--- a/internal/health/status.go
+++ b/internal/health/status.go
@@ -33,14 +33,11 @@ func ProbeHealthStatus(ctx context.Context, r runner.Runner) HealthStatus {
 	hs.Hardware.RemoteCPU = remoteprocs
 
 	dependenciesToCheck := FilterByHardware(TargetRequiredDependencies, hs.Hardware.Capabilities())
-	binaryExists := func(bin string) error {
-		return r.BinaryExists(bin)
-	}
 	commandSuccessful := func(fullCmd string) error {
 		_, err := r.Run(ctx, command.WrapInLoginShell(fullCmd))
 		return err
 	}
-	hs.Dependencies = PerformChecks(dependenciesToCheck, binaryExists, commandSuccessful)
+	hs.Dependencies = PerformChecks(ctx, dependenciesToCheck, r.BinaryExists, commandSuccessful)
 
 	return hs
 }

--- a/internal/health/status_test.go
+++ b/internal/health/status_test.go
@@ -18,7 +18,7 @@ func TestProbeHealthStatus(t *testing.T) {
 		r := &runner.Mock{}
 		r.On("Run", context.Background(), command.WrapInLoginShell("ls /sys/class/remoteproc")).Return("remoteproc0\nremoteproc1", nil)
 		r.On("Run", context.Background(), command.WrapInLoginShell("cat /sys/class/remoteproc/*/name")).Return("foo\nbar", nil)
-		r.On("BinaryExists", mock.AnythingOfType("string")).Maybe().Return(fmt.Errorf("not found"))
+		r.On("BinaryExists", context.Background(), mock.AnythingOfType("string")).Maybe().Return(fmt.Errorf("not found"))
 
 		ts := health.ProbeHealthStatus(context.Background(), r)
 
@@ -30,7 +30,7 @@ func TestProbeHealthStatus(t *testing.T) {
 	t.Run("succeeds when no remoteproc support", func(t *testing.T) {
 		r := &runner.Mock{}
 		r.On("Run", context.Background(), command.WrapInLoginShell("ls /sys/class/remoteproc")).Return("", fmt.Errorf("no such directory"))
-		r.On("BinaryExists", mock.AnythingOfType("string")).Maybe().Return(fmt.Errorf("not found"))
+		r.On("BinaryExists", context.Background(), mock.AnythingOfType("string")).Maybe().Return(fmt.Errorf("not found"))
 
 		ts := health.ProbeHealthStatus(context.Background(), r)
 

--- a/internal/health/status_test.go
+++ b/internal/health/status_test.go
@@ -18,7 +18,6 @@ func TestProbeHealthStatus(t *testing.T) {
 		r := &runner.Mock{}
 		r.On("Run", context.Background(), command.WrapInLoginShell("ls /sys/class/remoteproc")).Return("remoteproc0\nremoteproc1", nil)
 		r.On("Run", context.Background(), command.WrapInLoginShell("cat /sys/class/remoteproc/*/name")).Return("foo\nbar", nil)
-		r.On("Run", context.Background(), mock.AnythingOfType("string")).Maybe().Return("", fmt.Errorf("not found"))
 		r.On("BinaryExists", mock.AnythingOfType("string")).Maybe().Return(fmt.Errorf("not found"))
 
 		ts := health.ProbeHealthStatus(context.Background(), r)
@@ -28,24 +27,9 @@ func TestProbeHealthStatus(t *testing.T) {
 		r.AssertExpectations(t)
 	})
 
-	t.Run("reports binary name when lookup fails", func(t *testing.T) {
-		r := &runner.Mock{}
-		r.On("Run", context.Background(), command.WrapInLoginShell("ls /sys/class/remoteproc")).Return("", fmt.Errorf("not found"))
-		r.On("BinaryExists", "docker").Return(fmt.Errorf(`"docker" not found in $PATH`))
-		r.On("BinaryExists", "lscpu").Return(fmt.Errorf(`"lscpu" not found in $PATH`))
-
-		ts := health.ProbeHealthStatus(context.Background(), r)
-
-		for _, dep := range ts.Dependencies {
-			if dep.Error != nil {
-				assert.Contains(t, dep.Error.Error(), fmt.Sprintf("%q", dep.Dependency.Binary))
-			}
-		}
-	})
-
 	t.Run("succeeds when no remoteproc support", func(t *testing.T) {
 		r := &runner.Mock{}
-		r.On("Run", context.Background(), mock.AnythingOfType("string")).Return("", fmt.Errorf("no such directory"))
+		r.On("Run", context.Background(), command.WrapInLoginShell("ls /sys/class/remoteproc")).Return("", fmt.Errorf("no such directory"))
 		r.On("BinaryExists", mock.AnythingOfType("string")).Maybe().Return(fmt.Errorf("not found"))
 
 		ts := health.ProbeHealthStatus(context.Background(), r)

--- a/internal/health/status_test.go
+++ b/internal/health/status_test.go
@@ -27,6 +27,21 @@ func TestProbeHealthStatus(t *testing.T) {
 		r.AssertExpectations(t)
 	})
 
+	t.Run("reports binary name when lookup fails", func(t *testing.T) {
+		r := &runner.Mock{}
+		r.On("Run", context.Background(), command.WrapInLoginShell("ls /sys/class/remoteproc")).Return("", fmt.Errorf("not found"))
+		r.On("Run", context.Background(), command.UnsafeBinaryLookupCommand("docker")).Return("", fmt.Errorf("exit status 127"))
+		r.On("Run", context.Background(), command.UnsafeBinaryLookupCommand("lscpu")).Return("", fmt.Errorf("exit status 127"))
+
+		ts := health.ProbeHealthStatus(context.Background(), r)
+
+		for _, dep := range ts.Dependencies {
+			if dep.Error != nil {
+				assert.Contains(t, dep.Error.Error(), fmt.Sprintf("%q", dep.Dependency.Binary))
+			}
+		}
+	})
+
 	t.Run("succeeds when no remoteproc support", func(t *testing.T) {
 		r := &runner.Mock{}
 		r.On("Run", context.Background(), mock.AnythingOfType("string")).Return("", fmt.Errorf("no such directory"))

--- a/internal/health/status_test.go
+++ b/internal/health/status_test.go
@@ -19,6 +19,7 @@ func TestProbeHealthStatus(t *testing.T) {
 		r.On("Run", context.Background(), command.WrapInLoginShell("ls /sys/class/remoteproc")).Return("remoteproc0\nremoteproc1", nil)
 		r.On("Run", context.Background(), command.WrapInLoginShell("cat /sys/class/remoteproc/*/name")).Return("foo\nbar", nil)
 		r.On("Run", context.Background(), mock.AnythingOfType("string")).Maybe().Return("", fmt.Errorf("not found"))
+		r.On("BinaryExists", mock.AnythingOfType("string")).Maybe().Return(fmt.Errorf("not found"))
 
 		ts := health.ProbeHealthStatus(context.Background(), r)
 
@@ -30,8 +31,8 @@ func TestProbeHealthStatus(t *testing.T) {
 	t.Run("reports binary name when lookup fails", func(t *testing.T) {
 		r := &runner.Mock{}
 		r.On("Run", context.Background(), command.WrapInLoginShell("ls /sys/class/remoteproc")).Return("", fmt.Errorf("not found"))
-		r.On("Run", context.Background(), command.UnsafeBinaryLookupCommand("docker")).Return("", fmt.Errorf("exit status 127"))
-		r.On("Run", context.Background(), command.UnsafeBinaryLookupCommand("lscpu")).Return("", fmt.Errorf("exit status 127"))
+		r.On("BinaryExists", "docker").Return(fmt.Errorf(`"docker" not found in $PATH`))
+		r.On("BinaryExists", "lscpu").Return(fmt.Errorf(`"lscpu" not found in $PATH`))
 
 		ts := health.ProbeHealthStatus(context.Background(), r)
 
@@ -45,6 +46,7 @@ func TestProbeHealthStatus(t *testing.T) {
 	t.Run("succeeds when no remoteproc support", func(t *testing.T) {
 		r := &runner.Mock{}
 		r.On("Run", context.Background(), mock.AnythingOfType("string")).Return("", fmt.Errorf("no such directory"))
+		r.On("BinaryExists", mock.AnythingOfType("string")).Maybe().Return(fmt.Errorf("not found"))
 
 		ts := health.ProbeHealthStatus(context.Background(), r)
 

--- a/internal/runner/local.go
+++ b/internal/runner/local.go
@@ -23,7 +23,7 @@ func (r *Local) RunWithStdin(ctx context.Context, cmdStr string, stdin []byte) (
 	return r.exec(ctx, cmdStr, stdin)
 }
 
-func (r *Local) BinaryExists(bin string) error {
+func (r *Local) BinaryExists(_ context.Context, bin string) error {
 	if _, err := exec.LookPath(bin); err != nil {
 		return fmt.Errorf("%q not found in $PATH", bin)
 	}

--- a/internal/runner/local.go
+++ b/internal/runner/local.go
@@ -23,6 +23,13 @@ func (r *Local) RunWithStdin(ctx context.Context, cmdStr string, stdin []byte) (
 	return r.exec(ctx, cmdStr, stdin)
 }
 
+func (r *Local) BinaryExists(bin string) error {
+	if _, err := exec.LookPath(bin); err != nil {
+		return fmt.Errorf("%q not found in $PATH", bin)
+	}
+	return nil
+}
+
 func (r *Local) exec(ctx context.Context, cmdStr string, stdin []byte) (string, error) {
 	args, err := shlex.Split(cmdStr)
 	if err != nil {

--- a/internal/runner/local_test.go
+++ b/internal/runner/local_test.go
@@ -47,7 +47,7 @@ func TestLocal(t *testing.T) {
 		t.Run("returns nil for a binary that exists", func(t *testing.T) {
 			r := runner.NewLocal()
 
-			err := r.BinaryExists("ls")
+			err := r.BinaryExists(context.Background(), "ls")
 
 			assert.NoError(t, err)
 		})
@@ -55,7 +55,7 @@ func TestLocal(t *testing.T) {
 		t.Run("returns error mentioning binary name when not found", func(t *testing.T) {
 			r := runner.NewLocal()
 
-			err := r.BinaryExists("definitely-not-a-real-binary")
+			err := r.BinaryExists(context.Background(), "definitely-not-a-real-binary")
 
 			assert.EqualError(t, err, `"definitely-not-a-real-binary" not found in $PATH`)
 		})

--- a/internal/runner/local_test.go
+++ b/internal/runner/local_test.go
@@ -40,7 +40,6 @@ func TestLocal(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Equal(t, "hello && echo world\n", got)
 		})
-
 	})
 
 	t.Run("BinaryExists", func(t *testing.T) {

--- a/internal/runner/local_test.go
+++ b/internal/runner/local_test.go
@@ -40,3 +40,19 @@ func TestLocal(t *testing.T) {
 		assert.Equal(t, "hello && echo world\n", got)
 	})
 }
+
+func TestLocalBinaryExists(t *testing.T) {
+	r := runner.NewLocal()
+
+	t.Run("returns nil for a binary that exists", func(t *testing.T) {
+		err := r.BinaryExists("sh")
+
+		assert.NoError(t, err)
+	})
+
+	t.Run("returns error mentioning binary name when not found", func(t *testing.T) {
+		err := r.BinaryExists("definitely-not-a-real-binary")
+
+		assert.EqualError(t, err, `"definitely-not-a-real-binary" not found in $PATH`)
+	})
+}

--- a/internal/runner/local_test.go
+++ b/internal/runner/local_test.go
@@ -11,48 +11,53 @@ import (
 )
 
 func TestLocal(t *testing.T) {
-	t.Run("cancelled context returns timeout error", func(t *testing.T) {
-		ctx, cancel := context.WithCancel(context.Background())
-		cancel()
-		r := runner.NewLocal()
+	t.Run("Run", func(t *testing.T) {
+		t.Run("cancelled context returns timeout error", func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+			r := runner.NewLocal()
 
-		_, err := r.Run(ctx, "sleep 10")
+			_, err := r.Run(ctx, "sleep 10")
 
-		require.ErrorIs(t, err, runner.ErrTimeout)
+			require.ErrorIs(t, err, runner.ErrTimeout)
+		})
+
+		t.Run("expired deadline returns timeout error", func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
+			defer cancel()
+			time.Sleep(5 * time.Millisecond)
+			r := runner.NewLocal()
+
+			_, err := r.Run(ctx, "sleep 10")
+
+			require.ErrorIs(t, err, runner.ErrTimeout)
+		})
+
+		t.Run("executes binary directly without shell interpretation", func(t *testing.T) {
+			r := runner.NewLocal()
+			got, err := r.Run(context.Background(), "echo hello && echo world")
+
+			assert.NoError(t, err)
+			assert.Equal(t, "hello && echo world\n", got)
+		})
+
 	})
 
-	t.Run("expired deadline returns timeout error", func(t *testing.T) {
-		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
-		defer cancel()
-		time.Sleep(5 * time.Millisecond)
-		r := runner.NewLocal()
+	t.Run("BinaryExists", func(t *testing.T) {
+		t.Run("returns nil for a binary that exists", func(t *testing.T) {
+			r := runner.NewLocal()
 
-		_, err := r.Run(ctx, "sleep 10")
+			err := r.BinaryExists("sh")
 
-		require.ErrorIs(t, err, runner.ErrTimeout)
-	})
+			assert.NoError(t, err)
+		})
 
-	t.Run("executes binary directly without shell interpretation", func(t *testing.T) {
-		r := runner.NewLocal()
-		got, err := r.Run(context.Background(), "echo hello && echo world")
+		t.Run("returns error mentioning binary name when not found", func(t *testing.T) {
+			r := runner.NewLocal()
 
-		assert.NoError(t, err)
-		assert.Equal(t, "hello && echo world\n", got)
-	})
-}
+			err := r.BinaryExists("definitely-not-a-real-binary")
 
-func TestLocalBinaryExists(t *testing.T) {
-	r := runner.NewLocal()
-
-	t.Run("returns nil for a binary that exists", func(t *testing.T) {
-		err := r.BinaryExists("sh")
-
-		assert.NoError(t, err)
-	})
-
-	t.Run("returns error mentioning binary name when not found", func(t *testing.T) {
-		err := r.BinaryExists("definitely-not-a-real-binary")
-
-		assert.EqualError(t, err, `"definitely-not-a-real-binary" not found in $PATH`)
+			assert.EqualError(t, err, `"definitely-not-a-real-binary" not found in $PATH`)
+		})
 	})
 }

--- a/internal/runner/local_test.go
+++ b/internal/runner/local_test.go
@@ -47,7 +47,7 @@ func TestLocal(t *testing.T) {
 		t.Run("returns nil for a binary that exists", func(t *testing.T) {
 			r := runner.NewLocal()
 
-			err := r.BinaryExists("sh")
+			err := r.BinaryExists("ls")
 
 			assert.NoError(t, err)
 		})

--- a/internal/runner/mock.go
+++ b/internal/runner/mock.go
@@ -30,3 +30,8 @@ func (m *Mock) RunWithStdinAndArgs(ctx context.Context, command string, stdin []
 	args := m.Called(callArgs...)
 	return args.String(0), args.Error(1)
 }
+
+func (m *Mock) BinaryExists(bin string) error {
+	args := m.Called(bin)
+	return args.Error(0)
+}

--- a/internal/runner/mock.go
+++ b/internal/runner/mock.go
@@ -31,7 +31,7 @@ func (m *Mock) RunWithStdinAndArgs(ctx context.Context, command string, stdin []
 	return args.String(0), args.Error(1)
 }
 
-func (m *Mock) BinaryExists(bin string) error {
-	args := m.Called(bin)
+func (m *Mock) BinaryExists(ctx context.Context, bin string) error {
+	args := m.Called(ctx, bin)
 	return args.Error(0)
 }

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -13,7 +13,7 @@ var ErrTimeout = errors.New("timed out")
 type Runner interface {
 	Run(ctx context.Context, command string) (string, error)
 	RunWithStdin(ctx context.Context, command string, stdin []byte) (string, error)
-	BinaryExists(bin string) error
+	BinaryExists(ctx context.Context, bin string) error
 }
 
 func For(dest ssh.Destination, opts SSHOptions) Runner {

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -13,6 +13,7 @@ var ErrTimeout = errors.New("timed out")
 type Runner interface {
 	Run(ctx context.Context, command string) (string, error)
 	RunWithStdin(ctx context.Context, command string, stdin []byte) (string, error)
+	BinaryExists(bin string) error
 }
 
 func For(dest ssh.Destination, opts SSHOptions) Runner {

--- a/internal/runner/ssh.go
+++ b/internal/runner/ssh.go
@@ -57,7 +57,11 @@ func (r *SSH) RunWithStdinAndArgs(ctx context.Context, cmdStr string, stdin []by
 }
 
 func (r *SSH) BinaryExists(ctx context.Context, bin string) error {
-	if _, err := r.Run(ctx, command.UnsafeBinaryLookupCommand(bin)); err != nil {
+	cmd, err := command.BinaryLookupCommand(bin)
+	if err != nil {
+		return err
+	}
+	if _, err := r.Run(ctx, cmd); err != nil {
 		return fmt.Errorf("%q not found on remote target's $PATH", bin)
 	}
 	return nil

--- a/internal/runner/ssh.go
+++ b/internal/runner/ssh.go
@@ -56,8 +56,8 @@ func (r *SSH) RunWithStdinAndArgs(ctx context.Context, cmdStr string, stdin []by
 	return out, err
 }
 
-func (r *SSH) BinaryExists(bin string) error {
-	if _, err := r.Run(context.Background(), command.UnsafeBinaryLookupCommand(bin)); err != nil {
+func (r *SSH) BinaryExists(ctx context.Context, bin string) error {
+	if _, err := r.Run(ctx, command.UnsafeBinaryLookupCommand(bin)); err != nil {
 		return fmt.Errorf("%q not found on remote target's $PATH", bin)
 	}
 	return nil

--- a/internal/runner/ssh.go
+++ b/internal/runner/ssh.go
@@ -2,8 +2,10 @@ package runner
 
 import (
 	"context"
+	"fmt"
 	"runtime"
 
+	"github.com/arm/topo/internal/command"
 	"github.com/arm/topo/internal/ssh"
 )
 
@@ -52,6 +54,13 @@ func (r *SSH) RunWithStdinAndArgs(ctx context.Context, cmdStr string, stdin []by
 		return "", ErrTimeout
 	}
 	return out, err
+}
+
+func (r *SSH) BinaryExists(bin string) error {
+	if _, err := r.Run(context.Background(), command.UnsafeBinaryLookupCommand(bin)); err != nil {
+		return fmt.Errorf("%q not found on remote target's $PATH", bin)
+	}
+	return nil
 }
 
 func (r *SSH) exec(ctx context.Context, cmdStr string, stdin []byte, extraSSHArgs []string) (string, error) {

--- a/internal/target/hardware_probe.go
+++ b/internal/target/hardware_probe.go
@@ -81,7 +81,7 @@ func (p *HardwareProbe) ProbeRemoteproc(ctx context.Context) ([]RemoteprocCPU, e
 }
 
 func (p *HardwareProbe) collectCPUInfo(ctx context.Context) ([]HostProcessor, error) {
-	if _, err := p.runner.Run(ctx, command.UnsafeBinaryLookupCommand("lscpu")); err != nil {
+	if err := p.runner.BinaryExists("lscpu"); err != nil {
 		return nil, err
 	}
 

--- a/internal/target/hardware_probe.go
+++ b/internal/target/hardware_probe.go
@@ -81,7 +81,7 @@ func (p *HardwareProbe) ProbeRemoteproc(ctx context.Context) ([]RemoteprocCPU, e
 }
 
 func (p *HardwareProbe) collectCPUInfo(ctx context.Context) ([]HostProcessor, error) {
-	if err := p.runner.BinaryExists("lscpu"); err != nil {
+	if err := p.runner.BinaryExists(ctx, "lscpu"); err != nil {
 		return nil, err
 	}
 

--- a/internal/target/hardware_probe_test.go
+++ b/internal/target/hardware_probe_test.go
@@ -17,7 +17,7 @@ func TestHardwareProbe(t *testing.T) {
 	t.Run("Probe", func(t *testing.T) {
 		t.Run("returns model name and features", func(t *testing.T) {
 			r := &runner.Mock{}
-			r.On("Run", context.Background(), command.WrapInLoginShell("command -v lscpu")).Return("/usr/bin/lscpu", nil)
+			r.On("BinaryExists", "lscpu").Return(nil)
 			r.On("Run", context.Background(), command.WrapInLoginShell("lscpu --json")).Return(testutil.LsCpuOutputRaw, nil)
 			r.On("Run", context.Background(), command.WrapInLoginShell("ls /sys/class/remoteproc")).Return("", nil)
 			r.On("Run", context.Background(), command.WrapInLoginShell("cat /proc/meminfo")).Return("MemTotal:       16384000 kB", nil)
@@ -42,18 +42,18 @@ func TestHardwareProbe(t *testing.T) {
 
 		t.Run("returns error when lscpu not found", func(t *testing.T) {
 			r := &runner.Mock{}
-			r.On("Run", context.Background(), command.WrapInLoginShell("command -v lscpu")).Return("", fmt.Errorf("%q executable file not found in $PATH", "lscpu"))
+			r.On("BinaryExists", "lscpu").Return(fmt.Errorf(`"lscpu" not found in $PATH`))
 			probe := target.NewHardwareProbe(r)
 
 			_, err := probe.Probe(context.Background())
 
-			assert.ErrorContains(t, err, `"lscpu" executable file not found in $PATH`)
+			assert.ErrorContains(t, err, `"lscpu" not found in $PATH`)
 			r.AssertExpectations(t)
 		})
 
 		t.Run("returns error when lscpu output is invalid JSON", func(t *testing.T) {
 			r := &runner.Mock{}
-			r.On("Run", context.Background(), command.WrapInLoginShell("command -v lscpu")).Return("/usr/bin/lscpu", nil)
+			r.On("BinaryExists", "lscpu").Return(nil)
 			r.On("Run", context.Background(), command.WrapInLoginShell("lscpu --json")).Return("not json", nil)
 			probe := target.NewHardwareProbe(r)
 

--- a/internal/target/hardware_probe_test.go
+++ b/internal/target/hardware_probe_test.go
@@ -17,7 +17,7 @@ func TestHardwareProbe(t *testing.T) {
 	t.Run("Probe", func(t *testing.T) {
 		t.Run("returns model name and features", func(t *testing.T) {
 			r := &runner.Mock{}
-			r.On("BinaryExists", "lscpu").Return(nil)
+			r.On("BinaryExists", context.Background(), "lscpu").Return(nil)
 			r.On("Run", context.Background(), command.WrapInLoginShell("lscpu --json")).Return(testutil.LsCpuOutputRaw, nil)
 			r.On("Run", context.Background(), command.WrapInLoginShell("ls /sys/class/remoteproc")).Return("", nil)
 			r.On("Run", context.Background(), command.WrapInLoginShell("cat /proc/meminfo")).Return("MemTotal:       16384000 kB", nil)
@@ -42,7 +42,7 @@ func TestHardwareProbe(t *testing.T) {
 
 		t.Run("returns error when lscpu not found", func(t *testing.T) {
 			r := &runner.Mock{}
-			r.On("BinaryExists", "lscpu").Return(fmt.Errorf(`"lscpu" not found in $PATH`))
+			r.On("BinaryExists", context.Background(), "lscpu").Return(fmt.Errorf(`"lscpu" not found in $PATH`))
 			probe := target.NewHardwareProbe(r)
 
 			_, err := probe.Probe(context.Background())
@@ -53,7 +53,7 @@ func TestHardwareProbe(t *testing.T) {
 
 		t.Run("returns error when lscpu output is invalid JSON", func(t *testing.T) {
 			r := &runner.Mock{}
-			r.On("BinaryExists", "lscpu").Return(nil)
+			r.On("BinaryExists", context.Background(), "lscpu").Return(nil)
 			r.On("Run", context.Background(), command.WrapInLoginShell("lscpu --json")).Return("not json", nil)
 			probe := target.NewHardwareProbe(r)
 


### PR DESCRIPTION
## Changes

- Add `BinaryExists(bin string) error` to the `Runner` interface, with implementation-specific error messages: `Local` uses `exec.LookPath` and reports "not found in $PATH", `SSH` reports "not found on remote target's $PATH"
- Replace inline `command -v` binary lookups in `health/status.go` and `target/hardware_probe.go` with `Runner.BinaryExists`
- Migrate `CheckHost` to use the runner instead of standalone `BinaryExistsLocally`/`CommandSuccessfulLocally` helpers (now deleted)

### Before

```
❱ topo health --target localhost
...
Target
------
Container Engine: ❌ (local command failed: exit status 127 | stderr: )
Hardware Info: ❌ (local command failed: exit status 127 | stderr: )
...
```

### After

```
❱ topo health --target localhost
...
Target
------
Container Engine: ❌ ("docker" not found in $PATH)
Hardware Info: ❌ ("lscpu" not found in $PATH)
...
```