### PR TITLE
refactor: move internal setupkeys operations under operations/

### DIFF
--- a/internal/setupkeys/operations/pub_key_transfer.go
+++ b/internal/setupkeys/operations/pub_key_transfer.go
@@ -1,4 +1,4 @@
-package pubkeytransfer
+package operations
 
 import (
 	"context"

--- a/internal/setupkeys/operations/pub_key_transfer_test.go
+++ b/internal/setupkeys/operations/pub_key_transfer_test.go
@@ -1,4 +1,4 @@
-package pubkeytransfer_test
+package operations_test
 
 import (
 	"bytes"
@@ -6,9 +6,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/arm/topo/internal/deploy/docker/testutil"
 	"github.com/arm/topo/internal/runner"
-	"github.com/arm/topo/internal/setupkeys/pubkeytransfer"
-	"github.com/arm/topo/internal/testutil"
+	"github.com/arm/topo/internal/setupkeys/operations"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
@@ -33,7 +33,7 @@ func TestPubKeyTransfer(t *testing.T) {
 				"PreferredAuthentications=password",
 			).Return("ssh invoked", nil)
 
-			op := pubkeytransfer.NewPubKeyTransfer(privKeyPath, r)
+			op := operations.NewPubKeyTransfer(privKeyPath, r)
 
 			var buf bytes.Buffer
 			require.NoError(t, op.Run(&buf))

--- a/internal/setupkeys/operations/ssh_key_gen.go
+++ b/internal/setupkeys/operations/ssh_key_gen.go
@@ -1,4 +1,4 @@
-package sshkeygen
+package operations
 
 import (
 	"fmt"

--- a/internal/setupkeys/operations/ssh_key_gen_test.go
+++ b/internal/setupkeys/operations/ssh_key_gen_test.go
@@ -1,4 +1,4 @@
-package sshkeygen_test
+package operations_test
 
 import (
 	"bytes"
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/arm/topo/internal/setupkeys/sshkeygen"
+	"github.com/arm/topo/internal/setupkeys/operations"
 	"github.com/arm/topo/internal/ssh"
 	"github.com/arm/topo/internal/testutil"
 	"github.com/stretchr/testify/require"
@@ -15,12 +15,12 @@ import (
 
 func TestSSHKeyGenRun(t *testing.T) {
 	keyPath := filepath.Join(t.TempDir(), "keys", "id_ed25519_test")
-	opts := sshkeygen.SSHKeyGenOptions{
+	opts := operations.SSHKeyGenOptions{
 		WithMockKeyGen: func(keyType, keyPath, targetHost string) *exec.Cmd {
 			return testutil.CmdWithOutput("ssh-keygen invoked", 0)
 		},
 	}
-	op := sshkeygen.NewSSHKeyGen("Generate SSH key pair", ssh.NewDestination("user@example.com"), "ed25519", keyPath, opts)
+	op := operations.NewSSHKeyGen("Generate SSH key pair", ssh.NewDestination("user@example.com"), "ed25519", keyPath, opts)
 	var buf bytes.Buffer
 	require.NoError(t, op.Run(&buf))
 	require.Contains(t, buf.String(), "ssh-keygen invoked")

--- a/internal/setupkeys/setup_keys.go
+++ b/internal/setupkeys/setup_keys.go
@@ -7,8 +7,7 @@ import (
 
 	"github.com/arm/topo/internal/operation"
 	"github.com/arm/topo/internal/runner"
-	"github.com/arm/topo/internal/setupkeys/pubkeytransfer"
-	"github.com/arm/topo/internal/setupkeys/sshkeygen"
+	"github.com/arm/topo/internal/setupkeys/operations"
 	"github.com/arm/topo/internal/ssh"
 )
 
@@ -22,8 +21,8 @@ const (
 func NewKeySetup(dest ssh.Destination, privKeyPath string, keyType KeyType) (operation.Sequence, error) {
 	sshRunner := runner.NewSSH(dest, runner.SSHOptions{})
 	ops := []operation.Operation{
-		sshkeygen.NewSSHKeyGen("Generate SSH key pair for target", dest, string(keyType), privKeyPath, sshkeygen.SSHKeyGenOptions{}),
-		pubkeytransfer.NewPubKeyTransfer(privKeyPath, sshRunner),
+		operations.NewSSHKeyGen("Generate SSH key pair for target", dest, string(keyType), privKeyPath, operations.SSHKeyGenOptions{}),
+		operations.NewPubKeyTransfer(privKeyPath, sshRunner),
 	}
 	return operation.NewSequence(ops...), nil
 }

--- a/internal/setupkeys/setup_keys_test.go
+++ b/internal/setupkeys/setup_keys_test.go
@@ -5,8 +5,7 @@ import (
 	"testing"
 
 	"github.com/arm/topo/internal/setupkeys"
-	"github.com/arm/topo/internal/setupkeys/pubkeytransfer"
-	"github.com/arm/topo/internal/setupkeys/sshkeygen"
+	"github.com/arm/topo/internal/setupkeys/operations"
 	"github.com/arm/topo/internal/ssh"
 	"github.com/arm/topo/internal/testutil"
 	"github.com/stretchr/testify/require"
@@ -19,8 +18,8 @@ func TestNewKeySetup(t *testing.T) {
 
 			require.NoError(t, err)
 			require.Len(t, got, 2)
-			require.IsType(t, &sshkeygen.SSHKeyGen{}, got[0])
-			require.IsType(t, &pubkeytransfer.PubKeyTransfer{}, got[1])
+			require.IsType(t, &operations.SSHKeyGen{}, got[0])
+			require.IsType(t, &operations.PubKeyTransfer{}, got[1])
 		})
 
 		t.Run("ed25519 with custom private key path", func(t *testing.T) {
@@ -32,8 +31,8 @@ func TestNewKeySetup(t *testing.T) {
 
 			require.NoError(t, err)
 			require.Len(t, got, 2)
-			require.IsType(t, &sshkeygen.SSHKeyGen{}, got[0])
-			require.IsType(t, &pubkeytransfer.PubKeyTransfer{}, got[1])
+			require.IsType(t, &operations.SSHKeyGen{}, got[0])
+			require.IsType(t, &operations.PubKeyTransfer{}, got[1])
 		})
 
 		t.Run("rsa with custom private key path", func(t *testing.T) {
@@ -45,8 +44,8 @@ func TestNewKeySetup(t *testing.T) {
 
 			require.NoError(t, err)
 			require.Len(t, got, 2)
-			require.IsType(t, &sshkeygen.SSHKeyGen{}, got[0])
-			require.IsType(t, &pubkeytransfer.PubKeyTransfer{}, got[1])
+			require.IsType(t, &operations.SSHKeyGen{}, got[0])
+			require.IsType(t, &operations.PubKeyTransfer{}, got[1])
 		})
 	})
 }


### PR DESCRIPTION
## Changes

- Conglomerates all internal setup keys operations (key generation + key transfer) under the setupkeys' operations package
