### PR TITLE
test: commonise file-based testutils

### DIFF
--- a/e2e/templates_test.go
+++ b/e2e/templates_test.go
@@ -2,7 +2,6 @@ package e2e
 
 import (
 	"encoding/json"
-	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"
@@ -88,7 +87,6 @@ totalmemory_kb: 4194304
 func writeTargetDescription(t *testing.T, content string) string {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), "target-description.yaml")
-
-	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+	testutil.RequireWriteFile(t, path, content)
 	return path
 }

--- a/internal/compose/compose_test.go
+++ b/internal/compose/compose_test.go
@@ -1,7 +1,6 @@
 package compose_test
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -234,8 +233,7 @@ services:
         BAR: new-bar
 `
 		temporaryComposeFilePath := filepath.Join(t.TempDir(), "expected-compose.yml")
-		err := os.WriteFile(temporaryComposeFilePath, []byte(composeFileContents), 0o644)
-		require.NoError(t, err)
+		testutil.RequireWriteFile(t, temporaryComposeFilePath, composeFileContents)
 		proj, err := compose.ReadProject(temporaryComposeFilePath)
 		require.NoError(t, err)
 		composeFilePath := filepath.Join(t.TempDir(), "test-compose.yml")
@@ -243,9 +241,8 @@ services:
 		err = compose.WriteProject(proj, composeFilePath)
 		require.NoError(t, err)
 
-		got, err := os.ReadFile(composeFilePath)
-		require.NoError(t, err)
-		assert.YAMLEq(t, composeFileContents, string(got))
+		got := testutil.RequireReadFile(t, composeFilePath)
+		assert.YAMLEq(t, composeFileContents, got)
 	})
 }
 

--- a/internal/deploy/project_checks/project_checks_test.go
+++ b/internal/deploy/project_checks/project_checks_test.go
@@ -1,11 +1,10 @@
 package checks_test
 
 import (
-	"os"
-	"path/filepath"
 	"testing"
 
 	checks "github.com/arm/topo/internal/deploy/project_checks"
+	"github.com/arm/topo/internal/testutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -79,11 +78,5 @@ services:
 
 func writeComposeFile(t *testing.T, contents string) string {
 	t.Helper()
-
-	dir := t.TempDir()
-	path := filepath.Join(dir, "compose.yaml")
-	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
-		t.Fatalf("failed to write compose file: %v", err)
-	}
-	return path
+	return testutil.WriteComposeFile(t, t.TempDir(), contents)
 }

--- a/internal/describe/describe_test.go
+++ b/internal/describe/describe_test.go
@@ -1,11 +1,11 @@
 package describe_test
 
 import (
-	"os"
 	"testing"
 
 	"github.com/arm/topo/internal/describe"
 	"github.com/arm/topo/internal/target"
+	"github.com/arm/topo/internal/testutil"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/assert/yaml"
@@ -29,9 +29,8 @@ func TestWriteTargetDescriptionFile(t *testing.T) {
 		outputFile, err := describe.WriteTargetDescriptionToFile(dir, report)
 		require.NoError(t, err)
 
-		content, err := os.ReadFile(outputFile)
-		require.NoError(t, err)
-		err = yaml.Unmarshal(content, &reportOut)
+		content := testutil.RequireReadFile(t, outputFile)
+		err = yaml.Unmarshal([]byte(content), &reportOut)
 		require.NoError(t, err)
 		require.FileExists(t, outputFile)
 		assert.Equal(t, report, reportOut)
@@ -55,11 +54,10 @@ func TestWriteTargetDescriptionFile(t *testing.T) {
 		outputFile2, err := describe.WriteTargetDescriptionToFile(dir, report2)
 		require.NoError(t, err)
 
-		content, err := os.ReadFile(outputFile2)
-		require.NoError(t, err)
+		content := testutil.RequireReadFile(t, outputFile2)
 		require.Equal(t, outputFile1, outputFile2)
-		assert.Contains(t, string(content), "feature1")
-		assert.NotContains(t, string(content), "feature2")
+		assert.Contains(t, content, "feature1")
+		assert.NotContains(t, content, "feature2")
 	})
 }
 
@@ -77,7 +75,7 @@ remoteprocs:
   - name: remoteproc0
 totalmemory_kb: 16384
 `
-		require.NoError(t, os.WriteFile(filePath, []byte(content), 0o644))
+		testutil.RequireWriteFile(t, filePath, content)
 		profile, err := describe.ReadTargetDescriptionFromFile(filePath)
 
 		require.NoError(t, err)
