### PR TITLE
fix: stop prefixing commands with `sh -c` in local runner

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/dsnet/compress v0.0.2-0.20230904184137-39efe44ab707 // indirect
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
+	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/kevinburke/ssh_config v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -81,6 +81,8 @@ github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OI
 github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20200212024743-f11f1df84d12/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=

--- a/internal/runner/local.go
+++ b/internal/runner/local.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"fmt"
 	"os/exec"
+
+	"github.com/google/shlex"
 )
 
 type Local struct{}
@@ -22,8 +24,12 @@ func (r *Local) RunWithStdin(ctx context.Context, cmdStr string, stdin []byte) (
 }
 
 func (r *Local) exec(ctx context.Context, cmdStr string, stdin []byte) (string, error) {
+	args, err := shlex.Split(cmdStr)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse command: %w", err)
+	}
 	// #nosec G204 -- command should be validated by callers
-	cmd := exec.CommandContext(ctx, "/bin/sh", "-c", cmdStr)
+	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
 	if stdin != nil {
 		cmd.Stdin = bytes.NewReader(stdin)
 	}
@@ -31,7 +37,7 @@ func (r *Local) exec(ctx context.Context, cmdStr string, stdin []byte) (string, 
 	cmd.Stdout = &stdoutBuf
 	cmd.Stderr = &stderrBuf
 
-	err := cmd.Run()
+	err = cmd.Run()
 	if err != nil {
 		if ctx.Err() != nil {
 			return "", ErrTimeout

--- a/internal/runner/local_test.go
+++ b/internal/runner/local_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/arm/topo/internal/runner"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -29,5 +30,13 @@ func TestLocal(t *testing.T) {
 		_, err := r.Run(ctx, "sleep 10")
 
 		require.ErrorIs(t, err, runner.ErrTimeout)
+	})
+
+	t.Run("executes binary directly without shell interpretation", func(t *testing.T) {
+		r := runner.NewLocal()
+		got, err := r.Run(context.Background(), "echo hello && echo world")
+
+		assert.NoError(t, err)
+		assert.Equal(t, "hello && echo world\n", got)
 	})
 }


### PR DESCRIPTION
## Changes

- 🐛 Makes `Local` runner usable on Windows, where we don't have access to `sh -c`
- Local runner now uses `shlex.Split` to parse command strings and calls `exec.Command` directly, instead of wrapping every command in `/bin/sh -c`
- Adds `google/shlex` dependency
- Adds tests for local runner `Run`