### PR TITLE
feat: migrate-ssh command

### DIFF
--- a/cmd/topo/migrate_ssh.go
+++ b/cmd/topo/migrate_ssh.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"github.com/arm/topo/internal/ssh"
+	"github.com/spf13/cobra"
+)
+
+var migrateSSHCmd = &cobra.Command{
+	Use:    "migrate-ssh",
+	Short:  "Migrate from the legacy multi-file SSH config to the new single-file format",
+	Hidden: true,
+	Args:   cobra.ExactArgs(0),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+		return ssh.MigrateLegacyTopoConfig()
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(migrateSSHCmd)
+}

--- a/cmd/topo/setup_keys.go
+++ b/cmd/topo/setup_keys.go
@@ -59,12 +59,12 @@ var setupKeysCmd = &cobra.Command{
 			return err
 		}
 
-		directives := []ssh.ConfigDirective{
-			ssh.NewConfigDirectivePath("IdentityFile", privateKeyPath),
-			ssh.NewConfigDirective("IdentitiesOnly", "yes"),
+		modifiers := []ssh.ConfigDirectiveModifier{
+			ssh.NewEnsureConfigDirectivePath("IdentityFile", privateKeyPath),
+			ssh.NewEnsureConfigDirective("IdentitiesOnly", "yes"),
 		}
 
-		return ssh.CreateOrModifyConfigFile(dest, directives)
+		return ssh.CreateOrModifyConfigFile(dest, modifiers)
 	},
 }
 

--- a/cmd/topo/setup_keys.go
+++ b/cmd/topo/setup_keys.go
@@ -26,8 +26,10 @@ var setupKeysCmd = &cobra.Command{
 			return err
 		}
 
-		if err := ssh.CheckForLegacyTopoConfigEntries(); err != nil {
+		if exists, err := ssh.LegacyTopoConfigDirectoryExists(); err != nil {
 			return err
+		} else if exists {
+			return fmt.Errorf("legacy topo ssh config entries found; run 'topo migrate-ssh' to migrate to the new single-file format")
 		}
 
 		dest := ssh.NewDestination(targetArg)

--- a/internal/ssh/config_file.go
+++ b/internal/ssh/config_file.go
@@ -11,8 +11,6 @@ import (
 	sshconfig "github.com/kevinburke/ssh_config"
 )
 
-var errLegacyConfigEntries = fmt.Errorf("legacy topo ssh config entries found; run 'topo migrate-ssh' to migrate to the new single-file format")
-
 const (
 	defaultConfigFileName = "config"
 	topoConfigFileName    = "topo_config"
@@ -193,25 +191,25 @@ func CreateOrModifyConfigFile(dest Destination, modifiers []ConfigDirectiveModif
 	})
 }
 
