### PR TITLE
fix: skip buildable services during docker compose pull

### DIFF
--- a/internal/deploy/docker/operation/docker_compose.go
+++ b/internal/deploy/docker/operation/docker_compose.go
@@ -28,7 +28,7 @@ func NewDockerComposeBuild(composeFile string, h command.Host) *DockerCompose {
 }
 
 func NewDockerComposePull(composeFile string, h command.Host) *DockerCompose {
-	return NewDockerCompose("Pull images", composeFile, h, []string{"pull"})
+	return NewDockerCompose("Pull images", composeFile, h, []string{"pull", "--ignore-buildable"})
 }
 
 func NewDockerComposeStop(composeFile string, h command.Host) *DockerCompose {

--- a/internal/deploy/docker/operation/docker_compose_test.go
+++ b/internal/deploy/docker/operation/docker_compose_test.go
@@ -54,6 +54,30 @@ func TestNewDockerComposePull(t *testing.T) {
 
 		assert.Equal(t, "Pull images", got)
 	})
+
+	t.Run("Run", func(t *testing.T) {
+		testutil.RequireDocker(t)
+
+		t.Run("skips services that have a build context", func(t *testing.T) {
+			tmpDir := t.TempDir()
+			composeFilePath := filepath.Join(tmpDir, "compose.yaml")
+			composeFileContent := `
+services:
+  locally-built:
+    build:
+      context: .
+      dockerfile_inline: "FROM alpine:latest"
+    image: this-image-does-not-exist-on-docker-hub
+`
+			testutil.RequireWriteFile(t, composeFilePath, composeFileContent)
+			var buf bytes.Buffer
+			op := operation.NewDockerComposePull(composeFilePath, command.LocalHost)
+
+			err := op.Run(&buf)
+
+			require.NoError(t, err)
+		})
+	})
 }
 
 func TestNewDockerComposeRun(t *testing.T) {


### PR DESCRIPTION
## Changes

- Pass `--ignore-buildable` to `docker compose pull` so it skips services that have a `build:` context. Without this, pull tries to fetch locally-built image names from Docker Hub and fails with `pull access denied`.