### PR TITLE
feat: topo version check in health

### DIFF
--- a/e2e/testdata/TestHealthCheckJson.golden
+++ b/e2e/testdata/TestHealthCheckJson.golden
@@ -3,9 +3,8 @@
     "dependencies": [
       {
         "name": "Topo",
-        "status": "error",
-        "value": "out of date - current: dev, latest version: 4.1.0",
-        "fix": "run `curl -fsSL https://raw.githubusercontent.com/arm/topo/refs/heads/main/scripts/install.sh | sh`"
+        "status": "ok",
+        "value": "topo"
       },
       {
         "name": "SSH",

--- a/e2e/testdata/TestHealthCheckJson.golden
+++ b/e2e/testdata/TestHealthCheckJson.golden
@@ -2,6 +2,12 @@
   "host": {
     "dependencies": [
       {
+        "name": "Topo",
+        "status": "error",
+        "value": "out of date - current: dev, latest version: 4.1.0",
+        "fix": "run `curl -fsSL https://raw.githubusercontent.com/arm/topo/refs/heads/main/scripts/install.sh | sh`"
+      },
+      {
         "name": "SSH",
         "status": "ok",
         "value": "ssh"

--- a/internal/health/check.go
+++ b/internal/health/check.go
@@ -54,7 +54,7 @@ type VersionMatches struct {
 	Fix            string
 }
 
-func (v VersionMatches) Run(ctx context.Context, r runner.Runner, dep Dependency) (string, error) {
+func (v VersionMatches) Run(ctx context.Context, _ runner.Runner, _ Dependency) (string, error) {
 	latest, err := v.FetchLatest(ctx)
 	if err != nil {
 		logger.Warn(fmt.Sprintf("failed to fetch latest version: %v", err))

--- a/internal/health/check.go
+++ b/internal/health/check.go
@@ -3,11 +3,9 @@ package health
 import (
 	"context"
 	"fmt"
-	"runtime"
 
 	"github.com/arm/topo/internal/output/logger"
 	"github.com/arm/topo/internal/runner"
-	"github.com/arm/topo/internal/version"
 )
 
 type Check interface {
@@ -44,22 +42,21 @@ func (b BinaryExists) Run(ctx context.Context, r runner.Runner, dep Dependency) 
 	return b.Fix, err
 }
 
-type IsTopoUpToDate struct{}
+type VersionMatches struct {
+	CurrentVersion string
+	FetchLatest    func(ctx context.Context) (string, error)
+	Fix            string
+}
 
-func (c IsTopoUpToDate) Run(ctx context.Context, r runner.Runner, dep Dependency) (string, error) {
-	latest, err := version.FetchLatest(ctx, version.ArtifactoryBaseURL)
+func (v VersionMatches) Run(ctx context.Context, r runner.Runner, dep Dependency) (string, error) {
+	latest, err := v.FetchLatest(ctx)
 	if err != nil {
-		logger.Warn("failed to fetch latest topo version: %v", err)
+		logger.Warn(fmt.Sprintf("failed to fetch latest version: %v", err))
 		return "", nil
 	}
-	if latest == version.Version {
+	if latest == v.CurrentVersion {
 		return "", nil
 	}
 
-	fix := "run `curl -fsSL https://raw.githubusercontent.com/arm/topo/refs/heads/main/scripts/install.sh | sh`"
-	if runtime.GOOS == "windows" {
-		fix = "run `irm https://raw.githubusercontent.com/arm/topo/refs/heads/main/scripts/install.ps1 | iex`"
-	}
-
-	return fix, fmt.Errorf("topo is not up to date - current: %s, latest version: %s", version.Version, latest)
+	return v.Fix, fmt.Errorf("out of date - current: %s, latest version: %s", v.CurrentVersion, latest)
 }

--- a/internal/health/check.go
+++ b/internal/health/check.go
@@ -64,5 +64,5 @@ func (v VersionMatches) Run(ctx context.Context, r runner.Runner, dep Dependency
 		return "", nil
 	}
 
-	return v.Fix, fmt.Errorf("out of date - current: %s, latest version: %s", v.CurrentVersion, latest)
+	return v.Fix, InfoError{Err: fmt.Errorf("out of date - current: %s, latest version: %s", v.CurrentVersion, latest)}
 }

--- a/internal/health/check.go
+++ b/internal/health/check.go
@@ -2,8 +2,12 @@ package health
 
 import (
 	"context"
+	"fmt"
+	"runtime"
 
+	"github.com/arm/topo/internal/output/logger"
 	"github.com/arm/topo/internal/runner"
+	"github.com/arm/topo/internal/version"
 )
 
 type Check interface {
@@ -38,4 +42,24 @@ func (b BinaryExists) Run(ctx context.Context, r runner.Runner, dep Dependency) 
 		err = WarningError{Err: err}
 	}
 	return b.Fix, err
+}
+
+type IsTopoUpToDate struct{}
+
+func (c IsTopoUpToDate) Run(ctx context.Context, r runner.Runner, dep Dependency) (string, error) {
+	latest, err := version.FetchLatest(ctx, version.ArtifactoryBaseURL)
+	if err != nil {
+		logger.Warn("failed to fetch latest topo version: %v", err)
+		return "", nil
+	}
+	if latest == version.Version {
+		return "", nil
+	}
+
+	fix := "run `curl -fsSL https://raw.githubusercontent.com/arm/topo/refs/heads/main/scripts/install.sh | sh`"
+	if runtime.GOOS == "windows" {
+		fix = "run `irm https://raw.githubusercontent.com/arm/topo/refs/heads/main/scripts/install.ps1 | iex`"
+	}
+
+	return fix, fmt.Errorf("topo is not up to date - current: %s, latest version: %s", version.Version, latest)
 }

--- a/internal/health/check_test.go
+++ b/internal/health/check_test.go
@@ -2,11 +2,13 @@ package health_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/arm/topo/internal/health"
 	"github.com/arm/topo/internal/runner"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBinaryExists(t *testing.T) {
@@ -22,5 +24,53 @@ func TestBinaryExists(t *testing.T) {
 
 		wantErr := health.WarningError{Err: runner.BinaryExists(ctx, dependency.Binary)}
 		assert.Equal(t, wantErr, err)
+	})
+}
+
+func TestVersionMatches(t *testing.T) {
+	ctx := context.Background()
+	dep := health.Dependency{}
+	r := &runner.Fake{}
+
+	t.Run("returns error when version is outdated", func(t *testing.T) {
+		check := health.VersionMatches{
+			FetchLatest: func(ctx context.Context) (string, error) {
+				return "2.0.0", nil
+			},
+			CurrentVersion: "1.0.0",
+		}
+
+		_, err := check.Run(ctx, r, dep)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "1.0.0")
+		assert.Contains(t, err.Error(), "2.0.0")
+	})
+
+	t.Run("returns nil when version matches latest", func(t *testing.T) {
+		check := health.VersionMatches{
+			FetchLatest: func(ctx context.Context) (string, error) {
+				return "2.0.0", nil
+			},
+			CurrentVersion: "2.0.0",
+		}
+
+		fix, err := check.Run(ctx, r, dep)
+
+		assert.NoError(t, err)
+		assert.Empty(t, fix)
+	})
+
+	t.Run("degrades gracefully on fetch error", func(t *testing.T) {
+		check := health.VersionMatches{
+			FetchLatest: func(ctx context.Context) (string, error) {
+				return "", fmt.Errorf("connection refused")
+			},
+		}
+
+		fix, err := check.Run(ctx, r, dep)
+
+		assert.NoError(t, err)
+		assert.Empty(t, fix)
 	})
 }

--- a/internal/health/dependencies.go
+++ b/internal/health/dependencies.go
@@ -2,8 +2,10 @@ package health
 
 import (
 	"context"
+	"runtime"
 
 	"github.com/arm/topo/internal/runner"
+	"github.com/arm/topo/internal/version"
 )
 
 type CheckKind int
@@ -39,7 +41,13 @@ var HostRequiredDependencies = []Dependency{
 	{
 		Binary: "topo",
 		Label:  "Topo",
-		Checks: []Check{IsTopoUpToDate{}},
+		Checks: []Check{VersionMatches{
+			FetchLatest: func(ctx context.Context) (string, error) {
+				return version.FetchLatest(ctx, version.ArtifactoryBaseURL)
+			},
+			CurrentVersion: version.Version,
+			Fix:            getTopoInstallCommand(),
+		}},
 	},
 	{
 		Binary: "ssh",
@@ -168,4 +176,12 @@ func hasAnyInstalledPrerequisite(required []SoftwareDependency, installed map[So
 		}
 	}
 	return false
+}
+
+func getTopoInstallCommand() string {
+	if runtime.GOOS == "windows" {
+		return "run `irm https://raw.githubusercontent.com/arm/topo/refs/heads/main/scripts/install.ps1 | iex`"
+	}
+
+	return "run `curl -fsSL https://raw.githubusercontent.com/arm/topo/refs/heads/main/scripts/install.sh | sh`"
 }

--- a/internal/health/dependencies.go
+++ b/internal/health/dependencies.go
@@ -43,6 +43,10 @@ var HostRequiredDependencies = []Dependency{
 		Label:  "Topo",
 		Checks: []Check{VersionMatches{
 			FetchLatest: func(ctx context.Context) (string, error) {
+				if version.Version == "dev" {
+					return version.Version, nil
+				}
+
 				return version.FetchLatest(ctx, version.ArtifactoryBaseURL)
 			},
 			CurrentVersion: version.Version,

--- a/internal/health/dependencies.go
+++ b/internal/health/dependencies.go
@@ -37,6 +37,11 @@ type Dependency struct {
 
 var HostRequiredDependencies = []Dependency{
 	{
+		Binary: "topo",
+		Label:  "Topo",
+		Checks: []Check{IsTopoUpToDate{}},
+	},
+	{
 		Binary: "ssh",
 		Label:  "SSH",
 		Checks: []Check{BinaryExists{}},

--- a/internal/health/dependencies.go
+++ b/internal/health/dependencies.go
@@ -12,6 +12,10 @@ type WarningError struct{ Err error }
 
 func (w WarningError) Error() string { return w.Err.Error() }
 
+type InfoError struct{ Err error }
+
+func (i InfoError) Error() string { return i.Err.Error() }
+
 type HardwareCapability int
 
 const (

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -167,6 +167,8 @@ func generateDependencyReport(statuses []DependencyStatus) []HealthCheck {
 		} else {
 			if _, ok := errors.AsType[WarningError](ds.Error); ok {
 				hc.Status = CheckStatusWarning
+			} else if _, ok := errors.AsType[InfoError](ds.Error); ok {
+				hc.Status = CheckStatusInfo
 			} else {
 				hc.Status = CheckStatusError
 			}

--- a/internal/version/latest.go
+++ b/internal/version/latest.go
@@ -61,7 +61,9 @@ func FetchLatest(ctx context.Context, url string) (string, error) {
 	sort.Slice(versionsList, func(i, j int) bool {
 		return compareSemver(versionsList[i], versionsList[j]) < 0
 	})
-	return versionsList[len(versionsList)-1], nil
+	latest := versionsList[len(versionsList)-1]
+
+	return latest[1:], nil
 }
 
 func compareSemver(a, b string) int {

--- a/internal/version/latest.go
+++ b/internal/version/latest.go
@@ -1,0 +1,78 @@
+package version
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"maps"
+	"net/http"
+	"regexp"
+	"slices"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/arm/topo/internal/output/logger"
+)
+
+const ArtifactoryBaseURL = "https://artifacts.tools.arm.com/topo"
+
+var semverRe = regexp.MustCompile(`v(\d+)\.(\d+)\.(\d+)`)
+
+func FetchLatest(ctx context.Context, url string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", fmt.Errorf("creating request: %w", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("fetching version index: %w", err)
+	}
+	defer func() {
+		err = resp.Body.Close()
+		if err != nil {
+			logger.Error("failed to close version check response body: %v", err)
+		}
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("fetching version index: HTTP %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("reading version index: %w", err)
+	}
+
+	matches := semverRe.FindAllStringSubmatch(string(body), -1)
+	if len(matches) == 0 {
+		return "", fmt.Errorf("no versions found in %q", url)
+	}
+
+	versions := make(map[string]struct{})
+	for _, m := range matches {
+		v := m[0]
+		if _, ok := versions[v]; !ok {
+			versions[v] = struct{}{}
+		}
+	}
+
+	versionsList := slices.Collect(maps.Keys(versions))
+	sort.Slice(versionsList, func(i, j int) bool {
+		return compareSemver(versionsList[i], versionsList[j]) < 0
+	})
+	return versionsList[len(versionsList)-1], nil
+}
+
+func compareSemver(a, b string) int {
+	pa := semverRe.FindStringSubmatch(a)
+	pb := semverRe.FindStringSubmatch(b)
+	for i := 1; i <= 3; i++ {
+		na, _ := strconv.Atoi(pa[i])
+		nb, _ := strconv.Atoi(pb[i])
+		if na != nb {
+			return na - nb
+		}
+	}
+	return strings.Compare(a, b)
+}

--- a/internal/version/latest.go
+++ b/internal/version/latest.go
@@ -24,6 +24,7 @@ func FetchLatest(ctx context.Context, url string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("creating request: %w", err)
 	}
+	// #nosec G704 -- request to a hardcoded, trusted URL
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("fetching version index: %w", err)

--- a/internal/version/latest_test.go
+++ b/internal/version/latest_test.go
@@ -1,0 +1,126 @@
+package version_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/arm/topo/internal/version"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const artifactoryHTML = `<!DOCTYPE html>
+<html>
+<head><meta name="robots" content="noindex" />
+<title>Index of devx-topo/</title>
+</head>
+<body>
+<h1>Index of devx-topo/</h1>
+<pre>Name                        Last modified      Size</pre><hr/>
+<pre><a href="v0.0.0-2026-03-11-15-52-41/">v0.0.0-2026-03-11-15-52-41/</a>  11-Mar-2026 16:00    -
+<a href="v0.0.0-2026-03-12-09-42-30/">v0.0.0-2026-03-12-09-42-30/</a>  12-Mar-2026 09:50    -
+<a href="v1.0.0/">v1.0.0/</a>                      13-Mar-2026 08:38    -
+<a href="v1.0.0-2026-03-13-12-10-31/">v1.0.0-2026-03-13-12-10-31/</a>  13-Mar-2026 12:14    -
+<a href="v1.1.0/">v1.1.0/</a>                      13-Mar-2026 11:54    -
+<a href="v1.2.0-2026-03-16-11-36-49/">v1.2.0-2026-03-16-11-36-49/</a>  16-Mar-2026 11:41    -
+<a href="v1.3.0/">v1.3.0/</a>                      16-Mar-2026 13:10    -
+<a href="v1.3.1/">v1.3.1/</a>                      17-Mar-2026 14:45    -
+<a href="v1.4.0/">v1.4.0/</a>                      19-Mar-2026 10:03    -
+<a href="v1.4.1/">v1.4.1/</a>                      25-Mar-2026 13:02    -
+<a href="v2.0.0/">v2.0.0/</a>                      02-Apr-2026 12:18    -
+<a href="v3.0.0/">v3.0.0/</a>                      07-Apr-2026 16:06    -
+<a href="v3.0.1/">v3.0.1/</a>                      09-Apr-2026 10:38    -
+<a href="v4.0.0/">v4.0.0/</a>                      10-Apr-2026 15:12    -
+<a href="v4.1.0/">v4.1.0/</a>                      14-Apr-2026 15:56    -
+</pre>
+<hr/><address style="font-size:small;">Artifactory Online Server</address></body></html>`
+
+func createTestServerWithBody(t *testing.T, body string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+
+	t.Cleanup(func() {
+		srv.Close()
+	})
+
+	return srv
+}
+
+func TestFetchLatest(t *testing.T) {
+	t.Run("can reach real artifactory index page", func(t *testing.T) {
+		_, err := version.FetchLatest(context.Background(), version.ArtifactoryBaseURL)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("returns highest version from artifactory index", func(t *testing.T) {
+		srv := createTestServerWithBody(t, artifactoryHTML)
+
+		got, err := version.FetchLatest(context.Background(), srv.URL)
+
+		require.NoError(t, err)
+		assert.Equal(t, "v4.1.0", got)
+	})
+
+	t.Run("picks correct version when order is scrambled", func(t *testing.T) {
+		body := `<a href="v2.0.0/">v2.0.0/</a>
+<a href="v10.0.0/">v10.0.0/</a>
+<a href="v1.9.0/">v1.9.0/</a>
+<a href="v2.1.0/">v2.1.0/</a>`
+		srv := createTestServerWithBody(t, body)
+
+		got, err := version.FetchLatest(context.Background(), srv.URL)
+
+		require.NoError(t, err)
+		assert.Equal(t, "v10.0.0", got)
+	})
+
+	t.Run("deduplicates repeated versions", func(t *testing.T) {
+		body := `<a href="v1.0.0/">v1.0.0/</a>
+<a href="v1.0.0-2026-03-13/">v1.0.0-2026-03-13/</a>`
+		srv := createTestServerWithBody(t, body)
+
+		got, err := version.FetchLatest(context.Background(), srv.URL)
+
+		require.NoError(t, err)
+		assert.Equal(t, "v1.0.0", got)
+	})
+
+	t.Run("returns error when no versions found", func(t *testing.T) {
+		srv := createTestServerWithBody(t, "no versions here")
+
+		_, err := version.FetchLatest(context.Background(), srv.URL)
+
+		assert.ErrorContains(t, err, "no versions found")
+	})
+
+	t.Run("returns error on non-200 status", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		defer srv.Close()
+
+		_, err := version.FetchLatest(context.Background(), srv.URL)
+
+		assert.ErrorContains(t, err, "HTTP 500")
+	})
+
+	t.Run("returns error on connection failure", func(t *testing.T) {
+		_, err := version.FetchLatest(context.Background(), "something-invalid")
+		assert.Error(t, err)
+	})
+
+	t.Run("respects context cancellation", func(t *testing.T) {
+		srv := createTestServerWithBody(t, artifactoryHTML)
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		_, err := version.FetchLatest(ctx, srv.URL)
+
+		assert.Error(t, err)
+	})
+}

--- a/internal/version/latest_test.go
+++ b/internal/version/latest_test.go
@@ -63,7 +63,7 @@ func TestFetchLatest(t *testing.T) {
 		got, err := version.FetchLatest(context.Background(), srv.URL)
 
 		require.NoError(t, err)
-		assert.Equal(t, "v4.1.0", got)
+		assert.Equal(t, "4.1.0", got)
 	})
 
 	t.Run("picks correct version when order is scrambled", func(t *testing.T) {
@@ -76,7 +76,7 @@ func TestFetchLatest(t *testing.T) {
 		got, err := version.FetchLatest(context.Background(), srv.URL)
 
 		require.NoError(t, err)
-		assert.Equal(t, "v10.0.0", got)
+		assert.Equal(t, "10.0.0", got)
 	})
 
 	t.Run("deduplicates repeated versions", func(t *testing.T) {
@@ -87,7 +87,7 @@ func TestFetchLatest(t *testing.T) {
 		got, err := version.FetchLatest(context.Background(), srv.URL)
 
 		require.NoError(t, err)
-		assert.Equal(t, "v1.0.0", got)
+		assert.Equal(t, "1.0.0", got)
 	})
 
 	t.Run("returns error when no versions found", func(t *testing.T) {


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- Adds `version.FetchLatest` which re-implements some of the latest-version grabbing logic from the install scripts in pure go + corresponding tests.
  - I've raised a ticket in the backlog to consider adding a mutable `latest` tag to the publish flow on artifactory in the future but shouldn't block this work as is imo.
- Adds a new `VersionMatches` to fetch + compare two strings and display a nicely-formatted error message if they don't match.
  - Errors encountered while fetching the latest version are only surfaced as a warning log and thus do not result in a red X in the health output
- Adds `topo` itself as a host dependency checked with `topo health` making use of the new `VersionMatches` check
  - Gives a platform-specific fix string to copy-paste to update topo w/ our new scripts!

PR is a little beefier than I'd like - couldn't figure out a way to split this into more neatly without adding unused code, even if temporarily.