### PR TITLE
fix: use topo-signer rather than signer

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -123,7 +123,7 @@ jobs:
           app-id: ${{ secrets.ML_REPO_ACCESS_APP_ID }}
           private-key: ${{ secrets.ML_REPO_ACCESS_PRIVATE_KEY }}
           owner: Arm-Debug
-          repositories: signer
+          repositories: topo-signer
 
       - name: Trigger sign-and-release
         env:
@@ -131,7 +131,7 @@ jobs:
           VERSION: ${{ steps.calculate_next_version.outputs.next_version }}
         run: |
           gh workflow run sign-and-release.yml \
-            --repo Arm-Debug/signer \
+            --repo Arm-Debug/topo-signer \
             --ref v3 \
             --field run-id=${{ github.run_id }} \
             --field release-version=${VERSION} \


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- current release flow will not work without this change as signer has been renamed to topo-signer
