### PR TITLE
fix: standardise help text formatting across all commands

### DIFF
--- a/cmd/topo/clone.go
+++ b/cmd/topo/clone.go
@@ -24,18 +24,23 @@ interactive prompts.`,
 	Example: `  # Git repository
   topo clone git@github.com:user/repo.git
   topo clone https://github.com/user/repo.git#develop
+  topo clone git:git@github.com:user/repo.git
   topo clone git:https://github.com/user/repo.git#main
+  topo clone git:ubuntu@example.com:repo.git
   topo clone git:builder@host:tools/platform.git#v2
 
   # Local directory (must contain a Topo template)
   topo clone dir:/path/to/template/folder
   topo clone dir:./relative/path
 
+  # Will prompt for required args
+  topo clone https://github.com/Arm-Examples/topo-welcome.git
+
   # Provide build arguments explicitly
-  topo clone https://github.com/user/repo.git GREETING_NAME="World"
+  topo clone https://github.com/Arm-Examples/topo-welcome.git GREETING_NAME="World"
 
   # With an explicit path
-  topo clone https://github.com/user/repo.git my-demo GREETING_NAME="World"`,
+  topo clone https://github.com/Arm-Examples/topo-welcome.git my-demo GREETING_NAME="World"`,
 	Args: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true

--- a/cmd/topo/clone.go
+++ b/cmd/topo/clone.go
@@ -19,27 +19,23 @@ var topoCloneCmd = &cobra.Command{
 The project-source argument uses scheme prefixes to specify the source type.
 The git: prefix is optional for git@host and https:// URLs.
 
-Git repository:
+Some projects require build arguments. Supply them on the command line or answer
+interactive prompts.`,
+	Example: `  # Git repository
   topo clone git@github.com:user/repo.git
   topo clone https://github.com/user/repo.git#develop
-  topo clone git:git@github.com:user/repo.git
   topo clone git:https://github.com/user/repo.git#main
-  topo clone git:ubuntu@example.com:repo.git
   topo clone git:builder@host:tools/platform.git#v2
 
-Local directory (must contain a Topo template):
+  # Local directory (must contain a Topo template)
   topo clone dir:/path/to/template/folder
   topo clone dir:./relative/path
 
-Some projects require build arguments. Supply them on the command line or answer prompts:
+  # Provide build arguments explicitly
+  topo clone https://github.com/user/repo.git GREETING_NAME="World"
 
-  # Will prompt for required args
-  topo clone https://github.com/Arm-Examples/topo-welcome.git
-  # Provide args explicitly
-  topo clone https://github.com/Arm-Examples/topo-welcome.git GREETING_NAME="World"
   # With an explicit path
-  topo clone https://github.com/Arm-Examples/topo-welcome.git my-demo GREETING_NAME="World"
-`,
+  topo clone https://github.com/user/repo.git my-demo GREETING_NAME="World"`,
 	Args: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true

--- a/cmd/topo/deploy.go
+++ b/cmd/topo/deploy.go
@@ -33,7 +33,7 @@ var deployCmd = &cobra.Command{
 	Long: `Deploy services to the target host using definitions in the compose file.
 
 This command performs the following operations in sequence:
-  1. Build - Builds Container images defined in the compose file on the local host
+  1. Build - Builds container images defined in the compose file on the local host
   2. Pull - Pulls any required images from registries to the local host
   3. Transfer - Transfers built and pulled images and compose file to the target host
   4. Run - Runs docker compose up on the target host
@@ -141,11 +141,11 @@ func resolvePort(cmd *cobra.Command, flagValue string) (string, error) {
 
 func init() {
 	addTargetFlag(deployCmd)
-	deployCmd.Flags().StringVarP(&registryPort, "registry-port", "p", operation.DefaultRegistryPort, fmt.Sprintf("Registry and SSH tunnel port (can also be set via %s env var)", portEnvVar))
-	deployCmd.Flags().BoolVar(&noRegistry, "no-registry", false, "Disable private registry flow; use direct save/load transfer")
-	deployCmd.Flags().BoolVar(&forceRecreate, "force-recreate", false, "Force recreation of containers even if their configuration and image haven't changed")
-	deployCmd.Flags().BoolVar(&noRecreate, "no-recreate", false, "Prevent recreation of containers even if their configuration and image have changed")
-	deployCmd.Flags().BoolVar(&skipProjectChecks, "skip-project-checks", false, "Skip project compatibility checks for the target platform")
+	deployCmd.Flags().StringVarP(&registryPort, "registry-port", "p", operation.DefaultRegistryPort, fmt.Sprintf("registry and SSH tunnel port (can also be set via %s env var)", portEnvVar))
+	deployCmd.Flags().BoolVar(&noRegistry, "no-registry", false, "disable private registry flow; use direct save/load transfer")
+	deployCmd.Flags().BoolVar(&forceRecreate, "force-recreate", false, "force recreation of containers even if their configuration and image haven't changed")
+	deployCmd.Flags().BoolVar(&noRecreate, "no-recreate", false, "prevent recreation of containers even if their configuration and image have changed")
+	deployCmd.Flags().BoolVar(&skipProjectChecks, "skip-project-checks", false, "skip project compatibility checks for the target platform")
 	deployCmd.MarkFlagsMutuallyExclusive("force-recreate", "no-recreate")
 	rootCmd.AddCommand(deployCmd)
 }

--- a/cmd/topo/extend.go
+++ b/cmd/topo/extend.go
@@ -12,33 +12,26 @@ import (
 
 var extendCmd = &cobra.Command{
 	Use:   "extend <compose-filepath> <source> [flags] [-- ARG=VALUE ...]",
-	Short: "Add all services of source to the compose file from a template Name, git URL, or local directory",
-	Long: `Add all services of source to the compose file.
+	Short: "Add services from a template to the compose file",
+	Long: `Add all services from a source to the compose file.
 
-The source argument uses scheme prefixes to specify the source type:
+The source argument uses scheme prefixes to specify the source type.
+The git: prefix is optional for git@host and https:// URLs.
 
-Git repository (git: prefix is optional for git@host and https:// URLs):
-  topo extend compose.yaml git:https://github.com/user/repo.git
+Service templates may require build arguments. You can provide them after --
+or answer interactive prompts.`,
+	Example: `  # Git repository
   topo extend compose.yaml https://github.com/user/repo.git
   topo extend compose.yaml https://github.com/user/repo.git#develop
   topo extend compose.yaml git:git@github.com:user/repo.git
-  topo extend compose.yaml git@github.com:user/repo.git
-  topo extend compose.yaml git@github.com:user/repo.git#main
-  topo extend compose.yaml git:ubuntu@example.com:repo.git
   topo extend compose.yaml git:builder@host:tools/platform.git#v2
 
-Local directory:
+  # Local directory
   topo extend compose.yaml dir:/path/to/template/folder
   topo extend compose.yaml dir:./relative/path
 
-Service templates may require build arguments. You can provide them via the command line
-or interactively when prompted:
-
-  # Will prompt for required args
-  topo extend compose.yaml git:url
-  # Provide args explicitly
-  topo extend compose.yaml git:url -- GREETING="Hello" PORT=8080
-`,
+  # Provide build arguments explicitly
+  topo extend compose.yaml git:url -- GREETING="Hello" PORT=8080`,
 	Args: cobra.MinimumNArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true

--- a/cmd/topo/extend.go
+++ b/cmd/topo/extend.go
@@ -21,14 +21,21 @@ The git: prefix is optional for git@host and https:// URLs.
 Service templates may require build arguments. You can provide them after --
 or answer interactive prompts.`,
 	Example: `  # Git repository
+  topo extend compose.yaml git:https://github.com/user/repo.git
   topo extend compose.yaml https://github.com/user/repo.git
   topo extend compose.yaml https://github.com/user/repo.git#develop
   topo extend compose.yaml git:git@github.com:user/repo.git
+  topo extend compose.yaml git@github.com:user/repo.git
+  topo extend compose.yaml git@github.com:user/repo.git#main
+  topo extend compose.yaml git:ubuntu@example.com:repo.git
   topo extend compose.yaml git:builder@host:tools/platform.git#v2
 
   # Local directory
   topo extend compose.yaml dir:/path/to/template/folder
   topo extend compose.yaml dir:./relative/path
+
+  # Will prompt for required args
+  topo extend compose.yaml git:url
 
   # Provide build arguments explicitly
   topo extend compose.yaml git:url -- GREETING="Hello" PORT=8080`,

--- a/cmd/topo/health.go
+++ b/cmd/topo/health.go
@@ -16,7 +16,8 @@ const acceptNewHostFlag = "accept-new-host-keys"
 
 var healthCmd = &cobra.Command{
 	Use:   "health",
-	Short: "Check the target host environment (container engines, SSH availability)",
+	Short: "Check the target host environment",
+	Long:  "Check the target host environment, including container engines and SSH availability.",
 	Args:  cobra.ExactArgs(0),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
@@ -61,6 +62,6 @@ var healthCmd = &cobra.Command{
 func init() {
 	addTargetFlag(healthCmd)
 	addTimeoutFlag(healthCmd, defaultTimeout)
-	healthCmd.Flags().Bool(acceptNewHostFlag, false, "Automatically trust and add new SSH host keys for the target")
+	healthCmd.Flags().Bool(acceptNewHostFlag, false, "automatically trust and add new SSH host keys for the target")
 	rootCmd.AddCommand(healthCmd)
 }

--- a/cmd/topo/install.go
+++ b/cmd/topo/install.go
@@ -6,7 +6,7 @@ import (
 
 var installCmd = &cobra.Command{
 	Use:   "install",
-	Short: "Install components to target",
+	Short: "Install components to the target",
 }
 
 func init() {

--- a/cmd/topo/install_remoteproc_runtime.go
+++ b/cmd/topo/install_remoteproc_runtime.go
@@ -22,8 +22,7 @@ Fetches binaries from https://github.com/` + remoteprocRuntimeRepoURL + `
 Set GITHUB_TOKEN to authenticate with the GitHub API and avoid rate limits.
 
 Attempts to replace existing installations if found.
-Falls back to ~/bin if no suitable locations are automatically found.
-`,
+Falls back to ~/bin if no suitable locations are automatically found.`,
 	Args: cobra.ExactArgs(0),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true

--- a/cmd/topo/root.go
+++ b/cmd/topo/root.go
@@ -30,7 +30,7 @@ func init() {
 		"output",
 		"o",
 		"plain",
-		"Output format: plain or json",
+		"output format: plain or json",
 	)
 }
 
@@ -39,7 +39,7 @@ const targetEnvVar = "TOPO_TARGET"
 func addTargetFlag(cmd *cobra.Command) {
 	cmd.Flags().StringP(
 		"target", "t", "",
-		fmt.Sprintf("The SSH destination (can also be set via %s env var).", targetEnvVar),
+		fmt.Sprintf("SSH destination (can also be set via %s env var)", targetEnvVar),
 	)
 }
 
@@ -72,7 +72,7 @@ func requireTarget(cmd *cobra.Command) (string, error) {
 const defaultTimeout = 5 * time.Second
 
 func addTimeoutFlag(cmd *cobra.Command, defaultTimeout time.Duration) {
-	cmd.Flags().Duration("timeout", defaultTimeout, "Maximum time to wait for the command to complete (0 to disable timeout)")
+	cmd.Flags().Duration("timeout", defaultTimeout, "maximum time to wait for the command to complete (0 to disable timeout)")
 }
 
 func contextWithTimeout(cmd *cobra.Command) (context.Context, context.CancelFunc) {

--- a/cmd/topo/setup_keys.go
+++ b/cmd/topo/setup_keys.go
@@ -76,7 +76,7 @@ var setupKeysCmd = &cobra.Command{
 
 func init() {
 	addTargetFlag(setupKeysCmd)
-	setupKeysCmd.Flags().StringVar(&privateKeyPath, "key-path", "", "Specify the SSH path where the generated key pair will be stored. Default directory: ~/.ssh. Default public key file name: id_ed25519_topo_<target>.pub)")
-	setupKeysCmd.Flags().StringVar(&keyType, "key-type", "ed25519", fmt.Sprintf("Specify the type of SSH key to generate. Supported types: %s, %s. Default: %s", setupkeys.KeyTypeED25519, setupkeys.KeyTypeRSA, setupkeys.KeyTypeED25519))
+	setupKeysCmd.Flags().StringVar(&privateKeyPath, "key-path", "", "path to store the generated key pair (default: ~/.ssh/id_ed25519_topo_<target>)")
+	setupKeysCmd.Flags().StringVar(&keyType, "key-type", "ed25519", fmt.Sprintf("type of SSH key to generate: %s, %s", setupkeys.KeyTypeED25519, setupkeys.KeyTypeRSA))
 	rootCmd.AddCommand(setupKeysCmd)
 }

--- a/cmd/topo/templates.go
+++ b/cmd/topo/templates.go
@@ -14,7 +14,7 @@ import (
 
 var templatesCmd = &cobra.Command{
 	Use:   "templates",
-	Short: "List available Service Templates",
+	Short: "List available service templates",
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		cmd.SilenceUsage = true
 		outputFormat := resolveOutput(cmd)

--- a/cmd/topo/vscode.go
+++ b/cmd/topo/vscode.go
@@ -27,7 +27,7 @@ var getProjectCmd = &cobra.Command{
 var describeCmd = &cobra.Command{
 	Use:    "describe",
 	Short:  "Describe the hardware characteristics of the target host",
-	Long:   "Prints a description of the hardware characteristics of the target host including CPU ISA features and remoteproc capabilities.",
+	Long:   "Print a description of the hardware characteristics of the target host including CPU ISA features and remoteproc capabilities.",
 	Hidden: true,
 	Args:   cobra.ExactArgs(0),
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/topo/vscode.go
+++ b/cmd/topo/vscode.go
@@ -27,7 +27,7 @@ var getProjectCmd = &cobra.Command{
 var describeCmd = &cobra.Command{
 	Use:    "describe",
 	Short:  "Describe the hardware characteristics of the target host",
-	Long:   `Prints a description of the hardware characteristics of the target host including CPU ISA features and remoteproc capabilities`,
+	Long:   "Prints a description of the hardware characteristics of the target host including CPU ISA features and remoteproc capabilities.",
 	Hidden: true,
 	Args:   cobra.ExactArgs(0),
 	RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
## Changes

- Lowercase all flag descriptions to match Cobra's auto-generated style (`help for topo`, `version for topo`)
- Move usage examples from `Long` to `Example` field in `clone` and `extend` commands
- Add `Long` description to `health` (moved parenthetical detail from `Short`)
- Simplify verbose `setup-keys` flag descriptions
- Trim trailing newlines from `Long` descriptions
- and more