### PR TITLE
refactor: explicit passing of ssh directories

### DIFF
--- a/cmd/topo/migrate_ssh.go
+++ b/cmd/topo/migrate_ssh.go
@@ -12,7 +12,13 @@ var migrateSSHCmd = &cobra.Command{
 	Args:   cobra.ExactArgs(0),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		return ssh.MigrateLegacyTopoConfig()
+
+		sshDir, err := ssh.GetConfigDirectory()
+		if err != nil {
+			return err
+		}
+
+		return ssh.MigrateLegacyTopoConfig(sshDir)
 	},
 }
 

--- a/cmd/topo/setup_keys.go
+++ b/cmd/topo/setup_keys.go
@@ -31,9 +31,9 @@ var setupKeysCmd = &cobra.Command{
 			return err
 		}
 
-		if exists, err := ssh.LegacyTopoConfigDirectoryExists(sshDir); err != nil {
+		if isLegacyDir, err := ssh.IsLegacyTopoConfigDirectory(sshDir); err != nil {
 			return err
-		} else if exists {
+		} else if isLegacyDir {
 			return fmt.Errorf("legacy topo ssh config entries found; run 'topo migrate-ssh' to migrate to the new single-file format")
 		}
 

--- a/cmd/topo/setup_keys.go
+++ b/cmd/topo/setup_keys.go
@@ -26,7 +26,12 @@ var setupKeysCmd = &cobra.Command{
 			return err
 		}
 
-		if exists, err := ssh.LegacyTopoConfigDirectoryExists(); err != nil {
+		sshDir, err := ssh.GetConfigDirectory()
+		if err != nil {
+			return err
+		}
+
+		if exists, err := ssh.LegacyTopoConfigDirectoryExists(sshDir); err != nil {
 			return err
 		} else if exists {
 			return fmt.Errorf("legacy topo ssh config entries found; run 'topo migrate-ssh' to migrate to the new single-file format")
@@ -35,7 +40,7 @@ var setupKeysCmd = &cobra.Command{
 		dest := ssh.NewDestination(targetArg)
 		targetSlug := dest.Slugify()
 		if privateKeyPath == "" {
-			privateKeyPath, err = setupkeys.GetDefaultPrivateKeyPath(targetSlug)
+			privateKeyPath, err = setupkeys.GetDefaultPrivateKeyPath(sshDir, targetSlug)
 			if err != nil {
 				return err
 			}
@@ -66,7 +71,7 @@ var setupKeysCmd = &cobra.Command{
 			ssh.NewEnsureConfigDirective("IdentitiesOnly", "yes"),
 		}
 
-		return ssh.CreateOrModifyConfigFile(dest, modifiers)
+		return ssh.CreateOrModifyConfigFile(sshDir, dest, modifiers)
 	},
 }
 

--- a/internal/setupkeys/setup_keys.go
+++ b/internal/setupkeys/setup_keys.go
@@ -2,7 +2,6 @@ package setupkeys
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 
 	"github.com/arm/topo/internal/operation"
@@ -28,13 +27,9 @@ func NewKeySetup(dest ssh.Destination, privKeyPath string, keyType KeyType) (ope
 	return operation.NewSequence(ops...), nil
 }
 
-func GetDefaultPrivateKeyPath(targetSlug string) (string, error) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "", fmt.Errorf("failed to determine default key path: %w", err)
-	}
+func GetDefaultPrivateKeyPath(sshDir string, targetSlug string) (string, error) {
 	keyName := fmt.Sprintf("id_ed25519_topo_%s", targetSlug)
-	privKeyPath := filepath.Join(home, ".ssh", keyName)
+	privKeyPath := filepath.Join(sshDir, keyName)
 	return privKeyPath, nil
 }
 

--- a/internal/setupkeys/setup_keys_test.go
+++ b/internal/setupkeys/setup_keys_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/arm/topo/internal/setupkeys/pubkeytransfer"
 	"github.com/arm/topo/internal/setupkeys/sshkeygen"
 	"github.com/arm/topo/internal/ssh"
-	"github.com/arm/topo/internal/testutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -54,15 +53,13 @@ func TestNewKeySetup(t *testing.T) {
 func TestGetDefaultPrivateKeyPath(t *testing.T) {
 	t.Run("returns home-based ed25519 key path for target slug", func(t *testing.T) {
 		tmp := t.TempDir()
-		testutil.SetHomeDir(t, tmp)
-
 		target := "user@some1thing.com"
 		targetSlug := ssh.NewDestination(target).Slugify()
 
-		got, err := setupkeys.GetDefaultPrivateKeyPath(targetSlug)
+		got, err := setupkeys.GetDefaultPrivateKeyPath(tmp, targetSlug)
 
 		require.NoError(t, err)
-		require.Equal(t, filepath.Join(tmp, ".ssh", "id_ed25519_topo_user_some1thing.com"), got)
+		require.Equal(t, filepath.Join(tmp, "id_ed25519_topo_user_some1thing.com"), got)
 	})
 }
 

--- a/internal/ssh/config_file.go
+++ b/internal/ssh/config_file.go
@@ -185,7 +185,7 @@ func CreateOrModifyConfigFile(sshDir string, dest Destination, modifiers []Confi
 	})
 }
 
