### PR TITLE
feat: windows install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,22 +28,13 @@ The host and target can be the same system. If you're working directly on an Arm
 curl -fsSL https://raw.githubusercontent.com/arm/topo/refs/heads/main/scripts/install.sh | sh
 ```
 
-Alternatively, manually add the appropriate binary from [GitHub Releases](https://github.com/arm/topo/releases/latest) to your `PATH`.
-
 ### Windows
 
-Download the latest binary for Windows from [GitHub Releases](https://github.com/arm/topo/releases/latest).
-
-1. Extract the `.zip` file you downloaded.
-2. Open **Command Prompt** in the folder where `topo.exe` was extracted:
-   - Right-click in the folder → **Open in Terminal**
-3. Run the following command to install to path:
-
-```bat
-mkdir "$env:USERPROFILE\tools\topo" -Force; move .\topo.exe "$env:USERPROFILE\tools\topo\"; setx PATH "$env:PATH;$env:USERPROFILE\tools\topo"
+```sh
+irm https://raw.githubusercontent.com/arm/topo/refs/heads/main/scripts/install.ps1 | iex
 ```
 
-Then from a new terminal run `topo --help` to confirm installation.
+Alternatively, manually add the appropriate binary from [GitHub Releases](https://github.com/arm/topo/releases/latest) to your `PATH`.
 
 ## Getting Started
 

--- a/e2e/install_script_posix_test.go
+++ b/e2e/install_script_posix_test.go
@@ -1,10 +1,10 @@
+//go:build !windows
 package e2e
 
 import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -27,9 +27,6 @@ func runInstallScript(t *testing.T, args ...string) (string, error) {
 }
 
 func TestInstallScript(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("install script is not supported on Windows")
-	}
 	if testing.Short() {
 		t.Skip("skipping install script e2e tests in short mode")
 	}

--- a/e2e/install_script_posix_test.go
+++ b/e2e/install_script_posix_test.go
@@ -1,4 +1,5 @@
 //go:build !windows
+
 package e2e
 
 import (

--- a/e2e/install_script_windows_test.go
+++ b/e2e/install_script_windows_test.go
@@ -1,0 +1,95 @@
+//go:build windows
+
+package e2e
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func runInstallScript(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+
+	path, err := filepath.Abs("../scripts/install.ps1")
+	require.NoError(t, err)
+
+	tmpDir := t.TempDir()
+	homeDir := filepath.Join(tmpDir, "home")
+	localAppDataDir := filepath.Join(tmpDir, "localappdata")
+	appDataDir := filepath.Join(tmpDir, "appdata")
+	tempDir := filepath.Join(tmpDir, "tmp")
+
+	for _, dir := range []string{homeDir, localAppDataDir, appDataDir, tempDir} {
+		err := os.MkdirAll(dir, 0o755)
+		require.NoError(t, err)
+	}
+
+	cmdArgs := append([]string{
+		"-NoProfile",
+		"-ExecutionPolicy", "Bypass",
+		"-File", path,
+	}, args...)
+	cmd := exec.Command("powershell", cmdArgs...)
+	cmd.Env = append(os.Environ(),
+		"HOME="+homeDir,
+		"USERPROFILE="+homeDir,
+		"LOCALAPPDATA="+localAppDataDir,
+		"APPDATA="+appDataDir,
+		"TEMP="+tempDir,
+		"TMP="+tempDir,
+	)
+
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func TestInstallScriptWindows(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping install script e2e tests in short mode")
+	}
+
+	t.Run("installs latest version", func(t *testing.T) {
+		dir := t.TempDir()
+		bin := filepath.Join(dir, "topo.exe")
+
+		out, err := runInstallScript(t, "-Path", dir)
+
+		require.NoError(t, err, "script failed: %s", out)
+		assert.Contains(t, out, "Installed topo")
+		assert.FileExists(t, bin)
+	})
+
+	t.Run("installs a specific version", func(t *testing.T) {
+		version := "v4.0.0"
+		dir := t.TempDir()
+
+		out, err := runInstallScript(t, "-Version", version, "-Path", dir)
+
+		require.NoError(t, err, "script failed: %s", out)
+		assert.Contains(t, out, version)
+		assert.FileExists(t, filepath.Join(dir, "topo.exe"))
+	})
+
+	t.Run("can reinstall in place", func(t *testing.T) {
+		dir := t.TempDir()
+		_, err := runInstallScript(t, "-Path", dir)
+		require.NoError(t, err)
+
+		_, err = runInstallScript(t, "-Path", dir)
+
+		require.NoError(t, err)
+		assert.FileExists(t, filepath.Join(dir, "topo.exe"))
+	})
+
+	t.Run("fails on unknown flag", func(t *testing.T) {
+		out, err := runInstallScript(t, "-Bogus")
+
+		assert.Error(t, err)
+		assert.Contains(t, out, "Bogus")
+	})
+}

--- a/e2e/install_script_windows_test.go
+++ b/e2e/install_script_windows_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/arm/topo/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -19,15 +20,8 @@ func runInstallScript(t *testing.T, args ...string) (string, error) {
 	require.NoError(t, err)
 
 	tmpDir := t.TempDir()
-	homeDir := filepath.Join(tmpDir, "home")
 	localAppDataDir := filepath.Join(tmpDir, "localappdata")
-	appDataDir := filepath.Join(tmpDir, "appdata")
-	tempDir := filepath.Join(tmpDir, "tmp")
-
-	for _, dir := range []string{homeDir, localAppDataDir, appDataDir, tempDir} {
-		err := os.MkdirAll(dir, 0o755)
-		require.NoError(t, err)
-	}
+	testutil.RequireMkdirAll(t, localAppDataDir)
 
 	cmdArgs := append([]string{
 		"-NoProfile",
@@ -35,14 +29,7 @@ func runInstallScript(t *testing.T, args ...string) (string, error) {
 		"-File", path,
 	}, args...)
 	cmd := exec.Command("powershell", cmdArgs...)
-	cmd.Env = append(os.Environ(),
-		"HOME="+homeDir,
-		"USERPROFILE="+homeDir,
-		"LOCALAPPDATA="+localAppDataDir,
-		"APPDATA="+appDataDir,
-		"TEMP="+tempDir,
-		"TMP="+tempDir,
-	)
+	cmd.Env = append(os.Environ(), "LOCALAPPDATA="+localAppDataDir)
 
 	out, err := cmd.CombinedOutput()
 	return string(out), err

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -82,7 +82,7 @@ function Resolve-InstallDir {
     }
 
     # windows convention is to install user-local binaries under %LOCALAPPDATA%\Programs\$BinaryName
-    $default = Join-Path $env:LOCALAPPDATA 'Programs' $BinaryName
+    $default = Join-Path $env:LOCALAPPDATA (Join-Path 'Programs' $BinaryName)
     New-Item -ItemType Directory -Path $default -Force | Out-Null
     return (Resolve-Path -LiteralPath $default).ProviderPath
 }

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -151,4 +151,19 @@ $url        = Build-DownloadUrl -Version $resolvedVersion
 $installDir = Resolve-InstallDir -Requested $Path
 
 Install-Binary -Url $url -InstallDir $installDir -Version $resolvedVersion
-Add-ToUserPath -Dir $installDir
+
+# avoid modifying PATH if the user explicitly provided an install location
+if ($PSBoundParameters.ContainsKey('Path')) {
+    $onPath = ($env:PATH -split ';' |
+        Where-Object { $_ } |
+        ForEach-Object { $_.TrimEnd('\') }) -contains $installDir.TrimEnd('\')
+    if (-not $onPath) {
+        Write-Host ""
+        Write-Host "$installDir is not on your PATH. To add it for the current session:"
+        Write-Host "  `$env:PATH = `"`$env:PATH;$installDir`""
+        Write-Host "To persist across terminal restarts:"
+        Write-Host "  [Environment]::SetEnvironmentVariable('PATH', `"`$([Environment]::GetEnvironmentVariable('PATH','User'));$installDir`", 'User')"
+    }
+} else {
+    Add-ToUserPath -Dir $installDir
+}

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,151 @@
+#Requires -Version 5.1
+[CmdletBinding()]
+param(
+    [string]$Version = '',
+    [string]$Path = '',
+    [switch]$Help
+)
+
+$ErrorActionPreference = 'Stop'
+$ProgressPreference    = 'SilentlyContinue'
+
+$Usage = @'
+PowerShell installer for topo on Windows.
+Downloads a release from the Arm artifactory server, installs it under the
+current user, and ensures the install directory is on your PATH.
+
+Usage:
+  irm https://raw.githubusercontent.com/arm/topo/refs/heads/main/scripts/install.ps1 | iex
+
+To pass options, invoke the downloaded script as a scriptblock:
+  & ([scriptblock]::Create((irm https://raw.githubusercontent.com/arm/topo/refs/heads/main/scripts/install.ps1))) -Version v4.0.0 -Path C:\tools\topo
+
+Options:
+  -Version VERSION   Install a specific version (e.g. v4.0.0). Default: latest.
+  -Path DIRECTORY    Install the binary into DIRECTORY instead of auto-detecting.
+  -Help              Show this help message.
+'@
+
+$BaseUrl    = 'https://artifacts.tools.arm.com/topo'
+$BinaryName = 'topo'
+$ExeName    = 'topo.exe'
+
+function Get-Architecture {
+    # PROCESSOR_ARCHITEW6432 is set when a 32-bit process runs on 64-bit Windows.
+    $arch = if ($env:PROCESSOR_ARCHITEW6432) { $env:PROCESSOR_ARCHITEW6432 } else { $env:PROCESSOR_ARCHITECTURE }
+    switch ($arch) {
+        'AMD64' { 'amd64' }
+        'ARM64' { 'arm64' }
+        default { throw "Unsupported architecture: $arch" }
+    }
+}
+
+function Resolve-Version {
+    param([string]$Requested)
+
+    if ([string]::IsNullOrWhiteSpace($Requested)) {
+        Write-Host 'Resolving latest version...'
+        $page  = (Invoke-WebRequest -UseBasicParsing -Uri "$BaseUrl/").Content
+        $found = [regex]::Matches($page, 'v[0-9]+\.[0-9]+\.[0-9]+') |
+                 ForEach-Object { $_.Value } |
+                 Select-Object -Unique
+        if (-not $found) { throw "Could not determine latest version from $BaseUrl/" }
+        return ($found | Sort-Object { [version]($_.TrimStart('v')) } | Select-Object -Last 1)
+    }
+
+    if ($Requested -notmatch '^v') { return "v$Requested" }
+    return $Requested
+}
+
+function Build-DownloadUrl {
+    param([string]$Version)
+    $arch    = Get-Architecture
+    $archive = "${BinaryName}_windows_${arch}.zip"
+    return "$BaseUrl/$Version/windows/$archive"
+}
+
+function Resolve-InstallDir {
+    param([string]$Requested)
+
+    if (-not [string]::IsNullOrWhiteSpace($Requested)) {
+        New-Item -ItemType Directory -Path $Requested -Force | Out-Null
+        return (Resolve-Path -LiteralPath $Requested).ProviderPath
+    }
+
+    $existing = Get-Command $ExeName -CommandType Application -ErrorAction SilentlyContinue | Select-Object -First 1
+    if ($existing) {
+        $dir = Split-Path -Parent $existing.Source
+        $currentVersion = ''
+        try { $currentVersion = (& $existing.Source --version 2>$null) -join ' ' } catch { }
+        Write-Host "Existing installation found at $dir ($currentVersion), will update in-place"
+        return $dir
+    }
+
+    $default = Join-Path $env:LOCALAPPDATA 'Programs\topo'
+    New-Item -ItemType Directory -Path $default -Force | Out-Null
+    return (Resolve-Path -LiteralPath $default).ProviderPath
+}
+
+function Install-Binary {
+    param(
+        [string]$Url,
+        [string]$InstallDir,
+        [string]$Version
+    )
+
+    $tmp = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
+    New-Item -ItemType Directory -Path $tmp -Force | Out-Null
+    try {
+        $archive = Join-Path $tmp ([System.IO.Path]::GetFileName($Url))
+        Write-Host "Downloading $Url..."
+        Invoke-WebRequest -UseBasicParsing -Uri $Url -OutFile $archive
+
+        Expand-Archive -LiteralPath $archive -DestinationPath $tmp -Force
+
+        $src = Get-ChildItem -Path $tmp -Recurse -Filter $ExeName | Select-Object -First 1
+        if (-not $src) { throw "$ExeName not found in archive" }
+
+        $dst = Join-Path $InstallDir $ExeName
+        Copy-Item -LiteralPath $src.FullName -Destination $dst -Force
+        Write-Host "Installed $BinaryName $Version to $dst"
+    } finally {
+        Remove-Item -Recurse -Force -LiteralPath $tmp -ErrorAction SilentlyContinue
+    }
+}
+
+function Add-ToUserPath {
+    param([string]$Dir)
+
+    $userPath = [Environment]::GetEnvironmentVariable('PATH', 'User')
+    if (-not $userPath) { $userPath = '' }
+    $entries  = $userPath -split ';' | Where-Object { $_ }
+
+    if ($entries -notcontains $Dir) {
+        $newPath = if ($userPath) { "$userPath;$Dir" } else { $Dir }
+        [Environment]::SetEnvironmentVariable('PATH', $newPath, 'User')
+        Write-Host ""
+        Write-Host "Added $Dir to your user PATH."
+    } else {
+        Write-Host ""
+        Write-Host "Run '$BinaryName --help' to get started."
+    }
+
+    # Make the binary usable in the current session too.
+    if (($env:PATH -split ';') -notcontains $Dir) {
+        $env:PATH = "$env:PATH;$Dir"
+    }
+}
+
+if ($Help) {
+    Write-Host $Usage
+    return
+}
+
+$resolvedVersion = Resolve-Version -Requested $Version
+Write-Host "Installing $BinaryName $resolvedVersion"
+
+$url        = Build-DownloadUrl -Version $resolvedVersion
+$installDir = Resolve-InstallDir -Requested $Path
+
+Install-Binary -Url $url -InstallDir $installDir -Version $resolvedVersion
+Add-ToUserPath -Dir $installDir

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -81,7 +81,8 @@ function Resolve-InstallDir {
         return $dir
     }
 
-    $default = Join-Path $env:LOCALAPPDATA 'Programs\topo'
+    # windows convention is to install user-local binaries under %LOCALAPPDATA%\Programs\$BinaryName
+    $default = Join-Path $env:LOCALAPPDATA 'Programs' $BinaryName
     New-Item -ItemType Directory -Path $default -Force | Out-Null
     return (Resolve-Path -LiteralPath $default).ProviderPath
 }
@@ -113,6 +114,8 @@ function Install-Binary {
     }
 }
 
+# windows convention is to automatically add the install dir to user PATH for the user
+# since it's in its own directory, there's no risk of accidentally shadowing other binaries
 function Add-ToUserPath {
     param([string]$Dir)
 
@@ -130,7 +133,7 @@ function Add-ToUserPath {
         Write-Host "Run '$BinaryName --help' to get started."
     }
 
-    # Make the binary usable in the current session too.
+    # make the binary usable in the current session too.
     if (($env:PATH -split ';') -notcontains $Dir) {
         $env:PATH = "$env:PATH;$Dir"
     }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -130,8 +130,10 @@ resolve_install_dir() {
     return
   fi
 
+  prefered_dir="$HOME/.local/bin"
+
   # try conventional user-local directories already on PATH.
-  for candidate in "$HOME/.local/bin" "$HOME/bin"; do
+  for candidate in "$prefered_dir" "$HOME/bin"; do
     case ":${PATH}:" in
       *":${candidate}:"*)
         mkdir -p "$candidate" 2>/dev/null && echo "$candidate" && return
@@ -140,7 +142,9 @@ resolve_install_dir() {
   done
 
   echo "Error: could not find a user-writable directory on PATH." >&2
-  echo "Provide one explicitly with --path, or add ~/.local/bin to your PATH." >&2
+  echo "Provide one explicitly with --path, or add $prefered_dir to your PATH with the following command:" >&2
+  echo "  export PATH=\"\$PATH:$prefered_dir\""
+  echo "To persist across terminal restarts, add the export line to your shell's configuration file (e.g. ~/.bashrc, ~/.zshrc)"
   exit 1
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -130,10 +130,10 @@ resolve_install_dir() {
     return
   fi
 
-  prefered_dir="$HOME/.local/bin"
+  preferred_dir="$HOME/.local/bin"
 
   # try conventional user-local directories already on PATH.
-  for candidate in "$prefered_dir" "$HOME/bin"; do
+  for candidate in "$preferred_dir" "$HOME/bin"; do
     case ":${PATH}:" in
       *":${candidate}:"*)
         mkdir -p "$candidate" 2>/dev/null && echo "$candidate" && return
@@ -142,9 +142,9 @@ resolve_install_dir() {
   done
 
   echo "Error: could not find a user-writable directory on PATH." >&2
-  echo "Provide one explicitly with --path, or add $prefered_dir to your PATH with the following command:" >&2
-  echo "  export PATH=\"\$PATH:$prefered_dir\""
-  echo "To persist across terminal restarts, add the export line to your shell's configuration file (e.g. ~/.bashrc, ~/.zshrc)"
+  echo "Provide one explicitly with --path, or add $preferred_dir to your PATH with the following command:" >&2
+  echo "  export PATH=\"\$PATH:$preferred_dir\"" >&2
+  echo "To persist across terminal restarts, add the export line to your shell's configuration file (e.g. ~/.bashrc, ~/.zshrc)" >&2
   exit 1
 }
 


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- Adds a powershell windows installation script. This mostly mirrors the behaviour of the posix one with two notable exceptions;
  - Windows convention found in tools like vscode, python or the GH CLI is to install each binary in its own directory. There's no `~/.local/bin` idiom.
  - As a result, instead of requiring every user to add this new topo-specific binary dir to their `PATH`, we do it for them (unless they provide a `-Path` arg, then we don't touch it)
- Updates the README accordingly, moving the manual installation instructions below both automatic scripts so it's less prevalent and avoiding duplicating it under both OS-specific headings. 
- Adds an e2e test suite mirroring the posix one, updates to use go build tags instead of guards so it's _blazingly fast_

Tested on Windows 11 x86 and Arm with/without args and all looked good to me but I'm not going to pretend to be a powershell expert.
