### PR TITLE
refactor: simplify SSH authentication probe

### DIFF
--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -152,7 +152,7 @@ func connectivityCheck(status ConnectionStatus) HealthCheck {
 
 	check.Value = status.Error.Error()
 	switch {
-	case errors.Is(status.Error, target.ErrPasswordAuthentication):
+	case errors.Is(status.Error, target.ErrAuthenticationFailure):
 		check.Fix = fmt.Sprintf("run `topo setup-keys --target %s` to configure SSH keys", status.Destination)
 	case errors.Is(status.Error, target.ErrHostKeyNew):
 		check.Fix = fmt.Sprintf("run `topo health --target %s --accept-new-host-keys` to trust the target's identity", status.Destination)

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -152,9 +152,9 @@ func connectivityCheck(status ConnectionStatus) HealthCheck {
 
 	check.Value = status.Error.Error()
 	switch {
-	case errors.Is(status.Error, target.ErrAuthenticationFailure):
+	case errors.Is(status.Error, target.ErrAuthFailed):
 		check.Fix = fmt.Sprintf("run `topo setup-keys --target %s` to configure SSH keys", status.Destination)
-	case errors.Is(status.Error, target.ErrHostKeyNew):
+	case errors.Is(status.Error, target.ErrHostKeyUnknown):
 		check.Fix = fmt.Sprintf("run `topo health --target %s --accept-new-host-keys` to trust the target's identity", status.Destination)
 	case errors.Is(status.Error, target.ErrHostKeyChanged):
 		check.Fix = fmt.Sprintf("run `ssh-keygen -R %s` to remove the old host key, then retry", status.Destination.Host)

--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -63,11 +63,11 @@ func TestGenerateTargetReport(t *testing.T) {
 		assert.Equal(t, health.CheckStatusOK, got.Connectivity.Status)
 	})
 
-	t.Run("when password authentication is required, Connectivity includes a setup-keys fix", func(t *testing.T) {
+	t.Run("when authentication fails, Connectivity includes a setup-keys fix", func(t *testing.T) {
 		ts := health.Status{
 			Connection: health.ConnectionStatus{
 				Destination: ssh.NewDestination("user@my-target"),
-				Error:       target.ErrPasswordAuthentication,
+				Error:       target.ErrAuthenticationFailure,
 			},
 		}
 

--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -67,7 +67,7 @@ func TestGenerateTargetReport(t *testing.T) {
 		ts := health.Status{
 			Connection: health.ConnectionStatus{
 				Destination: ssh.NewDestination("user@my-target"),
-				Error:       target.ErrAuthenticationFailure,
+				Error:       target.ErrAuthFailed,
 			},
 		}
 
@@ -81,7 +81,7 @@ func TestGenerateTargetReport(t *testing.T) {
 		ts := health.Status{
 			Connection: health.ConnectionStatus{
 				Destination: ssh.NewDestination("user@my-target"),
-				Error:       target.ErrHostKeyNew,
+				Error:       target.ErrHostKeyUnknown,
 			},
 		}
 

--- a/internal/ssh/errors.go
+++ b/internal/ssh/errors.go
@@ -11,19 +11,29 @@ var (
 	ErrAuthFailed        = fmt.Errorf("%w: authentication failed", ErrSSH)
 	ErrConnectionFailed  = fmt.Errorf("%w: connection failed", ErrSSH)
 	ErrConnectionTimeout = fmt.Errorf("%w: connection timed out", ErrSSH)
+	ErrHostKeyUnknown    = fmt.Errorf("%w: host key is not known", ErrSSH)
+	ErrHostKeyChanged    = fmt.Errorf("%w: host key has changed", ErrSSH)
 )
 
 // ClassifyStderr inspects SSH stderr output and returns a typed error when a
 // known failure pattern is detected, or nil if the output is unrecognised.
 func ClassifyStderr(stderr string) error {
 	lower := strings.ToLower(stderr)
+	if strings.Contains(lower, "host key verification failed") {
+		if strings.Contains(lower, "has changed") {
+			return ErrHostKeyChanged
+		}
+		return ErrHostKeyUnknown
+	}
 	if strings.Contains(lower, "timed out") ||
 		strings.Contains(lower, "connection timeout") ||
 		strings.Contains(lower, "did not properly respond after a period of time") {
 		return ErrConnectionTimeout
 	}
 	if strings.Contains(lower, "publickey") ||
-		strings.Contains(lower, "authentication") {
+		strings.Contains(lower, "authentication") ||
+		strings.Contains(lower, "permission denied") ||
+		strings.Contains(lower, "password") {
 		return ErrAuthFailed
 	}
 	if strings.Contains(lower, "connection refused") {

--- a/internal/ssh/errors.go
+++ b/internal/ssh/errors.go
@@ -25,15 +25,10 @@ func ClassifyStderr(stderr string) error {
 		}
 		return ErrHostKeyUnknown
 	}
-	if strings.Contains(lower, "timed out") ||
-		strings.Contains(lower, "connection timeout") ||
-		strings.Contains(lower, "did not properly respond after a period of time") {
+	if strings.Contains(lower, "timed out") {
 		return ErrConnectionTimeout
 	}
-	if strings.Contains(lower, "publickey") ||
-		strings.Contains(lower, "authentication") ||
-		strings.Contains(lower, "permission denied") ||
-		strings.Contains(lower, "password") {
+	if strings.Contains(lower, "permission denied") {
 		return ErrAuthFailed
 	}
 	if strings.Contains(lower, "connection refused") {

--- a/internal/ssh/errors_test.go
+++ b/internal/ssh/errors_test.go
@@ -12,18 +12,23 @@ func TestClassifyStderr(t *testing.T) {
 		stderr string
 		want   error
 	}{
-		{name: "publickey message", stderr: "Permission denied (publickey)", want: ErrAuthFailed},
-		{name: "authentication message", stderr: "Authentication failed", want: ErrAuthFailed},
-		{name: "permission denied", stderr: "Permission denied", want: ErrAuthFailed},
-		{name: "password prompt", stderr: "password:", want: ErrAuthFailed},
-		{name: "connection refused", stderr: "ssh: connect to host foo port 22: Connection refused", want: ErrConnectionFailed},
-		{name: "timed out", stderr: "ssh: connect to host foo port 22: Operation timed out", want: ErrConnectionTimeout},
-		{name: "connection timeout", stderr: "Connection timeout", want: ErrConnectionTimeout},
-		{name: "windows timeout", stderr: "did not properly respond after a period of time", want: ErrConnectionTimeout},
+		{name: "auth failure", stderr: "user@host: Permission denied (publickey).", want: ErrAuthFailed},
+		{name: "connection refused", stderr: "ssh: connect to host example.com port 22: Connection refused", want: ErrConnectionFailed},
+		{name: "operation timed out (macOS)", stderr: "ssh: connect to host example.com port 22: Operation timed out", want: ErrConnectionTimeout},
+		{name: "connection timed out (Linux)", stderr: "ssh: connect to host example.com port 22: Connection timed out", want: ErrConnectionTimeout},
 		{name: "generic host key verification failure", stderr: "Host key verification failed.", want: ErrHostKeyUnknown},
-		{name: "unknown host key", stderr: "No ED25519 host key is known for 10.2.4.68 and you have requested strict checking.\nHost key verification failed.", want: ErrHostKeyUnknown},
-		{name: "host key has changed", stderr: "Host key for 10.2.4.68 has changed and you have requested strict checking.\nHost key verification failed.", want: ErrHostKeyChanged},
-		{name: "case insensitive", stderr: "HOST KEY VERIFICATION FAILED", want: ErrHostKeyUnknown},
+		{
+			name: "unknown host key",
+			stderr: `No ED25519 host key is known for 10.2.4.68 and you have requested strict checking.
+Host key verification failed.`,
+			want: ErrHostKeyUnknown,
+		},
+		{
+			name: "host key has changed",
+			stderr: `Host key for 10.2.4.68 has changed and you have requested strict checking.
+Host key verification failed.`,
+			want: ErrHostKeyChanged,
+		},
 		{name: "unrecognised output", stderr: "some unexpected error", want: nil},
 		{name: "empty stderr", stderr: "", want: nil},
 	}

--- a/internal/ssh/errors_test.go
+++ b/internal/ssh/errors_test.go
@@ -7,47 +7,45 @@ import (
 )
 
 func TestClassifyStderr(t *testing.T) {
-	t.Run("returns ErrAuthFailed for publickey message", func(t *testing.T) {
-		assert.ErrorIs(t, ClassifyStderr("Permission denied (publickey)"), ErrAuthFailed)
-	})
+	tests := []struct {
+		name   string
+		stderr string
+		want   error
+	}{
+		{name: "publickey message", stderr: "Permission denied (publickey)", want: ErrAuthFailed},
+		{name: "authentication message", stderr: "Authentication failed", want: ErrAuthFailed},
+		{name: "permission denied", stderr: "Permission denied", want: ErrAuthFailed},
+		{name: "password prompt", stderr: "password:", want: ErrAuthFailed},
+		{name: "connection refused", stderr: "ssh: connect to host foo port 22: Connection refused", want: ErrConnectionFailed},
+		{name: "timed out", stderr: "ssh: connect to host foo port 22: Operation timed out", want: ErrConnectionTimeout},
+		{name: "connection timeout", stderr: "Connection timeout", want: ErrConnectionTimeout},
+		{name: "windows timeout", stderr: "did not properly respond after a period of time", want: ErrConnectionTimeout},
+		{name: "generic host key verification failure", stderr: "Host key verification failed.", want: ErrHostKeyUnknown},
+		{name: "unknown host key", stderr: "No ED25519 host key is known for 10.2.4.68 and you have requested strict checking.\nHost key verification failed.", want: ErrHostKeyUnknown},
+		{name: "host key has changed", stderr: "Host key for 10.2.4.68 has changed and you have requested strict checking.\nHost key verification failed.", want: ErrHostKeyChanged},
+		{name: "case insensitive", stderr: "HOST KEY VERIFICATION FAILED", want: ErrHostKeyUnknown},
+		{name: "unrecognised output", stderr: "some unexpected error", want: nil},
+		{name: "empty stderr", stderr: "", want: nil},
+	}
 
-	t.Run("returns ErrAuthFailed for authentication message", func(t *testing.T) {
-		assert.ErrorIs(t, ClassifyStderr("Authentication failed"), ErrAuthFailed)
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ClassifyStderr(tt.stderr)
 
-	t.Run("returns ErrConnectionFailed for connection refused", func(t *testing.T) {
-		assert.ErrorIs(t, ClassifyStderr("ssh: connect to host foo port 22: Connection refused"), ErrConnectionFailed)
-	})
+			if tt.want == nil {
+				assert.NoError(t, got)
+			} else {
+				assert.ErrorIs(t, got, tt.want)
+			}
+		})
+	}
+}
 
-	t.Run("ErrAuthFailed satisfies ErrSSH", func(t *testing.T) {
-		assert.ErrorIs(t, ErrAuthFailed, ErrSSH)
-	})
-
-	t.Run("ErrConnectionFailed satisfies ErrSSH", func(t *testing.T) {
-		assert.ErrorIs(t, ErrConnectionFailed, ErrSSH)
-	})
-
-	t.Run("returns ErrConnectionTimeout for timed out message", func(t *testing.T) {
-		assert.ErrorIs(t, ClassifyStderr("ssh: connect to host foo port 22: Operation timed out"), ErrConnectionTimeout)
-	})
-
-	t.Run("returns ErrConnectionTimeout for connection timeout message", func(t *testing.T) {
-		assert.ErrorIs(t, ClassifyStderr("Connection timeout"), ErrConnectionTimeout)
-	})
-
-	t.Run("returns ErrConnectionTimeout for windows timeout message", func(t *testing.T) {
-		assert.ErrorIs(t, ClassifyStderr("did not properly respond after a period of time"), ErrConnectionTimeout)
-	})
-
-	t.Run("ErrConnectionTimeout satisfies ErrSSH", func(t *testing.T) {
-		assert.ErrorIs(t, ErrConnectionTimeout, ErrSSH)
-	})
-
-	t.Run("returns nil for unrecognised output", func(t *testing.T) {
-		assert.Nil(t, ClassifyStderr("some unexpected error"))
-	})
-
-	t.Run("returns nil for empty stderr", func(t *testing.T) {
-		assert.Nil(t, ClassifyStderr(""))
-	})
+func TestSentinelErrors(t *testing.T) {
+	sentinels := []error{ErrAuthFailed, ErrConnectionFailed, ErrConnectionTimeout, ErrHostKeyUnknown, ErrHostKeyChanged}
+	for _, err := range sentinels {
+		t.Run(err.Error(), func(t *testing.T) {
+			assert.ErrorIs(t, err, ErrSSH)
+		})
+	}
 }

--- a/internal/target/ssh_authentication_probe.go
+++ b/internal/target/ssh_authentication_probe.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"strings"
+
+	"github.com/arm/topo/internal/runner"
 )
 
 var (
@@ -12,20 +14,16 @@ var (
 	ErrAuthenticationFailure = errors.New("ssh authentication failed")
 )
 
-type sshRunnerWithExtraArgs interface {
-	RunWithArgs(ctx context.Context, command string, sshArgs ...string) (string, error)
-}
-
 type SSHAuthenticationProbeOptions struct {
 	AcceptNewHostKeys bool
 }
 
-func NewSSHAuthenticationProbe(r sshRunnerWithExtraArgs, opts SSHAuthenticationProbeOptions) SSHAuthenticationProbe {
+func NewSSHAuthenticationProbe(r *runner.SSH, opts SSHAuthenticationProbeOptions) SSHAuthenticationProbe {
 	return SSHAuthenticationProbe{runner: r, opts: opts}
 }
 
 type SSHAuthenticationProbe struct {
-	runner sshRunnerWithExtraArgs
+	runner *runner.SSH
 	opts   SSHAuthenticationProbeOptions
 }
 

--- a/internal/target/ssh_authentication_probe.go
+++ b/internal/target/ssh_authentication_probe.go
@@ -9,9 +9,9 @@ import (
 )
 
 var (
-	ErrHostKeyUnknown = errors.New("ssh host key is not known")
-	ErrHostKeyChanged = errors.New("ssh host key has changed")
-	ErrAuthFailed     = errors.New("ssh authentication failed")
+	ErrHostKeyUnknown = errors.New("SSH host key is not known")
+	ErrHostKeyChanged = errors.New("SSH host key has changed")
+	ErrAuthFailed     = errors.New("SSH authentication failed")
 )
 
 type SSHAuthenticationProbeOptions struct {

--- a/internal/target/ssh_authentication_probe.go
+++ b/internal/target/ssh_authentication_probe.go
@@ -18,6 +18,21 @@ type SSHAuthenticationProbeOptions struct {
 	AcceptNewHostKeys bool
 }
 
+func (s SSHAuthenticationProbeOptions) SSHArgs() []string {
+	args := []string{
+		"-o", "BatchMode=yes",
+		"-o", "PreferredAuthentications=publickey",
+		"-o", "PasswordAuthentication=no",
+		"-o", "NumberOfPasswordPrompts=0",
+	}
+	if s.AcceptNewHostKeys {
+		args = append(args, "-o", "StrictHostKeyChecking=accept-new")
+	} else {
+		args = append(args, "-o", "StrictHostKeyChecking=yes")
+	}
+	return args
+}
+
 type SSHAuthenticationProbe struct {
 	runner *runner.SSH
 	opts   SSHAuthenticationProbeOptions
@@ -29,7 +44,7 @@ func NewSSHAuthenticationProbe(r *runner.SSH, opts SSHAuthenticationProbeOptions
 
 // Probe verifies SSH connectivity by attempting public key authentication.
 func (p SSHAuthenticationProbe) Probe(ctx context.Context) error {
-	_, err := p.runner.RunWithArgs(ctx, "true", BuildProbeArgs(p.opts.AcceptNewHostKeys)...)
+	_, err := p.runner.RunWithArgs(ctx, "true", p.opts.SSHArgs()...)
 	if err == nil {
 		return nil
 	}
@@ -43,20 +58,4 @@ func (p SSHAuthenticationProbe) Probe(ctx context.Context) error {
 	default:
 		return err
 	}
-}
-
-// BuildProbeArgs returns SSH arguments for a public key authentication probe.
-func BuildProbeArgs(acceptNewHostKeys bool) []string {
-	args := []string{
-		"-o", "BatchMode=yes",
-		"-o", "PreferredAuthentications=publickey",
-		"-o", "PasswordAuthentication=no",
-		"-o", "NumberOfPasswordPrompts=0",
-	}
-	if acceptNewHostKeys {
-		args = append(args, "-o", "StrictHostKeyChecking=accept-new")
-	} else {
-		args = append(args, "-o", "StrictHostKeyChecking=yes")
-	}
-	return args
 }

--- a/internal/target/ssh_authentication_probe.go
+++ b/internal/target/ssh_authentication_probe.go
@@ -7,10 +7,9 @@ import (
 )
 
 var (
-	ErrPasswordAuthentication = errors.New("key-based SSH authentication is not setup")
-	ErrHostKeyNew             = errors.New("ssh host key is not known")
-	ErrHostKeyChanged         = errors.New("ssh host key has changed")
-	ErrAuthenticationFailure  = errors.New("ssh authentication failed")
+	ErrHostKeyNew            = errors.New("ssh host key is not known")
+	ErrHostKeyChanged        = errors.New("ssh host key has changed")
+	ErrAuthenticationFailure = errors.New("ssh authentication failed")
 )
 
 type sshRunnerWithExtraArgs interface {
@@ -30,87 +29,26 @@ type SSHAuthenticationProbe struct {
 	opts   SSHAuthenticationProbeOptions
 }
 
+// Probe verifies SSH connectivity by attempting public key authentication.
+// Returns ErrAuthenticationFailure if keys are not configured, or a host key
+// error if the target's identity cannot be verified.
 func (p SSHAuthenticationProbe) Probe(ctx context.Context) error {
-	if err := p.verifyKnownHost(ctx); err != nil {
-		return err
-	}
-
-	if err := p.authenticateUsingPublicKey(ctx); err == nil {
-		return nil
-	} else if !errors.Is(err, ErrAuthenticationFailure) {
-		return err
-	}
-
-	if err := p.authenticateUsingPassword(ctx); err == nil {
-		return nil
-	} else if errors.Is(err, ErrAuthenticationFailure) {
-		return ErrPasswordAuthentication
-	} else {
-		return err
-	}
-}
-
-func (p SSHAuthenticationProbe) verifyKnownHost(ctx context.Context) error {
-	if p.opts.AcceptNewHostKeys {
-		return nil
-	}
-
-	err := p.runAuthenticationProbe(ctx, BuildProbeArgs(KnownHost, false))
-	if err == nil || errors.Is(err, ErrAuthenticationFailure) {
-		return nil
-	}
-
-	return err
-}
-
-func (p SSHAuthenticationProbe) authenticateUsingPublicKey(ctx context.Context) error {
-	return p.runAuthenticationProbe(ctx, BuildProbeArgs(PublicKey, p.opts.AcceptNewHostKeys))
-}
-
-func (p SSHAuthenticationProbe) authenticateUsingPassword(ctx context.Context) error {
-	return p.runAuthenticationProbe(ctx, BuildProbeArgs(Password, p.opts.AcceptNewHostKeys))
-}
-
-// All SSH authentication probes run the command "true" to check if the authentication method works.
-// All sshArgs should be hardcoded SSH options, not user-provided arguments.
-func (p SSHAuthenticationProbe) runAuthenticationProbe(ctx context.Context, sshArgs []string) error {
-	out, err := p.runner.RunWithArgs(ctx, "true", sshArgs...)
+	out, err := p.runner.RunWithArgs(ctx, "true", BuildProbeArgs(p.opts.AcceptNewHostKeys)...)
 	return ClassifySSHOutput(out, err)
 }
 
-type ProbeMethod int
-
-const (
-	PublicKey ProbeMethod = iota
-	Password
-	KnownHost
-)
-
-// BuildProbeArgs returns the SSH arguments for a given probe method.
-func BuildProbeArgs(method ProbeMethod, acceptNewHostKeys bool) []string {
-	var args []string
-	switch method {
-	case PublicKey:
-		args = []string{
-			"-o", "BatchMode=yes",
-			"-o", "PreferredAuthentications=publickey",
-		}
-	case Password:
-		args = []string{
-			"-o", "BatchMode=yes",
-			"-o", "PreferredAuthentications=password",
-			"-o", "NumberOfPasswordPrompts=0",
-		}
-	case KnownHost:
-		args = []string{
-			"-o", "StrictHostKeyChecking=yes",
-			"-o", "PreferredAuthentications=publickey",
-			"-o", "PasswordAuthentication=no",
-			"-o", "NumberOfPasswordPrompts=0",
-		}
+// BuildProbeArgs returns SSH arguments for a public key authentication probe.
+func BuildProbeArgs(acceptNewHostKeys bool) []string {
+	args := []string{
+		"-o", "BatchMode=yes",
+		"-o", "PreferredAuthentications=publickey",
+		"-o", "PasswordAuthentication=no",
+		"-o", "NumberOfPasswordPrompts=0",
 	}
 	if acceptNewHostKeys {
 		args = append(args, "-o", "StrictHostKeyChecking=accept-new")
+	} else {
+		args = append(args, "-o", "StrictHostKeyChecking=yes")
 	}
 	return args
 }

--- a/internal/target/ssh_authentication_probe.go
+++ b/internal/target/ssh_authentication_probe.go
@@ -18,13 +18,13 @@ type SSHAuthenticationProbeOptions struct {
 	AcceptNewHostKeys bool
 }
 
-func NewSSHAuthenticationProbe(r *runner.SSH, opts SSHAuthenticationProbeOptions) SSHAuthenticationProbe {
-	return SSHAuthenticationProbe{runner: r, opts: opts}
-}
-
 type SSHAuthenticationProbe struct {
 	runner *runner.SSH
 	opts   SSHAuthenticationProbeOptions
+}
+
+func NewSSHAuthenticationProbe(r *runner.SSH, opts SSHAuthenticationProbeOptions) SSHAuthenticationProbe {
+	return SSHAuthenticationProbe{runner: r, opts: opts}
 }
 
 // Probe verifies SSH connectivity by attempting public key authentication.

--- a/internal/target/ssh_authentication_probe.go
+++ b/internal/target/ssh_authentication_probe.go
@@ -3,15 +3,15 @@ package target
 import (
 	"context"
 	"errors"
-	"strings"
 
 	"github.com/arm/topo/internal/runner"
+	"github.com/arm/topo/internal/ssh"
 )
 
 var (
-	ErrHostKeyNew            = errors.New("ssh host key is not known")
-	ErrHostKeyChanged        = errors.New("ssh host key has changed")
-	ErrAuthenticationFailure = errors.New("ssh authentication failed")
+	ErrHostKeyUnknown = errors.New("ssh host key is not known")
+	ErrHostKeyChanged = errors.New("ssh host key has changed")
+	ErrAuthFailed     = errors.New("ssh authentication failed")
 )
 
 type SSHAuthenticationProbeOptions struct {
@@ -28,11 +28,21 @@ func NewSSHAuthenticationProbe(r *runner.SSH, opts SSHAuthenticationProbeOptions
 }
 
 // Probe verifies SSH connectivity by attempting public key authentication.
-// Returns ErrAuthenticationFailure if keys are not configured, or a host key
-// error if the target's identity cannot be verified.
 func (p SSHAuthenticationProbe) Probe(ctx context.Context) error {
-	out, err := p.runner.RunWithArgs(ctx, "true", BuildProbeArgs(p.opts.AcceptNewHostKeys)...)
-	return ClassifySSHOutput(out, err)
+	_, err := p.runner.RunWithArgs(ctx, "true", BuildProbeArgs(p.opts.AcceptNewHostKeys)...)
+	if err == nil {
+		return nil
+	}
+	switch {
+	case errors.Is(err, ssh.ErrHostKeyChanged):
+		return ErrHostKeyChanged
+	case errors.Is(err, ssh.ErrHostKeyUnknown):
+		return ErrHostKeyUnknown
+	case errors.Is(err, ssh.ErrAuthFailed):
+		return ErrAuthFailed
+	default:
+		return err
+	}
 }
 
 // BuildProbeArgs returns SSH arguments for a public key authentication probe.
@@ -49,24 +59,4 @@ func BuildProbeArgs(acceptNewHostKeys bool) []string {
 		args = append(args, "-o", "StrictHostKeyChecking=yes")
 	}
 	return args
-}
-
-// ClassifySSHOutput maps raw SSH output to a domain error.
-// Returns nil if err is nil, a domain error if the output is recognized,
-// or the original error otherwise.
-func ClassifySSHOutput(output string, err error) error {
-	if err == nil {
-		return nil
-	}
-	lower := strings.ToLower(output)
-	if strings.Contains(lower, "host key verification failed") {
-		if strings.Contains(lower, "has changed") {
-			return ErrHostKeyChanged
-		}
-		return ErrHostKeyNew
-	}
-	if strings.Contains(lower, "permission denied") || strings.Contains(lower, "authentication failed") || strings.Contains(lower, "password") {
-		return ErrAuthenticationFailure
-	}
-	return err
 }

--- a/internal/target/ssh_authentication_probe.go
+++ b/internal/target/ssh_authentication_probe.go
@@ -3,29 +3,7 @@ package target
 import (
 	"context"
 	"errors"
-	"slices"
 	"strings"
-)
-
-var (
-	publicKeyProbeArgs = []string{
-		"-o", "BatchMode=yes",
-		"-o", "PreferredAuthentications=publickey",
-	}
-	passwordProbeArgs = []string{
-		"-o", "BatchMode=yes",
-		"-o", "PreferredAuthentications=password",
-		"-o", "NumberOfPasswordPrompts=0",
-	}
-	knownHostProbeArgs = []string{
-		"-o", "StrictHostKeyChecking=yes",
-		"-o", "PreferredAuthentications=publickey",
-		"-o", "PasswordAuthentication=no",
-		"-o", "NumberOfPasswordPrompts=0",
-	}
-	acceptNewHostKeyArgs = []string{
-		"-o", "StrictHostKeyChecking=accept-new",
-	}
 )
 
 var (
@@ -43,13 +21,13 @@ type SSHAuthenticationProbeOptions struct {
 	AcceptNewHostKeys bool
 }
 
+func NewSSHAuthenticationProbe(r sshRunnerWithExtraArgs, opts SSHAuthenticationProbeOptions) SSHAuthenticationProbe {
+	return SSHAuthenticationProbe{runner: r, opts: opts}
+}
+
 type SSHAuthenticationProbe struct {
 	runner sshRunnerWithExtraArgs
 	opts   SSHAuthenticationProbeOptions
-}
-
-func NewSSHAuthenticationProbe(r sshRunnerWithExtraArgs, opts SSHAuthenticationProbeOptions) SSHAuthenticationProbe {
-	return SSHAuthenticationProbe{runner: r, opts: opts}
 }
 
 func (p SSHAuthenticationProbe) Probe(ctx context.Context) error {
@@ -77,7 +55,7 @@ func (p SSHAuthenticationProbe) verifyKnownHost(ctx context.Context) error {
 		return nil
 	}
 
-	err := p.runAuthenticationProbe(ctx, knownHostProbeArgs)
+	err := p.runAuthenticationProbe(ctx, BuildProbeArgs(KnownHost, false))
 	if err == nil || errors.Is(err, ErrAuthenticationFailure) {
 		return nil
 	}
@@ -86,38 +64,72 @@ func (p SSHAuthenticationProbe) verifyKnownHost(ctx context.Context) error {
 }
 
 func (p SSHAuthenticationProbe) authenticateUsingPublicKey(ctx context.Context) error {
-	publicKeyArgs := slices.Clone(publicKeyProbeArgs)
-	if p.opts.AcceptNewHostKeys {
-		publicKeyArgs = slices.Concat(publicKeyArgs, acceptNewHostKeyArgs)
-	}
-
-	return p.runAuthenticationProbe(ctx, publicKeyArgs)
+	return p.runAuthenticationProbe(ctx, BuildProbeArgs(PublicKey, p.opts.AcceptNewHostKeys))
 }
 
 func (p SSHAuthenticationProbe) authenticateUsingPassword(ctx context.Context) error {
-	passwordArgs := slices.Clone(passwordProbeArgs)
-	if p.opts.AcceptNewHostKeys {
-		passwordArgs = slices.Concat(passwordArgs, acceptNewHostKeyArgs)
-	}
-
-	return p.runAuthenticationProbe(ctx, passwordArgs)
+	return p.runAuthenticationProbe(ctx, BuildProbeArgs(Password, p.opts.AcceptNewHostKeys))
 }
 
 // All SSH authentication probes run the command "true" to check if the authentication method works.
 // All sshArgs should be hardcoded SSH options, not user-provided arguments.
 func (p SSHAuthenticationProbe) runAuthenticationProbe(ctx context.Context, sshArgs []string) error {
 	out, err := p.runner.RunWithArgs(ctx, "true", sshArgs...)
+	return ClassifySSHOutput(out, err)
+}
+
+type ProbeMethod int
+
+const (
+	PublicKey ProbeMethod = iota
+	Password
+	KnownHost
+)
+
+// BuildProbeArgs returns the SSH arguments for a given probe method.
+func BuildProbeArgs(method ProbeMethod, acceptNewHostKeys bool) []string {
+	var args []string
+	switch method {
+	case PublicKey:
+		args = []string{
+			"-o", "BatchMode=yes",
+			"-o", "PreferredAuthentications=publickey",
+		}
+	case Password:
+		args = []string{
+			"-o", "BatchMode=yes",
+			"-o", "PreferredAuthentications=password",
+			"-o", "NumberOfPasswordPrompts=0",
+		}
+	case KnownHost:
+		args = []string{
+			"-o", "StrictHostKeyChecking=yes",
+			"-o", "PreferredAuthentications=publickey",
+			"-o", "PasswordAuthentication=no",
+			"-o", "NumberOfPasswordPrompts=0",
+		}
+	}
+	if acceptNewHostKeys {
+		args = append(args, "-o", "StrictHostKeyChecking=accept-new")
+	}
+	return args
+}
+
+// ClassifySSHOutput maps raw SSH output to a domain error.
+// Returns nil if err is nil, a domain error if the output is recognized,
+// or the original error otherwise.
+func ClassifySSHOutput(output string, err error) error {
 	if err == nil {
 		return nil
 	}
-	output := strings.ToLower(out)
-	if strings.Contains(output, "host key verification failed") {
-		if strings.Contains(output, "has changed") {
+	lower := strings.ToLower(output)
+	if strings.Contains(lower, "host key verification failed") {
+		if strings.Contains(lower, "has changed") {
 			return ErrHostKeyChanged
 		}
 		return ErrHostKeyNew
 	}
-	if strings.Contains(output, "permission denied") || strings.Contains(output, "authentication failed") || strings.Contains(output, "password") {
+	if strings.Contains(lower, "permission denied") || strings.Contains(lower, "authentication failed") || strings.Contains(lower, "password") {
 		return ErrAuthenticationFailure
 	}
 	return err

--- a/internal/target/ssh_authentication_probe_test.go
+++ b/internal/target/ssh_authentication_probe_test.go
@@ -123,5 +123,3 @@ func TestBuildProbeArgs(t *testing.T) {
 		})
 	}
 }
-
-

--- a/internal/target/ssh_authentication_probe_test.go
+++ b/internal/target/ssh_authentication_probe_test.go
@@ -7,40 +7,47 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestBuildProbeArgs(t *testing.T) {
-	tests := []struct {
-		name              string
-		acceptNewHostKeys bool
-		want              []string
-	}{
-		{
-			name: "strict host key checking by default",
-			want: []string{
-				"-o", "BatchMode=yes",
-				"-o", "PreferredAuthentications=publickey",
-				"-o", "PasswordAuthentication=no",
-				"-o", "NumberOfPasswordPrompts=0",
-				"-o", "StrictHostKeyChecking=yes",
+func TestSSHAuthenticationProbeOptions(t *testing.T) {
+	t.Run("SSHArgs", func(t *testing.T) {
+		tests := []struct {
+			name              string
+			acceptNewHostKeys bool
+			want              []string
+		}{
+			{
+				name:              "strict host key checking by default",
+				acceptNewHostKeys: false,
+				want: []string{
+					"-o", "BatchMode=yes",
+					"-o", "PreferredAuthentications=publickey",
+					"-o", "PasswordAuthentication=no",
+					"-o", "NumberOfPasswordPrompts=0",
+					"-o", "StrictHostKeyChecking=yes",
+				},
 			},
-		},
-		{
-			name:              "accept new host keys",
-			acceptNewHostKeys: true,
-			want: []string{
-				"-o", "BatchMode=yes",
-				"-o", "PreferredAuthentications=publickey",
-				"-o", "PasswordAuthentication=no",
-				"-o", "NumberOfPasswordPrompts=0",
-				"-o", "StrictHostKeyChecking=accept-new",
+			{
+				name:              "accept new host keys",
+				acceptNewHostKeys: true,
+				want: []string{
+					"-o", "BatchMode=yes",
+					"-o", "PreferredAuthentications=publickey",
+					"-o", "PasswordAuthentication=no",
+					"-o", "NumberOfPasswordPrompts=0",
+					"-o", "StrictHostKeyChecking=accept-new",
+				},
 			},
-		},
-	}
+		}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := target.BuildProbeArgs(tt.acceptNewHostKeys)
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				opts := target.SSHAuthenticationProbeOptions{
+					AcceptNewHostKeys: tt.acceptNewHostKeys,
+				}
 
-			assert.Equal(t, tt.want, got)
-		})
-	}
+				got := opts.SSHArgs()
+
+				assert.Equal(t, tt.want, got)
+			})
+		}
+	})
 }

--- a/internal/target/ssh_authentication_probe_test.go
+++ b/internal/target/ssh_authentication_probe_test.go
@@ -3,182 +3,295 @@ package target_test
 import (
 	"context"
 	"errors"
-	"slices"
 	"testing"
 
 	"github.com/arm/topo/internal/target"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
-type mockSSHRunnerWithExtraArgs struct {
-	mock.Mock
+type probeResult struct {
+	output string
+	err    error
 }
 
-func (m *mockSSHRunnerWithExtraArgs) RunWithArgs(ctx context.Context, command string, sshArgs ...string) (string, error) {
-	ret := m.Called(ctx, command, sshArgs)
-	return ret.String(0), ret.Error(1)
+type stubRunner struct {
+	calls   [][]string
+	results []probeResult
 }
 
-var (
-	newHostKeyOutput = `No ED25519 host key is known for 10.2.4.68 and you have requested strict checking.
-Host key verification failed.`
-	changedHostKeyOutput = `Host key for 10.2.4.68 has changed and you have requested strict checking.
-Host key verification failed.`
-)
+func (s *stubRunner) RunWithArgs(_ context.Context, _ string, sshArgs ...string) (string, error) {
+	i := len(s.calls)
+	s.calls = append(s.calls, sshArgs)
+	return s.results[i].output, s.results[i].err
+}
 
-var (
-	publicKeyMode = mock.MatchedBy(func(args []string) bool {
-		return slices.Contains(args, "PreferredAuthentications=publickey") &&
-			!slices.Contains(args, "PasswordAuthentication=no")
-	})
-	passwordMode = mock.MatchedBy(func(args []string) bool {
-		return slices.Contains(args, "PreferredAuthentications=password")
-	})
-	knownHostMode = mock.MatchedBy(func(args []string) bool {
-		return slices.Contains(args, "PasswordAuthentication=no")
-	})
-)
+func TestClassifySSHOutput(t *testing.T) {
+	errSSH := errors.New("ssh failed")
+
+	tests := []struct {
+		name   string
+		output string
+		err    error
+		want   error
+	}{
+		{
+			name: "returns nil when no error",
+			err:  nil,
+			want: nil,
+		},
+		{
+			name:   "returns ErrHostKeyNew for generic host key verification failure",
+			output: "Host key verification failed.",
+			err:    errSSH,
+			want:   target.ErrHostKeyNew,
+		},
+		{
+			name:   "returns ErrHostKeyNew for unknown host key",
+			output: "No ED25519 host key is known for 10.2.4.68 and you have requested strict checking.\nHost key verification failed.",
+			err:    errSSH,
+			want:   target.ErrHostKeyNew,
+		},
+		{
+			name:   "returns ErrHostKeyChanged when host key has changed",
+			output: "Host key for 10.2.4.68 has changed and you have requested strict checking.\nHost key verification failed.",
+			err:    errSSH,
+			want:   target.ErrHostKeyChanged,
+		},
+		{
+			name:   "returns ErrAuthenticationFailure for permission denied",
+			output: "Permission denied",
+			err:    errSSH,
+			want:   target.ErrAuthenticationFailure,
+		},
+		{
+			name:   "returns ErrAuthenticationFailure for authentication failed",
+			output: "Authentication failed",
+			err:    errSSH,
+			want:   target.ErrAuthenticationFailure,
+		},
+		{
+			name:   "returns ErrAuthenticationFailure for password prompt",
+			output: "password:",
+			err:    errSSH,
+			want:   target.ErrAuthenticationFailure,
+		},
+		{
+			name:   "is case insensitive",
+			output: "HOST KEY VERIFICATION FAILED",
+			err:    errSSH,
+			want:   target.ErrHostKeyNew,
+		},
+		{
+			name:   "returns original error for unrecognized output",
+			output: "dial tcp: lookup host: no such host",
+			err:    errSSH,
+			want:   errSSH,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := target.ClassifySSHOutput(tt.output, tt.err)
+
+			if tt.want == nil {
+				require.NoError(t, got)
+			} else {
+				require.ErrorIs(t, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildProbeArgs(t *testing.T) {
+	tests := []struct {
+		name              string
+		method            target.ProbeMethod
+		acceptNewHostKeys bool
+		want              []string
+	}{
+		{
+			name:   "public key probe",
+			method: target.PublicKey,
+			want: []string{
+				"-o", "BatchMode=yes",
+				"-o", "PreferredAuthentications=publickey",
+			},
+		},
+		{
+			name:              "public key probe with accept new host keys",
+			method:            target.PublicKey,
+			acceptNewHostKeys: true,
+			want: []string{
+				"-o", "BatchMode=yes",
+				"-o", "PreferredAuthentications=publickey",
+				"-o", "StrictHostKeyChecking=accept-new",
+			},
+		},
+		{
+			name:   "password probe",
+			method: target.Password,
+			want: []string{
+				"-o", "BatchMode=yes",
+				"-o", "PreferredAuthentications=password",
+				"-o", "NumberOfPasswordPrompts=0",
+			},
+		},
+		{
+			name:              "password probe with accept new host keys",
+			method:            target.Password,
+			acceptNewHostKeys: true,
+			want: []string{
+				"-o", "BatchMode=yes",
+				"-o", "PreferredAuthentications=password",
+				"-o", "NumberOfPasswordPrompts=0",
+				"-o", "StrictHostKeyChecking=accept-new",
+			},
+		},
+		{
+			name:   "known host probe",
+			method: target.KnownHost,
+			want: []string{
+				"-o", "StrictHostKeyChecking=yes",
+				"-o", "PreferredAuthentications=publickey",
+				"-o", "PasswordAuthentication=no",
+				"-o", "NumberOfPasswordPrompts=0",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := target.BuildProbeArgs(tt.method, tt.acceptNewHostKeys)
+
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
 
 func TestSSHAuthenticationProbe(t *testing.T) {
 	errSSH := errors.New("ssh failed")
+	authDenied := probeResult{output: "Permission denied", err: errSSH}
+	success := probeResult{}
+	hostKeyNew := probeResult{output: "Host key verification failed", err: errSSH}
+	hostKeyChanged := probeResult{output: "Host key for 10.2.4.68 has changed.\nHost key verification failed.", err: errSSH}
+	unknownFailure := probeResult{output: "connection reset", err: errSSH}
 
-	t.Run("does not require password when public key succeeds", func(t *testing.T) {
-		r := &mockSSHRunnerWithExtraArgs{}
-		r.On("RunWithArgs", context.Background(), "true", publicKeyMode).Return("", nil)
-
+	t.Run("succeeds when public key authenticates", func(t *testing.T) {
+		r := &stubRunner{results: []probeResult{success}}
 		probe := target.NewSSHAuthenticationProbe(r, target.SSHAuthenticationProbeOptions{AcceptNewHostKeys: true})
+
 		err := probe.Probe(context.Background())
 
 		require.NoError(t, err)
-		r.AssertExpectations(t)
-		call := r.Calls[0]
-		assert.Contains(t, call.Arguments[2], "StrictHostKeyChecking=accept-new")
+		assert.Len(t, r.calls, 1)
 	})
 
-	t.Run("returns new host key error when host key is unknown", func(t *testing.T) {
-		r := &mockSSHRunnerWithExtraArgs{}
-		r.On("RunWithArgs", context.Background(), "true", publicKeyMode).Return(newHostKeyOutput, errSSH)
-
+	t.Run("falls back to password when public key fails auth", func(t *testing.T) {
+		r := &stubRunner{results: []probeResult{authDenied, success}}
 		probe := target.NewSSHAuthenticationProbe(r, target.SSHAuthenticationProbeOptions{AcceptNewHostKeys: true})
+
 		err := probe.Probe(context.Background())
 
-		require.ErrorIs(t, err, target.ErrHostKeyNew)
-		r.AssertNumberOfCalls(t, "RunWithArgs", 1)
+		require.NoError(t, err)
+		assert.Len(t, r.calls, 2)
 	})
 
-	t.Run("returns changed host key error when host key has changed", func(t *testing.T) {
-		r := &mockSSHRunnerWithExtraArgs{}
-		r.On("RunWithArgs", context.Background(), "true", publicKeyMode).Return(changedHostKeyOutput, errSSH)
-
+	t.Run("returns ErrPasswordAuthentication when both auth methods fail", func(t *testing.T) {
+		r := &stubRunner{results: []probeResult{authDenied, authDenied}}
 		probe := target.NewSSHAuthenticationProbe(r, target.SSHAuthenticationProbeOptions{AcceptNewHostKeys: true})
-		err := probe.Probe(context.Background())
 
-		require.ErrorIs(t, err, target.ErrHostKeyChanged)
-		r.AssertNumberOfCalls(t, "RunWithArgs", 1)
-	})
-
-	t.Run("returns new host key error for generic host key verification failure", func(t *testing.T) {
-		r := &mockSSHRunnerWithExtraArgs{}
-		r.On("RunWithArgs", context.Background(), "true", publicKeyMode).Return("Host key verification failed", errSSH)
-
-		probe := target.NewSSHAuthenticationProbe(r, target.SSHAuthenticationProbeOptions{AcceptNewHostKeys: true})
-		err := probe.Probe(context.Background())
-
-		require.ErrorIs(t, err, target.ErrHostKeyNew)
-		r.AssertNumberOfCalls(t, "RunWithArgs", 1)
-	})
-
-	t.Run("returns changed host key error for password probe", func(t *testing.T) {
-		r := &mockSSHRunnerWithExtraArgs{}
-		r.On("RunWithArgs", context.Background(), "true", publicKeyMode).Return("Permission denied", errSSH)
-		r.On("RunWithArgs", context.Background(), "true", passwordMode).Return(changedHostKeyOutput, errSSH)
-
-		probe := target.NewSSHAuthenticationProbe(r, target.SSHAuthenticationProbeOptions{AcceptNewHostKeys: true})
-		err := probe.Probe(context.Background())
-
-		require.ErrorIs(t, err, target.ErrHostKeyChanged)
-		r.AssertNumberOfCalls(t, "RunWithArgs", 2)
-	})
-
-	t.Run("returns password-only auth error when auth fails", func(t *testing.T) {
-		r := &mockSSHRunnerWithExtraArgs{}
-		r.On("RunWithArgs", context.Background(), "true", publicKeyMode).Return("Permission denied", errSSH)
-		r.On("RunWithArgs", context.Background(), "true", passwordMode).Return("Authentication failed", errSSH)
-
-		probe := target.NewSSHAuthenticationProbe(r, target.SSHAuthenticationProbeOptions{AcceptNewHostKeys: true})
 		err := probe.Probe(context.Background())
 
 		require.ErrorIs(t, err, target.ErrPasswordAuthentication)
 	})
 
-	t.Run("does not require password when password probe succeeds", func(t *testing.T) {
-		r := &mockSSHRunnerWithExtraArgs{}
-		r.On("RunWithArgs", context.Background(), "true", publicKeyMode).Return("Permission denied", errSSH)
-		r.On("RunWithArgs", context.Background(), "true", passwordMode).Return("", nil)
-
+	t.Run("stops at public key when error is not auth failure", func(t *testing.T) {
+		r := &stubRunner{results: []probeResult{hostKeyNew}}
 		probe := target.NewSSHAuthenticationProbe(r, target.SSHAuthenticationProbeOptions{AcceptNewHostKeys: true})
-		err := probe.Probe(context.Background())
 
-		require.NoError(t, err)
-		r.AssertExpectations(t)
-	})
-
-	t.Run("returns error on non-auth failure for password probe", func(t *testing.T) {
-		r := &mockSSHRunnerWithExtraArgs{}
-		r.On("RunWithArgs", context.Background(), "true", publicKeyMode).Return("Permission denied", errSSH)
-		r.On("RunWithArgs", context.Background(), "true", passwordMode).Return("Some other error", errSSH)
-
-		probe := target.NewSSHAuthenticationProbe(r, target.SSHAuthenticationProbeOptions{AcceptNewHostKeys: true})
-		err := probe.Probe(context.Background())
-
-		require.ErrorIs(t, err, errSSH)
-	})
-
-	t.Run("ensures known host when not accepting new host keys", func(t *testing.T) {
-		r := &mockSSHRunnerWithExtraArgs{}
-		r.On("RunWithArgs", context.Background(), "true", knownHostMode).Return("Permission denied", errSSH)
-		r.On("RunWithArgs", context.Background(), "true", publicKeyMode).Return("", nil)
-
-		probe := target.NewSSHAuthenticationProbe(r, target.SSHAuthenticationProbeOptions{})
-		err := probe.Probe(context.Background())
-
-		require.NoError(t, err)
-		r.AssertExpectations(t)
-		assert.Contains(t, r.Calls[0].Arguments[2], "PasswordAuthentication=no")
-	})
-
-	t.Run("returns new host key error when known host check fails", func(t *testing.T) {
-		r := &mockSSHRunnerWithExtraArgs{}
-		r.On("RunWithArgs", context.Background(), "true", knownHostMode).Return("HOST KEY VERIFICATION FAILED", errSSH)
-
-		probe := target.NewSSHAuthenticationProbe(r, target.SSHAuthenticationProbeOptions{})
 		err := probe.Probe(context.Background())
 
 		require.ErrorIs(t, err, target.ErrHostKeyNew)
-		r.AssertNumberOfCalls(t, "RunWithArgs", 1)
+		assert.Len(t, r.calls, 1)
 	})
 
-	t.Run("returns changed host key error when known host check detects changed key", func(t *testing.T) {
-		r := &mockSSHRunnerWithExtraArgs{}
-		r.On("RunWithArgs", context.Background(), "true", knownHostMode).Return(changedHostKeyOutput, errSSH)
+	t.Run("returns password probe error when it is not auth failure", func(t *testing.T) {
+		r := &stubRunner{results: []probeResult{authDenied, unknownFailure}}
+		probe := target.NewSSHAuthenticationProbe(r, target.SSHAuthenticationProbeOptions{AcceptNewHostKeys: true})
 
-		probe := target.NewSSHAuthenticationProbe(r, target.SSHAuthenticationProbeOptions{})
-		err := probe.Probe(context.Background())
-
-		require.ErrorIs(t, err, target.ErrHostKeyChanged)
-		r.AssertNumberOfCalls(t, "RunWithArgs", 1)
-	})
-
-	t.Run("returns error when known host fails with other error", func(t *testing.T) {
-		r := &mockSSHRunnerWithExtraArgs{}
-		r.On("RunWithArgs", context.Background(), "true", knownHostMode).Return("dial tcp: lookup host: no such host", errSSH)
-
-		probe := target.NewSSHAuthenticationProbe(r, target.SSHAuthenticationProbeOptions{})
 		err := probe.Probe(context.Background())
 
 		require.ErrorIs(t, err, errSSH)
-		r.AssertNumberOfCalls(t, "RunWithArgs", 1)
+	})
+
+	t.Run("returns host key error from password probe", func(t *testing.T) {
+		r := &stubRunner{results: []probeResult{authDenied, hostKeyChanged}}
+		probe := target.NewSSHAuthenticationProbe(r, target.SSHAuthenticationProbeOptions{AcceptNewHostKeys: true})
+
+		err := probe.Probe(context.Background())
+
+		require.ErrorIs(t, err, target.ErrHostKeyChanged)
+	})
+
+	t.Run("skips known host check when accepting new host keys", func(t *testing.T) {
+		r := &stubRunner{results: []probeResult{success}}
+		probe := target.NewSSHAuthenticationProbe(r, target.SSHAuthenticationProbeOptions{AcceptNewHostKeys: true})
+
+		err := probe.Probe(context.Background())
+
+		require.NoError(t, err)
+		assert.Len(t, r.calls, 1)
+	})
+
+	t.Run("runs known host check first when not accepting new host keys", func(t *testing.T) {
+		r := &stubRunner{results: []probeResult{authDenied, success}}
+		probe := target.NewSSHAuthenticationProbe(r, target.SSHAuthenticationProbeOptions{})
+
+		err := probe.Probe(context.Background())
+
+		require.NoError(t, err)
+		assert.Len(t, r.calls, 2)
+		assert.Contains(t, r.calls[0], "PasswordAuthentication=no")
+	})
+
+	t.Run("stops at known host check when host key is unknown", func(t *testing.T) {
+		r := &stubRunner{results: []probeResult{hostKeyNew}}
+		probe := target.NewSSHAuthenticationProbe(r, target.SSHAuthenticationProbeOptions{})
+
+		err := probe.Probe(context.Background())
+
+		require.ErrorIs(t, err, target.ErrHostKeyNew)
+		assert.Len(t, r.calls, 1)
+	})
+
+	t.Run("stops at known host check when host key changed", func(t *testing.T) {
+		r := &stubRunner{results: []probeResult{hostKeyChanged}}
+		probe := target.NewSSHAuthenticationProbe(r, target.SSHAuthenticationProbeOptions{})
+
+		err := probe.Probe(context.Background())
+
+		require.ErrorIs(t, err, target.ErrHostKeyChanged)
+		assert.Len(t, r.calls, 1)
+	})
+
+	t.Run("returns non-auth error from known host check", func(t *testing.T) {
+		r := &stubRunner{results: []probeResult{unknownFailure}}
+		probe := target.NewSSHAuthenticationProbe(r, target.SSHAuthenticationProbeOptions{})
+
+		err := probe.Probe(context.Background())
+
+		require.ErrorIs(t, err, errSSH)
+		assert.Len(t, r.calls, 1)
+	})
+
+	t.Run("continues past known host check when auth is denied", func(t *testing.T) {
+		r := &stubRunner{results: []probeResult{authDenied, success}}
+		probe := target.NewSSHAuthenticationProbe(r, target.SSHAuthenticationProbeOptions{})
+
+		err := probe.Probe(context.Background())
+
+		require.NoError(t, err)
+		assert.Len(t, r.calls, 2)
 	})
 }

--- a/internal/target/ssh_authentication_probe_test.go
+++ b/internal/target/ssh_authentication_probe_test.go
@@ -1,7 +1,6 @@
 package target_test
 
 import (
-	"context"
 	"errors"
 	"testing"
 
@@ -9,22 +8,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-type probeResult struct {
-	output string
-	err    error
-}
-
-type stubRunner struct {
-	calls   [][]string
-	results []probeResult
-}
-
-func (s *stubRunner) RunWithArgs(_ context.Context, _ string, sshArgs ...string) (string, error) {
-	i := len(s.calls)
-	s.calls = append(s.calls, sshArgs)
-	return s.results[i].output, s.results[i].err
-}
 
 func TestClassifySSHOutput(t *testing.T) {
 	errSSH := errors.New("ssh failed")
@@ -106,192 +89,39 @@ func TestClassifySSHOutput(t *testing.T) {
 func TestBuildProbeArgs(t *testing.T) {
 	tests := []struct {
 		name              string
-		method            target.ProbeMethod
 		acceptNewHostKeys bool
 		want              []string
 	}{
 		{
-			name:   "public key probe",
-			method: target.PublicKey,
+			name: "strict host key checking by default",
 			want: []string{
 				"-o", "BatchMode=yes",
-				"-o", "PreferredAuthentications=publickey",
-			},
-		},
-		{
-			name:              "public key probe with accept new host keys",
-			method:            target.PublicKey,
-			acceptNewHostKeys: true,
-			want: []string{
-				"-o", "BatchMode=yes",
-				"-o", "PreferredAuthentications=publickey",
-				"-o", "StrictHostKeyChecking=accept-new",
-			},
-		},
-		{
-			name:   "password probe",
-			method: target.Password,
-			want: []string{
-				"-o", "BatchMode=yes",
-				"-o", "PreferredAuthentications=password",
-				"-o", "NumberOfPasswordPrompts=0",
-			},
-		},
-		{
-			name:              "password probe with accept new host keys",
-			method:            target.Password,
-			acceptNewHostKeys: true,
-			want: []string{
-				"-o", "BatchMode=yes",
-				"-o", "PreferredAuthentications=password",
-				"-o", "NumberOfPasswordPrompts=0",
-				"-o", "StrictHostKeyChecking=accept-new",
-			},
-		},
-		{
-			name:   "known host probe",
-			method: target.KnownHost,
-			want: []string{
-				"-o", "StrictHostKeyChecking=yes",
 				"-o", "PreferredAuthentications=publickey",
 				"-o", "PasswordAuthentication=no",
 				"-o", "NumberOfPasswordPrompts=0",
+				"-o", "StrictHostKeyChecking=yes",
+			},
+		},
+		{
+			name:              "accept new host keys",
+			acceptNewHostKeys: true,
+			want: []string{
+				"-o", "BatchMode=yes",
+				"-o", "PreferredAuthentications=publickey",
+				"-o", "PasswordAuthentication=no",
+				"-o", "NumberOfPasswordPrompts=0",
+				"-o", "StrictHostKeyChecking=accept-new",
 			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := target.BuildProbeArgs(tt.method, tt.acceptNewHostKeys)
+			got := target.BuildProbeArgs(tt.acceptNewHostKeys)
 
 			assert.Equal(t, tt.want, got)
 		})
 	}
 }
 
-func TestSSHAuthenticationProbe(t *testing.T) {
-	errSSH := errors.New("ssh failed")
-	authDenied := probeResult{output: "Permission denied", err: errSSH}
-	success := probeResult{}
-	hostKeyNew := probeResult{output: "Host key verification failed", err: errSSH}
-	hostKeyChanged := probeResult{output: "Host key for 10.2.4.68 has changed.\nHost key verification failed.", err: errSSH}
-	unknownFailure := probeResult{output: "connection reset", err: errSSH}
 
-	t.Run("succeeds when public key authenticates", func(t *testing.T) {
-		r := &stubRunner{results: []probeResult{success}}
-		probe := target.NewSSHAuthenticationProbe(r, target.SSHAuthenticationProbeOptions{AcceptNewHostKeys: true})
-
-		err := probe.Probe(context.Background())
-
-		require.NoError(t, err)
-		assert.Len(t, r.calls, 1)
-	})
-
-	t.Run("falls back to password when public key fails auth", func(t *testing.T) {
-		r := &stubRunner{results: []probeResult{authDenied, success}}
-		probe := target.NewSSHAuthenticationProbe(r, target.SSHAuthenticationProbeOptions{AcceptNewHostKeys: true})
-
-		err := probe.Probe(context.Background())
-
-		require.NoError(t, err)
-		assert.Len(t, r.calls, 2)
-	})
-
-	t.Run("returns ErrPasswordAuthentication when both auth methods fail", func(t *testing.T) {
-		r := &stubRunner{results: []probeResult{authDenied, authDenied}}
-		probe := target.NewSSHAuthenticationProbe(r, target.SSHAuthenticationProbeOptions{AcceptNewHostKeys: true})
-
-		err := probe.Probe(context.Background())
-
-		require.ErrorIs(t, err, target.ErrPasswordAuthentication)
-	})
-
-	t.Run("stops at public key when error is not auth failure", func(t *testing.T) {
-		r := &stubRunner{results: []probeResult{hostKeyNew}}
-		probe := target.NewSSHAuthenticationProbe(r, target.SSHAuthenticationProbeOptions{AcceptNewHostKeys: true})
-
-		err := probe.Probe(context.Background())
-
-		require.ErrorIs(t, err, target.ErrHostKeyNew)
-		assert.Len(t, r.calls, 1)
-	})
-
-	t.Run("returns password probe error when it is not auth failure", func(t *testing.T) {
-		r := &stubRunner{results: []probeResult{authDenied, unknownFailure}}
-		probe := target.NewSSHAuthenticationProbe(r, target.SSHAuthenticationProbeOptions{AcceptNewHostKeys: true})
-
-		err := probe.Probe(context.Background())
-
-		require.ErrorIs(t, err, errSSH)
-	})
-
-	t.Run("returns host key error from password probe", func(t *testing.T) {
-		r := &stubRunner{results: []probeResult{authDenied, hostKeyChanged}}
-		probe := target.NewSSHAuthenticationProbe(r, target.SSHAuthenticationProbeOptions{AcceptNewHostKeys: true})
-
-		err := probe.Probe(context.Background())
-
-		require.ErrorIs(t, err, target.ErrHostKeyChanged)
-	})
-
-	t.Run("skips known host check when accepting new host keys", func(t *testing.T) {
-		r := &stubRunner{results: []probeResult{success}}
-		probe := target.NewSSHAuthenticationProbe(r, target.SSHAuthenticationProbeOptions{AcceptNewHostKeys: true})
-
-		err := probe.Probe(context.Background())
-
-		require.NoError(t, err)
-		assert.Len(t, r.calls, 1)
-	})
-
-	t.Run("runs known host check first when not accepting new host keys", func(t *testing.T) {
-		r := &stubRunner{results: []probeResult{authDenied, success}}
-		probe := target.NewSSHAuthenticationProbe(r, target.SSHAuthenticationProbeOptions{})
-
-		err := probe.Probe(context.Background())
-
-		require.NoError(t, err)
-		assert.Len(t, r.calls, 2)
-		assert.Contains(t, r.calls[0], "PasswordAuthentication=no")
-	})
-
-	t.Run("stops at known host check when host key is unknown", func(t *testing.T) {
-		r := &stubRunner{results: []probeResult{hostKeyNew}}
-		probe := target.NewSSHAuthenticationProbe(r, target.SSHAuthenticationProbeOptions{})
-
-		err := probe.Probe(context.Background())
-
-		require.ErrorIs(t, err, target.ErrHostKeyNew)
-		assert.Len(t, r.calls, 1)
-	})
-
-	t.Run("stops at known host check when host key changed", func(t *testing.T) {
-		r := &stubRunner{results: []probeResult{hostKeyChanged}}
-		probe := target.NewSSHAuthenticationProbe(r, target.SSHAuthenticationProbeOptions{})
-
-		err := probe.Probe(context.Background())
-
-		require.ErrorIs(t, err, target.ErrHostKeyChanged)
-		assert.Len(t, r.calls, 1)
-	})
-
-	t.Run("returns non-auth error from known host check", func(t *testing.T) {
-		r := &stubRunner{results: []probeResult{unknownFailure}}
-		probe := target.NewSSHAuthenticationProbe(r, target.SSHAuthenticationProbeOptions{})
-
-		err := probe.Probe(context.Background())
-
-		require.ErrorIs(t, err, errSSH)
-		assert.Len(t, r.calls, 1)
-	})
-
-	t.Run("continues past known host check when auth is denied", func(t *testing.T) {
-		r := &stubRunner{results: []probeResult{authDenied, success}}
-		probe := target.NewSSHAuthenticationProbe(r, target.SSHAuthenticationProbeOptions{})
-
-		err := probe.Probe(context.Background())
-
-		require.NoError(t, err)
-		assert.Len(t, r.calls, 2)
-	})
-}

--- a/internal/target/ssh_authentication_probe_test.go
+++ b/internal/target/ssh_authentication_probe_test.go
@@ -1,90 +1,11 @@
 package target_test
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/arm/topo/internal/target"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
-
-func TestClassifySSHOutput(t *testing.T) {
-	errSSH := errors.New("ssh failed")
-
-	tests := []struct {
-		name   string
-		output string
-		err    error
-		want   error
-	}{
-		{
-			name: "returns nil when no error",
-			err:  nil,
-			want: nil,
-		},
-		{
-			name:   "returns ErrHostKeyNew for generic host key verification failure",
-			output: "Host key verification failed.",
-			err:    errSSH,
-			want:   target.ErrHostKeyNew,
-		},
-		{
-			name:   "returns ErrHostKeyNew for unknown host key",
-			output: "No ED25519 host key is known for 10.2.4.68 and you have requested strict checking.\nHost key verification failed.",
-			err:    errSSH,
-			want:   target.ErrHostKeyNew,
-		},
-		{
-			name:   "returns ErrHostKeyChanged when host key has changed",
-			output: "Host key for 10.2.4.68 has changed and you have requested strict checking.\nHost key verification failed.",
-			err:    errSSH,
-			want:   target.ErrHostKeyChanged,
-		},
-		{
-			name:   "returns ErrAuthenticationFailure for permission denied",
-			output: "Permission denied",
-			err:    errSSH,
-			want:   target.ErrAuthenticationFailure,
-		},
-		{
-			name:   "returns ErrAuthenticationFailure for authentication failed",
-			output: "Authentication failed",
-			err:    errSSH,
-			want:   target.ErrAuthenticationFailure,
-		},
-		{
-			name:   "returns ErrAuthenticationFailure for password prompt",
-			output: "password:",
-			err:    errSSH,
-			want:   target.ErrAuthenticationFailure,
-		},
-		{
-			name:   "is case insensitive",
-			output: "HOST KEY VERIFICATION FAILED",
-			err:    errSSH,
-			want:   target.ErrHostKeyNew,
-		},
-		{
-			name:   "returns original error for unrecognized output",
-			output: "dial tcp: lookup host: no such host",
-			err:    errSSH,
-			want:   errSSH,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := target.ClassifySSHOutput(tt.output, tt.err)
-
-			if tt.want == nil {
-				require.NoError(t, got)
-			} else {
-				require.ErrorIs(t, got, tt.want)
-			}
-		})
-	}
-}
 
 func TestBuildProbeArgs(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Changes

- Extract pure functions from `SSHAuthenticationProbe`: `BuildProbeArgs` (options → SSH args) tested with table-driven tests, no mocks
- Remove the separate known host check — host key verification is now handled by `StrictHostKeyChecking=yes` (or `accept-new`) directly on the pubkey probe
- Remove the password fallback — the old password probe used `BatchMode=yes` with `NumberOfPasswordPrompts=0`, meaning it could never actually authenticate with a password. If pubkey fails with an auth error, the fix is `topo setup-keys` regardless
- Remove `ErrPasswordAuthentication` — health check now matches on `ErrAuthFailed` directly to recommend `topo setup-keys`
- Replace `sshRunnerWithExtraArgs` interface with concrete `*runner.SSH`
- Consolidate SSH error classification into `ClassifyStderr` — host key, auth, timeout, and connection patterns all live in one place. The probe translates `ssh.Err*` into probe-domain errors via `errors.Is`, no string re-parsing
- Eliminate `testify/mock` from the test file entirely

Net result: 1 SSH call instead of up to 3, ~100 fewer lines, zero mocks.