### PR TITLE
fix(templates): report target connectivity failures from probes

### DIFF
--- a/cmd/topo/templates.go
+++ b/cmd/topo/templates.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"errors"
+	"fmt"
 	"os"
 
 	"github.com/arm/topo/internal/catalog"
@@ -31,6 +33,9 @@ var templatesCmd = &cobra.Command{
 			defer cancel()
 			hwProfile, err := probe.Hardware(ctx, r)
 			if err != nil {
+				if errors.Is(err, ssh.ErrSSH) || errors.Is(err, runner.ErrTimeout) {
+					return fmt.Errorf("failed to reach target %s: %w", targetArg, err)
+				}
 				return err
 			}
 			profile = &hwProfile

--- a/internal/runner/ssh.go
+++ b/internal/runner/ssh.go
@@ -62,8 +62,9 @@ func (r *SSH) BinaryExists(ctx context.Context, bin string) error {
 	if err != nil {
 		return err
 	}
+
 	if _, err := r.Run(ctx, cmd); err != nil {
-		if errors.Is(err, ssh.ErrSSH) {
+		if errors.Is(err, ssh.ErrSSH) || errors.Is(err, ErrTimeout) {
 			return err
 		}
 		return fmt.Errorf("%q not found on remote target's $PATH", bin)


### PR DESCRIPTION
Currently, `topo templates --target <host>` can fail with a misleading probe-level error such as:

```
"lscpu" not found on remote target's $PATH
```

...even when the real problem is that the target cannot be reached.

The failure comes from the interaction between probing and SSH command lookup:
Hardware compatibility detection starts by probing the target, and the first probe is `CPU()`, which checks for `lscpu` via `runner.(*SSH).BinaryExists`.

In the SSH runner, `BinaryExists` treats non-SSH execution failures as "binary not found", so transport failures can be surfaced as a missing-binary error from the first probe that happened to run.

## Changes

- Preserve SSH and timeout errors in `runner.(*SSH).BinaryExists` instead of rewriting them as missing-binary failures.