-func CheckForLegacyTopoConfigEntries() error {
+func LegacyTopoConfigDirectoryExists() (bool, error) {
 	topoConfigPath, err := getConfigFilePath(topoConfigFileName)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	info, err := os.Stat(topoConfigPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil
+			return false, nil
 		}
-		return fmt.Errorf("failed to check for legacy topo ssh config file: %w", err)
+		return false, fmt.Errorf("failed to check for legacy topo ssh config file: %w", err)
 	}
 
 	if info.IsDir() {
-		return errLegacyConfigEntries
+		return true, nil
 	}
 
-	return nil
+	return false, nil
 }
 
 func MigrateLegacyTopoConfig() error {
@@ -220,11 +218,10 @@ func MigrateLegacyTopoConfig() error {
 		return err
 	}
 
-	if err := CheckForLegacyTopoConfigEntries(); err != errLegacyConfigEntries {
-		if err == nil {
-			return fmt.Errorf("legacy topo ssh config directory not found at %s; nothing to migrate", legacyDir)
-		}
+	if exists, err := LegacyTopoConfigDirectoryExists(); err != nil {
 		return err
+	} else if !exists {
+		return fmt.Errorf("legacy topo ssh config directory not found at %s; nothing to migrate", legacyDir)
 	}
 
 	legacyGlob := filepath.Join(legacyDir, "*.conf")

--- a/internal/ssh/config_file.go
+++ b/internal/ssh/config_file.go
@@ -125,7 +125,7 @@ func findOrCreateHostBlock(cfg *sshconfig.Config, alias string) (*sshconfig.Host
 
 func directiveMatches(node sshconfig.Node, directive sshconfig.KV) bool {
 	if kv, ok := node.(*sshconfig.KV); ok {
-		return kv.Key == directive.Key && kv.Value == directive.Value
+		return kv.Key == directive.Key
 	}
 
 	if include, ok := node.(*sshconfig.Include); ok {

--- a/internal/ssh/config_file.go
+++ b/internal/ssh/config_file.go
@@ -11,19 +11,64 @@ import (
 	sshconfig "github.com/kevinburke/ssh_config"
 )
 
-type ConfigDirective = sshconfig.KV
+var errLegacyConfigEntries = fmt.Errorf("legacy topo ssh config entries found; run 'topo migrate-ssh' to migrate to the new single-file format")
 
-func NewConfigDirectivePath(key, path string) ConfigDirective {
-	return ConfigDirective{
-		Key:   key,
-		Value: filepath.ToSlash(path),
+type ConfigDirectiveModifier interface {
+	Apply(host *sshconfig.Host)
+}
+
+type EnsureConfigDirective struct {
+	sshconfig.KV
+}
+
+func NewEnsureConfigDirective(key, value string) EnsureConfigDirective {
+	return EnsureConfigDirective{
+		KV: sshconfig.KV{
+			Key:   key,
+			Value: value,
+		},
 	}
 }
 
-func NewConfigDirective(key, value string) ConfigDirective {
-	return ConfigDirective{
-		Key:   key,
-		Value: value,
+func NewEnsureConfigDirectivePath(key, path string) EnsureConfigDirective {
+	return EnsureConfigDirective{
+		KV: sshconfig.KV{
+			Key:   key,
+			Value: filepath.ToSlash(path),
+		},
+	}
+}
+
+func (d EnsureConfigDirective) Apply(host *sshconfig.Host) {
+	for i, node := range host.Nodes {
+		if directiveMatches(node, d.KV) {
+			host.Nodes[i] = &d
+			return
+		}
+	}
+
+	host.Nodes = append(host.Nodes, &d)
+}
+
+type RemoveConfigDirective struct {
+	sshconfig.KV
+}
+
+func NewRemoveConfigDirectivePath(key, value string) RemoveConfigDirective {
+	return RemoveConfigDirective{
+		KV: sshconfig.KV{
+			Key:   key,
+			Value: filepath.ToSlash(value),
+		},
+	}
+}
+
+func (d RemoveConfigDirective) Apply(host *sshconfig.Host) {
+	for i, node := range host.Nodes {
+		if directiveMatches(node, d.KV) {
+			host.Nodes = append(host.Nodes[:i], host.Nodes[i+1:]...)
+			return
+		}
 	}
 }
 
@@ -78,25 +123,19 @@ func findOrCreateHostBlock(cfg *sshconfig.Config, alias string) (*sshconfig.Host
 	return newHost, nil
 }
 
-func addOrReplaceDirective(host *sshconfig.Host, directive ConfigDirective) {
-	for i, node := range host.Nodes {
-		if kv, ok := node.(*sshconfig.KV); ok && kv.Key == directive.Key {
-			host.Nodes[i] = &directive
-			return
-		}
-
-		if include, ok := node.(*sshconfig.Include); ok && include.String() == directive.String() {
-			return
-		}
+func directiveMatches(node sshconfig.Node, directive sshconfig.KV) bool {
+	if kv, ok := node.(*sshconfig.KV); ok {
+		return kv.Key == directive.Key && kv.Value == directive.Value
 	}
 
-	host.Nodes = append(host.Nodes, &sshconfig.KV{
-		Key:   directive.Key,
-		Value: directive.Value,
-	})
+	if include, ok := node.(*sshconfig.Include); ok {
+		return include.String() == directive.String()
+	}
+
+	return false
 }
 
-func updateConfigFile(path string, host string, directives []ConfigDirective) error {
+func updateConfigFile(path string, host string, modifiers []ConfigDirectiveModifier) error {
 	cfg, err := readConfigFile(path)
 	if err != nil {
 		return err
@@ -107,8 +146,8 @@ func updateConfigFile(path string, host string, directives []ConfigDirective) er
 		return fmt.Errorf("failed to find or create host block: %w", err)
 	}
 
-	for _, directive := range directives {
-		addOrReplaceDirective(hostBlock, directive)
+	for _, modifier := range modifiers {
+		modifier.Apply(hostBlock)
 	}
 
 	cfgBytes, err := cfg.MarshalText()
@@ -122,20 +161,20 @@ func updateConfigFile(path string, host string, directives []ConfigDirective) er
 	return nil
 }
 
-func CreateOrModifyConfigFile(dest Destination, directives []ConfigDirective) error {
+func CreateOrModifyConfigFile(dest Destination, modifiers []ConfigDirectiveModifier) error {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return fmt.Errorf("failed to determine home directory for SSH config: %w", err)
 	}
 
 	topoConfigPath := filepath.Join(home, ".ssh", "topo_config")
-	if err := updateConfigFile(topoConfigPath, dest.Host, directives); err != nil {
+	if err := updateConfigFile(topoConfigPath, dest.Host, modifiers); err != nil {
 		return err
 	}
 
 	defaultConfigPath := filepath.Join(home, ".ssh", "config")
-	return updateConfigFile(defaultConfigPath, "", []ConfigDirective{
-		NewConfigDirectivePath("Include", topoConfigPath),
+	return updateConfigFile(defaultConfigPath, "", []ConfigDirectiveModifier{
+		NewEnsureConfigDirectivePath("Include", topoConfigPath),
 	})
 }
 
@@ -155,8 +194,62 @@ func CheckForLegacyTopoConfigEntries() error {
 	}
 
 	if info.IsDir() {
-		return fmt.Errorf("legacy topo ssh config found at %s; please delete the directory and the corresponding Include directive from your ssh config to proceed. note: you will need to re-run topo setup-keys for any affected targets", topoConfigPath)
+		return errLegacyConfigEntries
 	}
 
 	return nil
+}
+
+func MigrateLegacyTopoConfig() error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("failed to determine home directory for SSH config: %w", err)
+	}
+
+	legacyDir := filepath.Join(home, ".ssh", "topo_config")
+	if err := CheckForLegacyTopoConfigEntries(); err != errLegacyConfigEntries {
+		if err == nil {
+			return fmt.Errorf("legacy topo ssh config directory not found at %s; nothing to migrate", legacyDir)
+		}
+		return err
+	}
+
+	legacyGlob := filepath.Join(legacyDir, "*.conf")
+	confFiles, err := filepath.Glob(legacyGlob)
+	if err != nil {
+		return fmt.Errorf("failed to list config files in %s: %w", legacyDir, err)
+	}
+
+	if len(confFiles) == 0 {
+		return fmt.Errorf("no .conf files found in %s; nothing to migrate", legacyDir)
+	}
+
+	var combined []byte
+	for _, confFile := range confFiles {
+		content, err := os.ReadFile(confFile)
+		if err != nil {
+			return fmt.Errorf("failed to read %s: %w", confFile, err)
+		}
+		combined = append(combined, content...)
+	}
+
+	unifiedPath := legacyDir + ".new"
+	// #nosec G703 -- ssh config is always stored in the user's home directory
+	if err := os.WriteFile(unifiedPath, combined, 0o600); err != nil {
+		return fmt.Errorf("failed to write unified config to %s: %w", unifiedPath, err)
+	}
+
+	if err := os.RemoveAll(legacyDir); err != nil {
+		return fmt.Errorf("failed to remove legacy config directory %s: %w", legacyDir, err)
+	}
+
+	if err := os.Rename(unifiedPath, legacyDir); err != nil {
+		return fmt.Errorf("failed to move migrated config to %s: %w", legacyDir, err)
+	}
+
+	defaultConfigPath := filepath.Join(home, ".ssh", "config")
+	return updateConfigFile(defaultConfigPath, "", []ConfigDirectiveModifier{
+		NewRemoveConfigDirectivePath("Include", legacyGlob),
+		NewEnsureConfigDirectivePath("Include", legacyDir),
+	})
 }

--- a/internal/ssh/config_file.go
+++ b/internal/ssh/config_file.go
@@ -230,10 +230,6 @@ func MigrateLegacyTopoConfig() error {
 		return fmt.Errorf("failed to list config files in %s: %w", legacyDir, err)
 	}
 
-	if len(confFiles) == 0 {
-		return fmt.Errorf("no .conf files found in %s; nothing to migrate", legacyDir)
-	}
-
 	var combined []byte
 	for _, confFile := range confFiles {
 		content, err := os.ReadFile(confFile)

--- a/internal/ssh/config_file.go
+++ b/internal/ssh/config_file.go
@@ -13,6 +13,11 @@ import (
 
 var errLegacyConfigEntries = fmt.Errorf("legacy topo ssh config entries found; run 'topo migrate-ssh' to migrate to the new single-file format")
 
+const (
+	defaultConfigFileName = "config"
+	topoConfigFileName    = "topo_config"
+)
+
 type ConfigDirectiveModifier interface {
 	Apply(host *sshconfig.Host)
 }
@@ -161,30 +166,39 @@ func updateConfigFile(path string, host string, modifiers []ConfigDirectiveModif
 	return nil
 }
 
-func CreateOrModifyConfigFile(dest Destination, modifiers []ConfigDirectiveModifier) error {
+func getSshConfigFilePath(name string) (string, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
-		return fmt.Errorf("failed to determine home directory for SSH config: %w", err)
+		return "", fmt.Errorf("failed to determine home directory for SSH config: %w", err)
 	}
 
-	topoConfigPath := filepath.Join(home, ".ssh", "topo_config")
+	return filepath.Join(home, ".ssh", name), nil
+}
+
+func CreateOrModifyConfigFile(dest Destination, modifiers []ConfigDirectiveModifier) error {
+	topoConfigPath, err := getSshConfigFilePath(topoConfigFileName)
+	if err != nil {
+		return err
+	}
 	if err := updateConfigFile(topoConfigPath, dest.Host, modifiers); err != nil {
 		return err
 	}
 
-	defaultConfigPath := filepath.Join(home, ".ssh", "config")
+	defaultConfigPath, err := getSshConfigFilePath(defaultConfigFileName)
+	if err != nil {
+		return err
+	}
 	return updateConfigFile(defaultConfigPath, "", []ConfigDirectiveModifier{
 		NewEnsureConfigDirectivePath("Include", topoConfigPath),
 	})
 }
 
 func CheckForLegacyTopoConfigEntries() error {
-	home, err := os.UserHomeDir()
+	topoConfigPath, err := getSshConfigFilePath(topoConfigFileName)
 	if err != nil {
-		return fmt.Errorf("failed to determine home directory for SSH config: %w", err)
+		return err
 	}
 
-	topoConfigPath := filepath.Join(home, ".ssh", "topo_config")
 	info, err := os.Stat(topoConfigPath)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -201,12 +215,11 @@ func CheckForLegacyTopoConfigEntries() error {
 }
 
 func MigrateLegacyTopoConfig() error {
-	home, err := os.UserHomeDir()
+	legacyDir, err := getSshConfigFilePath(topoConfigFileName)
 	if err != nil {
-		return fmt.Errorf("failed to determine home directory for SSH config: %w", err)
+		return err
 	}
 
-	legacyDir := filepath.Join(home, ".ssh", "topo_config")
 	if err := CheckForLegacyTopoConfigEntries(); err != errLegacyConfigEntries {
 		if err == nil {
 			return fmt.Errorf("legacy topo ssh config directory not found at %s; nothing to migrate", legacyDir)
@@ -247,7 +260,11 @@ func MigrateLegacyTopoConfig() error {
 		return fmt.Errorf("failed to move migrated config to %s: %w", legacyDir, err)
 	}
 
-	defaultConfigPath := filepath.Join(home, ".ssh", "config")
+	defaultConfigPath, err := getSshConfigFilePath(defaultConfigFileName)
+	if err != nil {
+		return err
+	}
+
 	return updateConfigFile(defaultConfigPath, "", []ConfigDirectiveModifier{
 		NewRemoveConfigDirectivePath("Include", legacyGlob),
 		NewEnsureConfigDirectivePath("Include", legacyDir),

--- a/internal/ssh/config_file.go
+++ b/internal/ssh/config_file.go
@@ -166,7 +166,7 @@ func updateConfigFile(path string, host string, modifiers []ConfigDirectiveModif
 	return nil
 }
 
-func getSshConfigFilePath(name string) (string, error) {
+func getConfigFilePath(name string) (string, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", fmt.Errorf("failed to determine home directory for SSH config: %w", err)
@@ -176,7 +176,7 @@ func getSshConfigFilePath(name string) (string, error) {
 }
 
 func CreateOrModifyConfigFile(dest Destination, modifiers []ConfigDirectiveModifier) error {
-	topoConfigPath, err := getSshConfigFilePath(topoConfigFileName)
+	topoConfigPath, err := getConfigFilePath(topoConfigFileName)
 	if err != nil {
 		return err
 	}
@@ -184,7 +184,7 @@ func CreateOrModifyConfigFile(dest Destination, modifiers []ConfigDirectiveModif
 		return err
 	}
 
-	defaultConfigPath, err := getSshConfigFilePath(defaultConfigFileName)
+	defaultConfigPath, err := getConfigFilePath(defaultConfigFileName)
 	if err != nil {
 		return err
 	}
@@ -194,7 +194,7 @@ func CreateOrModifyConfigFile(dest Destination, modifiers []ConfigDirectiveModif
 }
 
 func CheckForLegacyTopoConfigEntries() error {
-	topoConfigPath, err := getSshConfigFilePath(topoConfigFileName)
+	topoConfigPath, err := getConfigFilePath(topoConfigFileName)
 	if err != nil {
 		return err
 	}
@@ -215,7 +215,7 @@ func CheckForLegacyTopoConfigEntries() error {
 }
 
 func MigrateLegacyTopoConfig() error {
-	legacyDir, err := getSshConfigFilePath(topoConfigFileName)
+	legacyDir, err := getConfigFilePath(topoConfigFileName)
 	if err != nil {
 		return err
 	}
@@ -260,7 +260,7 @@ func MigrateLegacyTopoConfig() error {
 		return fmt.Errorf("failed to move migrated config to %s: %w", legacyDir, err)
 	}
 
-	defaultConfigPath, err := getSshConfigFilePath(defaultConfigFileName)
+	defaultConfigPath, err := getConfigFilePath(defaultConfigFileName)
 	if err != nil {
 		return err
 	}

--- a/internal/ssh/config_file_test.go
+++ b/internal/ssh/config_file_test.go
@@ -122,24 +122,25 @@ User homer
 }
 
 func TestCheckForLegacyConfigEntries(t *testing.T) {
-	t.Run("returns nil if no legacy config file exists", func(t *testing.T) {
+	t.Run("detects if legacy config directory does not exist", func(t *testing.T) {
 		tmp := t.TempDir()
 		testutil.SetHomeDir(t, tmp)
 
-		err := ssh.CheckForLegacyTopoConfigEntries()
+		exists, err := ssh.LegacyTopoConfigDirectoryExists()
 
 		assert.NoError(t, err)
+		assert.False(t, exists)
 	})
 
-	t.Run("returns error if legacy config directory exists", func(t *testing.T) {
+	t.Run("detects if legacy config directory exists", func(t *testing.T) {
 		tmp := t.TempDir()
 		testutil.SetHomeDir(t, tmp)
 		testutil.RequireMkdirAll(t, filepath.Join(tmp, ".ssh", "topo_config"))
 
-		err := ssh.CheckForLegacyTopoConfigEntries()
+		exists, err := ssh.LegacyTopoConfigDirectoryExists()
 
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "legacy topo ssh config")
+		assert.NoError(t, err)
+		assert.True(t, exists)
 	})
 }
 

--- a/internal/ssh/config_file_test.go
+++ b/internal/ssh/config_file_test.go
@@ -18,11 +18,11 @@ func TestCreateOrModifyConfigFile(t *testing.T) {
 		testutil.SetHomeDir(t, tmp)
 		require.NoError(t, os.MkdirAll(filepath.Join(tmp, ".ssh"), 0o700))
 		dest := ssh.Destination{Host: "board1"}
-		directives := []ssh.ConfigDirective{
-			ssh.NewConfigDirective("IdentityFile", "~/.ssh/id_ed25519"),
+		modifiers := []ssh.ConfigDirectiveModifier{
+			ssh.NewEnsureConfigDirective("IdentityFile", "~/.ssh/id_ed25519"),
 		}
 
-		err := ssh.CreateOrModifyConfigFile(dest, directives)
+		err := ssh.CreateOrModifyConfigFile(dest, modifiers)
 		require.NoError(t, err)
 
 		configPath := filepath.Join(tmp, ".ssh", "config")
@@ -36,11 +36,11 @@ func TestCreateOrModifyConfigFile(t *testing.T) {
 		testutil.SetHomeDir(t, tmp)
 		require.NoError(t, os.MkdirAll(filepath.Join(tmp, ".ssh"), 0o700))
 		dest := ssh.Destination{Host: "board1"}
-		directives := []ssh.ConfigDirective{
-			ssh.NewConfigDirective("User", "homer"),
+		modifiers := []ssh.ConfigDirectiveModifier{
+			ssh.NewEnsureConfigDirective("User", "homer"),
 		}
 
-		err := ssh.CreateOrModifyConfigFile(dest, directives)
+		err := ssh.CreateOrModifyConfigFile(dest, modifiers)
 		require.NoError(t, err)
 
 		topoConfigPath := filepath.Join(tmp, ".ssh", "topo_config")
@@ -54,13 +54,13 @@ User homer
 		testutil.SetHomeDir(t, tmp)
 		require.NoError(t, os.MkdirAll(filepath.Join(tmp, ".ssh"), 0o700))
 		dest := ssh.Destination{Host: "board1"}
-		directives := []ssh.ConfigDirective{
-			ssh.NewConfigDirective("IdentityFile", "~/.ssh/id_ed25519"),
+		modifiers := []ssh.ConfigDirectiveModifier{
+			ssh.NewEnsureConfigDirective("IdentityFile", "~/.ssh/id_ed25519"),
 		}
-		err := ssh.CreateOrModifyConfigFile(dest, directives)
+		err := ssh.CreateOrModifyConfigFile(dest, modifiers)
 		require.NoError(t, err)
 
-		err = ssh.CreateOrModifyConfigFile(dest, directives)
+		err = ssh.CreateOrModifyConfigFile(dest, modifiers)
 
 		require.NoError(t, err)
 		got, err := os.ReadFile(filepath.Join(tmp, ".ssh", "config"))
@@ -76,13 +76,13 @@ User homer
 		require.NoError(t, os.MkdirAll(filepath.Join(tmp, ".ssh"), 0o700))
 		err := ssh.CreateOrModifyConfigFile(
 			ssh.Destination{Host: "board1"},
-			[]ssh.ConfigDirective{ssh.NewConfigDirective("IdentityFile", "~/.ssh/key1")},
+			[]ssh.ConfigDirectiveModifier{ssh.NewEnsureConfigDirective("IdentityFile", "~/.ssh/key1")},
 		)
 		require.NoError(t, err)
 
 		err = ssh.CreateOrModifyConfigFile(
 			ssh.Destination{Host: "board2"},
-			[]ssh.ConfigDirective{ssh.NewConfigDirective("IdentityFile", "~/.ssh/key2")},
+			[]ssh.ConfigDirectiveModifier{ssh.NewEnsureConfigDirective("IdentityFile", "~/.ssh/key2")},
 		)
 		require.NoError(t, err)
 
@@ -102,14 +102,14 @@ IdentityFile ~/.ssh/key2
 		testutil.SetHomeDir(t, tmp)
 		require.NoError(t, os.MkdirAll(filepath.Join(tmp, ".ssh"), 0o700))
 		dest := ssh.Destination{Host: "board1"}
-		err := ssh.CreateOrModifyConfigFile(dest, []ssh.ConfigDirective{
-			ssh.NewConfigDirective("IdentityFile", "~/.ssh/key_old"),
-			ssh.NewConfigDirective("User", "homer"),
+		err := ssh.CreateOrModifyConfigFile(dest, []ssh.ConfigDirectiveModifier{
+			ssh.NewEnsureConfigDirective("IdentityFile", "~/.ssh/key_old"),
+			ssh.NewEnsureConfigDirective("User", "homer"),
 		})
 		require.NoError(t, err)
 
-		err = ssh.CreateOrModifyConfigFile(dest, []ssh.ConfigDirective{
-			ssh.NewConfigDirective("IdentityFile", "~/.ssh/key_new"),
+		err = ssh.CreateOrModifyConfigFile(dest, []ssh.ConfigDirectiveModifier{
+			ssh.NewEnsureConfigDirective("IdentityFile", "~/.ssh/key_new"),
 		})
 		require.NoError(t, err)
 
@@ -146,5 +146,80 @@ func TestCheckForLegacyConfigEntries(t *testing.T) {
 
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "legacy topo ssh config")
+	})
+}
+
+func TestMigrateLegacyConfig(t *testing.T) {
+	t.Run("returns error when no legacy topo config directory exists", func(t *testing.T) {
+		tmp := t.TempDir()
+		testutil.SetHomeDir(t, tmp)
+
+		err := ssh.MigrateLegacyTopoConfig()
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "nothing to migrate")
+	})
+
+	t.Run("returns error when legacy directory has no conf files", func(t *testing.T) {
+		tmp := t.TempDir()
+		testutil.SetHomeDir(t, tmp)
+		require.NoError(t, os.MkdirAll(filepath.Join(tmp, ".ssh", "topo_config"), 0o700))
+
+		err := ssh.MigrateLegacyTopoConfig()
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "no .conf files")
+	})
+
+	t.Run("concatenates conf files into unified config and removes directory", func(t *testing.T) {
+		tmp := t.TempDir()
+		testutil.SetHomeDir(t, tmp)
+		legacyDir := filepath.Join(tmp, ".ssh", "topo_config")
+		require.NoError(t, os.MkdirAll(legacyDir, 0o700))
+		require.NoError(t, os.WriteFile(filepath.Join(legacyDir, "topo_board1.conf"), []byte(`Host board1
+  IdentityFile ~/.ssh/key1
+`), 0o600))
+		require.NoError(t, os.WriteFile(filepath.Join(legacyDir, "topo_board2.conf"), []byte(`Host board2
+  IdentityFile ~/.ssh/key2
+`), 0o600))
+		topoConfigSlash := filepath.ToSlash(legacyDir)
+		require.NoError(t, os.WriteFile(filepath.Join(tmp, ".ssh", "config"),
+			[]byte(`Include `+topoConfigSlash+`/*.conf
+
+Host *
+`), 0o600))
+
+		err := ssh.MigrateLegacyTopoConfig()
+
+		require.NoError(t, err)
+		info, err := os.Stat(filepath.Join(tmp, ".ssh", "topo_config"))
+		require.NoError(t, err)
+		assert.False(t, info.IsDir())
+		content, err := os.ReadFile(filepath.Join(tmp, ".ssh", "topo_config"))
+		require.NoError(t, err)
+		assert.Contains(t, string(content), "Host board1")
+		assert.Contains(t, string(content), "Host board2")
+		sshConfig, err := os.ReadFile(filepath.Join(tmp, ".ssh", "config"))
+		require.NoError(t, err)
+		assert.Contains(t, string(sshConfig), "Include "+topoConfigSlash+`
+`)
+		assert.NotContains(t, string(sshConfig), "*.conf")
+	})
+
+	t.Run("adds include directive if ssh config does not exist", func(t *testing.T) {
+		tmp := t.TempDir()
+		testutil.SetHomeDir(t, tmp)
+		legacyDir := filepath.Join(tmp, ".ssh", "topo_config")
+		require.NoError(t, os.MkdirAll(legacyDir, 0o700))
+		require.NoError(t, os.WriteFile(filepath.Join(legacyDir, "topo_board1.conf"), []byte(`Host board1
+  IdentityFile ~/.ssh/key1
+`), 0o600))
+
+		err := ssh.MigrateLegacyTopoConfig()
+
+		require.NoError(t, err)
+		sshConfig, err := os.ReadFile(filepath.Join(tmp, ".ssh", "config"))
+		require.NoError(t, err)
+		assert.Contains(t, string(sshConfig), "Include")
 	})
 }

--- a/internal/ssh/config_file_test.go
+++ b/internal/ssh/config_file_test.go
@@ -1,9 +1,8 @@
 package ssh_test
 
 import (
-	"os"
+	"fmt"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/arm/topo/internal/ssh"
@@ -16,7 +15,7 @@ func TestCreateOrModifyConfigFile(t *testing.T) {
 	t.Run("writes include directive to default config file", func(t *testing.T) {
 		tmp := t.TempDir()
 		testutil.SetHomeDir(t, tmp)
-		require.NoError(t, os.MkdirAll(filepath.Join(tmp, ".ssh"), 0o700))
+		testutil.RequireMkdirAll(t, filepath.Join(tmp, ".ssh"))
 		dest := ssh.Destination{Host: "board1"}
 		modifiers := []ssh.ConfigDirectiveModifier{
 			ssh.NewEnsureConfigDirective("IdentityFile", "~/.ssh/id_ed25519"),
@@ -34,7 +33,7 @@ func TestCreateOrModifyConfigFile(t *testing.T) {
 	t.Run("creates topo-managed config file if it does not exist", func(t *testing.T) {
 		tmp := t.TempDir()
 		testutil.SetHomeDir(t, tmp)
-		require.NoError(t, os.MkdirAll(filepath.Join(tmp, ".ssh"), 0o700))
+		testutil.RequireMkdirAll(t, filepath.Join(tmp, ".ssh"))
 		dest := ssh.Destination{Host: "board1"}
 		modifiers := []ssh.ConfigDirectiveModifier{
 			ssh.NewEnsureConfigDirective("User", "homer"),
@@ -52,7 +51,7 @@ User homer
 	t.Run("does not duplicate include directive in default config file if it already exists", func(t *testing.T) {
 		tmp := t.TempDir()
 		testutil.SetHomeDir(t, tmp)
-		require.NoError(t, os.MkdirAll(filepath.Join(tmp, ".ssh"), 0o700))
+		testutil.RequireMkdirAll(t, filepath.Join(tmp, ".ssh"))
 		dest := ssh.Destination{Host: "board1"}
 		modifiers := []ssh.ConfigDirectiveModifier{
 			ssh.NewEnsureConfigDirective("IdentityFile", "~/.ssh/id_ed25519"),
@@ -62,18 +61,16 @@ User homer
 
 		err = ssh.CreateOrModifyConfigFile(dest, modifiers)
 
+		wantConfig := fmt.Sprintf(`Include %s
+`, filepath.ToSlash(filepath.Join(tmp, ".ssh", "topo_config")))
 		require.NoError(t, err)
-		got, err := os.ReadFile(filepath.Join(tmp, ".ssh", "config"))
-		require.NoError(t, err)
-		count := strings.Count(string(got), "Include")
-		assert.Equal(t, 1, count, `Include directive should appear exactly once, got:
-%s`, got)
+		testutil.AssertFileContents(t, wantConfig, filepath.Join(tmp, ".ssh", "config"))
 	})
 
 	t.Run("adds new entry to existing topo-managed config file", func(t *testing.T) {
 		tmp := t.TempDir()
 		testutil.SetHomeDir(t, tmp)
-		require.NoError(t, os.MkdirAll(filepath.Join(tmp, ".ssh"), 0o700))
+		testutil.RequireMkdirAll(t, filepath.Join(tmp, ".ssh"))
 		err := ssh.CreateOrModifyConfigFile(
 			ssh.Destination{Host: "board1"},
 			[]ssh.ConfigDirectiveModifier{ssh.NewEnsureConfigDirective("IdentityFile", "~/.ssh/key1")},
@@ -100,7 +97,7 @@ IdentityFile ~/.ssh/key2
 	t.Run("modifies existing entry in topo-managed config file, preserving unmodified directives", func(t *testing.T) {
 		tmp := t.TempDir()
 		testutil.SetHomeDir(t, tmp)
-		require.NoError(t, os.MkdirAll(filepath.Join(tmp, ".ssh"), 0o700))
+		testutil.RequireMkdirAll(t, filepath.Join(tmp, ".ssh"))
 		dest := ssh.Destination{Host: "board1"}
 		err := ssh.CreateOrModifyConfigFile(dest, []ssh.ConfigDirectiveModifier{
 			ssh.NewEnsureConfigDirective("IdentityFile", "~/.ssh/key_old"),
@@ -137,12 +134,9 @@ func TestCheckForLegacyConfigEntries(t *testing.T) {
 	t.Run("returns error if legacy config directory exists", func(t *testing.T) {
 		tmp := t.TempDir()
 		testutil.SetHomeDir(t, tmp)
-		err := os.MkdirAll(filepath.Join(tmp, ".ssh"), 0o700)
-		require.NoError(t, err)
-		err = os.Mkdir(filepath.Join(tmp, ".ssh", "topo_config"), 0o600)
-		require.NoError(t, err)
+		testutil.RequireMkdirAll(t, filepath.Join(tmp, ".ssh", "topo_config"))
 
-		err = ssh.CheckForLegacyTopoConfigEntries()
+		err := ssh.CheckForLegacyTopoConfigEntries()
 
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "legacy topo ssh config")
@@ -163,7 +157,7 @@ func TestMigrateLegacyConfig(t *testing.T) {
 	t.Run("returns error when legacy directory has no conf files", func(t *testing.T) {
 		tmp := t.TempDir()
 		testutil.SetHomeDir(t, tmp)
-		require.NoError(t, os.MkdirAll(filepath.Join(tmp, ".ssh", "topo_config"), 0o700))
+		testutil.RequireMkdirAll(t, filepath.Join(tmp, ".ssh", "topo_config"))
 
 		err := ssh.MigrateLegacyTopoConfig()
 
@@ -175,51 +169,47 @@ func TestMigrateLegacyConfig(t *testing.T) {
 		tmp := t.TempDir()
 		testutil.SetHomeDir(t, tmp)
 		legacyDir := filepath.Join(tmp, ".ssh", "topo_config")
-		require.NoError(t, os.MkdirAll(legacyDir, 0o700))
-		require.NoError(t, os.WriteFile(filepath.Join(legacyDir, "topo_board1.conf"), []byte(`Host board1
+		legacyDirSlash := filepath.ToSlash(legacyDir)
+		board1Conf := `Host board1
   IdentityFile ~/.ssh/key1
-`), 0o600))
-		require.NoError(t, os.WriteFile(filepath.Join(legacyDir, "topo_board2.conf"), []byte(`Host board2
+`
+		board2Conf := `Host board2
   IdentityFile ~/.ssh/key2
-`), 0o600))
-		topoConfigSlash := filepath.ToSlash(legacyDir)
-		require.NoError(t, os.WriteFile(filepath.Join(tmp, ".ssh", "config"),
-			[]byte(`Include `+topoConfigSlash+`/*.conf
+`
+		sshConf := "Include " + legacyDirSlash + `/*.conf
 
 Host *
-`), 0o600))
+`
+		testutil.RequireMkdirAll(t, legacyDir)
+		testutil.RequireWriteFile(t, filepath.Join(legacyDir, "topo_board1.conf"), board1Conf)
+		testutil.RequireWriteFile(t, filepath.Join(legacyDir, "topo_board2.conf"), board2Conf)
+		testutil.RequireWriteFile(t, filepath.Join(tmp, ".ssh", "config"), sshConf)
 
-		err := ssh.MigrateLegacyTopoConfig()
+		require.NoError(t, ssh.MigrateLegacyTopoConfig())
 
-		require.NoError(t, err)
-		info, err := os.Stat(filepath.Join(tmp, ".ssh", "topo_config"))
-		require.NoError(t, err)
-		assert.False(t, info.IsDir())
-		content, err := os.ReadFile(filepath.Join(tmp, ".ssh", "topo_config"))
-		require.NoError(t, err)
-		assert.Contains(t, string(content), "Host board1")
-		assert.Contains(t, string(content), "Host board2")
-		sshConfig, err := os.ReadFile(filepath.Join(tmp, ".ssh", "config"))
-		require.NoError(t, err)
-		assert.Contains(t, string(sshConfig), "Include "+topoConfigSlash+`
-`)
-		assert.NotContains(t, string(sshConfig), "*.conf")
+		mergedFile := legacyDirSlash
+		wantSshConfAfterMigration := fmt.Sprintf(`
+Include %s
+Host *
+`, mergedFile)
+		testutil.AssertFileContents(t, board1Conf+board2Conf, mergedFile)
+		testutil.AssertFileContents(t, wantSshConfAfterMigration, filepath.Join(tmp, ".ssh", "config"))
 	})
 
 	t.Run("adds include directive if ssh config does not exist", func(t *testing.T) {
 		tmp := t.TempDir()
 		testutil.SetHomeDir(t, tmp)
 		legacyDir := filepath.Join(tmp, ".ssh", "topo_config")
-		require.NoError(t, os.MkdirAll(legacyDir, 0o700))
-		require.NoError(t, os.WriteFile(filepath.Join(legacyDir, "topo_board1.conf"), []byte(`Host board1
+		testutil.RequireMkdirAll(t, legacyDir)
+		testutil.RequireWriteFile(t, filepath.Join(legacyDir, "topo_board1.conf"), `Host board1
   IdentityFile ~/.ssh/key1
-`), 0o600))
+`)
 
 		err := ssh.MigrateLegacyTopoConfig()
 
+		wantConfig := fmt.Sprintf(`Include %s
+`, filepath.ToSlash(legacyDir))
 		require.NoError(t, err)
-		sshConfig, err := os.ReadFile(filepath.Join(tmp, ".ssh", "config"))
-		require.NoError(t, err)
-		assert.Contains(t, string(sshConfig), "Include")
+		testutil.AssertFileContents(t, wantConfig, filepath.Join(tmp, ".ssh", "config"))
 	})
 }

--- a/internal/ssh/config_file_test.go
+++ b/internal/ssh/config_file_test.go
@@ -155,17 +155,6 @@ func TestMigrateLegacyConfig(t *testing.T) {
 		assert.Contains(t, err.Error(), "nothing to migrate")
 	})
 
-	t.Run("returns error when legacy directory has no conf files", func(t *testing.T) {
-		tmp := t.TempDir()
-		testutil.SetHomeDir(t, tmp)
-		testutil.RequireMkdirAll(t, filepath.Join(tmp, ".ssh", "topo_config"))
-
-		err := ssh.MigrateLegacyTopoConfig()
-
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "no .conf files")
-	})
-
 	t.Run("concatenates conf files into unified config and removes directory", func(t *testing.T) {
 		tmp := t.TempDir()
 		testutil.SetHomeDir(t, tmp)

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -57,6 +57,12 @@ func RequireWriteFile(t testing.TB, path, content string) {
 	require.NoError(t, err)
 }
 
+func RequireMkdirAll(t testing.TB, path string) {
+	t.Helper()
+	err := os.MkdirAll(path, 0o700)
+	require.NoError(t, err)
+}
+
 func SanitiseTestName(t testing.TB) string {
 	name := strings.ToLower(t.Name())
 	name = strings.ReplaceAll(name, "/", "-")


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- Addresses a suggestion from @muchzill4 [here](https://github.com/arm/topo/pull/179#pullrequestreview-4067572306) to provide a user-friendly path to migrating from the legacy per-target config files to a single config file. 
  - Such an approach can be utilised by vscode to delegate as much responsibility to the CLI as possible
- Only surfaces this command to the user if they encounter the related error when running `setup-keys`, otherwise you can safely continue to use the older ssh config as normal
- Slightly refactors `config_file.go` to provide 'modifier' structs as we now need to delete statements as well as just add/replace (now called 'ensure')

I'm open to auto-migrating when running `setup-keys` instead of requiring manual running a different command or indeed adding a new `--migrate` flag to `setup-keys` to do this. My thinking was if we're going to eventually remove this command it makes sense to decouple it from functionality that will remain as much as possible but lmk!