### PR TITLE
fix: improve error message phrasing consistency

### DIFF
--- a/cmd/topo/deploy.go
+++ b/cmd/topo/deploy.go
@@ -45,7 +45,7 @@ The compose file (compose.yaml) must be in the current working directory, as thi
 
 		portChanged := cmd.Flags().Changed("registry-port")
 		if portChanged && noRegistry {
-			logger.Warn("--registry-port has no effect when --no-registry is set. Define SSH port in your SSH config instead.")
+			logger.Warn("--registry-port has no effect when --no-registry is set. Define a port in your ssh config instead.")
 		}
 
 		targetArg, err := requireTarget(cmd)

--- a/cmd/topo/setup_keys.go
+++ b/cmd/topo/setup_keys.go
@@ -40,7 +40,7 @@ var setupKeysCmd = &cobra.Command{
 		dest := ssh.NewDestination(targetArg)
 		user, err := ssh.GetUserFromConfig(dest)
 		if err != nil {
-			return fmt.Errorf("%w; note: a per user SSH config entry should be created when setting up keys", err)
+			return fmt.Errorf("%w; note: a per user ssh config entry should be created when setting up keys", err)
 		}
 
 		dest.User = user

--- a/e2e/setup_keys_test.go
+++ b/e2e/setup_keys_test.go
@@ -19,13 +19,13 @@ func TestSetupKeysJourney(t *testing.T) {
 
 	Step(t, "health reports unknown host key and suggests accept-new-host-keys")
 	out := runTopo(t, topo, "health", "--target", container.SSHDestination)
-	assert.Contains(t, out, "Connectivity: ❌ (SSH host key is not known)")
+	assert.Contains(t, out, "Connectivity: ❌ (ssh host key is unknown)")
 	wantFix := fmt.Sprintf("run `topo health --target %s --accept-new-host-keys", container.SSHDestination)
 	assert.Contains(t, out, wantFix)
 
 	Step(t, "health with accept-new-host-keys trusts host and suggests setup-keys")
 	out = runTopo(t, topo, "health", "--target", container.SSHDestination, "--accept-new-host-keys")
-	assert.Contains(t, out, "Connectivity: ❌ (SSH authentication failed)")
+	assert.Contains(t, out, "Connectivity: ❌ (ssh authentication failed)")
 	wantFix = fmt.Sprintf("run `topo setup-keys --target %s`", container.SSHDestination)
 	assert.Contains(t, out, wantFix)
 

--- a/internal/compose/compose.go
+++ b/internal/compose/compose.go
@@ -200,7 +200,7 @@ func WriteProject(project *types.Project, targetComposeFile string) error {
 	}
 
 	if err := os.WriteFile(targetComposeFile, projectInYAML, 0o600); err != nil {
-		return fmt.Errorf("failed to write compose file %s %w", targetComposeFile, err)
+		return fmt.Errorf("failed to write compose file %s: %w", targetComposeFile, err)
 	}
 	return nil
 }

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -148,7 +148,7 @@ func connectivityCheck(status ConnectionStatus) HealthCheck {
 	check.Value = status.Error.Error()
 	switch {
 	case errors.Is(status.Error, probe.ErrAuthFailed):
-		check.Fix = fmt.Sprintf("run `topo setup-keys --target %s` to configure SSH keys", status.Destination)
+		check.Fix = fmt.Sprintf("run `topo setup-keys --target %s` to configure ssh keys", status.Destination)
 	case errors.Is(status.Error, probe.ErrHostKeyUnknown):
 		check.Fix = fmt.Sprintf("run `topo health --target %s --accept-new-host-keys` to trust the target's identity", status.Destination)
 	case errors.Is(status.Error, probe.ErrHostKeyChanged):

--- a/internal/probe/memory.go
+++ b/internal/probe/memory.go
@@ -21,7 +21,7 @@ func Memory(ctx context.Context, r runner.Runner) (int64, error) {
 
 	value, err := findKeyValue(key, out)
 	if err != nil {
-		return 0, fmt.Errorf("in checking %s", path)
+		return 0, fmt.Errorf("failed to read %s: %w", path, err)
 	}
 	return value, nil
 }

--- a/internal/probe/ssh_authentication.go
+++ b/internal/probe/ssh_authentication.go
@@ -9,9 +9,9 @@ import (
 )
 
 var (
-	ErrHostKeyUnknown = errors.New("SSH host key is not known")
-	ErrHostKeyChanged = errors.New("SSH host key has changed")
-	ErrAuthFailed     = errors.New("SSH authentication failed")
+	ErrHostKeyUnknown = errors.New("ssh host key is unknown")
+	ErrHostKeyChanged = errors.New("ssh host key has changed")
+	ErrAuthFailed     = errors.New("ssh authentication failed")
 )
 
 // SSHAuthentication verifies SSH connectivity by attempting public key authentication.

--- a/internal/ssh/config_file.go
+++ b/internal/ssh/config_file.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/arm/topo/internal/output/logger"
 	sshconfig "github.com/kevinburke/ssh_config"
 )
 
@@ -80,13 +79,7 @@ func readConfigFile(path string) (*sshconfig.Config, error) {
 	if err != nil && !os.IsNotExist(err) {
 		return nil, fmt.Errorf("failed to open topo ssh config file: %w", err)
 	}
-	defer func() {
-		if cfgFile != nil {
-			if err := cfgFile.Close(); err != nil {
-				logger.Error("failed to close topo ssh config file", "error", err)
-			}
-		}
-	}()
+	defer cfgFile.Close() // nolint:errcheck
 
 	cfgReader := io.Reader(cfgFile)
 	if cfgFile == nil {

--- a/internal/ssh/config_file.go
+++ b/internal/ssh/config_file.go
@@ -160,7 +160,7 @@ func updateConfigFile(path string, host string, modifiers []ConfigDirectiveModif
 func GetConfigDirectory() (string, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
-		return "", fmt.Errorf("failed to determine home directory for SSH config: %w", err)
+		return "", fmt.Errorf("failed to determine home directory for ssh config: %w", err)
 	}
 
 	return filepath.Join(home, ".ssh"), nil

--- a/internal/ssh/errors.go
+++ b/internal/ssh/errors.go
@@ -7,7 +7,7 @@ import (
 )
 
 var (
-	ErrSSH               = errors.New("SSH failed")
+	ErrSSH               = errors.New("ssh failed")
 	ErrAuthFailed        = fmt.Errorf("%w: authentication failed", ErrSSH)
 	ErrConnectionFailed  = fmt.Errorf("%w: connection failed", ErrSSH)
 	ErrConnectionTimeout = fmt.Errorf("%w: connection timed out", ErrSSH)

--- a/internal/ssh/ssh_tunnel.go
+++ b/internal/ssh/ssh_tunnel.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/arm/topo/internal/command"
 	"github.com/arm/topo/internal/operation"
-	"github.com/arm/topo/internal/output/logger"
 )
 
 const TunnelPIDPlaceholder = "<ssh tunnel pid>"
@@ -23,10 +22,7 @@ func isPortTaken(port string) bool {
 	if err != nil {
 		return false
 	}
-	err = conn.Close()
-	if err != nil {
-		logger.Error(fmt.Sprintf("error closing tcp port probe: %v", err))
-	}
+	conn.Close() // nolint:errcheck
 	return true
 }
 

--- a/internal/ssh/ssh_tunnel.go
+++ b/internal/ssh/ssh_tunnel.go
@@ -90,7 +90,7 @@ func (s *SSHTunnelStart) Run(w io.Writer) error {
 		}
 
 		formattedError := command.FormatError(cmd.Args, err)
-		return fmt.Errorf("failed to open SSH tunnel: %w", formattedError)
+		return fmt.Errorf("failed to open ssh tunnel: %w", formattedError)
 	}
 	if cmd.Process != nil {
 		s.Process = cmd.Process
@@ -134,7 +134,7 @@ func (ct *CheckSSHTunnelSecurity) Run(w io.Writer) error {
 
 	err := cmd.Run()
 	if err == nil {
-		return fmt.Errorf("SSH tunnel to %s is not secure: able to access registry port without authentication", ct.TargetDest)
+		return fmt.Errorf("ssh tunnel to %s is not secure: able to access registry port without authentication", ct.TargetDest)
 	}
 
 	_, _ = fmt.Fprintf(w, "Port %s is not exposed on target to local network\n", ct.Port)
@@ -213,7 +213,7 @@ func (s *SSHTunnelProcessStop) Run(w io.Writer) error {
 	if err := cmd.Run(); err != nil {
 		pid := s.Start.Process.Pid
 		formattedError := command.FormatError(cmd.Args, err)
-		return fmt.Errorf("failed to stop SSH tunnel process (pid: %d): %w", pid, formattedError)
+		return fmt.Errorf("failed to stop ssh tunnel process (pid: %d): %w", pid, formattedError)
 	}
 	s.Start.Process = nil
 	return nil

--- a/internal/ssh/ssh_tunnel_test.go
+++ b/internal/ssh/ssh_tunnel_test.go
@@ -120,7 +120,7 @@ func TestSSHTunnelStart(t *testing.T) {
 			err := st.Run(&buf)
 
 			require.Error(t, err)
-			assert.Contains(t, err.Error(), "failed to open SSH tunnel:")
+			assert.Contains(t, err.Error(), "failed to open ssh tunnel:")
 			assert.NotContains(t, err.Error(), "port already in use")
 		})
 	})

--- a/scripts/update_templates/fetch.go
+++ b/scripts/update_templates/fetch.go
@@ -50,7 +50,7 @@ func fetchComposeFile(client *http.Client, githubToken string, repoSpec string) 
 
 	yamlBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("read body: %w", err)
+		return nil, fmt.Errorf("failed to read response body: %w", err)
 	}
 	yamlReader := bytes.NewReader(yamlBytes)
 

--- a/scripts/update_templates/parse.go
+++ b/scripts/update_templates/parse.go
@@ -11,7 +11,7 @@ import (
 func BuildTemplate(repoURL string, compose io.Reader) (Template, error) {
 	tmpl, err := template.FromContent(compose)
 	if err != nil {
-		return Template{}, fmt.Errorf("parse compose definition: %w", err)
+		return Template{}, fmt.Errorf("failed to parse compose definition: %w", err)
 	}
 
 	metadata := tmpl.Metadata


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- Makes a pass over the repo to improve error message consistency to adhere to the form; "failed to X %s: %w"
- Uncapitalises SSH in the ssh auth errors - felt better to me but happy to be disagreed with.
- Removes a couple error logging when closing resources which are not actionable + adds nolint instead
