### PR TITLE
feat: Improve clone's logging output

### DIFF
--- a/cmd/topo/clone.go
+++ b/cmd/topo/clone.go
@@ -77,7 +77,7 @@ Some projects require build arguments. Supply them on the command line or answer
 
 		argProvider := arguments.NewStrictProviderChain(providers...)
 
-		return project.Clone(path, projectSource, argProvider)
+		return project.NewClone(path, projectSource, argProvider).Run(os.Stdout)
 	},
 }
 

--- a/internal/arguments/interactive_provider.go
+++ b/internal/arguments/interactive_provider.go
@@ -23,7 +23,7 @@ func (p *InteractiveProvider) Provide(args []Arg) ([]ResolvedArg, error) {
 
 	for i, arg := range args {
 		if i != 0 {
-			fmt.Printf("\n")
+			fmt.Fprintf(p.output, "\n")
 		}
 		_, err := fmt.Fprintf(p.output, "Provide: %s\n", arg.Description)
 		if err != nil {

--- a/internal/arguments/interactive_provider.go
+++ b/internal/arguments/interactive_provider.go
@@ -21,8 +21,11 @@ func (p *InteractiveProvider) Provide(args []Arg) ([]ResolvedArg, error) {
 	var result []ResolvedArg
 	scanner := bufio.NewScanner(p.input)
 
-	for _, arg := range args {
-		_, err := fmt.Fprintf(p.output, "\n%s\n", arg.Description)
+	for i, arg := range args {
+		if i != 0 {
+			fmt.Printf("\n")
+		}
+		_, err := fmt.Fprintf(p.output, "Provide: %s\n", arg.Description)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/arguments/interactive_provider.go
+++ b/internal/arguments/interactive_provider.go
@@ -23,7 +23,10 @@ func (p *InteractiveProvider) Provide(args []Arg) ([]ResolvedArg, error) {
 
 	for i, arg := range args {
 		if i != 0 {
-			fmt.Fprintf(p.output, "\n")
+			_, err := fmt.Fprintf(p.output, "\n")
+			if err != nil {
+				return nil, err
+			}
 		}
 		_, err := fmt.Fprintf(p.output, "Provide: %s\n", arg.Description)
 		if err != nil {

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -31,8 +31,8 @@ func Clone(path string, src template.Source, argProvider arguments.Provider) err
 		}
 		return fmt.Errorf("init failed: %w", err)
 	}
-
-	return nil
+	fmt.Printf("%s", path)
+	return err
 }
 
 func ResolveAndApplyArgs(composeFilePath string, argProvider arguments.Provider) error {

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -3,11 +3,13 @@ package project
 import (
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 
 	"github.com/arm/topo/internal/arguments"
 	"github.com/arm/topo/internal/compose"
+	"github.com/arm/topo/internal/operation"
 	"github.com/arm/topo/internal/output/logger"
 	"github.com/arm/topo/internal/template"
 	"github.com/compose-spec/compose-go/v2/types"
@@ -15,24 +17,23 @@ import (
 )
 
 func Clone(path string, src template.Source, argProvider arguments.Provider) error {
-	if err := src.CopyTo(path); err != nil {
-		if errDestDirExists, ok := errors.AsType[template.DestDirExistsError](err); ok {
-			return fmt.Errorf("%w: please choose a different project directory or remove the existing directory", errDestDirExists)
-		}
-		return fmt.Errorf("failed to copy Service Template: %w", err)
-	}
+	return NewClone(path, src, argProvider).Run(nil)
+}
 
-	composeFile := filepath.Join(path, template.ComposeFilename)
-
-	err := ResolveAndApplyArgs(composeFile, argProvider)
-	if err != nil {
-		if rmErr := os.RemoveAll(path); rmErr != nil {
-			return errors.Join(err, rmErr)
-		}
-		return fmt.Errorf("init failed: %w", err)
-	}
-	fmt.Printf("%s", path)
-	return err
+func NewClone(path string, src template.Source, argProvider arguments.Provider) operation.Sequence {
+	return operation.NewSequence(
+		copyTemplateOperation{
+			path: path,
+			src:  src,
+		},
+		resolveArgsOperation{
+			path:        path,
+			argProvider: argProvider,
+		},
+		printProjectDirectoryOperation{
+			path: path,
+		},
+	)
 }
 
 func ResolveAndApplyArgs(composeFilePath string, argProvider arguments.Provider) error {
@@ -254,4 +255,59 @@ func argsToMap(args []arguments.ResolvedArg) map[string]string {
 		result[arg.Name] = arg.Value
 	}
 	return result
+}
+
+type copyTemplateOperation struct {
+	path string
+	src  template.Source
+}
+
+func (o copyTemplateOperation) Description() string {
+	return "Git clone"
+}
+
+func (o copyTemplateOperation) Run(_ io.Writer) error {
+	if err := o.src.CopyTo(o.path); err != nil {
+		if errDestDirExists, ok := errors.AsType[template.DestDirExistsError](err); ok {
+			return fmt.Errorf("%w: please choose a different project directory or remove the existing directory", errDestDirExists)
+		}
+		return fmt.Errorf("failed to copy Service Template: %w", err)
+	}
+	return nil
+}
+
+type resolveArgsOperation struct {
+	path        string
+	argProvider arguments.Provider
+}
+
+func (o resolveArgsOperation) Description() string {
+	return "Input args"
+}
+
+func (o resolveArgsOperation) Run(_ io.Writer) error {
+	composeFile := filepath.Join(o.path, template.ComposeFilename)
+	if err := ResolveAndApplyArgs(composeFile, o.argProvider); err != nil {
+		if rmErr := os.RemoveAll(o.path); rmErr != nil {
+			return errors.Join(err, rmErr)
+		}
+		return fmt.Errorf("init failed: %w", err)
+	}
+	return nil
+}
+
+type printProjectDirectoryOperation struct {
+	path string
+}
+
+func (o printProjectDirectoryOperation) Description() string {
+	return "Project directory"
+}
+
+func (o printProjectDirectoryOperation) Run(w io.Writer) error {
+	if w == nil {
+		return nil
+	}
+	_, err := fmt.Fprintln(w, o.path)
+	return err
 }

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -263,7 +263,7 @@ type copyTemplateOperation struct {
 }
 
 func (o copyTemplateOperation) Description() string {
-	return "Git clone"
+	return "Copy files"
 }
 
 func (o copyTemplateOperation) Run(_ io.Writer) error {

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -30,7 +30,7 @@ func NewClone(path string, src template.Source, argProvider arguments.Provider) 
 			path:        path,
 			argProvider: argProvider,
 		},
-		printProjectDirectoryOperation{
+		printSummary{
 			path: path,
 		},
 	)
@@ -296,18 +296,24 @@ func (o resolveArgsOperation) Run(_ io.Writer) error {
 	return nil
 }
 
-type printProjectDirectoryOperation struct {
+type printSummary struct {
 	path string
 }
 
-func (o printProjectDirectoryOperation) Description() string {
-	return "Project directory"
+func (o printSummary) Description() string {
+	return "Project ready"
 }
 
-func (o printProjectDirectoryOperation) Run(w io.Writer) error {
+func (o printSummary) Run(w io.Writer) error {
 	if w == nil {
 		return nil
 	}
-	_, err := fmt.Fprintln(w, o.path)
+	toPrint := fmt.Sprintf(`Created in '%s'
+
+Now run:
+  cd %s
+  topo deploy`, o.path, o.path)
+
+	_, err := fmt.Fprintln(w, toPrint)
 	return err
 }

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -56,6 +56,48 @@ func TestInit(t *testing.T) {
 	})
 }
 
+func TestClone(t *testing.T) {
+	t.Run("clones source into destination directory", func(t *testing.T) {
+		dir := t.TempDir()
+		destDir := filepath.Join(dir, "demo")
+		mockSource := mockTemplateSourceWithContent(t, `
+services:
+  app:
+    image: nginx:alpine
+`, "demo-source")
+
+		err := project.Clone(destDir, mockSource, arguments.NewStrictProviderChain())
+
+		require.NoError(t, err)
+		composeFilePath := filepath.Join(destDir, template.ComposeFilename)
+		_, statErr := os.Stat(composeFilePath)
+		require.NoError(t, statErr)
+	})
+
+	t.Run("removes destination directory when args resolution fails", func(t *testing.T) {
+		dir := t.TempDir()
+		destDir := filepath.Join(dir, "demo")
+		mockSource := mockTemplateSourceWithContent(t, `
+services:
+  app:
+    build:
+      args:
+        GREETING: ${GREETING}
+x-topo:
+  args:
+    GREETING:
+      description: "Greeting"
+      required: true
+`, "demo-source")
+
+		err := project.Clone(destDir, mockSource, arguments.NewStrictProviderChain())
+
+		require.Error(t, err)
+		_, statErr := os.Stat(destDir)
+		assert.True(t, os.IsNotExist(statErr))
+	})
+}
+
 func mockTemplateSourceWithContent(t *testing.T, content, sourceName string) *mockTemplateSource {
 	mockSource := &mockTemplateSource{}
 	mockSource.On("CopyTo", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
@@ -63,7 +105,7 @@ func mockTemplateSourceWithContent(t *testing.T, content, sourceName string) *mo
 		testutil.RequireMkdirAll(t, destDir)
 		testutil.RequireWriteFile(t, filepath.Join(destDir, template.ComposeFilename), content)
 	})
-	mockSource.On("GetName").Return(sourceName, nil)
+	mockSource.On("GetName").Return(sourceName, nil).Maybe()
 	t.Cleanup(func() {
 		mockSource.AssertExpectations(t)
 	})
@@ -73,7 +115,7 @@ func mockTemplateSourceWithContent(t *testing.T, content, sourceName string) *mo
 func mockTemplateSourceWithErrorOnCopy(t *testing.T, errToReturn error, sourceName string) *mockTemplateSource {
 	mockSource := &mockTemplateSource{}
 	mockSource.On("CopyTo", mock.Anything).Return(errToReturn)
-	mockSource.On("GetName").Return(sourceName, nil)
+	mockSource.On("GetName").Return(sourceName, nil).Maybe()
 	t.Cleanup(func() {
 		mockSource.AssertExpectations(t)
 	})

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -60,7 +60,7 @@ func TestClone(t *testing.T) {
 	t.Run("clones source into destination directory", func(t *testing.T) {
 		dir := t.TempDir()
 		destDir := filepath.Join(dir, "demo")
-		mockSource := mockCloneSourceWithContent(t, `
+		mockSource := mockSourceWithContent(t, `
 services:
   app:
     image: nginx:alpine
@@ -70,14 +70,13 @@ services:
 
 		require.NoError(t, err)
 		composeFilePath := filepath.Join(destDir, template.ComposeFilename)
-		_, statErr := os.Stat(composeFilePath)
-		require.NoError(t, statErr)
+		assert.FileExists(t, composeFilePath)
 	})
 
 	t.Run("removes destination directory when args resolution fails", func(t *testing.T) {
 		dir := t.TempDir()
 		destDir := filepath.Join(dir, "demo")
-		mockSource := mockCloneSourceWithContent(t, `
+		mockSource := mockSourceWithContent(t, `
 services:
   app:
     build:
@@ -98,14 +97,14 @@ x-topo:
 	})
 }
 
-func mockTemplateSourceWithContent(t *testing.T, content, sourceName string) *mockTemplateSource {
+func mockSourceWithContent(t *testing.T, content, sourceName string) *mockTemplateSource {
 	mockSource := &mockTemplateSource{}
 	mockSource.On("CopyTo", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
 		destDir := args.String(0)
 		testutil.RequireMkdirAll(t, destDir)
 		testutil.RequireWriteFile(t, filepath.Join(destDir, template.ComposeFilename), content)
 	})
-	mockSource.On("GetName").Return(sourceName, nil)
+	mockSource.On("GetName").Maybe().Return(sourceName, nil)
 	t.Cleanup(func() {
 		mockSource.AssertExpectations(t)
 	})
@@ -122,19 +121,6 @@ func mockTemplateSourceWithErrorOnCopy(t *testing.T, errToReturn error, sourceNa
 	return mockSource
 }
 
-func mockCloneSourceWithContent(t *testing.T, content, sourceName string) *mockTemplateSource {
-	mockSource := &mockTemplateSource{}
-	mockSource.On("CopyTo", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
-		destDir := args.String(0)
-		testutil.RequireMkdirAll(t, destDir)
-		testutil.RequireWriteFile(t, filepath.Join(destDir, template.ComposeFilename), content)
-	})
-	t.Cleanup(func() {
-		mockSource.AssertExpectations(t)
-	})
-	return mockSource
-}
-
 func TestExtend(t *testing.T) {
 	t.Run("extends service from TemplateSource", func(t *testing.T) {
 		dir := t.TempDir()
@@ -144,7 +130,7 @@ name: example-project
 services: {}
 `
 		targetProjectFile := testutil.WriteComposeFile(t, dir, projectYAML)
-		mockSource := mockTemplateSourceWithContent(t, `
+		mockSource := mockSourceWithContent(t, `
 services:
   app:
     image: nginx:alpine
@@ -194,7 +180,7 @@ services:
 		dir := t.TempDir()
 		targetProjectFile := testutil.WriteComposeFile(t, dir, emptyComposeProject)
 		sourceName := "ginger"
-		mockSource := mockTemplateSourceWithContent(t, `
+		mockSource := mockSourceWithContent(t, `
 services:
   app:
     volumes:
@@ -228,7 +214,7 @@ volumes:
 		dir := t.TempDir()
 		targetProjectFile := testutil.WriteComposeFile(t, dir, emptyComposeProject)
 		sourceName := "piggy-service"
-		mockSource := mockTemplateSourceWithContent(t, `
+		mockSource := mockSourceWithContent(t, `
 services:
   app:
     image: nginx:alpine
@@ -269,7 +255,7 @@ services:
 		dir := t.TempDir()
 		targetProjectFile := testutil.WriteComposeFile(t, dir, emptyComposeProject)
 		sourceName := "service-args-scope"
-		mockSource := mockTemplateSourceWithContent(t, `
+		mockSource := mockSourceWithContent(t, `
 services:
   app:
     image: nginx:alpine
@@ -327,7 +313,7 @@ services:
 		dir := t.TempDir()
 		targetProjectFile := testutil.WriteComposeFile(t, dir, emptyComposeProject)
 		sourceName := "oyster-service"
-		mockSource := mockTemplateSourceWithContent(t, `
+		mockSource := mockSourceWithContent(t, `
 services:
   app:
     image: nginx:alpine
@@ -372,7 +358,7 @@ services:
 		targetProjectFile := testutil.WriteComposeFile(t, dir, emptyComposeProject)
 
 		sourceName := "vinegar-service"
-		mockSource := mockTemplateSourceWithContent(t, `
+		mockSource := mockSourceWithContent(t, `
 services:
   app:
     image: nginx:alpine

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -129,7 +129,6 @@ func mockCloneSourceWithContent(t *testing.T, content, sourceName string) *mockT
 		testutil.RequireMkdirAll(t, destDir)
 		testutil.RequireWriteFile(t, filepath.Join(destDir, template.ComposeFilename), content)
 	})
-	mockSource.On("String").Return(sourceName).Maybe()
 	t.Cleanup(func() {
 		mockSource.AssertExpectations(t)
 	})

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -1,6 +1,7 @@
 package project_test
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"os"
@@ -57,6 +58,26 @@ func TestInit(t *testing.T) {
 }
 
 func TestClone(t *testing.T) {
+	t.Run("prints summary with next steps", func(t *testing.T) {
+		dir := t.TempDir()
+		destDir := filepath.Join(dir, "demo")
+		mockSource := mockSourceWithContent(t, `
+services:
+  app:
+    image: nginx:alpine
+`, "demo-source")
+		var output bytes.Buffer
+
+		err := project.NewClone(destDir, mockSource, arguments.NewStrictProviderChain()).Run(&output)
+
+		require.NoError(t, err)
+		out := output.String()
+		assert.Contains(t, out, "Project ready")
+		assert.Contains(t, out, fmt.Sprintf("Created in '%s'", destDir))
+		assert.Contains(t, out, "cd "+destDir)
+		assert.Contains(t, out, "topo deploy")
+	})
+
 	t.Run("clones source into destination directory", func(t *testing.T) {
 		dir := t.TempDir()
 		destDir := filepath.Join(dir, "demo")

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -60,7 +60,7 @@ func TestClone(t *testing.T) {
 	t.Run("clones source into destination directory", func(t *testing.T) {
 		dir := t.TempDir()
 		destDir := filepath.Join(dir, "demo")
-		mockSource := mockTemplateSourceWithContent(t, `
+		mockSource := mockCloneSourceWithContent(t, `
 services:
   app:
     image: nginx:alpine
@@ -77,7 +77,7 @@ services:
 	t.Run("removes destination directory when args resolution fails", func(t *testing.T) {
 		dir := t.TempDir()
 		destDir := filepath.Join(dir, "demo")
-		mockSource := mockTemplateSourceWithContent(t, `
+		mockSource := mockCloneSourceWithContent(t, `
 services:
   app:
     build:
@@ -105,7 +105,7 @@ func mockTemplateSourceWithContent(t *testing.T, content, sourceName string) *mo
 		testutil.RequireMkdirAll(t, destDir)
 		testutil.RequireWriteFile(t, filepath.Join(destDir, template.ComposeFilename), content)
 	})
-	mockSource.On("GetName").Return(sourceName, nil).Maybe()
+	mockSource.On("GetName").Return(sourceName, nil)
 	t.Cleanup(func() {
 		mockSource.AssertExpectations(t)
 	})
@@ -115,7 +115,21 @@ func mockTemplateSourceWithContent(t *testing.T, content, sourceName string) *mo
 func mockTemplateSourceWithErrorOnCopy(t *testing.T, errToReturn error, sourceName string) *mockTemplateSource {
 	mockSource := &mockTemplateSource{}
 	mockSource.On("CopyTo", mock.Anything).Return(errToReturn)
-	mockSource.On("GetName").Return(sourceName, nil).Maybe()
+	mockSource.On("GetName").Return(sourceName, nil)
+	t.Cleanup(func() {
+		mockSource.AssertExpectations(t)
+	})
+	return mockSource
+}
+
+func mockCloneSourceWithContent(t *testing.T, content, sourceName string) *mockTemplateSource {
+	mockSource := &mockTemplateSource{}
+	mockSource.On("CopyTo", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		destDir := args.String(0)
+		testutil.RequireMkdirAll(t, destDir)
+		testutil.RequireWriteFile(t, filepath.Join(destDir, template.ComposeFilename), content)
+	})
+	mockSource.On("String").Return(sourceName).Maybe()
 	t.Cleanup(func() {
 		mockSource.AssertExpectations(t)
 	})


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- The UX of topo clone was inconsistent with the rest of the cli's UX.
- This PR Utilises the standard operations sequence to make it look a little nicer.
- It also adds a print dir path step, following responses from UX reviews where users failed to understand where their project had been cloned to.
