### PR TITLE
feat: Use https in template updater

### DIFF
--- a/scripts/update_templates/main.go
+++ b/scripts/update_templates/main.go
@@ -45,7 +45,7 @@ func main() {
 			continue
 		}
 
-		repoURL := fmt.Sprintf("git@github.com:%s.git", repo)
+		repoURL := fmt.Sprintf("https://github.com/%s.git", repo)
 
 		tmpl, err := BuildTemplate(repoURL, composeBytes)
 		if err != nil {


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- Uses https in the template updater rather than ssh for the ease of the users, since ssh may require credentials the user doesn't have set up.