### PR TITLE
feat: add help to add dir to PATH when failed to find writable install dir

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -130,8 +130,10 @@ resolve_install_dir() {
     return
   fi
 
+  prefered_dir="$HOME/.local/bin"
+
   # try conventional user-local directories already on PATH.
-  for candidate in "$HOME/.local/bin" "$HOME/bin"; do
+  for candidate in "$prefered_dir" "$HOME/bin"; do
     case ":${PATH}:" in
       *":${candidate}:"*)
         mkdir -p "$candidate" 2>/dev/null && echo "$candidate" && return
@@ -140,7 +142,9 @@ resolve_install_dir() {
   done
 
   echo "Error: could not find a user-writable directory on PATH." >&2
-  echo "Provide one explicitly with --path, or add ~/.local/bin to your PATH." >&2
+  echo "Provide one explicitly with --path, or add $prefered_dir to your PATH with the following command:" >&2
+  echo "  export PATH=\"\$PATH:$prefered_dir\""
+  echo "To persist across terminal restarts, add the export line to your shell's configuration file (e.g. ~/.bashrc, ~/.zshrc)"
   exit 1
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -130,10 +130,10 @@ resolve_install_dir() {
     return
   fi
 
-  prefered_dir="$HOME/.local/bin"
+  preferred_dir="$HOME/.local/bin"
 
   # try conventional user-local directories already on PATH.
-  for candidate in "$prefered_dir" "$HOME/bin"; do
+  for candidate in "$preferred_dir" "$HOME/bin"; do
     case ":${PATH}:" in
       *":${candidate}:"*)
         mkdir -p "$candidate" 2>/dev/null && echo "$candidate" && return
@@ -142,9 +142,9 @@ resolve_install_dir() {
   done
 
   echo "Error: could not find a user-writable directory on PATH." >&2
-  echo "Provide one explicitly with --path, or add $prefered_dir to your PATH with the following command:" >&2
-  echo "  export PATH=\"\$PATH:$prefered_dir\""
-  echo "To persist across terminal restarts, add the export line to your shell's configuration file (e.g. ~/.bashrc, ~/.zshrc)"
+  echo "Provide one explicitly with --path, or add $preferred_dir to your PATH with the following command:" >&2
+  echo "  export PATH=\"\$PATH:$preferred_dir\"" >&2
+  echo "To persist across terminal restarts, add the export line to your shell's configuration file (e.g. ~/.bashrc, ~/.zshrc)" >&2
   exit 1
 }
 


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- Adds a couple lines to the install script when none of the candidate directories are on the path on how to add one of them to the `PATH`