-func LegacyTopoConfigDirectoryExists(sshDir string) (bool, error) {
+func IsLegacyTopoConfigDirectory(sshDir string) (bool, error) {
 	info, err := os.Stat(filepath.Join(sshDir, TopoConfigFileName))
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -194,18 +194,14 @@ func LegacyTopoConfigDirectoryExists(sshDir string) (bool, error) {
 		return false, fmt.Errorf("failed to check for legacy topo ssh config file: %w", err)
 	}
 
-	if info.IsDir() {
-		return true, nil
-	}
-
-	return false, nil
+	return info.IsDir(), nil
 }
 
 func MigrateLegacyTopoConfig(sshDir string) error {
 	legacyDir := filepath.Join(sshDir, TopoConfigFileName)
-	if exists, err := LegacyTopoConfigDirectoryExists(sshDir); err != nil {
+	if isLegacyDir, err := IsLegacyTopoConfigDirectory(sshDir); err != nil {
 		return err
-	} else if !exists {
+	} else if !isLegacyDir {
 		return fmt.Errorf("legacy topo ssh config directory not found at %s; nothing to migrate", legacyDir)
 	}
 

--- a/internal/ssh/config_file.go
+++ b/internal/ssh/config_file.go
@@ -12,8 +12,8 @@ import (
 )
 
 const (
-	defaultConfigFileName = "config"
-	topoConfigFileName    = "topo_config"
+	DefaultConfigFileName = "config"
+	TopoConfigFileName    = "topo_config"
 )
 
 type ConfigDirectiveModifier interface {
@@ -164,40 +164,30 @@ func updateConfigFile(path string, host string, modifiers []ConfigDirectiveModif
 	return nil
 }
 
-func getConfigFilePath(name string) (string, error) {
+// TODO write tests for this
+func GetConfigDirectory() (string, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", fmt.Errorf("failed to determine home directory for SSH config: %w", err)
 	}
 
-	return filepath.Join(home, ".ssh", name), nil
+	return filepath.Join(home, ".ssh"), nil
 }
 
-func CreateOrModifyConfigFile(dest Destination, modifiers []ConfigDirectiveModifier) error {
-	topoConfigPath, err := getConfigFilePath(topoConfigFileName)
-	if err != nil {
-		return err
-	}
+func CreateOrModifyConfigFile(sshDir string, dest Destination, modifiers []ConfigDirectiveModifier) error {
+	topoConfigPath := filepath.Join(sshDir, TopoConfigFileName)
 	if err := updateConfigFile(topoConfigPath, dest.Host, modifiers); err != nil {
 		return err
 	}
 
-	defaultConfigPath, err := getConfigFilePath(defaultConfigFileName)
-	if err != nil {
-		return err
-	}
+	defaultConfigPath := filepath.Join(sshDir, DefaultConfigFileName)
 	return updateConfigFile(defaultConfigPath, "", []ConfigDirectiveModifier{
 		NewEnsureConfigDirectivePath("Include", topoConfigPath),
 	})
 }
 
-func LegacyTopoConfigDirectoryExists() (bool, error) {
-	topoConfigPath, err := getConfigFilePath(topoConfigFileName)
-	if err != nil {
-		return false, err
-	}
-
-	info, err := os.Stat(topoConfigPath)
+func LegacyTopoConfigDirectoryExists(sshDir string) (bool, error) {
+	info, err := os.Stat(filepath.Join(sshDir, TopoConfigFileName))
 	if err != nil {
 		if os.IsNotExist(err) {
 			return false, nil
@@ -212,13 +202,9 @@ func LegacyTopoConfigDirectoryExists() (bool, error) {
 	return false, nil
 }
 
-func MigrateLegacyTopoConfig() error {
-	legacyDir, err := getConfigFilePath(topoConfigFileName)
-	if err != nil {
-		return err
-	}
-
-	if exists, err := LegacyTopoConfigDirectoryExists(); err != nil {
+func MigrateLegacyTopoConfig(sshDir string) error {
+	legacyDir := filepath.Join(sshDir, TopoConfigFileName)
+	if exists, err := LegacyTopoConfigDirectoryExists(sshDir); err != nil {
 		return err
 	} else if !exists {
 		return fmt.Errorf("legacy topo ssh config directory not found at %s; nothing to migrate", legacyDir)
@@ -253,11 +239,7 @@ func MigrateLegacyTopoConfig() error {
 		return fmt.Errorf("failed to move migrated config to %s: %w", legacyDir, err)
 	}
 
-	defaultConfigPath, err := getConfigFilePath(defaultConfigFileName)
-	if err != nil {
-		return err
-	}
-
+	defaultConfigPath := filepath.Join(sshDir, DefaultConfigFileName)
 	return updateConfigFile(defaultConfigPath, "", []ConfigDirectiveModifier{
 		NewRemoveConfigDirectivePath("Include", legacyGlob),
 		NewEnsureConfigDirectivePath("Include", legacyDir),

--- a/internal/ssh/config_file.go
+++ b/internal/ssh/config_file.go
@@ -164,7 +164,6 @@ func updateConfigFile(path string, host string, modifiers []ConfigDirectiveModif
 	return nil
 }
 
-// TODO write tests for this
 func GetConfigDirectory() (string, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {

--- a/internal/ssh/config_file_test.go
+++ b/internal/ssh/config_file_test.go
@@ -11,79 +11,77 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func mustCreateSshDirectory(t *testing.T) string {
+	tmp := t.TempDir()
+	testutil.RequireMkdirAll(t, filepath.Join(tmp, ".ssh"))
+	return filepath.Join(tmp, ".ssh")
+}
+
 func TestCreateOrModifyConfigFile(t *testing.T) {
 	t.Run("writes include directive to default config file", func(t *testing.T) {
-		tmp := t.TempDir()
-		testutil.SetHomeDir(t, tmp)
-		testutil.RequireMkdirAll(t, filepath.Join(tmp, ".ssh"))
+		sshDir := mustCreateSshDirectory(t)
 		dest := ssh.Destination{Host: "board1"}
 		modifiers := []ssh.ConfigDirectiveModifier{
 			ssh.NewEnsureConfigDirective("IdentityFile", "~/.ssh/id_ed25519"),
 		}
 
-		err := ssh.CreateOrModifyConfigFile(dest, modifiers)
+		err := ssh.CreateOrModifyConfigFile(sshDir, dest, modifiers)
 		require.NoError(t, err)
 
-		configPath := filepath.Join(tmp, ".ssh", "config")
-		topoConfigPath := filepath.ToSlash(filepath.Join(tmp, ".ssh", "topo_config"))
+		configPath := filepath.Join(sshDir, ssh.DefaultConfigFileName)
+		topoConfigPath := filepath.ToSlash(filepath.Join(sshDir, ssh.TopoConfigFileName))
 		testutil.AssertFileContents(t, `Include `+topoConfigPath+`
 `, configPath)
 	})
 
 	t.Run("creates topo-managed config file if it does not exist", func(t *testing.T) {
-		tmp := t.TempDir()
-		testutil.SetHomeDir(t, tmp)
-		testutil.RequireMkdirAll(t, filepath.Join(tmp, ".ssh"))
+		sshDir := mustCreateSshDirectory(t)
 		dest := ssh.Destination{Host: "board1"}
 		modifiers := []ssh.ConfigDirectiveModifier{
 			ssh.NewEnsureConfigDirective("User", "homer"),
 		}
 
-		err := ssh.CreateOrModifyConfigFile(dest, modifiers)
+		err := ssh.CreateOrModifyConfigFile(sshDir, dest, modifiers)
 		require.NoError(t, err)
 
-		topoConfigPath := filepath.Join(tmp, ".ssh", "topo_config")
+		topoConfigPath := filepath.Join(sshDir, ssh.TopoConfigFileName)
 		testutil.AssertFileContents(t, `Host board1
 User homer
 `, topoConfigPath)
 	})
 
 	t.Run("does not duplicate include directive in default config file if it already exists", func(t *testing.T) {
-		tmp := t.TempDir()
-		testutil.SetHomeDir(t, tmp)
-		testutil.RequireMkdirAll(t, filepath.Join(tmp, ".ssh"))
+		sshDir := mustCreateSshDirectory(t)
 		dest := ssh.Destination{Host: "board1"}
 		modifiers := []ssh.ConfigDirectiveModifier{
 			ssh.NewEnsureConfigDirective("IdentityFile", "~/.ssh/id_ed25519"),
 		}
-		err := ssh.CreateOrModifyConfigFile(dest, modifiers)
+		err := ssh.CreateOrModifyConfigFile(sshDir, dest, modifiers)
 		require.NoError(t, err)
 
-		err = ssh.CreateOrModifyConfigFile(dest, modifiers)
+		err = ssh.CreateOrModifyConfigFile(sshDir, dest, modifiers)
 
 		wantConfig := fmt.Sprintf(`Include %s
-`, filepath.ToSlash(filepath.Join(tmp, ".ssh", "topo_config")))
+`, filepath.ToSlash(filepath.Join(sshDir, ssh.TopoConfigFileName)))
 		require.NoError(t, err)
-		testutil.AssertFileContents(t, wantConfig, filepath.Join(tmp, ".ssh", "config"))
+		testutil.AssertFileContents(t, wantConfig, filepath.Join(sshDir, ssh.DefaultConfigFileName))
 	})
 
 	t.Run("adds new entry to existing topo-managed config file", func(t *testing.T) {
-		tmp := t.TempDir()
-		testutil.SetHomeDir(t, tmp)
-		testutil.RequireMkdirAll(t, filepath.Join(tmp, ".ssh"))
-		err := ssh.CreateOrModifyConfigFile(
+		sshDir := mustCreateSshDirectory(t)
+		err := ssh.CreateOrModifyConfigFile(sshDir,
 			ssh.Destination{Host: "board1"},
 			[]ssh.ConfigDirectiveModifier{ssh.NewEnsureConfigDirective("IdentityFile", "~/.ssh/key1")},
 		)
 		require.NoError(t, err)
 
-		err = ssh.CreateOrModifyConfigFile(
+		err = ssh.CreateOrModifyConfigFile(sshDir,
 			ssh.Destination{Host: "board2"},
 			[]ssh.ConfigDirectiveModifier{ssh.NewEnsureConfigDirective("IdentityFile", "~/.ssh/key2")},
 		)
 		require.NoError(t, err)
 
-		topoConfigPath := filepath.Join(tmp, ".ssh", "topo_config")
+		topoConfigPath := filepath.Join(sshDir, ssh.TopoConfigFileName)
 		testutil.AssertFileContents(t,
 			`Host board1
 IdentityFile ~/.ssh/key1
@@ -95,22 +93,20 @@ IdentityFile ~/.ssh/key2
 	})
 
 	t.Run("modifies existing entry in topo-managed config file, preserving unmodified directives", func(t *testing.T) {
-		tmp := t.TempDir()
-		testutil.SetHomeDir(t, tmp)
-		testutil.RequireMkdirAll(t, filepath.Join(tmp, ".ssh"))
+		sshDir := mustCreateSshDirectory(t)
 		dest := ssh.Destination{Host: "board1"}
-		err := ssh.CreateOrModifyConfigFile(dest, []ssh.ConfigDirectiveModifier{
+		err := ssh.CreateOrModifyConfigFile(sshDir, dest, []ssh.ConfigDirectiveModifier{
 			ssh.NewEnsureConfigDirective("IdentityFile", "~/.ssh/key_old"),
 			ssh.NewEnsureConfigDirective("User", "homer"),
 		})
 		require.NoError(t, err)
 
-		err = ssh.CreateOrModifyConfigFile(dest, []ssh.ConfigDirectiveModifier{
+		err = ssh.CreateOrModifyConfigFile(sshDir, dest, []ssh.ConfigDirectiveModifier{
 			ssh.NewEnsureConfigDirective("IdentityFile", "~/.ssh/key_new"),
 		})
 		require.NoError(t, err)
 
-		topoConfigPath := filepath.Join(tmp, ".ssh", "topo_config")
+		topoConfigPath := filepath.Join(sshDir, ssh.TopoConfigFileName)
 		testutil.AssertFileContents(t,
 			`Host board1
 IdentityFile ~/.ssh/key_new
@@ -123,21 +119,19 @@ User homer
 
 func TestCheckForLegacyConfigEntries(t *testing.T) {
 	t.Run("detects if legacy config directory does not exist", func(t *testing.T) {
-		tmp := t.TempDir()
-		testutil.SetHomeDir(t, tmp)
+		sshDir := mustCreateSshDirectory(t)
 
-		exists, err := ssh.LegacyTopoConfigDirectoryExists()
+		exists, err := ssh.LegacyTopoConfigDirectoryExists(sshDir)
 
 		assert.NoError(t, err)
 		assert.False(t, exists)
 	})
 
 	t.Run("detects if legacy config directory exists", func(t *testing.T) {
-		tmp := t.TempDir()
-		testutil.SetHomeDir(t, tmp)
-		testutil.RequireMkdirAll(t, filepath.Join(tmp, ".ssh", "topo_config"))
+		sshDir := mustCreateSshDirectory(t)
+		testutil.RequireMkdirAll(t, filepath.Join(sshDir, ssh.TopoConfigFileName))
 
-		exists, err := ssh.LegacyTopoConfigDirectoryExists()
+		exists, err := ssh.LegacyTopoConfigDirectoryExists(sshDir)
 
 		assert.NoError(t, err)
 		assert.True(t, exists)
@@ -146,19 +140,17 @@ func TestCheckForLegacyConfigEntries(t *testing.T) {
 
 func TestMigrateLegacyConfig(t *testing.T) {
 	t.Run("returns error when no legacy topo config directory exists", func(t *testing.T) {
-		tmp := t.TempDir()
-		testutil.SetHomeDir(t, tmp)
+		sshDir := mustCreateSshDirectory(t)
 
-		err := ssh.MigrateLegacyTopoConfig()
+		err := ssh.MigrateLegacyTopoConfig(sshDir)
 
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "nothing to migrate")
 	})
 
 	t.Run("concatenates conf files into unified config and removes directory", func(t *testing.T) {
-		tmp := t.TempDir()
-		testutil.SetHomeDir(t, tmp)
-		legacyDir := filepath.Join(tmp, ".ssh", "topo_config")
+		sshDir := mustCreateSshDirectory(t)
+		legacyDir := filepath.Join(sshDir, ssh.TopoConfigFileName)
 		legacyDirSlash := filepath.ToSlash(legacyDir)
 		board1Conf := `Host board1
   IdentityFile ~/.ssh/key1
@@ -173,9 +165,9 @@ Host *
 		testutil.RequireMkdirAll(t, legacyDir)
 		testutil.RequireWriteFile(t, filepath.Join(legacyDir, "topo_board1.conf"), board1Conf)
 		testutil.RequireWriteFile(t, filepath.Join(legacyDir, "topo_board2.conf"), board2Conf)
-		testutil.RequireWriteFile(t, filepath.Join(tmp, ".ssh", "config"), sshConf)
+		testutil.RequireWriteFile(t, filepath.Join(sshDir, ssh.DefaultConfigFileName), sshConf)
 
-		require.NoError(t, ssh.MigrateLegacyTopoConfig())
+		require.NoError(t, ssh.MigrateLegacyTopoConfig(sshDir))
 
 		mergedFile := legacyDirSlash
 		wantSshConfAfterMigration := fmt.Sprintf(`
@@ -183,23 +175,22 @@ Include %s
 Host *
 `, mergedFile)
 		testutil.AssertFileContents(t, board1Conf+board2Conf, mergedFile)
-		testutil.AssertFileContents(t, wantSshConfAfterMigration, filepath.Join(tmp, ".ssh", "config"))
+		testutil.AssertFileContents(t, wantSshConfAfterMigration, filepath.Join(sshDir, ssh.DefaultConfigFileName))
 	})
 
 	t.Run("adds include directive if ssh config does not exist", func(t *testing.T) {
-		tmp := t.TempDir()
-		testutil.SetHomeDir(t, tmp)
-		legacyDir := filepath.Join(tmp, ".ssh", "topo_config")
+		sshDir := mustCreateSshDirectory(t)
+		legacyDir := filepath.Join(sshDir, ssh.TopoConfigFileName)
 		testutil.RequireMkdirAll(t, legacyDir)
 		testutil.RequireWriteFile(t, filepath.Join(legacyDir, "topo_board1.conf"), `Host board1
   IdentityFile ~/.ssh/key1
 `)
 
-		err := ssh.MigrateLegacyTopoConfig()
+		err := ssh.MigrateLegacyTopoConfig(sshDir)
 
 		wantConfig := fmt.Sprintf(`Include %s
 `, filepath.ToSlash(legacyDir))
 		require.NoError(t, err)
-		testutil.AssertFileContents(t, wantConfig, filepath.Join(tmp, ".ssh", "config"))
+		testutil.AssertFileContents(t, wantConfig, filepath.Join(sshDir, ssh.DefaultConfigFileName))
 	})
 }

--- a/internal/ssh/config_file_test.go
+++ b/internal/ssh/config_file_test.go
@@ -2,6 +2,7 @@ package ssh_test
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -192,5 +193,17 @@ Host *
 `, filepath.ToSlash(legacyDir))
 		require.NoError(t, err)
 		testutil.AssertFileContents(t, wantConfig, filepath.Join(sshDir, ssh.DefaultConfigFileName))
+	})
+}
+
+func TestGetConfigDirectory(t *testing.T) {
+	t.Run("returns path to .ssh directory in user's home directory", func(t *testing.T) {
+		homeDir, err := os.UserHomeDir()
+		require.NoError(t, err)
+
+		got, err := ssh.GetConfigDirectory()
+
+		require.NoError(t, err)
+		require.Equal(t, filepath.Join(homeDir, ".ssh"), got)
 	})
 }

--- a/internal/ssh/config_file_test.go
+++ b/internal/ssh/config_file_test.go
@@ -122,20 +122,20 @@ func TestCheckForLegacyConfigEntries(t *testing.T) {
 	t.Run("detects if legacy config directory does not exist", func(t *testing.T) {
 		sshDir := mustCreateSshDirectory(t)
 
-		exists, err := ssh.LegacyTopoConfigDirectoryExists(sshDir)
+		isLegacyDir, err := ssh.IsLegacyTopoConfigDirectory(sshDir)
 
 		assert.NoError(t, err)
-		assert.False(t, exists)
+		assert.False(t, isLegacyDir)
 	})
 
 	t.Run("detects if legacy config directory exists", func(t *testing.T) {
 		sshDir := mustCreateSshDirectory(t)
 		testutil.RequireMkdirAll(t, filepath.Join(sshDir, ssh.TopoConfigFileName))
 
-		exists, err := ssh.LegacyTopoConfigDirectoryExists(sshDir)
+		isLegacyDir, err := ssh.IsLegacyTopoConfigDirectory(sshDir)
 
 		assert.NoError(t, err)
-		assert.True(t, exists)
+		assert.True(t, isLegacyDir)
 	})
 }
 

--- a/internal/testutil/testutil_posix.go
+++ b/internal/testutil/testutil_posix.go
@@ -6,11 +6,6 @@ import (
 	"testing"
 )
 
-func SetHomeDir(t testing.TB, dir string) {
-	t.Helper()
-	t.Setenv("HOME", dir)
-}
-
 func IsPrivilegeError(t *testing.T, err error) bool {
 	t.Helper()
 	return false

--- a/internal/testutil/testutil_windows.go
+++ b/internal/testutil/testutil_windows.go
@@ -3,26 +3,9 @@
 package testutil
 
 import (
-	"path/filepath"
 	"syscall"
 	"testing"
 )
-
-func SetHomeDir(t testing.TB, dir string) {
-	t.Helper()
-	t.Setenv("HOME", dir)
-	t.Setenv("USERPROFILE", dir)
-	volume := filepath.VolumeName(dir)
-	if volume == "" {
-		return
-	}
-	path := dir[len(volume):]
-	t.Setenv("HOMEDRIVE", volume)
-	if path == "" {
-		path = "\\"
-	}
-	t.Setenv("HOMEPATH", path)
-}
 
 func IsPrivilegeError(t *testing.T, err error) bool {
 	t.Helper()


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- Replaces the implicit dependency many of our sshconfig-manipulating functions have on the user's home directory with an explicit one in the form of a function parameter. Why?
  - Allows us to eliminate `testutil.SetHomeDir` - one less thing to forget about when writing tests + denoises them a bit
  - Explicit dependency good, implicit bad 😠 
  -  Hoists the repeated decision of where the user's ssh config dir is located up the stack