@@ -104,7 +102,7 @@ totalmemory_kb: 16384
 	t.Run("returns error when target description yaml is invalid", func(t *testing.T) {
 		dir := t.TempDir()
 		filePath := dir + "/invalid.yaml"
-		require.NoError(t, os.WriteFile(filePath, []byte("host_processor: ["), 0o644))
+		testutil.RequireWriteFile(t, filePath, "host_processor: [")
 
 		_, err := describe.ReadTargetDescriptionFromFile(filePath)
 

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -49,10 +49,9 @@ func TestInit(t *testing.T) {
 		require.NoError(t, project.Init(dir))
 
 		composeFile := filepath.Join(dir, template.ComposeFilename)
-		data, err := os.ReadFile(composeFile)
-		require.NoError(t, err)
+		data := testutil.RequireReadFile(t, composeFile)
 		var p types.Project
-		require.NoError(t, yaml.Unmarshal(data, &p))
+		require.NoError(t, yaml.Unmarshal([]byte(data), &p))
 		assert.Empty(t, p.Services)
 	})
 }
@@ -61,8 +60,8 @@ func mockTemplateSourceWithContent(t *testing.T, content, sourceName string) *mo
 	mockSource := &mockTemplateSource{}
 	mockSource.On("CopyTo", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
 		destDir := args.String(0)
-		require.NoError(t, os.MkdirAll(destDir, 0o755))
-		require.NoError(t, os.WriteFile(filepath.Join(destDir, template.ComposeFilename), []byte(content), 0o644))
+		testutil.RequireMkdirAll(t, destDir)
+		testutil.RequireWriteFile(t, filepath.Join(destDir, template.ComposeFilename), content)
 	})
 	mockSource.On("GetName").Return(sourceName, nil)
 	t.Cleanup(func() {
@@ -106,8 +105,7 @@ x-topo:
 		err := project.Extend(targetProjectFile, mockSource, argProvider)
 		require.NoError(t, err)
 
-		data, err := os.ReadFile(targetProjectFile)
-		require.NoError(t, err, "failed to read compose file")
+		data := testutil.RequireReadFile(t, targetProjectFile)
 		sourcePath := filepath.Join(sourceName, "compose.yaml")
 		wantYAML := fmt.Sprintf(`
 name: example-project
@@ -121,7 +119,7 @@ services:
       file: %[1]s
       service: app2
 `, sourcePath)
-		assert.YAMLEq(t, wantYAML, string(data))
+		assert.YAMLEq(t, wantYAML, data)
 	})
 
 	t.Run("errors when directory exists", func(t *testing.T) {
@@ -156,8 +154,7 @@ x-topo:
 		err := project.Extend(targetProjectFile, mockSource, argProvider)
 		require.NoError(t, err)
 
-		got, err := os.ReadFile(targetProjectFile)
-		require.NoError(t, err)
+		got := testutil.RequireReadFile(t, targetProjectFile)
 		sourcePath := filepath.Join(sourceName, "compose.yaml")
 		want := fmt.Sprintf(`
 name: example-project
@@ -169,7 +166,7 @@ services:
 volumes:
   pretty_data: {}
 `, sourcePath)
-		assert.YAMLEq(t, want, string(got))
+		assert.YAMLEq(t, want, got)
 	})
 
 	t.Run("collects and injects build arguments", func(t *testing.T) {
@@ -197,8 +194,7 @@ x-topo:
 		err := project.Extend(targetProjectFile, mockSource, provider)
 		require.NoError(t, err)
 
-		got, err := os.ReadFile(targetProjectFile)
-		require.NoError(t, err)
+		got := testutil.RequireReadFile(t, targetProjectFile)
 		sourcePath := filepath.Join(sourceName, "compose.yaml")
 		want := fmt.Sprintf(`
 name: example-project
@@ -211,7 +207,7 @@ services:
       args:
         GREETING: "Hello, World"
 `, sourcePath)
-		assert.YAMLEq(t, want, string(got))
+		assert.YAMLEq(t, want, got)
 	})
 
 	t.Run("injects arguments only into services that declare them", func(t *testing.T) {
@@ -249,8 +245,7 @@ x-topo:
 		err := project.Extend(targetProjectFile, mockSource, provider)
 		require.NoError(t, err)
 
-		got, err := os.ReadFile(targetProjectFile)
-		require.NoError(t, err)
+		got := testutil.RequireReadFile(t, targetProjectFile)
 		sourcePath := filepath.Join(sourceName, "compose.yaml")
 		want := fmt.Sprintf(`
 name: example-project
@@ -270,7 +265,7 @@ services:
       args:
         PORT: "9090"
 `, sourcePath, sourcePath)
-		assert.YAMLEq(t, want, string(got))
+		assert.YAMLEq(t, want, got)
 	})
 
 	t.Run("does not collect optional arguments into x-topo", func(t *testing.T) {
@@ -301,8 +296,7 @@ x-topo:
 		err := project.Extend(targetProjectFile, mockSource, provider)
 		require.NoError(t, err)
 
-		got, err := os.ReadFile(targetProjectFile)
-		require.NoError(t, err)
+		got := testutil.RequireReadFile(t, targetProjectFile)
 		sourcePath := filepath.Join(sourceName, "compose.yaml")
 		want := fmt.Sprintf(`
 name: example-project
@@ -315,7 +309,7 @@ services:
       args:
         GREETING: "Hello, World"
 `, sourcePath)
-		assert.YAMLEq(t, want, string(got))
+		assert.YAMLEq(t, want, got)
 	})
 
 	t.Run("cleans up service directory when argument collection fails ", func(t *testing.T) {
@@ -398,10 +392,9 @@ x-topo:
       required: true
       example: bar
 `
-		got, err := os.ReadFile(composeFilePath)
-		require.NoError(t, err)
+		got := testutil.RequireReadFile(t, composeFilePath)
 
-		assert.YAMLEq(t, want, string(got))
+		assert.YAMLEq(t, want, got)
 	})
 }
 
@@ -418,12 +411,11 @@ services:
 
 		require.NoError(t, project.RemoveService(targetProjectFile, "removeMe"))
 
-		data, err := os.ReadFile(targetProjectFile)
-		require.NoError(t, err)
+		data := testutil.RequireReadFile(t, targetProjectFile)
 		want := `name: example-project
 services: {}
 `
-		assert.YAMLEq(t, want, string(data))
+		assert.YAMLEq(t, want, data)
 	})
 
 	t.Run("preserves comments when a service is removed", func(t *testing.T) {
@@ -442,8 +434,7 @@ services:
 
 		require.NoError(t, project.RemoveService(targetProjectFile, "removeMe"))
 
-		data, err := os.ReadFile(targetProjectFile)
-		require.NoError(t, err)
+		data := testutil.RequireReadFile(t, targetProjectFile)
 		want := `name: example-project
 services:
   # This is a comment that should be preserved
@@ -451,6 +442,6 @@ services:
     build:
       context: ./keepMe
 `
-		assert.Equal(t, want, string(data))
+		assert.Equal(t, want, data)
 	})
 }

--- a/internal/setupkeys/pubkeytransfer/pub_key_transfer_test.go
+++ b/internal/setupkeys/pubkeytransfer/pub_key_transfer_test.go
@@ -2,13 +2,13 @@ package pubkeytransfer_test
 
 import (
 	"bytes"
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/arm/topo/internal/runner"
 	"github.com/arm/topo/internal/setupkeys/pubkeytransfer"
+	"github.com/arm/topo/internal/testutil"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
@@ -19,7 +19,7 @@ func TestPubKeyTransfer(t *testing.T) {
 			tmp := t.TempDir()
 			privKeyPath := filepath.Join(tmp, "id_ed25519_testrun")
 			pubKeyContent := []byte("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAItestkey")
-			require.NoError(t, os.WriteFile(privKeyPath+".pub", pubKeyContent, 0o600))
+			testutil.RequireWriteFile(t, privKeyPath+".pub", string(pubKeyContent))
 
 			r := &runner.Mock{}
 			r.On(

--- a/internal/template/source_test.go
+++ b/internal/template/source_test.go
@@ -224,21 +224,17 @@ func TestDirSource(t *testing.T) {
 	t.Run("CopyTo", func(t *testing.T) {
 		t.Run("copies directory contents to destination", func(t *testing.T) {
 			srcDir := t.TempDir()
-			require.NoError(t, os.WriteFile(filepath.Join(srcDir, "file.txt"), []byte("content"), 0o644))
-			require.NoError(t, os.Mkdir(filepath.Join(srcDir, "subdir"), 0o755))
-			require.NoError(t, os.WriteFile(filepath.Join(srcDir, "subdir", "nested.txt"), []byte("nested"), 0o644))
+			testutil.RequireWriteFile(t, filepath.Join(srcDir, "file.txt"), "content")
+			testutil.RequireMkdirAll(t, filepath.Join(srcDir, "subdir"))
+			testutil.RequireWriteFile(t, filepath.Join(srcDir, "subdir", "nested.txt"), "nested")
 			dstDir := filepath.Join(t.TempDir(), "dest")
 			src := template.DirSource{Path: srcDir}
 
 			err := src.CopyTo(dstDir)
 
 			require.NoError(t, err)
-			content, err := os.ReadFile(filepath.Join(dstDir, "file.txt"))
-			require.NoError(t, err)
-			assert.Equal(t, "content", string(content))
-			nested, err := os.ReadFile(filepath.Join(dstDir, "subdir", "nested.txt"))
-			require.NoError(t, err)
-			assert.Equal(t, "nested", string(nested))
+			testutil.AssertFileContents(t, "content", filepath.Join(dstDir, "file.txt"))
+			testutil.AssertFileContents(t, "nested", filepath.Join(dstDir, "subdir", "nested.txt"))
 		})
 
 		t.Run("preserves file permissions", func(t *testing.T) {
@@ -275,7 +271,7 @@ func TestDirSource(t *testing.T) {
 		t.Run("preserves symlinks as symlinks", func(t *testing.T) {
 			srcDir := t.TempDir()
 			targetFile := filepath.Join(srcDir, "target.txt")
-			require.NoError(t, os.WriteFile(targetFile, []byte("target content"), 0o644))
+			testutil.RequireWriteFile(t, targetFile, "target content")
 			symlinkPath := filepath.Join(srcDir, "link.txt")
 			if err := os.Symlink("target.txt", symlinkPath); err != nil {
 				if linkError, ok := err.(*os.LinkError); ok {
@@ -312,7 +308,7 @@ func TestDirSource(t *testing.T) {
 
 		t.Run("errors when source is a file", func(t *testing.T) {
 			srcFile := filepath.Join(t.TempDir(), "file.txt")
-			require.NoError(t, os.WriteFile(srcFile, []byte("content"), 0o644))
+			testutil.RequireWriteFile(t, srcFile, "content")
 			src := template.DirSource{Path: srcFile}
 			dstDir := filepath.Join(t.TempDir(), "dest")
 
@@ -336,7 +332,7 @@ func TestDirSource(t *testing.T) {
 
 		t.Run("errors when destination already exists", func(t *testing.T) {
 			srcDir := t.TempDir()
-			require.NoError(t, os.WriteFile(filepath.Join(srcDir, "file.txt"), []byte("content"), 0o644))
+			testutil.RequireWriteFile(t, filepath.Join(srcDir, "file.txt"), "content")
 			dstDir := t.TempDir()
 			src := template.DirSource{Path: srcDir}
 

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -102,6 +102,13 @@ func CmdWithOutput(output string, exitCode int) *exec.Cmd {
 	return exec.Command("sh", "-c", fmt.Sprintf("printf %%s \"$1\"; exit %d", exitCode), "sh", output)
 }
 
+func RequireReadFile(t testing.TB, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	return string(data)
+}
+
 func AssertFileContents(t *testing.T, wantContents string, path string) {
 	t.Helper()
 

--- a/internal/vscode/project_test.go
+++ b/internal/vscode/project_test.go
@@ -2,11 +2,9 @@ package vscode_test
 
 import (
 	"bytes"
-	"os"
-	"path/filepath"
 	"testing"
 
-	"github.com/arm/topo/internal/template"
+	"github.com/arm/topo/internal/testutil"
 	"github.com/arm/topo/internal/vscode"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -15,8 +13,7 @@ import (
 func TestPrintProject(t *testing.T) {
 	compose := `name: demo
 services: {}`
-	composePath := filepath.Join(t.TempDir(), template.ComposeFilename)
-	require.NoError(t, os.WriteFile(composePath, []byte(compose), 0o644))
+	composePath := testutil.WriteComposeFile(t, t.TempDir(), compose)
 	var buf bytes.Buffer
 
 	err := vscode.PrintProject(&buf, composePath)

--- a/scripts/update_templates/write_test.go
+++ b/scripts/update_templates/write_test.go
@@ -2,10 +2,10 @@ package main
 
 import (
 	"encoding/json"
-	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/arm/topo/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -25,10 +25,9 @@ func TestWriteTemplates(t *testing.T) {
 		err := WriteTemplates(path, input)
 		require.NoError(t, err)
 
-		raw, err := os.ReadFile(path)
-		require.NoError(t, err)
+		raw := testutil.RequireReadFile(t, path)
 		var decoded []Template
-		require.NoError(t, json.Unmarshal(raw, &decoded))
+		require.NoError(t, json.Unmarshal([]byte(raw), &decoded))
 		assert.Equal(t, input, decoded)
 	})
 }


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- Makes use of our existing file/dir-writing `testutil` functions across the test suites to reduce noise
- Adds a new `testutil.RequireWriteFile` to round out the trio of read file/write file/mkdir
