### PR TITLE
docs: remove instructions to build from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,6 @@ The full format specification is at [arm/topo-template-format](https://github.co
 
 Download the latest binary for your platform from [GitHub Releases](https://github.com/arm/topo/releases/latest), extract it, and place it on your `PATH`.
 
-To build from source instead (requires Go 1.26+):
-
-```sh
-go build ./cmd/topo
-```
-
 ### Prerequisites
 
 **Host machine** (where you run `topo`):

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -2,6 +2,16 @@
 
 This guide covers the development workflow, tools, and conventions for contributing to `topo`.
 
+## Prerequisites 
+
+- Go 1.26+
+
+## Building 
+
+```sh
+go build ./cmd/topo
+```
+
 ## Linting
 
 The project uses [golangci-lint](https://golangci-lint.run/) for Go code quality checks.


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- remove instructions to build from source from readme
