### PR TITLE
fix: display accurate error when SSH fails to connect

### DIFF
--- a/internal/runner/ssh.go
+++ b/internal/runner/ssh.go
@@ -2,6 +2,7 @@ package runner
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"runtime"
 
@@ -62,6 +63,9 @@ func (r *SSH) BinaryExists(ctx context.Context, bin string) error {
 		return err
 	}
 	if _, err := r.Run(ctx, cmd); err != nil {
+		if errors.Is(err, ssh.ErrSSH) {
+			return err
+		}
 		return fmt.Errorf("%q not found on remote target's $PATH", bin)
 	}
 	return nil

--- a/internal/ssh/errors.go
+++ b/internal/ssh/errors.go
@@ -34,5 +34,8 @@ func ClassifyStderr(stderr string) error {
 	if strings.Contains(lower, "connection refused") {
 		return ErrConnectionFailed
 	}
+	if strings.Contains(lower, "could not resolve hostname") {
+		return ErrConnectionFailed
+	}
 	return nil
 }

--- a/internal/ssh/errors_test.go
+++ b/internal/ssh/errors_test.go
@@ -14,6 +14,7 @@ func TestClassifyStderr(t *testing.T) {
 	}{
 		{name: "auth failure", stderr: "user@host: Permission denied (publickey).", want: ErrAuthFailed},
 		{name: "connection refused", stderr: "ssh: connect to host example.com port 22: Connection refused", want: ErrConnectionFailed},
+		{name: "hostname not resolved", stderr: "ssh: Could not resolve hostname not-valid: Temporary failure in name resolution", want: ErrConnectionFailed},
 		{name: "operation timed out (macOS)", stderr: "ssh: connect to host example.com port 22: Operation timed out", want: ErrConnectionTimeout},
 		{name: "connection timed out (Linux)", stderr: "ssh: connect to host example.com port 22: Connection timed out", want: ErrConnectionTimeout},
 		{name: "generic host key verification failure", stderr: "Host key verification failed.", want: ErrHostKeyUnknown},


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

-  `BinaryExists` now propagates SSH connection errors instead of masking them as "binary not found".

Error goes from

```sh
$ topo describe --target not-valid
16:21:43 ERR collecting CPU info: "lscpu" not found on remote target's $PATH
```

to

```sh
$ topo describe --target not-valid
16:18:29 ERR collecting CPU info: ssh command to ssh://not-valid failed: SSH failed: connection failed | stderr: ssh: Could not resolve hostname not-valid: Temporary failure in name resolution
```