### PR TITLE
chore: drop TestNewKeySetup

### DIFF
--- a/cmd/topo/setup_keys.go
+++ b/cmd/topo/setup_keys.go
@@ -57,10 +57,7 @@ var setupKeysCmd = &cobra.Command{
 			return err
 		}
 
-		seq, err := setupkeys.NewKeySetup(dest, privateKeyPath, parsedKeyType)
-		if err != nil {
-			return err
-		}
+		seq := setupkeys.NewKeySetup(dest, privateKeyPath, parsedKeyType)
 
 		err = seq.Run(os.Stdout)
 		if err != nil {

--- a/internal/setupkeys/setup_keys.go
+++ b/internal/setupkeys/setup_keys.go
@@ -17,13 +17,13 @@ const (
 	KeyTypeRSA     KeyType = "rsa"
 )
 
-func NewKeySetup(dest ssh.Destination, privKeyPath string, keyType KeyType) (operation.Sequence, error) {
+func NewKeySetup(dest ssh.Destination, privKeyPath string, keyType KeyType) operation.Sequence {
 	sshRunner := runner.NewSSH(dest, runner.SSHOptions{})
 	ops := []operation.Operation{
 		operations.NewSSHKeyGen("Generate SSH key pair for target", dest, string(keyType), privKeyPath, operations.SSHKeyGenOptions{}),
 		operations.NewPubKeyTransfer(privKeyPath, sshRunner),
 	}
-	return operation.NewSequence(ops...), nil
+	return operation.NewSequence(ops...)
 }
 
 func GetDefaultPrivateKeyPath(sshDir string, targetSlug string) (string, error) {

--- a/internal/setupkeys/setup_keys_test.go
+++ b/internal/setupkeys/setup_keys_test.go
@@ -5,49 +5,9 @@ import (
 	"testing"
 
 	"github.com/arm/topo/internal/setupkeys"
-	"github.com/arm/topo/internal/setupkeys/operations"
 	"github.com/arm/topo/internal/ssh"
 	"github.com/stretchr/testify/require"
 )
-
-func TestNewKeySetup(t *testing.T) {
-	t.Run("NewKeySetup returns SSHKeyGen then PubKeyTransfer for supported key types", func(t *testing.T) {
-		t.Run("ed25519 with empty private key path", func(t *testing.T) {
-			got, err := setupkeys.NewKeySetup(ssh.NewDestination("user@some1thing.com"), "", setupkeys.KeyTypeED25519)
-
-			require.NoError(t, err)
-			require.Len(t, got, 2)
-			require.IsType(t, &operations.SSHKeyGen{}, got[0])
-			require.IsType(t, &operations.PubKeyTransfer{}, got[1])
-		})
-
-		t.Run("ed25519 with custom private key path", func(t *testing.T) {
-			got, err := setupkeys.NewKeySetup(
-				ssh.NewDestination("user@some1thing.com"),
-				filepath.Join(t.TempDir(), "id_ed25519_custom"),
-				setupkeys.KeyTypeED25519,
-			)
-
-			require.NoError(t, err)
-			require.Len(t, got, 2)
-			require.IsType(t, &operations.SSHKeyGen{}, got[0])
-			require.IsType(t, &operations.PubKeyTransfer{}, got[1])
-		})
-
-		t.Run("rsa with custom private key path", func(t *testing.T) {
-			got, err := setupkeys.NewKeySetup(
-				ssh.NewDestination("user@some2thing.com"),
-				filepath.Join(t.TempDir(), "id_rsa_custom"),
-				setupkeys.KeyTypeRSA,
-			)
-
-			require.NoError(t, err)
-			require.Len(t, got, 2)
-			require.IsType(t, &operations.SSHKeyGen{}, got[0])
-			require.IsType(t, &operations.PubKeyTransfer{}, got[1])
-		})
-	})
-}
 
 func TestGetDefaultPrivateKeyPath(t *testing.T) {
 	t.Run("returns home-based ed25519 key path for target slug", func(t *testing.T) {


### PR DESCRIPTION
## Changes

- Remove `TestNewKeySetup` — it only asserts the return types of a trivial constructor with no branching logic, no error paths, and a vestigial `error` return that is always `nil`. All three sub-cases exercise the same code path.