### PR TITLE
refactor: make dependency checks structs

### DIFF
--- a/internal/health/check.go
+++ b/internal/health/check.go
@@ -7,7 +7,7 @@ import (
 )
 
 type Check interface {
-	Apply(ctx context.Context, r runner.Runner, dep Dependency) (string, error)
+	Run(ctx context.Context, r runner.Runner, dep Dependency) (string, error)
 }
 
 type CheckSeverity int
@@ -22,7 +22,7 @@ type CommandSuccessful struct {
 	Fix string
 }
 
-func (c CommandSuccessful) Apply(ctx context.Context, r runner.Runner, dep Dependency) (string, error) {
+func (c CommandSuccessful) Run(ctx context.Context, r runner.Runner, dep Dependency) (string, error) {
 	_, err := r.Run(ctx, c.Cmd)
 	return c.Fix, err
 }
@@ -32,7 +32,7 @@ type BinaryExists struct {
 	Fix      string
 }
 
-func (b BinaryExists) Apply(ctx context.Context, r runner.Runner, dep Dependency) (string, error) {
+func (b BinaryExists) Run(ctx context.Context, r runner.Runner, dep Dependency) (string, error) {
 	err := r.BinaryExists(ctx, dep.Binary)
 	if b.Severity == SeverityWarning && err != nil {
 		err = WarningError{Err: err}

--- a/internal/health/check.go
+++ b/internal/health/check.go
@@ -1,0 +1,41 @@
+package health
+
+import (
+	"context"
+
+	"github.com/arm/topo/internal/runner"
+)
+
+type Check interface {
+	Apply(ctx context.Context, r runner.Runner, dep Dependency) (string, error)
+}
+
+type CheckSeverity int
+
+const (
+	SeverityError CheckSeverity = iota
+	SeverityWarning
+)
+
+type CommandSuccessful struct {
+	Cmd string
+	Fix string
+}
+
+func (c CommandSuccessful) Apply(ctx context.Context, r runner.Runner, dep Dependency) (string, error) {
+	_, err := r.Run(ctx, c.Cmd)
+	return c.Fix, err
+}
+
+type BinaryExists struct {
+	Severity CheckSeverity
+	Fix      string
+}
+
+func (b BinaryExists) Apply(ctx context.Context, r runner.Runner, dep Dependency) (string, error) {
+	err := r.BinaryExists(ctx, dep.Binary)
+	if b.Severity == SeverityWarning && err != nil {
+		err = WarningError{Err: err}
+	}
+	return b.Fix, err
+}

--- a/internal/health/check_test.go
+++ b/internal/health/check_test.go
@@ -1,0 +1,26 @@
+package health_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/arm/topo/internal/health"
+	"github.com/arm/topo/internal/runner"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBinaryExists(t *testing.T) {
+	t.Run("wraps error as WarningError when severity is warning", func(t *testing.T) {
+		check := health.BinaryExists{
+			Severity: health.SeverityWarning,
+		}
+		dependency := health.Dependency{Binary: "nonexistent"}
+		runner := &runner.Fake{}
+		ctx := context.Background()
+
+		_, err := check.Apply(ctx, runner, dependency)
+
+		wantErr := health.WarningError{Err: runner.BinaryExists(ctx, dependency.Binary)}
+		assert.Equal(t, wantErr, err)
+	})
+}

--- a/internal/health/check_test.go
+++ b/internal/health/check_test.go
@@ -18,7 +18,7 @@ func TestBinaryExists(t *testing.T) {
 		runner := &runner.Fake{}
 		ctx := context.Background()
 
-		_, err := check.Apply(ctx, runner, dependency)
+		_, err := check.Run(ctx, runner, dependency)
 
 		wantErr := health.WarningError{Err: runner.BinaryExists(ctx, dependency.Binary)}
 		assert.Equal(t, wantErr, err)

--- a/internal/health/dependencies.go
+++ b/internal/health/dependencies.go
@@ -138,15 +138,12 @@ func PerformChecks(ctx context.Context, dependencies []Dependency, runner runner
 		var err error
 		for _, check := range dep.Checks {
 			fix, err = check.Run(ctx, runner, dep)
+			if _, ok := check.(BinaryExists); ok && err == nil {
+				installed[dep.SoftwareEnumID] = struct{}{}
+			}
+
 			if err != nil {
 				break
-			}
-		}
-
-		if err == nil && dep.SoftwareEnumID != UnsetSoftwareDependency {
-			exists := runner.BinaryExists(ctx, dep.Binary)
-			if exists == nil {
-				installed[dep.SoftwareEnumID] = struct{}{}
 			}
 		}
 

--- a/internal/health/dependencies.go
+++ b/internal/health/dependencies.go
@@ -8,36 +8,9 @@ import (
 
 type CheckKind int
 
-const (
-	CheckBinaryExists CheckKind = iota
-	CheckCommandSuccessful
-)
-
-type CheckSeverity int
-
-const (
-	SeverityError CheckSeverity = iota
-	SeverityWarning
-)
-
 type WarningError struct{ Err error }
 
 func (w WarningError) Error() string { return w.Err.Error() }
-
-type Check struct {
-	Kind     CheckKind
-	Arg      string
-	Severity CheckSeverity
-	Fix      string
-}
-
-func BinaryExists() Check {
-	return Check{Kind: CheckBinaryExists, Severity: SeverityError}
-}
-
-func BinaryExistsWarning() Check {
-	return Check{Kind: CheckBinaryExists, Severity: SeverityWarning}
-}
 
 type HardwareCapability int
 
@@ -66,18 +39,19 @@ var HostRequiredDependencies = []Dependency{
 	{
 		Binary: "ssh",
 		Label:  "SSH",
-		Checks: []Check{BinaryExists()},
+		Checks: []Check{BinaryExists{}},
 	},
 	{
 		Binary:         "docker",
 		Label:          "Container Engine",
 		SoftwareEnumID: Docker,
-		Checks: []Check{BinaryExists(), {
-			Kind:     CheckCommandSuccessful,
-			Arg:      "docker info",
-			Severity: SeverityError,
-			Fix:      "Ensure current user can run docker commands",
-		}},
+		Checks: []Check{
+			BinaryExists{},
+			CommandSuccessful{
+				Cmd: "docker info",
+				Fix: "Ensure current user can run docker commands",
+			},
+		},
 	},
 }
 
@@ -86,12 +60,13 @@ var TargetRequiredDependencies = []Dependency{
 		Binary:         "docker",
 		Label:          "Container Engine",
 		SoftwareEnumID: Docker,
-		Checks: []Check{BinaryExists(), {
-			Kind:     CheckCommandSuccessful,
-			Arg:      "docker info",
-			Severity: SeverityError,
-			Fix:      "Ensure current user can run docker commands",
-		}},
+		Checks: []Check{
+			BinaryExists{},
+			CommandSuccessful{
+				Cmd: "docker info",
+				Fix: "Ensure current user can run docker commands",
+			},
+		},
 	},
 	{
 		Binary:                "remoteproc-runtime",
@@ -99,8 +74,7 @@ var TargetRequiredDependencies = []Dependency{
 		SoftwarePrerequisites: []SoftwareDependency{Docker},
 		HardwarePrerequisite:  []HardwareCapability{Remoteproc},
 		Checks: []Check{
-			{
-				Kind:     CheckBinaryExists,
+			BinaryExists{
 				Severity: SeverityWarning,
 				Fix:      "run `topo install remoteproc-runtime`",
 			},
@@ -112,8 +86,7 @@ var TargetRequiredDependencies = []Dependency{
 		SoftwarePrerequisites: []SoftwareDependency{Docker},
 		HardwarePrerequisite:  []HardwareCapability{Remoteproc},
 		Checks: []Check{
-			{
-				Kind:     CheckBinaryExists,
+			BinaryExists{
 				Severity: SeverityWarning,
 				Fix:      "run `topo install remoteproc-runtime`",
 			},
@@ -123,7 +96,7 @@ var TargetRequiredDependencies = []Dependency{
 		Binary:         "lscpu",
 		Label:          "Hardware Info",
 		SoftwareEnumID: Lscpu,
-		Checks:         []Check{BinaryExists()},
+		Checks:         []Check{BinaryExists{}},
 	},
 }
 
@@ -161,23 +134,18 @@ func PerformChecks(ctx context.Context, dependencies []Dependency, runner runner
 			continue
 		}
 
-		var err error
-		var fix string
-		for _, check := range dep.Checks {
-			switch check.Kind {
-			case CheckBinaryExists:
-				err = runner.BinaryExists(ctx, dep.Binary)
-				if err == nil && dep.SoftwareEnumID != UnsetSoftwareDependency {
-					installed[dep.SoftwareEnumID] = struct{}{}
-				}
-			case CheckCommandSuccessful:
-				_, err = runner.Run(ctx, check.Arg)
+		if dep.SoftwareEnumID != UnsetSoftwareDependency {
+			exists := runner.BinaryExists(ctx, dep.Binary)
+			if exists == nil {
+				installed[dep.SoftwareEnumID] = struct{}{}
 			}
+		}
+
+		var fix string
+		var err error
+		for _, check := range dep.Checks {
+			fix, err = check.Apply(ctx, runner, dep)
 			if err != nil {
-				if check.Severity == SeverityWarning {
-					err = WarningError{Err: err}
-				}
-				fix = check.Fix
 				break
 			}
 		}

--- a/internal/health/dependencies.go
+++ b/internal/health/dependencies.go
@@ -134,19 +134,19 @@ func PerformChecks(ctx context.Context, dependencies []Dependency, runner runner
 			continue
 		}
 
-		if dep.SoftwareEnumID != UnsetSoftwareDependency {
-			exists := runner.BinaryExists(ctx, dep.Binary)
-			if exists == nil {
-				installed[dep.SoftwareEnumID] = struct{}{}
-			}
-		}
-
 		var fix string
 		var err error
 		for _, check := range dep.Checks {
 			fix, err = check.Apply(ctx, runner, dep)
 			if err != nil {
 				break
+			}
+		}
+
+		if err == nil && dep.SoftwareEnumID != UnsetSoftwareDependency {
+			exists := runner.BinaryExists(ctx, dep.Binary)
+			if exists == nil {
+				installed[dep.SoftwareEnumID] = struct{}{}
 			}
 		}
 

--- a/internal/health/dependencies.go
+++ b/internal/health/dependencies.go
@@ -137,7 +137,7 @@ func PerformChecks(ctx context.Context, dependencies []Dependency, runner runner
 		var fix string
 		var err error
 		for _, check := range dep.Checks {
-			fix, err = check.Apply(ctx, runner, dep)
+			fix, err = check.Run(ctx, runner, dep)
 			if err != nil {
 				break
 			}

--- a/internal/health/dependencies_test.go
+++ b/internal/health/dependencies_test.go
@@ -52,8 +52,8 @@ func TestDependencyFormat(t *testing.T) {
 
 func TestPerformChecks(t *testing.T) {
 	t.Run("when no dependencies are found, statuses show not installed", func(t *testing.T) {
-		fooDependency := health.Dependency{Binary: "foo", Label: "bar", Checks: []health.Check{health.BinaryExists()}}
-		bazDependency := health.Dependency{Binary: "baz", Label: "qux", Checks: []health.Check{health.BinaryExists()}}
+		fooDependency := health.Dependency{Binary: "foo", Label: "bar", Checks: []health.Check{health.BinaryExists{}}}
+		bazDependency := health.Dependency{Binary: "baz", Label: "qux", Checks: []health.Check{health.BinaryExists{}}}
 		deps := []health.Dependency{fooDependency, bazDependency}
 		runner := &runner.Fake{}
 
@@ -65,23 +65,9 @@ func TestPerformChecks(t *testing.T) {
 		assert.Equal(t, want, got)
 	})
 
-	t.Run("wraps error as WarningError when binary exists check severity is warning", func(t *testing.T) {
-		missingBin := health.Dependency{Binary: "missing-bin", Label: "Missing", Checks: []health.Check{health.BinaryExistsWarning()}}
-		deps := []health.Dependency{missingBin}
-		runner := &runner.Fake{}
-
-		got := health.PerformChecks(context.Background(), deps, runner)
-
-		assert.Len(t, got, 1)
-		wantBin := health.DependencyStatus{Dependency: missingBin}
-		wantBin.Error = health.WarningError{Err: runner.BinaryExists(context.Background(), missingBin.Binary)}
-		want := []health.DependencyStatus{wantBin}
-		assert.Equal(t, want, got)
-	})
-
 	t.Run("when a dependency is found, its status entry reflects that", func(t *testing.T) {
 		deps := []health.Dependency{
-			{Binary: "baz", Label: "qux", Checks: []health.Check{health.BinaryExists()}},
+			{Binary: "baz", Label: "qux", Checks: []health.Check{health.BinaryExists{}}},
 		}
 		runner := &runner.Fake{
 			Binaries: []string{"baz"},
@@ -91,7 +77,7 @@ func TestPerformChecks(t *testing.T) {
 
 		want := []health.DependencyStatus{
 			{
-				Dependency: health.Dependency{Binary: "baz", Label: "qux", Checks: []health.Check{health.BinaryExists()}},
+				Dependency: health.Dependency{Binary: "baz", Label: "qux", Checks: []health.Check{health.BinaryExists{}}},
 				Error:      nil,
 			},
 		}
@@ -99,10 +85,10 @@ func TestPerformChecks(t *testing.T) {
 	})
 
 	t.Run("omits dependency when none of its SoftwarePrerequisites are installed", func(t *testing.T) {
-		dockerDependecy := health.Dependency{Binary: "docker", Label: "Container Engine", Checks: []health.Check{health.BinaryExists()}}
+		dockerDependecy := health.Dependency{Binary: "docker", Label: "Container Engine", Checks: []health.Check{health.BinaryExists{}}}
 		deps := []health.Dependency{
 			dockerDependecy,
-			{Binary: "runtime", Label: "Runtime", SoftwarePrerequisites: []health.SoftwareDependency{health.Docker}, Checks: []health.Check{health.BinaryExists()}},
+			{Binary: "runtime", Label: "Runtime", SoftwarePrerequisites: []health.SoftwareDependency{health.Docker}, Checks: []health.Check{health.BinaryExists{}}},
 		}
 		runner := &runner.Fake{
 			Binaries: []string{"runtime"},
@@ -117,8 +103,8 @@ func TestPerformChecks(t *testing.T) {
 
 	t.Run("checks dependency when one of its SoftwarePrerequisites is installed", func(t *testing.T) {
 		deps := []health.Dependency{
-			{Binary: "docker", Label: "Container Engine", SoftwareEnumID: health.Docker, Checks: []health.Check{health.BinaryExists()}},
-			{Binary: "runtime", Label: "Runtime", SoftwarePrerequisites: []health.SoftwareDependency{health.Docker}, Checks: []health.Check{health.BinaryExists()}},
+			{Binary: "docker", Label: "Container Engine", SoftwareEnumID: health.Docker, Checks: []health.Check{health.BinaryExists{}}},
+			{Binary: "runtime", Label: "Runtime", SoftwarePrerequisites: []health.SoftwareDependency{health.Docker}, Checks: []health.Check{health.BinaryExists{}}},
 		}
 		runner := &runner.Fake{
 			Binaries: []string{"runtime", "docker"},
@@ -127,8 +113,8 @@ func TestPerformChecks(t *testing.T) {
 		got := health.PerformChecks(context.Background(), deps, runner)
 
 		want := []health.DependencyStatus{
-			{Dependency: health.Dependency{Binary: "docker", Label: "Container Engine", SoftwareEnumID: health.Docker, Checks: []health.Check{health.BinaryExists()}}, Error: nil},
-			{Dependency: health.Dependency{Binary: "runtime", Label: "Runtime", SoftwarePrerequisites: []health.SoftwareDependency{health.Docker}, Checks: []health.Check{health.BinaryExists()}}, Error: nil},
+			{Dependency: health.Dependency{Binary: "docker", Label: "Container Engine", SoftwareEnumID: health.Docker, Checks: []health.Check{health.BinaryExists{}}}, Error: nil},
+			{Dependency: health.Dependency{Binary: "runtime", Label: "Runtime", SoftwarePrerequisites: []health.SoftwareDependency{health.Docker}, Checks: []health.Check{health.BinaryExists{}}}, Error: nil},
 		}
 		assert.Equal(t, want, got)
 	})
@@ -137,7 +123,12 @@ func TestPerformChecks(t *testing.T) {
 		dep := health.Dependency{
 			Binary: "vader.exe",
 			Label:  "Sith",
-			Checks: []health.Check{{Kind: health.CheckBinaryExists, Severity: health.SeverityWarning, Fix: "turn Anakin into a bad man"}},
+			Checks: []health.Check{
+				health.BinaryExists{
+					Severity: health.SeverityWarning,
+					Fix:      "turn Anakin into a bad man",
+				},
+			},
 		}
 		runner := &runner.Fake{}
 
@@ -149,7 +140,7 @@ func TestPerformChecks(t *testing.T) {
 
 	t.Run("checks dependency with no SoftwarePrerequisites unconditionally", func(t *testing.T) {
 		deps := []health.Dependency{
-			{Binary: "standalone", Label: "Tools", Checks: []health.Check{health.BinaryExists()}},
+			{Binary: "standalone", Label: "Tools", Checks: []health.Check{health.BinaryExists{}}},
 		}
 		runner := &runner.Fake{
 			Binaries: []string{"standalone"},
@@ -158,7 +149,7 @@ func TestPerformChecks(t *testing.T) {
 		got := health.PerformChecks(context.Background(), deps, runner)
 
 		want := []health.DependencyStatus{
-			{Dependency: health.Dependency{Binary: "standalone", Label: "Tools", Checks: []health.Check{health.BinaryExists()}}, Error: nil},
+			{Dependency: health.Dependency{Binary: "standalone", Label: "Tools", Checks: []health.Check{health.BinaryExists{}}}, Error: nil},
 		}
 		assert.Equal(t, want, got)
 	})
@@ -167,11 +158,9 @@ func TestPerformChecks(t *testing.T) {
 		dep := health.Dependency{
 			Binary: "potatoes",
 			Label:  "Air Fryer Engine",
-			Checks: []health.Check{health.BinaryExists(), {
-				Kind:     health.CheckCommandSuccessful,
-				Arg:      "potatoes --cook-well",
-				Severity: health.SeverityError,
-				Fix:      "Ensure current user can run the potatoe cooker",
+			Checks: []health.Check{health.BinaryExists{}, health.CommandSuccessful{
+				Cmd: "potatoes --cook-well",
+				Fix: "Ensure current user can run the potatoe cooker",
 			}},
 		}
 		runner := &runner.Fake{


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- Removes the `CheckKind` enum + corresponding switch and replaces it with a `Check` interface that takes context, runner and the current dependency, performs whatever is needed and returns a fix string and an error as needed.
  - This is more extensible than the previous approach if we, for example, want to assert things about the stdout of a command - for example topo latest version checking or ensuring that `docker info` contains what we expect, even with a zero exit code
- Moves the warning-wrapping logic based on severity out of `PerformChecks` and into the check itself. Currently only used in `BinaryExists` but this seemed to fit better to me.
  - Deletes the old test for this and creates a new one that tests `BinaryExists` in isolation
- Decouples prerequisite installation checking from the health checks themselves - now installation checking is performed after all the checks have passed. i.e. if docker is installed but `docker info` does not pass, we don't check other deps that rely on docker
  - Not sure if this behaviour is quite right - it sounds right to me when you interpret a check as validating the software is installed and ready-to-use i.e. you can't use remoteproc-runtime even if it's installed if docker isn't working.

All in all should read a little bit cleaner and adds a lot more flexibility in what our checks can do - this will be utilised in a follow-up PR for topo version checking!