### PR TITLE
chore: remove double space in error string

### DIFF
--- a/cmd/topo/setup_keys.go
+++ b/cmd/topo/setup_keys.go
@@ -46,7 +46,7 @@ var setupKeysCmd = &cobra.Command{
 
 		err = ssh.IsDestinationAlreadyConfiguredWithAnotherUser(dest)
 		if err != nil {
-			return fmt.Errorf("%w; note: a per user SSH config entry should be created  when setting up keys", err)
+			return fmt.Errorf("%w; note: a per user SSH config entry should be created when setting up keys", err)
 		}
 
 		seq, err := setupkeys.NewKeySetup(dest, privateKeyPath, parsedKeyType)


### PR DESCRIPTION
Fix a typo
