### PR TITLE
refactor: introduce StartContainer with pluggable container specs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -97,5 +97,4 @@ jobs:
         env: 
           DOCKER_HOST: ${{ matrix.docker_host }}
         run: |
-          docker build -t topo-e2e-target:latest ./internal/testutil/test-container
           go test ./... -p 1 -v -covermode=atomic -coverprofile=coverage.out

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -26,13 +26,9 @@ The project uses [Go's built-in support for unit testing](https://pkg.go.dev/cmd
 go test ./...
 ```
 
-Some tests have a dependency on docker and a smaller subset of these depend on the existence of a test container to act as topo target. This image can be built like so:
+Some tests have a dependency on docker. Test container images are built automatically when needed.
 
-```bash
-docker build -t topo-e2e-target:latest ./internal/testutil/test-container
-```
-
-> Note that if either of these test dependencies are missing, the dependent tests will just be skipped as opposed to failing.
+> Note that if docker is missing, the dependent tests will just be skipped as opposed to failing.
 
 ### Golden Files
 

--- a/e2e/deploy_test.go
+++ b/e2e/deploy_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestDeploy(t *testing.T) {
-	target := testutil.StartTargetContainer(t)
+	target := testutil.StartContainer(t, testutil.DinDContainer)
 	topo := buildBinary(t)
 
 	t.Run("Init, add and Deploy", func(t *testing.T) {

--- a/e2e/deploy_test.go
+++ b/e2e/deploy_test.go
@@ -15,14 +15,14 @@ import (
 )
 
 func TestDeploy(t *testing.T) {
-	target := testutil.StartContainer(t, testutil.DinDContainer)
+	container := testutil.StartContainer(t, testutil.DinDContainer)
 	topo := buildBinary(t)
 
 	t.Run("Init, add and Deploy", func(t *testing.T) {
 		projectDir := t.TempDir()
 		composeFile := filepath.Join(projectDir, "compose.yaml")
 		t.Cleanup(func() {
-			composeDown(t, composeFile, target.SSHDestination)
+			composeDown(t, composeFile, container.SSHDestination)
 		})
 
 		requireInit(t, topo, projectDir)
@@ -32,8 +32,8 @@ func TestDeploy(t *testing.T) {
 
 		requireExtend(t, topo, projectDir, composeFile, nameArgValue)
 
-		requireDeploy(t, topo, projectDir, target.SSHDestination)
-		port, err := testutil.GetContainerPublicPort(target.ContainerName, "8080")
+		requireDeploy(t, topo, projectDir, container.SSHDestination)
+		port, err := testutil.GetContainerPublicPort(container.Name, "8080")
 		require.NoError(t, err)
 		assertResponseBody(t, fmt.Sprintf("http://localhost:%s/", port), expectedResponse)
 	})
@@ -43,14 +43,14 @@ func TestDeploy(t *testing.T) {
 		cloneDir := filepath.Join(baseDir, "project")
 		composeFile := filepath.Join(cloneDir, "compose.yaml")
 		t.Cleanup(func() {
-			composeDown(t, composeFile, target.SSHDestination)
+			composeDown(t, composeFile, container.SSHDestination)
 		})
 
 		nameArgValue := "Topo"
 		requireClone(t, topo, baseDir, cloneDir, "testdata/services/hello-server", fmt.Sprintf("NAME=%s", nameArgValue))
-		requireDeploy(t, topo, cloneDir, target.SSHDestination)
+		requireDeploy(t, topo, cloneDir, container.SSHDestination)
 		expectedResponse := fmt.Sprintf("Hello %s\n", nameArgValue)
-		port, err := testutil.GetContainerPublicPort(target.ContainerName, "8080")
+		port, err := testutil.GetContainerPublicPort(container.Name, "8080")
 		require.NoError(t, err)
 		assertResponseBody(t, fmt.Sprintf("http://localhost:%s/", port), expectedResponse)
 	})

--- a/e2e/health_test.go
+++ b/e2e/health_test.go
@@ -10,11 +10,11 @@ import (
 )
 
 func TestHealthCheck(t *testing.T) {
-	target := testutil.StartContainer(t, testutil.DinDContainer)
+	container := testutil.StartContainer(t, testutil.DinDContainer)
 	topo := buildBinary(t)
 
 	t.Run("accurately shows host health status", func(t *testing.T) {
-		out, err := runCheckHealth(topo, target)
+		out, err := runCheckHealth(topo, container)
 		require.NoError(t, err)
 
 		assert.Contains(t, out, "SSH: ✅ (ssh)")
@@ -22,7 +22,7 @@ func TestHealthCheck(t *testing.T) {
 	})
 
 	t.Run("shows that it's connected to a valid target", func(t *testing.T) {
-		out, err := runCheckHealth(topo, target)
+		out, err := runCheckHealth(topo, container)
 		require.NoError(t, err)
 
 		assert.Contains(t, out, "Connectivity: ✅")
@@ -31,7 +31,7 @@ func TestHealthCheck(t *testing.T) {
 	t.Run("fails to connect to an invalid target", func(t *testing.T) {
 		fakeContainer := testutil.Container{
 			SSHDestination: "fake@target",
-			ContainerName:  "fake-tgt-container",
+			Name:           "fake-tgt-container",
 		}
 		out, err := runCheckHealth(topo, &fakeContainer)
 		assert.NoError(t, err)
@@ -39,7 +39,7 @@ func TestHealthCheck(t *testing.T) {
 	})
 
 	t.Run("outputs JSON when specified", func(t *testing.T) {
-		out, err := runCheckHealth(topo, target, "--output", "json")
+		out, err := runCheckHealth(topo, container, "--output", "json")
 
 		assert.NoError(t, err)
 		testutil.AssertJsonGoldenFile(t, out, "testdata/TestHealthCheckJson.golden")

--- a/e2e/health_test.go
+++ b/e2e/health_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestHealthCheck(t *testing.T) {
-	target := testutil.StartTargetContainer(t)
+	target := testutil.StartContainer(t, testutil.DinDContainer)
 	topo := buildBinary(t)
 
 	t.Run("accurately shows host health status", func(t *testing.T) {
@@ -29,7 +29,7 @@ func TestHealthCheck(t *testing.T) {
 	})
 
 	t.Run("fails to connect to an invalid target", func(t *testing.T) {
-		fakeContainer := testutil.TargetContainer{
+		fakeContainer := testutil.Container{
 			SSHDestination: "fake@target",
 			ContainerName:  "fake-tgt-container",
 		}
@@ -46,7 +46,7 @@ func TestHealthCheck(t *testing.T) {
 	})
 }
 
-func runCheckHealth(topo string, target *testutil.TargetContainer, args ...string) (string, error) {
+func runCheckHealth(topo string, target *testutil.Container, args ...string) (string, error) {
 	args = append([]string{"health", "--target", target.SSHDestination}, args...)
 	healthCmd := exec.Command(topo, args...)
 

--- a/e2e/install_test.go
+++ b/e2e/install_test.go
@@ -9,14 +9,14 @@ import (
 )
 
 func TestInstall(t *testing.T) {
-	target := testutil.StartContainer(t, testutil.DinDContainer)
+	container := testutil.StartContainer(t, testutil.DinDContainer)
 	topo := buildBinary(t)
 
 	t.Run("installs the binary", func(t *testing.T) {
-		out, err := installRemoteprocRuntime(topo, target.SSHDestination)
+		out, err := installRemoteprocRuntime(topo, container.SSHDestination)
 
 		require.NoError(t, err, out)
-		requireInstalled(t, "remoteproc-runtime", target.SSHDestination)
+		requireInstalled(t, "remoteproc-runtime", container.SSHDestination)
 	})
 }
 

--- a/e2e/install_test.go
+++ b/e2e/install_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestInstall(t *testing.T) {
-	target := testutil.StartTargetContainer(t)
+	target := testutil.StartContainer(t, testutil.DinDContainer)
 	topo := buildBinary(t)
 
 	t.Run("installs the binary", func(t *testing.T) {

--- a/e2e/templates_test.go
+++ b/e2e/templates_test.go
@@ -50,7 +50,7 @@ totalmemory_kb: 4194304
 
 		t.Run("correctly handles the --target flag when no target description is provided", func(t *testing.T) {
 			bin := buildBinary(t)
-			target := testutil.StartTargetContainer(t)
+			target := testutil.StartContainer(t, testutil.DinDContainer)
 
 			cmd := exec.Command(bin, "templates", "--target", target.SSHDestination)
 			out, err := cmd.CombinedOutput()

--- a/e2e/templates_test.go
+++ b/e2e/templates_test.go
@@ -50,9 +50,9 @@ totalmemory_kb: 4194304
 
 		t.Run("correctly handles the --target flag when no target description is provided", func(t *testing.T) {
 			bin := buildBinary(t)
-			target := testutil.StartContainer(t, testutil.DinDContainer)
+			container := testutil.StartContainer(t, testutil.DinDContainer)
 
-			cmd := exec.Command(bin, "templates", "--target", target.SSHDestination)
+			cmd := exec.Command(bin, "templates", "--target", container.SSHDestination)
 			out, err := cmd.CombinedOutput()
 			output := string(out)
 

--- a/internal/deploy/docker/deploy_test.go
+++ b/internal/deploy/docker/deploy_test.go
@@ -149,7 +149,7 @@ func TestDeployment(t *testing.T) {
 	testutil.RequireDocker(t)
 
 	t.Run("Run", func(t *testing.T) {
-		target := testutil.StartTargetContainer(t)
+		target := testutil.StartContainer(t, testutil.DinDContainer)
 
 		t.Run("builds images, transfers them, and starts services", func(t *testing.T) {
 			remoteDockerHost := ssh.NewDestination(target.SSHDestination)

--- a/internal/deploy/docker/deploy_test.go
+++ b/internal/deploy/docker/deploy_test.go
@@ -149,10 +149,10 @@ func TestDeployment(t *testing.T) {
 	testutil.RequireDocker(t)
 
 	t.Run("Run", func(t *testing.T) {
-		target := testutil.StartContainer(t, testutil.DinDContainer)
+		container := testutil.StartContainer(t, testutil.DinDContainer)
 
 		t.Run("builds images, transfers them, and starts services", func(t *testing.T) {
-			remoteDockerHost := ssh.NewDestination(target.SSHDestination)
+			remoteDockerHost := ssh.NewDestination(container.SSHDestination)
 			tmpDir := t.TempDir()
 			dockerFilePath := filepath.Join(tmpDir, "Dockerfile")
 			dockerFileContent := `

--- a/internal/deploy/docker/stop_test.go
+++ b/internal/deploy/docker/stop_test.go
@@ -45,7 +45,7 @@ func TestDeploymentStop(t *testing.T) {
 	testutil.RequireDocker(t)
 
 	t.Run("Run", func(t *testing.T) {
-		target := testutil.StartTargetContainer(t)
+		target := testutil.StartContainer(t, testutil.DinDContainer)
 
 		t.Run("deploys services then confirms stop shuts down containers", func(t *testing.T) {
 			remoteDockerHost := ssh.NewDestination(target.SSHDestination)

--- a/internal/deploy/docker/stop_test.go
+++ b/internal/deploy/docker/stop_test.go
@@ -45,10 +45,10 @@ func TestDeploymentStop(t *testing.T) {
 	testutil.RequireDocker(t)
 
 	t.Run("Run", func(t *testing.T) {
-		target := testutil.StartContainer(t, testutil.DinDContainer)
+		container := testutil.StartContainer(t, testutil.DinDContainer)
 
 		t.Run("deploys services then confirms stop shuts down containers", func(t *testing.T) {
-			remoteDockerHost := ssh.NewDestination(target.SSHDestination)
+			remoteDockerHost := ssh.NewDestination(container.SSHDestination)
 			tmpDir := t.TempDir()
 			dockerFilePath := filepath.Join(tmpDir, "Dockerfile")
 			dockerFileContent := `

--- a/internal/deploy/docker/testutil/testutil.go
+++ b/internal/deploy/docker/testutil/testutil.go
@@ -14,12 +14,12 @@ import (
 )
 
 var (
-	RequireDocker       = gtestutil.RequireDocker
+	RequireDocker            = gtestutil.RequireDocker
 	RequireLinuxDockerEngine = gtestutil.RequireLinuxDockerEngine
-	RequireWriteFile    = gtestutil.RequireWriteFile
-	SanitiseTestName    = gtestutil.SanitiseTestName
-	StartContainer      = gtestutil.StartContainer
-	DinDContainer       = gtestutil.DinDContainer
+	RequireWriteFile         = gtestutil.RequireWriteFile
+	SanitiseTestName         = gtestutil.SanitiseTestName
+	StartContainer           = gtestutil.StartContainer
+	DinDContainer            = gtestutil.DinDContainer
 )
 
 func TestImageName(t *testing.T) string {

--- a/internal/deploy/docker/testutil/testutil.go
+++ b/internal/deploy/docker/testutil/testutil.go
@@ -14,11 +14,12 @@ import (
 )
 
 var (
-	RequireDocker            = gtestutil.RequireDocker
+	RequireDocker       = gtestutil.RequireDocker
 	RequireLinuxDockerEngine = gtestutil.RequireLinuxDockerEngine
-	RequireWriteFile         = gtestutil.RequireWriteFile
-	SanitiseTestName         = gtestutil.SanitiseTestName
-	StartTargetContainer     = gtestutil.StartTargetContainer
+	RequireWriteFile    = gtestutil.RequireWriteFile
+	SanitiseTestName    = gtestutil.SanitiseTestName
+	StartContainer      = gtestutil.StartContainer
+	DinDContainer       = gtestutil.DinDContainer
 )
 
 func TestImageName(t *testing.T) string {

--- a/internal/testutil/container.go
+++ b/internal/testutil/container.go
@@ -15,7 +15,7 @@ import (
 
 type Container struct {
 	SSHDestination string
-	ContainerName  string
+	Name           string
 }
 
 type ContainerSpec struct {
@@ -72,7 +72,7 @@ func StartContainer(t *testing.T, spec ContainerSpec) *Container {
 
 	c := &Container{
 		SSHDestination: fmt.Sprintf("ssh://root@localhost:%s", port),
-		ContainerName:  containerName,
+		Name:           containerName,
 	}
 
 	if spec.setup != nil {
@@ -188,7 +188,7 @@ func waitForPort(host string, port string, timeout time.Duration) error {
 }
 
 func waitForDockerDaemon(c *Container) error {
-	containerName := c.ContainerName
+	containerName := c.Name
 	deadline := time.Now().Add(20 * time.Second)
 	var lastErr error
 

--- a/internal/testutil/container.go
+++ b/internal/testutil/container.go
@@ -3,37 +3,62 @@ package testutil
 import (
 	"fmt"
 	"net"
+	"net/url"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
 )
 
-const TargetContainerHost = "root@localhost"
-
-const TargetContainerImage = "topo-e2e-target:latest"
-
-type TargetContainer struct {
+type Container struct {
 	SSHDestination string
 	ContainerName  string
 }
 
-func StartTargetContainer(t *testing.T) *TargetContainer {
+type ContainerSpec struct {
+	context string
+	image   string
+	runArgs []string
+	setup   func(c *Container) error
+	cleanup func(c *Container)
+}
+
+var DinDContainer = ContainerSpec{
+	context: relPath("test-container"),
+	image:   "topo-e2e-target:latest",
+	runArgs: []string{"--privileged"},
+	setup: func(c *Container) error {
+		if err := acceptHostKey(c); err != nil {
+			return err
+		}
+		return waitForDockerDaemon(c)
+	},
+	cleanup: func(c *Container) {
+		removeHostKey(c)
+	},
+}
+
+func StartContainer(t *testing.T, spec ContainerSpec) *Container {
 	t.Helper()
 	if testing.Short() {
-		t.Skip("skipping test that requires a target container in short mode")
+		t.Skip("skipping test that requires a container in short mode")
 	}
 	RequireLinuxDockerEngine(t)
 
-	containerName := generateTargetContainerName(t)
+	if err := buildImage(spec); err != nil {
+		t.Fatalf("failed to build image: %v", err)
+	}
 
+	containerName := generateContainerName(t)
 	t.Cleanup(func() {
 		deleteContainer(containerName)
 	})
 
-	if err := createTargetContainer(t, containerName); err != nil {
-		t.Fatalf("failed to create vm: %v", err)
+	if err := runContainer(containerName, spec); err != nil {
+		t.Fatalf("failed to start container: %v", err)
 	}
 
 	port, err := GetContainerPublicPort(containerName, "22")
@@ -41,52 +66,27 @@ func StartTargetContainer(t *testing.T) *TargetContainer {
 		t.Fatalf("failed to get container port: %v", err)
 	}
 
-	waitForDockerReady(t, TargetContainerHost, port)
+	if err := waitForPort("localhost", port, 10*time.Second); err != nil {
+		t.Fatalf("container port not ready: %v", err)
+	}
 
-	// #nosec G204 -- ignore as its a test helper
-	return &TargetContainer{
-		SSHDestination: fmt.Sprintf("ssh://%s:%s", TargetContainerHost, port),
+	c := &Container{
+		SSHDestination: fmt.Sprintf("ssh://root@localhost:%s", port),
 		ContainerName:  containerName,
 	}
-}
 
-func generateTargetContainerName(t *testing.T) string {
-	return fmt.Sprintf("topo-test-%s", SanitiseTestName(t))
-}
-
-func requireImageExists(t *testing.T, imageName string) {
-	t.Helper()
-	// #nosec G204 -- ignore as its a test helper
-	cmd := exec.Command("docker", "images", "-q", imageName)
-	output, err := cmd.Output()
-	if err != nil {
-		t.Fatalf("failed to check for docker image %s: %v", imageName, err)
+	if spec.setup != nil {
+		if err := spec.setup(c); err != nil {
+			t.Fatalf("container setup failed: %v", err)
+		}
 	}
-	if len(strings.TrimSpace(string(output))) == 0 {
-		t.Skipf("required docker image %s not found. Please build it before running the tests.", imageName)
+	if spec.cleanup != nil {
+		t.Cleanup(func() {
+			spec.cleanup(c)
+		})
 	}
-}
 
-func createTargetContainer(t *testing.T, containerName string) error {
-	t.Helper()
-	requireImageExists(t, TargetContainerImage)
-	deleteContainer(containerName)
-	// #nosec G204 -- ignore as its a test helper
-	cmd := exec.Command("docker", "run", "--name", containerName, "--detach", "-P", "--privileged", TargetContainerImage)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("failed to start target container: %w", err)
-	}
-	return nil
-}
-
-func deleteContainer(containerName string) {
-	// #nosec G204 -- ignore as its a test helper
-	cmd := exec.Command("docker", "rm", "--force", containerName)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	_ = cmd.Run()
+	return c
 }
 
 func GetContainerPublicPort(containerName string, privatePort string) (string, error) {
@@ -107,21 +107,101 @@ func GetContainerPublicPort(containerName string, privatePort string) (string, e
 	return port, nil
 }
 
-func waitForDockerReady(t *testing.T, host string, port string) {
-	t.Helper()
+func relPath(dir string) string {
+	_, thisFile, _, _ := runtime.Caller(0)
+	return filepath.Join(filepath.Dir(thisFile), dir)
+}
+
+func buildImage(spec ContainerSpec) error {
+	// #nosec G204 -- ignore as its a test helper
+	cmd := exec.Command("docker", "build", "-t", spec.image, spec.context)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to build %s: %w", spec.image, err)
+	}
+	return nil
+}
+
+func generateContainerName(t *testing.T) string {
+	return fmt.Sprintf("topo-test-%s", SanitiseTestName(t))
+}
+
+func runContainer(containerName string, spec ContainerSpec) error {
+	deleteContainer(containerName)
+	// #nosec G204 -- ignore as its a test helper
+	args := append([]string{"run", "--name", containerName, "--detach", "-P"}, spec.runArgs...)
+	args = append(args, spec.image)
+	cmd := exec.Command("docker", args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to start container: %w", err)
+	}
+	return nil
+}
+
+func deleteContainer(containerName string) {
+	// #nosec G204 -- ignore as its a test helper
+	cmd := exec.Command("docker", "rm", "--force", containerName)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	_ = cmd.Run()
+}
+
+func acceptHostKey(c *Container) error {
+	// #nosec G204 -- ignore as its a test helper
+	cmd := exec.Command("ssh", c.SSHDestination, "-o", "StrictHostKeyChecking=accept-new", "true")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%w output: %s", err, strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+
+func removeHostKey(c *Container) {
+	u, err := url.Parse(c.SSHDestination)
+	if err != nil {
+		return
+	}
+	host := fmt.Sprintf("[%s]:%s", u.Hostname(), u.Port())
+	// #nosec G204 -- ignore as its a test helper
+	_ = exec.Command("ssh-keygen", "-R", host).Run()
+}
+
+func waitForPort(host string, port string, timeout time.Duration) error {
+	addr := net.JoinHostPort(host, port)
+	deadline := time.Now().Add(timeout)
+	var lastErr error
+
+	for time.Now().Before(deadline) {
+		conn, err := net.DialTimeout("tcp", addr, 2*time.Second)
+		if err == nil {
+			_ = conn.Close()
+			return nil
+		}
+		lastErr = err
+		time.Sleep(200 * time.Millisecond)
+	}
+
+	return fmt.Errorf("port %s not ready: %w", addr, lastErr)
+}
+
+func waitForDockerDaemon(c *Container) error {
+	containerName := c.ContainerName
 	deadline := time.Now().Add(20 * time.Second)
 	var lastErr error
 
 	for time.Now().Before(deadline) {
 		// #nosec G204 -- ignore as its a test helper
-		cmd := exec.Command("ssh", "-p", port, "-o", "ConnectTimeout=2", "-o", "StrictHostKeyChecking=accept-new", "--", host, "docker", "info")
+		cmd := exec.Command("docker", "exec", containerName, "docker", "info")
 		output, err := cmd.CombinedOutput()
 		if err == nil {
-			return
+			return nil
 		}
-		lastErr = fmt.Errorf("docker info failed: %w output: %s", err, strings.TrimSpace(string(output)))
+		lastErr = fmt.Errorf("%w output: %s", err, strings.TrimSpace(string(output)))
 		time.Sleep(200 * time.Millisecond)
 	}
 
-	t.Fatalf("docker daemon not ready in target container: %v", lastErr)
+	return fmt.Errorf("docker daemon not ready: %w", lastErr)
 }


### PR DESCRIPTION
## Changes

- Replace `StartTargetContainer` with `StartContainer(t, spec)` that accepts a `ContainerSpec`
    - ℹ️ I'm planning to leverage the `ContainerSpec` for e2e testing of `setup-keys` which will be a separate PR
    - `DinDContainer` is provided as the first spec, with setup/cleanup hooks for SSH host key management and Docker daemon readiness
- Images are auto-built from Dockerfiles, removing the manual `docker build` prerequisite from CI and local development
- Readiness uses TCP port check (`waitForPort`) instead of SSH-based polling
- Host key acceptance is explicit with cleanup on test teardown, instead of being a hidden side effect of the readiness probe
- `TargetContainer` renamed to `Container`
- Low-level functions decoupled from `*testing.T` — they return errors instead
- Updated `docs/DEVELOPMENT.md` to reflect that container images are built automatically
 