### PR TITLE
refactor: replace probe structs with plain functions

### DIFF
--- a/cmd/topo/describe.go
+++ b/cmd/topo/describe.go
@@ -25,10 +25,9 @@ var describeCmd = &cobra.Command{
 		}
 
 		r := runner.For(ssh.NewDestination(targetArg), runner.SSHOptions{Multiplex: true})
-		probe := target.NewHardwareProbe(r)
 		ctx, cancel := contextWithTimeout(cmd)
 		defer cancel()
-		hwProfile, err := probe.Probe(ctx)
+		hwProfile, err := target.ProbeHardware(ctx, r)
 		if err != nil {
 			return err
 		}

--- a/cmd/topo/templates.go
+++ b/cmd/topo/templates.go
@@ -37,10 +37,9 @@ var templatesCmd = &cobra.Command{
 			targetArg, exists := lookupTarget(cmd)
 			if exists {
 				r := runner.For(ssh.NewDestination(targetArg), runner.SSHOptions{Multiplex: true})
-				probe := target.NewHardwareProbe(r)
 				ctx, cancel := contextWithTimeout(cmd)
 				defer cancel()
-				hwProfile, err := probe.Probe(ctx)
+				hwProfile, err := target.ProbeHardware(ctx, r)
 				if err != nil {
 					return err
 				}

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -103,8 +103,7 @@ func prepareRunner(ctx context.Context, dest ssh.Destination, probeOpts target.S
 		return runner.NewLocal(), nil
 	}
 	sshOpts := runner.SSHOptions{Multiplex: true}
-	authProbe := target.NewSSHAuthenticationProbe(runner.NewSSH(dest, sshOpts), probeOpts)
-	if err := authProbe.Probe(ctx); err != nil {
+	if err := target.ProbeSSHAuthentication(ctx, runner.NewSSH(dest, sshOpts), probeOpts); err != nil {
 		return nil, err
 	}
 	return runner.NewSSH(dest, sshOpts), nil

--- a/internal/health/status.go
+++ b/internal/health/status.go
@@ -28,8 +28,7 @@ type HealthStatus struct {
 func ProbeHealthStatus(ctx context.Context, r runner.Runner) HealthStatus {
 	var hs HealthStatus
 
-	probe := target.NewHardwareProbe(r)
-	remoteprocs, _ := probe.ProbeRemoteproc(ctx)
+	remoteprocs, _ := target.ProbeRemoteproc(ctx, r)
 	hs.Hardware.RemoteCPU = remoteprocs
 
 	dependenciesToCheck := FilterByHardware(TargetRequiredDependencies, hs.Hardware.Capabilities())

--- a/internal/target/hardware_probe.go
+++ b/internal/target/hardware_probe.go
@@ -29,30 +29,22 @@ type HardwareProfile struct {
 	TotalMemoryKb int64           `yaml:"totalmemory_kb"`
 }
 
-type HardwareProbe struct {
-	runner runner.Runner
-}
-
-func NewHardwareProbe(r runner.Runner) HardwareProbe {
-	return HardwareProbe{runner: r}
-}
-
-func (p *HardwareProbe) Probe(ctx context.Context) (HardwareProfile, error) {
+func ProbeHardware(ctx context.Context, r runner.Runner) (HardwareProfile, error) {
 	var hp HardwareProfile
 
-	cpuProfile, err := p.collectCPUInfo(ctx)
+	cpuProfile, err := collectCPUInfo(ctx, r)
 	if err != nil {
 		return hp, fmt.Errorf("collecting CPU info: %w", err)
 	}
 	hp.HostProcessor = cpuProfile
 
-	cpus, err := p.ProbeRemoteproc(ctx)
+	cpus, err := ProbeRemoteproc(ctx, r)
 	if err != nil {
 		return hp, fmt.Errorf("collecting remote CPUs: %w", err)
 	}
 	hp.RemoteCPU = cpus
 
-	memTotal, err := p.collectMemInfo(ctx)
+	memTotal, err := collectMemInfo(ctx, r)
 	if err != nil {
 		return hp, fmt.Errorf("collecting memory info: %w", err)
 	}
@@ -61,14 +53,14 @@ func (p *HardwareProbe) Probe(ctx context.Context) (HardwareProfile, error) {
 	return hp, nil
 }
 
-func (p *HardwareProbe) ProbeRemoteproc(ctx context.Context) ([]RemoteprocCPU, error) {
+func ProbeRemoteproc(ctx context.Context, r runner.Runner) ([]RemoteprocCPU, error) {
 	var remoteProcs []RemoteprocCPU
-	out, err := p.runner.Run(ctx, command.WrapInLoginShell("ls /sys/class/remoteproc"))
+	out, err := r.Run(ctx, command.WrapInLoginShell("ls /sys/class/remoteproc"))
 	if err != nil || out == "" {
 		return remoteProcs, nil
 	}
 
-	out, err = p.runner.Run(ctx, command.WrapInLoginShell("cat /sys/class/remoteproc/*/name"))
+	out, err = r.Run(ctx, command.WrapInLoginShell("cat /sys/class/remoteproc/*/name"))
 	if err != nil {
 		return remoteProcs, err
 	}
@@ -80,12 +72,12 @@ func (p *HardwareProbe) ProbeRemoteproc(ctx context.Context) ([]RemoteprocCPU, e
 	return remoteProcs, nil
 }
 
-func (p *HardwareProbe) collectCPUInfo(ctx context.Context) ([]HostProcessor, error) {
-	if err := p.runner.BinaryExists(ctx, "lscpu"); err != nil {
+func collectCPUInfo(ctx context.Context, r runner.Runner) ([]HostProcessor, error) {
+	if err := r.BinaryExists(ctx, "lscpu"); err != nil {
 		return nil, err
 	}
 
-	out, err := p.runner.Run(ctx, command.WrapInLoginShell("lscpu --json"))
+	out, err := r.Run(ctx, command.WrapInLoginShell("lscpu --json"))
 	if err != nil {
 		return nil, err
 	}
@@ -99,11 +91,11 @@ func (p *HardwareProbe) collectCPUInfo(ctx context.Context) ([]HostProcessor, er
 	return CreateCPUProfile(lscpuOutput.Lscpu)
 }
 
-func (p *HardwareProbe) collectMemInfo(ctx context.Context) (int64, error) {
+func collectMemInfo(ctx context.Context, r runner.Runner) (int64, error) {
 	key := "MemTotal"
 	path := "/proc/meminfo"
 
-	out, err := p.runner.Run(ctx, command.WrapInLoginShell(fmt.Sprintf("cat %s", path)))
+	out, err := r.Run(ctx, command.WrapInLoginShell(fmt.Sprintf("cat %s", path)))
 	if err != nil {
 		return 0, err
 	}

--- a/internal/target/hardware_probe_test.go
+++ b/internal/target/hardware_probe_test.go
@@ -23,9 +23,8 @@ func TestHardwareProbe(t *testing.T) {
 					command.WrapInLoginShell("cat /proc/meminfo"):        {Output: "MemTotal:       16384000 kB"},
 				},
 			}
-			probe := target.NewHardwareProbe(r)
 
-			got, err := probe.Probe(context.Background())
+			got, err := target.ProbeHardware(context.Background(), r)
 
 			require.NoError(t, err)
 			want := target.HardwareProfile{
@@ -43,9 +42,8 @@ func TestHardwareProbe(t *testing.T) {
 
 		t.Run("returns error when lscpu not found", func(t *testing.T) {
 			r := &runner.Fake{}
-			probe := target.NewHardwareProbe(r)
 
-			_, err := probe.Probe(context.Background())
+			_, err := target.ProbeHardware(context.Background(), r)
 
 			assert.ErrorContains(t, err, `"lscpu" not found in $PATH`)
 		})
@@ -57,9 +55,8 @@ func TestHardwareProbe(t *testing.T) {
 					command.WrapInLoginShell("lscpu --json"): {Output: "not json"},
 				},
 			}
-			probe := target.NewHardwareProbe(r)
 
-			_, err := probe.Probe(context.Background())
+			_, err := target.ProbeHardware(context.Background(), r)
 
 			assert.ErrorContains(t, err, "collecting CPU info")
 		})

--- a/internal/target/ssh_authentication_probe.go
+++ b/internal/target/ssh_authentication_probe.go
@@ -33,18 +33,9 @@ func (s SSHAuthenticationProbeOptions) SSHArgs() []string {
 	return args
 }
 
-type SSHAuthenticationProbe struct {
-	runner *runner.SSH
-	opts   SSHAuthenticationProbeOptions
-}
-
-func NewSSHAuthenticationProbe(r *runner.SSH, opts SSHAuthenticationProbeOptions) SSHAuthenticationProbe {
-	return SSHAuthenticationProbe{runner: r, opts: opts}
-}
-
-// Probe verifies SSH connectivity by attempting public key authentication.
-func (p SSHAuthenticationProbe) Probe(ctx context.Context) error {
-	_, err := p.runner.RunWithArgs(ctx, "true", p.opts.SSHArgs()...)
+// ProbeSSHAuthentication verifies SSH connectivity by attempting public key authentication.
+func ProbeSSHAuthentication(ctx context.Context, r *runner.SSH, opts SSHAuthenticationProbeOptions) error {
+	_, err := r.RunWithArgs(ctx, "true", opts.SSHArgs()...)
 	if err == nil {
 		return nil
 	}


### PR DESCRIPTION
## Changes

- Remove `HardwareProbe` and `SSHAuthenticationProbe` structs and their constructors
- Replace `NewProbeXXX().Probe()` pattern with plain `ProbeXXX()` functions
- Update all call sites in `describe`, `templates`, `health`