### PR TITLE
fix(security): bump golang to 1.26.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/arm/topo
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/compose-spec/compose-go/v2 v2.10.1


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- Fixes https://pkg.go.dev/vuln/GO-2026-4947