### PR TITLE
feat!: Remove template ID

### DIFF
--- a/cmd/topo/clone.go
+++ b/cmd/topo/clone.go
@@ -19,9 +19,6 @@ var topoCloneCmd = &cobra.Command{
 The project-source argument uses scheme prefixes to specify the source type.
 The git: prefix is optional for git@host and https:// URLs.
 
-Template Name (from built-in catalog):
-  topo clone template:topo-welcome
-
 Git repository:
   topo clone git@github.com:user/repo.git
   topo clone https://github.com/user/repo.git#develop
@@ -37,11 +34,11 @@ Local directory (must contain a Topo template):
 Some projects require build arguments. Supply them on the command line or answer prompts:
 
   # Will prompt for required args
-  topo clone template:topo-welcome
+  topo clone dir:topo-welcome
   # Provide args explicitly
-  topo clone template:topo-welcome GREETING_NAME="World"
+  topo clone dir:topo-welcome GREETING_NAME="World"
   # With an explicit path
-  topo clone template:topo-welcome my-demo GREETING_NAME="World"
+  topo clone dir:topo-welcome my-demo GREETING_NAME="World"
 `,
 	Args: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/topo/clone.go
+++ b/cmd/topo/clone.go
@@ -34,11 +34,11 @@ Local directory (must contain a Topo template):
 Some projects require build arguments. Supply them on the command line or answer prompts:
 
   # Will prompt for required args
-  topo clone dir:topo-welcome
+  topo clone https://github.com/Arm-Examples/topo-welcome.git
   # Provide args explicitly
-  topo clone dir:topo-welcome GREETING_NAME="World"
+  topo clone https://github.com/Arm-Examples/topo-welcome.git GREETING_NAME="World"
   # With an explicit path
-  topo clone dir:topo-welcome my-demo GREETING_NAME="World"
+  topo clone https://github.com/Arm-Examples/topo-welcome.git my-demo GREETING_NAME="World"
 `,
 	Args: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/topo/extend.go
+++ b/cmd/topo/extend.go
@@ -17,9 +17,6 @@ var extendCmd = &cobra.Command{
 
 The source argument uses scheme prefixes to specify the source type:
 
-Template Name (from built-in templates):
-  topo extend compose.yaml template:topo-welcome
-
 Git repository (git: prefix is optional for git@host and https:// URLs):
   topo extend compose.yaml git:https://github.com/user/repo.git
   topo extend compose.yaml https://github.com/user/repo.git

--- a/e2e/templates_test.go
+++ b/e2e/templates_test.go
@@ -46,7 +46,7 @@ totalmemory_kb: 4194304
 
 			require.NoError(t, err, output)
 			assert.Contains(t, output, "✅ Hello World")
-			assert.Contains(t, output, "❌ Lightbulb moment")
+			assert.Contains(t, output, "❌ Lightbulb Moment")
 		})
 
 		t.Run("correctly handles the --target flag when no target description is provided", func(t *testing.T) {

--- a/e2e/templates_test.go
+++ b/e2e/templates_test.go
@@ -22,8 +22,8 @@ func TestTemplates(t *testing.T) {
 
 		output := string(out)
 
-		assert.Contains(t, output, "topo-welcome")
-		assert.Contains(t, output, "https://github.com/")
+		assert.Contains(t, output, "Hello World")
+		assert.Contains(t, output, "https://github.com")
 		assert.Contains(t, output, "Features:")
 	})
 
@@ -45,8 +45,8 @@ totalmemory_kb: 4194304
 			output := string(out)
 
 			require.NoError(t, err, output)
-			assert.Contains(t, output, "✅ topo-welcome")
-			assert.Contains(t, output, "❌ topo-lightbulb-moment")
+			assert.Contains(t, output, "✅ Hello World")
+			assert.Contains(t, output, "❌ Lightbulb moment")
 		})
 
 		t.Run("correctly handles the --target flag when no target description is provided", func(t *testing.T) {
@@ -58,7 +58,7 @@ totalmemory_kb: 4194304
 			output := string(out)
 
 			require.NoError(t, err, output)
-			assert.Contains(t, output, "✅ topo-welcome")
+			assert.Contains(t, output, "✅ Hello World")
 		})
 	})
 

