### PR TITLE
refactor: always wrap ssh Runner commands in login shell, use runner to check deps

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -21,7 +21,7 @@ func BinaryLookupCommand(bin string) (string, error) {
 		return "", err
 	}
 
-	return WrapInLoginShell(fmt.Sprintf("command -v %s", bin)), nil
+	return fmt.Sprintf("command -v %s", bin), nil
 }
 
 func shellEscapeForDoubleQuotes(s string) string {

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/arm/topo/internal/command"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestWrapInLoginShell(t *testing.T) {
@@ -18,13 +17,6 @@ func TestWrapInLoginShell(t *testing.T) {
 }
 
 func TestBinaryLookupCommand(t *testing.T) {
-	t.Run("returns wrapped command for valid binary", func(t *testing.T) {
-		got, err := command.BinaryLookupCommand("docker")
-
-		require.NoError(t, err)
-		assert.Equal(t, command.WrapInLoginShell("command -v docker"), got)
-	})
-
 	t.Run("returns error for invalid binary", func(t *testing.T) {
 		got, err := command.BinaryLookupCommand("bad name")
 

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/arm/topo/internal/command"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestWrapInLoginShell(t *testing.T) {
@@ -17,6 +18,13 @@ func TestWrapInLoginShell(t *testing.T) {
 }
 
 func TestBinaryLookupCommand(t *testing.T) {
+	t.Run("returns wrapped command for valid binary", func(t *testing.T) {
+		got, err := command.BinaryLookupCommand("docker")
+
+		require.NoError(t, err)
+		assert.Equal(t, "command -v docker", got)
+	})
+
 	t.Run("returns error for invalid binary", func(t *testing.T) {
 		got, err := command.BinaryLookupCommand("bad name")
 

--- a/internal/health/dependencies.go
+++ b/internal/health/dependencies.go
@@ -1,6 +1,10 @@
 package health
 
-import "context"
+import (
+	"context"
+
+	"github.com/arm/topo/internal/runner"
+)
 
 type CheckKind int
 
@@ -153,7 +157,7 @@ type (
 	CommandSuccessfulFn = func(fullCmd string) error
 )
 
-func PerformChecks(ctx context.Context, dependencies []Dependency, binaryExists BinaryExistsFn, commandSuccessful CommandSuccessfulFn) []DependencyStatus {
+func PerformChecks(ctx context.Context, dependencies []Dependency, runner runner.Runner) []DependencyStatus {
 	installed := make(map[SoftwareDependency]struct{})
 	result := make([]DependencyStatus, 0, len(dependencies))
 
@@ -167,12 +171,12 @@ func PerformChecks(ctx context.Context, dependencies []Dependency, binaryExists 
 		for _, check := range dep.Checks {
 			switch check.Kind {
 			case CheckBinaryExists:
-				err = binaryExists(ctx, dep.Binary)
+				err = runner.BinaryExists(ctx, dep.Binary)
 				if err == nil && dep.SoftwareEnumID != UnsetSoftwareDependency {
 					installed[dep.SoftwareEnumID] = struct{}{}
 				}
 			case CheckCommandSuccessful:
-				err = commandSuccessful(check.Arg)
+				_, err = runner.Run(ctx, check.Arg)
 			}
 			if err != nil {
 				if check.Severity == SeverityWarning {

--- a/internal/health/dependencies.go
+++ b/internal/health/dependencies.go
@@ -152,11 +152,6 @@ func hardwareCapabilityMatches(required []HardwareCapability, available map[Hard
 	return false
 }
 
-type (
-	BinaryExistsFn      = func(ctx context.Context, bin string) error
-	CommandSuccessfulFn = func(fullCmd string) error
-)
-
 func PerformChecks(ctx context.Context, dependencies []Dependency, runner runner.Runner) []DependencyStatus {
 	installed := make(map[SoftwareDependency]struct{})
 	result := make([]DependencyStatus, 0, len(dependencies))

--- a/internal/health/dependencies_test.go
+++ b/internal/health/dependencies_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/arm/topo/internal/command"
 	"github.com/arm/topo/internal/health"
+	"github.com/arm/topo/internal/runner"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -56,21 +57,18 @@ func TestPerformChecks(t *testing.T) {
 			{Binary: "foo", Label: "bar", Checks: []health.Check{health.BinaryExists()}},
 			{Binary: "baz", Label: "qux", Checks: []health.Check{health.BinaryExists()}},
 		}
-		mockBinaryExists := func(_ context.Context, bin string) error {
-			return fmt.Errorf("%q executable file not found in $PATH", bin)
-		}
-		mockCommandSuccessful := func(string) error { return nil }
+		runner := &runner.Fake{}
 
-		got := health.PerformChecks(context.Background(), deps, mockBinaryExists, mockCommandSuccessful)
+		got := health.PerformChecks(context.Background(), deps, runner)
 
 		want := []health.DependencyStatus{
 			{
 				Dependency: health.Dependency{Binary: "foo", Label: "bar", Checks: []health.Check{health.BinaryExists()}},
-				Error:      mockBinaryExists(context.Background(), "foo"),
+				Error:      errors.New("\"foo\" not found in $PATH"),
 			},
 			{
 				Dependency: health.Dependency{Binary: "baz", Label: "qux", Checks: []health.Check{health.BinaryExists()}},
-				Error:      mockBinaryExists(context.Background(), "baz"),
+				Error:      errors.New("\"baz\" not found in $PATH"),
 			},
 		}
 		assert.Equal(t, want, got)
@@ -79,18 +77,15 @@ func TestPerformChecks(t *testing.T) {
 	t.Run("wraps error as WarningError when binary exists check severity is warning", func(t *testing.T) {
 		missingBin := health.Dependency{Binary: "missing-bin", Label: "Missing", Checks: []health.Check{health.BinaryExistsWarning()}}
 		deps := []health.Dependency{missingBin}
-		mockBinaryExists := func(_ context.Context, bin string) error {
-			return fmt.Errorf("%q executable file not found in $PATH", bin)
-		}
-		mockCommandSuccessful := func(string) error { return nil }
+		runner := &runner.Fake{}
 
-		got := health.PerformChecks(context.Background(), deps, mockBinaryExists, mockCommandSuccessful)
+		got := health.PerformChecks(context.Background(), deps, runner)
 
 		assert.Len(t, got, 1)
 		want := []health.DependencyStatus{
 			{
 				Dependency: missingBin,
-				Error:      health.WarningError{Err: mockBinaryExists(context.Background(), "missing-bin")},
+				Error:      health.WarningError{Err: errors.New("\"missing-bin\" not found in $PATH")},
 			},
 		}
 		assert.Equal(t, want, got)
@@ -100,15 +95,11 @@ func TestPerformChecks(t *testing.T) {
 		deps := []health.Dependency{
 			{Binary: "baz", Label: "qux", Checks: []health.Check{health.BinaryExists()}},
 		}
-		mockBinaryExists := func(_ context.Context, bin string) error {
-			if bin == "baz" {
-				return nil
-			}
-			return fmt.Errorf("%q executable file not found in $PATH", bin)
+		runner := &runner.Fake{
+			Binaries: []string{"baz"},
 		}
-		mockCommandSuccessful := func(string) error { return nil }
 
-		got := health.PerformChecks(context.Background(), deps, mockBinaryExists, mockCommandSuccessful)
+		got := health.PerformChecks(context.Background(), deps, runner)
 
 		want := []health.DependencyStatus{
 			{
@@ -124,18 +115,14 @@ func TestPerformChecks(t *testing.T) {
 			{Binary: "docker", Label: "Container Engine", Checks: []health.Check{health.BinaryExists()}},
 			{Binary: "runtime", Label: "Runtime", SoftwarePrerequisites: []health.SoftwareDependency{health.Docker}, Checks: []health.Check{health.BinaryExists()}},
 		}
-		mockBinaryExists := func(_ context.Context, bin string) error {
-			if bin == "runtime" {
-				return nil
-			}
-			return fmt.Errorf("%q executable file not found in $PATH", bin)
+		runner := &runner.Fake{
+			Binaries: []string{"runtime"},
 		}
-		mockCommandSuccessful := func(string) error { return nil }
 
-		got := health.PerformChecks(context.Background(), deps, mockBinaryExists, mockCommandSuccessful)
+		got := health.PerformChecks(context.Background(), deps, runner)
 
 		want := []health.DependencyStatus{
-			{Dependency: health.Dependency{Binary: "docker", Label: "Container Engine", Checks: []health.Check{health.BinaryExists()}}, Error: mockBinaryExists(context.Background(), "docker")},
+			{Dependency: health.Dependency{Binary: "docker", Label: "Container Engine", Checks: []health.Check{health.BinaryExists()}}, Error: fmt.Errorf(`"docker" not found in $PATH`)},
 		}
 		assert.Equal(t, want, got)
 	})
@@ -145,12 +132,11 @@ func TestPerformChecks(t *testing.T) {
 			{Binary: "docker", Label: "Container Engine", SoftwareEnumID: health.Docker, Checks: []health.Check{health.BinaryExists()}},
 			{Binary: "runtime", Label: "Runtime", SoftwarePrerequisites: []health.SoftwareDependency{health.Docker}, Checks: []health.Check{health.BinaryExists()}},
 		}
-		mockBinaryExists := func(_ context.Context, bin string) error {
-			return nil
+		runner := &runner.Fake{
+			Binaries: []string{"runtime", "docker"},
 		}
-		mockCommandSuccessful := func(string) error { return nil }
 
-		got := health.PerformChecks(context.Background(), deps, mockBinaryExists, mockCommandSuccessful)
+		got := health.PerformChecks(context.Background(), deps, runner)
 
 		want := []health.DependencyStatus{
 			{Dependency: health.Dependency{Binary: "docker", Label: "Container Engine", SoftwareEnumID: health.Docker, Checks: []health.Check{health.BinaryExists()}}, Error: nil},
@@ -165,12 +151,9 @@ func TestPerformChecks(t *testing.T) {
 			Label:  "Sith",
 			Checks: []health.Check{{Kind: health.CheckBinaryExists, Severity: health.SeverityWarning, Fix: "turn Anakin into a bad man"}},
 		}
-		mockBinaryExists := func(_ context.Context, bin string) error {
-			return errors.New("vader not found")
-		}
-		mockCommandSuccessful := func(string) error { return nil }
+		runner := &runner.Fake{}
 
-		got := health.PerformChecks(context.Background(), []health.Dependency{dep}, mockBinaryExists, mockCommandSuccessful)
+		got := health.PerformChecks(context.Background(), []health.Dependency{dep}, runner)
 
 		assert.Len(t, got, 1)
 		assert.Equal(t, "turn Anakin into a bad man", got[0].Fix)
@@ -180,12 +163,11 @@ func TestPerformChecks(t *testing.T) {
 		deps := []health.Dependency{
 			{Binary: "standalone", Label: "Tools", Checks: []health.Check{health.BinaryExists()}},
 		}
-		mockBinaryExists := func(_ context.Context, bin string) error {
-			return nil
+		runner := &runner.Fake{
+			Binaries: []string{"standalone"},
 		}
-		mockCommandSuccessful := func(string) error { return nil }
 
-		got := health.PerformChecks(context.Background(), deps, mockBinaryExists, mockCommandSuccessful)
+		got := health.PerformChecks(context.Background(), deps, runner)
 
 		want := []health.DependencyStatus{
 			{Dependency: health.Dependency{Binary: "standalone", Label: "Tools", Checks: []health.Check{health.BinaryExists()}}, Error: nil},
@@ -204,15 +186,16 @@ func TestPerformChecks(t *testing.T) {
 				Fix:      "Ensure current user can run the potatoe cooker",
 			}},
 		}
-		mockBinaryExists := func(context.Context, string) error { return nil }
-		mockCommandSuccessful := func(cmd string) error {
-			if cmd == "potatoes --cook-well" {
-				return errors.New("permission denied")
-			}
-			return nil
+		runner := &runner.Fake{
+			Binaries: []string{"potatoes"},
+			Commands: map[string]runner.FakeResult{
+				"potatoes --cook-well": {
+					Err: errors.New("permission denied"),
+				},
+			},
 		}
 
-		got := health.PerformChecks(context.Background(), []health.Dependency{dep}, mockBinaryExists, mockCommandSuccessful)
+		got := health.PerformChecks(context.Background(), []health.Dependency{dep}, runner)
 
 		want := []health.DependencyStatus{
 			{

--- a/internal/health/dependencies_test.go
+++ b/internal/health/dependencies_test.go
@@ -3,7 +3,6 @@ package health_test
 import (
 	"context"
 	"errors"
-	"fmt"
 	"testing"
 
 	"github.com/arm/topo/internal/command"
@@ -53,24 +52,16 @@ func TestDependencyFormat(t *testing.T) {
 
 func TestPerformChecks(t *testing.T) {
 	t.Run("when no dependencies are found, statuses show not installed", func(t *testing.T) {
-		deps := []health.Dependency{
-			{Binary: "foo", Label: "bar", Checks: []health.Check{health.BinaryExists()}},
-			{Binary: "baz", Label: "qux", Checks: []health.Check{health.BinaryExists()}},
-		}
+		fooDependency := health.Dependency{Binary: "foo", Label: "bar", Checks: []health.Check{health.BinaryExists()}}
+		bazDependency := health.Dependency{Binary: "baz", Label: "qux", Checks: []health.Check{health.BinaryExists()}}
+		deps := []health.Dependency{fooDependency, bazDependency}
 		runner := &runner.Fake{}
 
 		got := health.PerformChecks(context.Background(), deps, runner)
 
-		want := []health.DependencyStatus{
-			{
-				Dependency: health.Dependency{Binary: "foo", Label: "bar", Checks: []health.Check{health.BinaryExists()}},
-				Error:      errors.New("\"foo\" not found in $PATH"),
-			},
-			{
-				Dependency: health.Dependency{Binary: "baz", Label: "qux", Checks: []health.Check{health.BinaryExists()}},
-				Error:      errors.New("\"baz\" not found in $PATH"),
-			},
-		}
+		wantFoo := health.DependencyStatus{Dependency: fooDependency, Error: runner.BinaryExists(context.Background(), fooDependency.Binary)}
+		wantBar := health.DependencyStatus{Dependency: bazDependency, Error: runner.BinaryExists(context.Background(), bazDependency.Binary)}
+		want := []health.DependencyStatus{wantFoo, wantBar}
 		assert.Equal(t, want, got)
 	})
 
@@ -82,12 +73,9 @@ func TestPerformChecks(t *testing.T) {
 		got := health.PerformChecks(context.Background(), deps, runner)
 
 		assert.Len(t, got, 1)
-		want := []health.DependencyStatus{
-			{
-				Dependency: missingBin,
-				Error:      health.WarningError{Err: errors.New("\"missing-bin\" not found in $PATH")},
-			},
-		}
+		wantBin := health.DependencyStatus{Dependency: missingBin}
+		wantBin.Error = health.WarningError{Err: runner.BinaryExists(context.Background(), missingBin.Binary)}
+		want := []health.DependencyStatus{wantBin}
 		assert.Equal(t, want, got)
 	})
 
@@ -111,8 +99,9 @@ func TestPerformChecks(t *testing.T) {
 	})
 
 	t.Run("omits dependency when none of its SoftwarePrerequisites are installed", func(t *testing.T) {
+		dockerDependecy := health.Dependency{Binary: "docker", Label: "Container Engine", Checks: []health.Check{health.BinaryExists()}}
 		deps := []health.Dependency{
-			{Binary: "docker", Label: "Container Engine", Checks: []health.Check{health.BinaryExists()}},
+			dockerDependecy,
 			{Binary: "runtime", Label: "Runtime", SoftwarePrerequisites: []health.SoftwareDependency{health.Docker}, Checks: []health.Check{health.BinaryExists()}},
 		}
 		runner := &runner.Fake{
@@ -121,9 +110,8 @@ func TestPerformChecks(t *testing.T) {
 
 		got := health.PerformChecks(context.Background(), deps, runner)
 
-		want := []health.DependencyStatus{
-			{Dependency: health.Dependency{Binary: "docker", Label: "Container Engine", Checks: []health.Check{health.BinaryExists()}}, Error: fmt.Errorf(`"docker" not found in $PATH`)},
-		}
+		wantDocker := health.DependencyStatus{Dependency: dockerDependecy, Error: runner.BinaryExists(context.Background(), dockerDependecy.Binary)}
+		want := []health.DependencyStatus{wantDocker}
 		assert.Equal(t, want, got)
 	})
 

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -64,11 +64,7 @@ func (r TargetReport) MarshalJSON() ([]byte, error) {
 
 func CheckHost() HostReport {
 	r := runner.NewLocal()
-	commandSuccessful := func(fullCmd string) error {
-		_, err := r.Run(context.Background(), fullCmd)
-		return err
-	}
-	dependencyStatuses := PerformChecks(context.Background(), HostRequiredDependencies, r.BinaryExists, commandSuccessful)
+	dependencyStatuses := PerformChecks(context.Background(), HostRequiredDependencies, r)
 	return GenerateHostReport(dependencyStatuses)
 }
 

--- a/internal/health/status.go
+++ b/internal/health/status.go
@@ -3,7 +3,6 @@ package health
 import (
 	"context"
 
-	"github.com/arm/topo/internal/command"
 	"github.com/arm/topo/internal/runner"
 	"github.com/arm/topo/internal/target"
 )
@@ -33,7 +32,7 @@ func ProbeHealthStatus(ctx context.Context, r runner.Runner) HealthStatus {
 
 	dependenciesToCheck := FilterByHardware(TargetRequiredDependencies, hs.Hardware.Capabilities())
 	commandSuccessful := func(fullCmd string) error {
-		_, err := r.Run(ctx, command.WrapInLoginShell(fullCmd))
+		_, err := r.Run(ctx, fullCmd)
 		return err
 	}
 	hs.Dependencies = PerformChecks(ctx, dependenciesToCheck, r.BinaryExists, commandSuccessful)

--- a/internal/health/status.go
+++ b/internal/health/status.go
@@ -31,11 +31,7 @@ func ProbeHealthStatus(ctx context.Context, r runner.Runner) HealthStatus {
 	hs.Hardware.RemoteCPU = remoteprocs
 
 	dependenciesToCheck := FilterByHardware(TargetRequiredDependencies, hs.Hardware.Capabilities())
-	commandSuccessful := func(fullCmd string) error {
-		_, err := r.Run(ctx, fullCmd)
-		return err
-	}
-	hs.Dependencies = PerformChecks(ctx, dependenciesToCheck, r.BinaryExists, commandSuccessful)
+	hs.Dependencies = PerformChecks(ctx, dependenciesToCheck, r)
 
 	return hs
 }

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -34,7 +34,7 @@ type PathCandidate struct {
 }
 
 func getPathDirs(r runner.Runner) ([]string, error) {
-	output, err := r.Run(context.TODO(), command.WrapInLoginShell("echo $PATH"))
+	output, err := r.Run(context.TODO(), "echo $PATH")
 	if err != nil {
 		return nil, err
 	}
@@ -46,7 +46,7 @@ func getPathDirs(r runner.Runner) ([]string, error) {
 }
 
 func getHomeDir(r runner.Runner) (string, error) {
-	output, err := r.Run(context.TODO(), command.WrapInLoginShell("echo $HOME"))
+	output, err := r.Run(context.TODO(), "echo $HOME")
 	if err != nil {
 		return "", err
 	}
@@ -283,7 +283,7 @@ func install(installPath string, r runner.Runner, binaries map[string][]byte) er
 		}
 
 		installCmd := fmt.Sprintf("install -D -m %s /dev/stdin %s/%s", mode, installPath, binaryName)
-		output, err := r.RunWithStdin(context.TODO(), command.WrapInLoginShell(installCmd), binaryData)
+		output, err := r.RunWithStdin(context.TODO(), installCmd, binaryData)
 		if err != nil {
 			if errors.Is(err, ssh.ErrSSH) {
 				return err

--- a/internal/runner/ssh.go
+++ b/internal/runner/ssh.go
@@ -68,7 +68,7 @@ func (r *SSH) BinaryExists(ctx context.Context, bin string) error {
 }
 
 func (r *SSH) exec(ctx context.Context, cmdStr string, stdin []byte, extraSSHArgs []string) (string, error) {
-	out, err := ssh.RunCommand(ctx, r.dest, cmdStr, stdin, extraSSHArgs...)
+	out, err := ssh.RunCommand(ctx, r.dest, command.WrapInLoginShell(cmdStr), stdin, extraSSHArgs...)
 	if err != nil && ctx.Err() != nil {
 		return "", ErrTimeout
 	}

--- a/internal/setupkeys/operations/pub_key_transfer.go
+++ b/internal/setupkeys/operations/pub_key_transfer.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-
-	"github.com/arm/topo/internal/command"
 )
 
 const remoteAuthorizedKeysCommand = "mkdir -p ~/.ssh && chmod 700 ~/.ssh && cat >> ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys"
@@ -41,7 +39,7 @@ func (kt *PubKeyTransfer) Run(outputWriter io.Writer) error {
 		return fmt.Errorf("failed to read public key %s: %w", kt.pubKeyPath, err)
 	}
 
-	cmdOutput, err := kt.r.RunWithStdinAndArgs(context.TODO(), command.WrapInLoginShell(remoteAuthorizedKeysCommand), pubKey, passwordAuthArgs...)
+	cmdOutput, err := kt.r.RunWithStdinAndArgs(context.TODO(), remoteAuthorizedKeysCommand, pubKey, passwordAuthArgs...)
 	if err != nil {
 		return fmt.Errorf("failed to transfer public key to target: %w", err)
 	}

--- a/internal/target/cpu_probe.go
+++ b/internal/target/cpu_probe.go
@@ -7,7 +7,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/arm/topo/internal/command"
 	"github.com/arm/topo/internal/runner"
 )
 
@@ -22,7 +21,7 @@ func ProbeCPU(ctx context.Context, r runner.Runner) ([]HostProcessor, error) {
 		return nil, err
 	}
 
-	out, err := r.Run(ctx, command.WrapInLoginShell("lscpu --json"))
+	out, err := r.Run(ctx, "lscpu --json")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/target/cpu_probe_test.go
+++ b/internal/target/cpu_probe_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/arm/topo/internal/command"
 	"github.com/arm/topo/internal/runner"
 	"github.com/arm/topo/internal/target"
 	"github.com/arm/topo/internal/testutil"
@@ -17,7 +16,7 @@ func TestProbeCPU(t *testing.T) {
 		r := &runner.Fake{
 			Binaries: []string{"lscpu"},
 			Commands: map[string]runner.FakeResult{
-				command.WrapInLoginShell("lscpu --json"): {Output: testutil.LsCpuOutputRaw},
+				"lscpu --json": {Output: testutil.LsCpuOutputRaw},
 			},
 		}
 
@@ -46,7 +45,7 @@ func TestProbeCPU(t *testing.T) {
 		r := &runner.Fake{
 			Binaries: []string{"lscpu"},
 			Commands: map[string]runner.FakeResult{
-				command.WrapInLoginShell("lscpu --json"): {Output: "not json"},
+				"lscpu --json": {Output: "not json"},
 			},
 		}
 

--- a/internal/target/memory_probe.go
+++ b/internal/target/memory_probe.go
@@ -7,7 +7,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/arm/topo/internal/command"
 	"github.com/arm/topo/internal/runner"
 )
 
@@ -15,7 +14,7 @@ func ProbeMemory(ctx context.Context, r runner.Runner) (int64, error) {
 	key := "MemTotal"
 	path := "/proc/meminfo"
 
-	out, err := r.Run(ctx, command.WrapInLoginShell(fmt.Sprintf("cat %s", path)))
+	out, err := r.Run(ctx, fmt.Sprintf("cat %s", path))
 	if err != nil {
 		return 0, err
 	}

--- a/internal/target/remoteproc_probe.go
+++ b/internal/target/remoteproc_probe.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"strings"
 
-	"github.com/arm/topo/internal/command"
 	"github.com/arm/topo/internal/runner"
 )
 
@@ -14,12 +13,12 @@ type RemoteprocCPU struct {
 
 func ProbeRemoteproc(ctx context.Context, r runner.Runner) ([]RemoteprocCPU, error) {
 	var remoteProcs []RemoteprocCPU
-	out, err := r.Run(ctx, command.WrapInLoginShell("ls /sys/class/remoteproc"))
+	out, err := r.Run(ctx, "ls /sys/class/remoteproc")
 	if err != nil || out == "" {
 		return remoteProcs, nil
 	}
 
-	out, err = r.Run(ctx, command.WrapInLoginShell("cat /sys/class/remoteproc/*/name"))
+	out, err = r.Run(ctx, "cat /sys/class/remoteproc/*/name")
 	if err != nil {
 		return remoteProcs, err
 	}

--- a/internal/target/remoteproc_probe_test.go
+++ b/internal/target/remoteproc_probe_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/arm/topo/internal/command"
 	"github.com/arm/topo/internal/runner"
 	"github.com/arm/topo/internal/target"
 	"github.com/stretchr/testify/assert"
@@ -16,8 +15,8 @@ func TestProbeRemoteproc(t *testing.T) {
 	t.Run("returns remote processors", func(t *testing.T) {
 		r := &runner.Fake{
 			Commands: map[string]runner.FakeResult{
-				command.WrapInLoginShell("ls /sys/class/remoteproc"):         {Output: "remoteproc0\nremoteproc1"},
-				command.WrapInLoginShell("cat /sys/class/remoteproc/*/name"): {Output: "virtio0\nvirtio1"},
+				"ls /sys/class/remoteproc":         {Output: "remoteproc0\nremoteproc1"},
+				"cat /sys/class/remoteproc/*/name": {Output: "virtio0\nvirtio1"},
 			},
 		}
 
@@ -34,7 +33,7 @@ func TestProbeRemoteproc(t *testing.T) {
 	t.Run("returns empty when no remoteproc directory", func(t *testing.T) {
 		r := &runner.Fake{
 			Commands: map[string]runner.FakeResult{
-				command.WrapInLoginShell("ls /sys/class/remoteproc"): {Output: "", Err: errors.New("no such file")},
+				"ls /sys/class/remoteproc": {Output: "", Err: errors.New("no such file")},
 			},
 		}
 
@@ -47,7 +46,7 @@ func TestProbeRemoteproc(t *testing.T) {
 	t.Run("returns empty when remoteproc directory is empty", func(t *testing.T) {
 		r := &runner.Fake{
 			Commands: map[string]runner.FakeResult{
-				command.WrapInLoginShell("ls /sys/class/remoteproc"): {Output: ""},
+				"ls /sys/class/remoteproc": {Output: ""},
 			},
 		}
 
@@ -60,8 +59,8 @@ func TestProbeRemoteproc(t *testing.T) {
 	t.Run("returns error when reading names fails", func(t *testing.T) {
 		r := &runner.Fake{
 			Commands: map[string]runner.FakeResult{
-				command.WrapInLoginShell("ls /sys/class/remoteproc"):         {Output: "remoteproc0"},
-				command.WrapInLoginShell("cat /sys/class/remoteproc/*/name"): {Err: errors.New("permission denied")},
+				"ls /sys/class/remoteproc":         {Output: "remoteproc0"},
+				"cat /sys/class/remoteproc/*/name": {Err: errors.New("permission denied")},
 			},
 		}
 


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

Two-pronged refactor:

- Removes `command.WrapInLoginShell` from the call site of every command invocation we run on the target and hoists into the ssh runner itself, lowering mental burden remembering if you have to provide it or not. Lmk if I missed a scenario where we would want to execute a command on the target without login shell.
- With this change, we can collapse the two `CommandSuccessfulFn` and `BinaryExistsFn`s we pass to the dependency checker into just passing the runner directly. 
   - This also allows us to clean up the related test suite a fair bit by using `runner.Fake` :)

This refactor is in service of making health checks a bit more flexible - allowing us to write ones that assert things about stdout of given commands which will be required for checks like an "is this version of topo the latest?".