--- a/e2e/testdata/TestTemplatesJson.golden
+++ b/e2e/testdata/TestTemplatesJson.golden
@@ -7,7 +7,7 @@
     "ref": "main"
   },
   {
-    "name": "Lightbulb moment",
+    "name": "Lightbulb Moment",
     "description": "Reads a switch over GPIO pins on an M class cpu, reports switch state over Remoteproc Message, then a web application on the A class reads this and displays a lightbulb in either the on or off state. The lightbulb state is described by an LLM in any user-specified style.",
     "features": [
       "remoteproc-runtime"

--- a/e2e/testdata/TestTemplatesJson.golden
+++ b/e2e/testdata/TestTemplatesJson.golden
@@ -1,13 +1,13 @@
 [
   {
-    "name": "topo-welcome",
+    "name": "Hello World",
     "description": "A minimal \"Hello, World\" web app for validating a Topo setup and deployment.\nIt runs a single service that exposes a web page on the target,\nwith the greeting text customizable via the GREETING_NAME parameter.\n",
     "features": null,
     "url": "https://github.com/Arm-Examples/topo-welcome.git",
     "ref": "main"
   },
   {
-    "name": "topo-lightbulb-moment",
+    "name": "Lightbulb moment",
     "description": "Reads a switch over GPIO pins on an M class cpu, reports switch state over Remoteproc Message, then a web application on the A class reads this and displays a lightbulb in either the on or off state. The lightbulb state is described by an LLM in any user-specified style.",
     "features": [
       "remoteproc-runtime"
@@ -16,8 +16,8 @@
     "ref": "main"
   },
   {
-    "name": "topo-cpu-ai-chat",
-    "description": "Complete LLM chat application optimized for Arm CPU inference.\n\nThis project demonstrates running large language models on CPU\nusing llama.cpp compiled with Arm baseline optimizations and \naccelerated using NEON SIMD and SVE (when supported and enabled).\n\nThe stack includes:\n- llama.cpp server with Arm NEON optimizations (SVE optional)\n- Quantized Qwen2.5-1.5B-Instruct model bundled in the image (~1.12 GB)\n- Simple web-based chat interface\n- No GPU required - pure CPU inference\n\nPerfect for demos and testing! The bundled Qwen2.5-1.5B model allows the\nproject to run immediately without downloading additional models.\n\nIdeal for testing LLM workloads on Arm hardware without GPU dependencies,\nshowcasing how far you can push NEON acceleration. Rebuild with SVE enabled\nwhen wider vectors are available.\n",
+    "name": "Topo CPU AI Chat",
+    "description": "Complete LLM chat application optimized for Arm CPU inference.\n\nThis project demonstrates running large language models on CPU\nusing llama.cpp compiled with Arm baseline optimizations and \naccelerated using NEON SIMD and SVE (when supported and enabled).\n\nThe stack includes:\n- llama.cpp server with Arm NEON optimizations (SVE optional)\n- Quantized Qwen3.5-0.8B model bundled in the image\n- Simple web-based chat interface\n- No GPU required - pure CPU inference\n\nPerfect for demos and testing! The bundled Qwen3.5-0.8B model allows the\nproject to run immediately without downloading additional models.\n\nIdeal for testing LLM workloads on Arm hardware without GPU dependencies,\nshowcasing how far you can push NEON acceleration. Rebuild with SVE enabled\nwhen wider vectors are available.\n",
     "features": [
       "SVE",
       "NEON"
@@ -26,7 +26,7 @@
     "ref": "main"
   },
   {
-    "name": "topo-simd-visual-benchmark",
+    "name": "SIMD Visual Benchmark",
     "description": "Visual demonstration of SIMD performance benefits on Arm processors.\nCompare scalar (no SIMD), NEON (128-bit), and SVE (scalable vector)\nimplementations running identical image processing workloads side-by-side.\n\nThis demo shows real hardware acceleration through three C++ services\ncompiled with different architecture flags, processing the same box blur\nalgorithm on images. Performance differences are measured in real-time\nand displayed in an interactive web dashboard.\n\nPerfect for demonstrating to non-technical audiences the concrete benefits\nof SIMD optimizations, with visual results and quantified speedups.\n",
     "features": [
       "NEON",

--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -19,10 +19,6 @@ type Repo struct {
 	Ref         string   `json:"ref"`
 }
 
-func GetTemplateRepo(name string) (*Repo, error) {
-	return GetRepo(name, TemplatesJSON)
-}
-
 func ParseRepos(b []byte) ([]Repo, error) {
 	var templates []Repo
 	dec := json.NewDecoder(bytes.NewReader(b))

--- a/internal/catalog/catalog_test.go
+++ b/internal/catalog/catalog_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-
 func TestListRepos(t *testing.T) {
 	t.Run("parses valid JSON successfully", func(t *testing.T) {
 		jsonData := []byte(`[

--- a/internal/catalog/catalog_test.go
+++ b/internal/catalog/catalog_test.go
@@ -8,26 +8,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGetTemplateRepo(t *testing.T) {
-	t.Run("when template exists it is found", func(t *testing.T) {
-		template, err := catalog.GetTemplateRepo("topo-lightbulb-moment")
-
-		require.NoError(t, err)
-		assert.Equal(t, &catalog.Repo{
-			Name:        "topo-lightbulb-moment",
-			Description: "Reads a switch over GPIO pins on an M class cpu, reports switch state over Remoteproc Message, then a web application on the A class reads this and displays a lightbulb in either the on or off state. The lightbulb state is described by an LLM in any user-specified style.",
-			Features:    []string{"remoteproc-runtime"},
-			URL:         "https://github.com/Arm-Examples/topo-lightbulb-moment.git",
-			Ref:         "main",
-		}, template)
-	})
-	t.Run("when template does not exist, it errors", func(t *testing.T) {
-		_, err := catalog.GetTemplateRepo("nonexistent-template")
-
-		require.Error(t, err)
-		assert.ErrorContains(t, err, `"nonexistent-template" not found`)
-	})
-}
 
 func TestListRepos(t *testing.T) {
 	t.Run("parses valid JSON successfully", func(t *testing.T) {

--- a/internal/catalog/data/templates.json
+++ b/internal/catalog/data/templates.json
@@ -3,7 +3,7 @@
     "name": "Hello World",
     "description": "A minimal \"Hello, World\" web app for validating a Topo setup and deployment.\nIt runs a single service that exposes a web page on the target,\nwith the greeting text customizable via the GREETING_NAME parameter.\n",
     "features": null,
-    "url": "git@github.com:Arm-Examples/topo-welcome.git",
+    "url": "https://github.com/Arm-Examples/topo-welcome.git",
     "ref": "main"
   },
   {
@@ -12,7 +12,7 @@
     "features": [
       "remoteproc-runtime"
     ],
-    "url": "git@github.com:Arm-Examples/topo-lightbulb-moment.git",
+    "url": "https://github.com/Arm-Examples/topo-lightbulb-moment.git",
     "ref": "main"
   },
   {
@@ -22,7 +22,7 @@
       "SVE",
       "NEON"
     ],
-    "url": "git@github.com:Arm-Examples/topo-cpu-ai-chat.git",
+    "url": "https://github.com/Arm-Examples/topo-cpu-ai-chat.git",
     "ref": "main"
   },
   {
@@ -32,7 +32,7 @@
       "NEON",
       "SVE"
     ],
-    "url": "git@github.com:Arm-Examples/topo-simd-visual-benchmark.git",
+    "url": "https://github.com/Arm-Examples/topo-simd-visual-benchmark.git",
     "ref": "main"
   }
 ]

--- a/internal/catalog/data/templates.json
+++ b/internal/catalog/data/templates.json
@@ -7,7 +7,7 @@
     "ref": "main"
   },
   {
-    "name": "Lightbulb moment",
+    "name": "Lightbulb Moment",
     "description": "Reads a switch over GPIO pins on an M class cpu, reports switch state over Remoteproc Message, then a web application on the A class reads this and displays a lightbulb in either the on or off state. The lightbulb state is described by an LLM in any user-specified style.",
     "features": [
       "remoteproc-runtime"

--- a/internal/catalog/data/templates.json
+++ b/internal/catalog/data/templates.json
@@ -1,30 +1,38 @@
 [
   {
-    "name": "topo-welcome",
+    "name": "Hello World",
     "description": "A minimal \"Hello, World\" web app for validating a Topo setup and deployment.\nIt runs a single service that exposes a web page on the target,\nwith the greeting text customizable via the GREETING_NAME parameter.\n",
     "features": null,
-    "url": "https://github.com/Arm-Examples/topo-welcome.git",
+    "url": "git@github.com:Arm-Examples/topo-welcome.git",
     "ref": "main"
   },
   {
-    "name": "topo-lightbulb-moment",
+    "name": "Lightbulb moment",
     "description": "Reads a switch over GPIO pins on an M class cpu, reports switch state over Remoteproc Message, then a web application on the A class reads this and displays a lightbulb in either the on or off state. The lightbulb state is described by an LLM in any user-specified style.",
-    "features": ["remoteproc-runtime"],
-    "url": "https://github.com/Arm-Examples/topo-lightbulb-moment.git",
+    "features": [
+      "remoteproc-runtime"
+    ],
+    "url": "git@github.com:Arm-Examples/topo-lightbulb-moment.git",
     "ref": "main"
   },
   {
-    "name": "topo-cpu-ai-chat",
-    "description": "Complete LLM chat application optimized for Arm CPU inference.\n\nThis project demonstrates running large language models on CPU\nusing llama.cpp compiled with Arm baseline optimizations and \naccelerated using NEON SIMD and SVE (when supported and enabled).\n\nThe stack includes:\n- llama.cpp server with Arm NEON optimizations (SVE optional)\n- Quantized Qwen2.5-1.5B-Instruct model bundled in the image (~1.12 GB)\n- Simple web-based chat interface\n- No GPU required - pure CPU inference\n\nPerfect for demos and testing! The bundled Qwen2.5-1.5B model allows the\nproject to run immediately without downloading additional models.\n\nIdeal for testing LLM workloads on Arm hardware without GPU dependencies,\nshowcasing how far you can push NEON acceleration. Rebuild with SVE enabled\nwhen wider vectors are available.\n",
-    "features": ["SVE", "NEON"],
-    "url": "https://github.com/Arm-Examples/topo-cpu-ai-chat.git",
+    "name": "Topo CPU AI Chat",
+    "description": "Complete LLM chat application optimized for Arm CPU inference.\n\nThis project demonstrates running large language models on CPU\nusing llama.cpp compiled with Arm baseline optimizations and \naccelerated using NEON SIMD and SVE (when supported and enabled).\n\nThe stack includes:\n- llama.cpp server with Arm NEON optimizations (SVE optional)\n- Quantized Qwen3.5-0.8B model bundled in the image\n- Simple web-based chat interface\n- No GPU required - pure CPU inference\n\nPerfect for demos and testing! The bundled Qwen3.5-0.8B model allows the\nproject to run immediately without downloading additional models.\n\nIdeal for testing LLM workloads on Arm hardware without GPU dependencies,\nshowcasing how far you can push NEON acceleration. Rebuild with SVE enabled\nwhen wider vectors are available.\n",
+    "features": [
+      "SVE",
+      "NEON"
+    ],
+    "url": "git@github.com:Arm-Examples/topo-cpu-ai-chat.git",
     "ref": "main"
   },
   {
-    "name": "topo-simd-visual-benchmark",
+    "name": "SIMD Visual Benchmark",
     "description": "Visual demonstration of SIMD performance benefits on Arm processors.\nCompare scalar (no SIMD), NEON (128-bit), and SVE (scalable vector)\nimplementations running identical image processing workloads side-by-side.\n\nThis demo shows real hardware acceleration through three C++ services\ncompiled with different architecture flags, processing the same box blur\nalgorithm on images. Performance differences are measured in real-time\nand displayed in an interactive web dashboard.\n\nPerfect for demonstrating to non-technical audiences the concrete benefits\nof SIMD optimizations, with visual results and quantified speedups.\n",
-    "features": ["NEON", "SVE"],
-    "url": "https://github.com/Arm-Examples/topo-simd-visual-benchmark.git",
+    "features": [
+      "NEON",
+      "SVE"
+    ],
+    "url": "git@github.com:Arm-Examples/topo-simd-visual-benchmark.git",
     "ref": "main"
   }
 ]

--- a/internal/template/source.go
+++ b/internal/template/source.go
@@ -43,7 +43,7 @@ func NewSource(source string) (Source, error) {
 		case "dir":
 			return DirSource{Path: sourceValue}, nil
 		default:
-			return nil, fmt.Errorf("unsupported source type: %s (supported: git:, dir:)", sourceType)
+			return nil, fmt.Errorf("unsupported source type: %s (check --help for expected format)", sourceType)
 		}
 	}
 
@@ -53,7 +53,7 @@ func NewSource(source string) (Source, error) {
 
 	sourceType, _, hasType := strings.Cut(source, ":")
 	if hasType {
-		return nil, fmt.Errorf("unsupported source type: %s (supported: git:, dir:)", sourceType)
+		return nil, fmt.Errorf("unsupported source type: %s (check --help for expected format)", sourceType)
 	}
 
 	return nil, fmt.Errorf("invalid source format: %s (check --help for expected formats)", source)

--- a/internal/template/source.go
+++ b/internal/template/source.go
@@ -7,8 +7,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
-
-	"github.com/arm/topo/internal/catalog"
 )
 
 type DestDirExistsError struct {
@@ -26,10 +24,10 @@ type Source interface {
 }
 
 func NewSource(source string) (Source, error) {
-	if strings.HasPrefix(source, "template:") || strings.HasPrefix(source, "git:") || strings.HasPrefix(source, "dir:") {
+	if strings.HasPrefix(source, "git:") || strings.HasPrefix(source, "dir:") {
 		parts := strings.SplitN(source, ":", 2)
 		if len(parts) != 2 {
-			return nil, fmt.Errorf("invalid source format: %s (expected format: <type>:<value>, e.g., template:hello-world or git:https://github.com/user/repo.git)", source)
+			return nil, fmt.Errorf("invalid source format: %s (check --help for expected format)", source)
 		}
 
 		sourceType := parts[0]
@@ -40,14 +38,12 @@ func NewSource(source string) (Source, error) {
 		}
 
 		switch sourceType {
-		case "template":
-			return TemplateNameSource(sourceValue), nil
 		case "git":
 			return NewGitSource(sourceValue), nil
 		case "dir":
 			return DirSource{Path: sourceValue}, nil
 		default:
-			return nil, fmt.Errorf("unsupported source type: %s (supported: template:, git:, dir:)", sourceType)
+			return nil, fmt.Errorf("unsupported source type: %s (supported: git:, dir:)", sourceType)
 		}
 	}
 
@@ -57,10 +53,10 @@ func NewSource(source string) (Source, error) {
 
 	sourceType, _, hasType := strings.Cut(source, ":")
 	if hasType {
-		return nil, fmt.Errorf("unsupported source type: %s (supported: template:, git:, dir:)", sourceType)
+		return nil, fmt.Errorf("unsupported source type: %s (supported: git:, dir:)", sourceType)
 	}
 
-	return nil, fmt.Errorf("invalid source format: %s (expected format: <type>:<value>, e.g., template:hello-world or git:https://github.com/user/repo.git)", source)
+	return nil, fmt.Errorf("invalid source format: %s (check --help for expected formats)", source)
 }
 
 func isGitURL(source string) bool {
@@ -69,36 +65,6 @@ func isGitURL(source string) bool {
 		strings.HasPrefix(source, "https://") ||
 		strings.HasPrefix(source, "http://") ||
 		strings.HasPrefix(source, "git://")
-}
-
-type TemplateNameSource string
-
-func (t TemplateNameSource) CopyTo(destDir string) error {
-	templateRepo, err := catalog.GetTemplateRepo(string(t))
-	if err != nil {
-		return err
-	}
-	gitSource := GitSource{
-		URL: templateRepo.URL,
-		Ref: templateRepo.Ref,
-	}
-	return gitSource.CopyTo(destDir)
-}
-
-func (t TemplateNameSource) String() string {
-	return fmt.Sprintf("template:%s", string(t))
-}
-
-func (t TemplateNameSource) GetName() (string, error) {
-	templateRepo, err := catalog.GetTemplateRepo(string(t))
-	if err != nil {
-		return "", err
-	}
-	gitSource := GitSource{
-		URL: templateRepo.URL,
-		Ref: templateRepo.Ref,
-	}
-	return gitSource.GetName()
 }
 
 type GitSource struct {

--- a/internal/template/source_test.go
+++ b/internal/template/source_test.go
@@ -13,14 +13,6 @@ import (
 )
 
 func TestNewSource(t *testing.T) {
-	t.Run("template source", func(t *testing.T) {
-		got, err := template.NewSource("template:hello")
-
-		require.NoError(t, err)
-		want := template.TemplateNameSource("hello")
-		assert.Equal(t, want, got)
-	})
-
 	t.Run("dir source", func(t *testing.T) {
 		tests := []struct {
 			name  string
@@ -148,11 +140,6 @@ func TestNewSource(t *testing.T) {
 				errorContains: "invalid source format",
 			},
 			{
-				name:          "empty value",
-				input:         "template:",
-				errorContains: "source value cannot be empty",
-			},
-			{
 				name:          "empty source",
 				input:         "",
 				errorContains: "invalid source format",
@@ -171,15 +158,6 @@ func TestNewSource(t *testing.T) {
 				assert.ErrorContains(t, err, tt.errorContains)
 			})
 		}
-	})
-}
-
-func TestTemplateIdSource(t *testing.T) {
-	t.Run("String", func(t *testing.T) {
-		t.Run("returns template name in correct format", func(t *testing.T) {
-			src := template.TemplateNameSource("hello-world")
-			assert.Equal(t, "template:hello-world", src.String())
-		})
 	})
 }
 

--- a/scripts/update_templates/main.go
+++ b/scripts/update_templates/main.go
@@ -45,7 +45,7 @@ func main() {
 			continue
 		}
 
-		repoURL := fmt.Sprintf("git@github.com:%s.git", repo)
+		repoURL := fmt.Sprintf("https://github.com/%s.git", repo)
 
 		tmpl, err := BuildTemplate(repoURL, composeBytes)
 		if err != nil {

--- a/scripts/update_templates/parse.go
+++ b/scripts/update_templates/parse.go
@@ -35,11 +35,3 @@ func parseRepoSpec(spec string) (repo, ref string) {
 	}
 	return
 }
-
-func slugifyTemplateName(name string) string {
-	parts := strings.Fields(name)
-	if len(parts) == 0 {
-		return ""
-	}
-	return strings.Join(parts, "-")
-}

--- a/scripts/update_templates/parse.go
+++ b/scripts/update_templates/parse.go
@@ -20,7 +20,7 @@ func BuildTemplate(repoURL string, compose io.Reader) (Template, error) {
 	}
 
 	return Template{
-		Name:        slugifyTemplateName(metadata.Name),
+		Name:        metadata.Name,
 		Description: metadata.Description,
 		Features:    metadata.Features,
 		URL:         repoURL,

--- a/scripts/update_templates/parse_test.go
+++ b/scripts/update_templates/parse_test.go
@@ -23,7 +23,7 @@ func TestBuildTemplate(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, Template{
-			Name:        "Example-Template",
+			Name:        "Example Template",
 			Description: "Example description",
 			Features:    []string{"SME", "NEON"},
 			URL:         "git@github.com:Arm-Debug/example.git",


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- Template ID has no clear justification for existing. It complicates the user experience for limited benefit.
- Remove use of template ID in cloning and extending.
