### PR TITLE
fix: handling of health timeout error for remoteproc

### DIFF
--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -120,9 +120,9 @@ func GenerateTargetReport(targetStatus Status) TargetReport {
 	report.SubsystemDriver.Name = "Subsystem Driver (remoteproc)"
 	remoteCPUs := targetStatus.Hardware.RemoteCPU
 	switch {
-	case targetStatus.Hardware.RemoteCPUErr != nil:
+	case targetStatus.Hardware.Err != nil:
 		report.SubsystemDriver.Status = CheckStatusError
-		report.SubsystemDriver.Value = targetStatus.Hardware.RemoteCPUErr.Error()
+		report.SubsystemDriver.Value = targetStatus.Hardware.Err.Error()
 	case len(remoteCPUs) > 0:
 		names := make([]string, len(remoteCPUs))
 		for i, remoteProc := range remoteCPUs {

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -119,14 +119,18 @@ func GenerateTargetReport(targetStatus Status) TargetReport {
 
 	report.SubsystemDriver.Name = "Subsystem Driver (remoteproc)"
 	remoteCPUs := targetStatus.Hardware.RemoteCPU
-	if len(remoteCPUs) > 0 {
+	switch {
+	case targetStatus.Hardware.RemoteCPUErr != nil:
+		report.SubsystemDriver.Status = CheckStatusError
+		report.SubsystemDriver.Value = targetStatus.Hardware.RemoteCPUErr.Error()
+	case len(remoteCPUs) > 0:
 		names := make([]string, len(remoteCPUs))
 		for i, remoteProc := range remoteCPUs {
 			names[i] = remoteProc.Name
 		}
 		report.SubsystemDriver.Status = CheckStatusOK
 		report.SubsystemDriver.Value = strings.Join(names, ", ")
-	} else {
+	default:
 		report.SubsystemDriver.Status = CheckStatusInfo
 		report.SubsystemDriver.Value = "no remoteproc devices found"
 	}

--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -36,7 +36,7 @@ func TestGenerateTargetReport(t *testing.T) {
 	t.Run("when remoteproc probe fails, SubsystemDriver reports the error", func(t *testing.T) {
 		ts := health.Status{
 			Hardware: health.HardwareProfile{
-				RemoteCPUErr: fmt.Errorf("timed out"),
+				Err: fmt.Errorf("timed out"),
 			},
 		}
 

--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -33,6 +33,19 @@ func TestGenerateTargetReport(t *testing.T) {
 		assert.Equal(t, "no remoteproc devices found", got.SubsystemDriver.Value)
 	})
 
+	t.Run("when remoteproc probe fails, SubsystemDriver reports the error", func(t *testing.T) {
+		ts := health.Status{
+			Hardware: health.HardwareProfile{
+				RemoteCPUErr: fmt.Errorf("timed out"),
+			},
+		}
+
+		got := health.GenerateTargetReport(ts)
+
+		assert.Equal(t, health.CheckStatusError, got.SubsystemDriver.Status)
+		assert.Equal(t, "timed out", got.SubsystemDriver.Value)
+	})
+
 	t.Run("when remoteproc devices are found, SubsystemDriver status is ok and includes device names", func(t *testing.T) {
 		ts := health.Status{
 			Hardware: health.HardwareProfile{

--- a/internal/health/status.go
+++ b/internal/health/status.go
@@ -8,7 +8,8 @@ import (
 )
 
 type HardwareProfile struct {
-	RemoteCPU []probe.RemoteprocCPU
+	RemoteCPU    []probe.RemoteprocCPU
+	RemoteCPUErr error
 }
 
 func (h HardwareProfile) Capabilities() map[HardwareCapability]struct{} {
@@ -27,8 +28,9 @@ type HealthStatus struct {
 func ProbeHealthStatus(ctx context.Context, r runner.Runner) HealthStatus {
 	var hs HealthStatus
 
-	remoteprocs, _ := probe.Remoteproc(ctx, r)
+	remoteprocs, err := probe.Remoteproc(ctx, r)
 	hs.Hardware.RemoteCPU = remoteprocs
+	hs.Hardware.RemoteCPUErr = err
 
 	dependenciesToCheck := FilterByHardware(TargetRequiredDependencies, hs.Hardware.Capabilities())
 	hs.Dependencies = PerformChecks(ctx, dependenciesToCheck, r)

--- a/internal/health/status.go
+++ b/internal/health/status.go
@@ -8,8 +8,8 @@ import (
 )
 
 type HardwareProfile struct {
-	RemoteCPU    []probe.RemoteprocCPU
-	RemoteCPUErr error
+	RemoteCPU []probe.RemoteprocCPU
+	Err       error
 }
 
 func (h HardwareProfile) Capabilities() map[HardwareCapability]struct{} {
@@ -30,7 +30,7 @@ func ProbeHealthStatus(ctx context.Context, r runner.Runner) HealthStatus {
 
 	remoteprocs, err := probe.Remoteproc(ctx, r)
 	hs.Hardware.RemoteCPU = remoteprocs
-	hs.Hardware.RemoteCPUErr = err
+	hs.Hardware.Err = err
 
 	dependenciesToCheck := FilterByHardware(TargetRequiredDependencies, hs.Hardware.Capabilities())
 	hs.Dependencies = PerformChecks(ctx, dependenciesToCheck, r)

--- a/internal/probe/remoteproc.go
+++ b/internal/probe/remoteproc.go
@@ -14,11 +14,8 @@ type RemoteprocCPU struct {
 func Remoteproc(ctx context.Context, r runner.Runner) ([]RemoteprocCPU, error) {
 	var remoteProcs []RemoteprocCPU
 	out, err := r.Run(ctx, "ls /sys/class/remoteproc 2>/dev/null || true")
-	if err != nil {
+	if err != nil || out == "" {
 		return remoteProcs, err
-	}
-	if out == "" {
-		return remoteProcs, nil
 	}
 
 	out, err = r.Run(ctx, "cat /sys/class/remoteproc/*/name")

--- a/internal/probe/remoteproc.go
+++ b/internal/probe/remoteproc.go
@@ -13,7 +13,7 @@ type RemoteprocCPU struct {
 
 func Remoteproc(ctx context.Context, r runner.Runner) ([]RemoteprocCPU, error) {
 	var remoteProcs []RemoteprocCPU
-	out, err := r.Run(ctx, "ls /sys/class/remoteproc")
+	out, err := r.Run(ctx, "ls /sys/class/remoteproc 2>/dev/null || true")
 	if err != nil {
 		return remoteProcs, err
 	}

--- a/internal/probe/remoteproc.go
+++ b/internal/probe/remoteproc.go
@@ -14,7 +14,10 @@ type RemoteprocCPU struct {
 func Remoteproc(ctx context.Context, r runner.Runner) ([]RemoteprocCPU, error) {
 	var remoteProcs []RemoteprocCPU
 	out, err := r.Run(ctx, "ls /sys/class/remoteproc")
-	if err != nil || out == "" {
+	if err != nil {
+		return remoteProcs, err
+	}
+	if out == "" {
 		return remoteProcs, nil
 	}
 

--- a/internal/probe/remoteproc.go
+++ b/internal/probe/remoteproc.go
@@ -2,6 +2,7 @@ package probe
 
 import (
 	"context"
+	"errors"
 	"strings"
 
 	"github.com/arm/topo/internal/runner"
@@ -13,14 +14,20 @@ type RemoteprocCPU struct {
 
 func Remoteproc(ctx context.Context, r runner.Runner) ([]RemoteprocCPU, error) {
 	var remoteProcs []RemoteprocCPU
-	out, err := r.Run(ctx, "ls /sys/class/remoteproc 2>/dev/null || true")
-	if err != nil || out == "" {
-		return remoteProcs, err
+	_, err := r.Run(ctx, "test -d /sys/class/remoteproc")
+	if err != nil {
+		if errors.Is(err, runner.ErrTimeout) {
+			return remoteProcs, err
+		}
+		return remoteProcs, nil
 	}
 
-	out, err = r.Run(ctx, "cat /sys/class/remoteproc/*/name")
+	out, err := r.Run(ctx, "cat /sys/class/remoteproc/*/name")
 	if err != nil {
-		return remoteProcs, err
+		if errors.Is(err, runner.ErrTimeout) {
+			return remoteProcs, err
+		}
+		return remoteProcs, nil
 	}
 
 	remoteCPU := strings.FieldsSeq(out)

--- a/internal/probe/remoteproc_test.go
+++ b/internal/probe/remoteproc_test.go
@@ -15,8 +15,8 @@ func TestProbeRemoteproc(t *testing.T) {
 	t.Run("returns remote processors", func(t *testing.T) {
 		r := &runner.Fake{
 			Commands: map[string]runner.FakeResult{
-				"ls /sys/class/remoteproc 2>/dev/null || true": {Output: "remoteproc0\nremoteproc1"},
-				"cat /sys/class/remoteproc/*/name":             {Output: "virtio0\nvirtio1"},
+				"test -d /sys/class/remoteproc":    {},
+				"cat /sys/class/remoteproc/*/name": {Output: "virtio0\nvirtio1"},
 			},
 		}
 
@@ -30,22 +30,10 @@ func TestProbeRemoteproc(t *testing.T) {
 		assert.Equal(t, want, got)
 	})
 
-	t.Run("returns error when listing remoteproc directory fails", func(t *testing.T) {
+	t.Run("returns empty when remoteproc directory does not exist", func(t *testing.T) {
 		r := &runner.Fake{
 			Commands: map[string]runner.FakeResult{
-				"ls /sys/class/remoteproc 2>/dev/null || true": {Output: "", Err: errors.New("connection lost")},
-			},
-		}
-
-		_, err := probe.Remoteproc(context.Background(), r)
-
-		assert.ErrorContains(t, err, "connection lost")
-	})
-
-	t.Run("returns empty when remoteproc directory is empty", func(t *testing.T) {
-		r := &runner.Fake{
-			Commands: map[string]runner.FakeResult{
-				"ls /sys/class/remoteproc 2>/dev/null || true": {Output: ""},
+				"test -d /sys/class/remoteproc": {Output: "", Err: errors.New("exit status 1")},
 			},
 		}
 
@@ -55,16 +43,56 @@ func TestProbeRemoteproc(t *testing.T) {
 		assert.Empty(t, got)
 	})
 
-	t.Run("returns error when reading names fails", func(t *testing.T) {
+	t.Run("returns error when listing remoteproc directory fails", func(t *testing.T) {
 		r := &runner.Fake{
 			Commands: map[string]runner.FakeResult{
-				"ls /sys/class/remoteproc 2>/dev/null || true": {Output: "remoteproc0"},
-				"cat /sys/class/remoteproc/*/name":             {Err: errors.New("permission denied")},
+				"test -d /sys/class/remoteproc": {Output: "", Err: runner.ErrTimeout},
 			},
 		}
 
 		_, err := probe.Remoteproc(context.Background(), r)
 
-		assert.ErrorContains(t, err, "permission denied")
+		assert.ErrorIs(t, err, runner.ErrTimeout)
+	})
+
+	t.Run("returns empty when no remoteproc names found", func(t *testing.T) {
+		r := &runner.Fake{
+			Commands: map[string]runner.FakeResult{
+				"test -d /sys/class/remoteproc":    {},
+				"cat /sys/class/remoteproc/*/name": {Output: ""},
+			},
+		}
+
+		got, err := probe.Remoteproc(context.Background(), r)
+
+		require.NoError(t, err)
+		assert.Empty(t, got)
+	})
+
+	t.Run("returns empty when reading names fails with non-timeout error", func(t *testing.T) {
+		r := &runner.Fake{
+			Commands: map[string]runner.FakeResult{
+				"test -d /sys/class/remoteproc":    {},
+				"cat /sys/class/remoteproc/*/name": {Err: errors.New("No such file or directory")},
+			},
+		}
+
+		got, err := probe.Remoteproc(context.Background(), r)
+
+		require.NoError(t, err)
+		assert.Empty(t, got)
+	})
+
+	t.Run("returns error when reading names times out", func(t *testing.T) {
+		r := &runner.Fake{
+			Commands: map[string]runner.FakeResult{
+				"test -d /sys/class/remoteproc":    {},
+				"cat /sys/class/remoteproc/*/name": {Err: runner.ErrTimeout},
+			},
+		}
+
+		_, err := probe.Remoteproc(context.Background(), r)
+
+		assert.ErrorIs(t, err, runner.ErrTimeout)
 	})
 }

--- a/internal/probe/remoteproc_test.go
+++ b/internal/probe/remoteproc_test.go
@@ -15,8 +15,8 @@ func TestProbeRemoteproc(t *testing.T) {
 	t.Run("returns remote processors", func(t *testing.T) {
 		r := &runner.Fake{
 			Commands: map[string]runner.FakeResult{
-				"ls /sys/class/remoteproc":         {Output: "remoteproc0\nremoteproc1"},
-				"cat /sys/class/remoteproc/*/name": {Output: "virtio0\nvirtio1"},
+				"ls /sys/class/remoteproc 2>/dev/null || true": {Output: "remoteproc0\nremoteproc1"},
+				"cat /sys/class/remoteproc/*/name":             {Output: "virtio0\nvirtio1"},
 			},
 		}
 
@@ -33,19 +33,19 @@ func TestProbeRemoteproc(t *testing.T) {
 	t.Run("returns error when listing remoteproc directory fails", func(t *testing.T) {
 		r := &runner.Fake{
 			Commands: map[string]runner.FakeResult{
-				"ls /sys/class/remoteproc": {Output: "", Err: errors.New("no such file")},
+				"ls /sys/class/remoteproc 2>/dev/null || true": {Output: "", Err: errors.New("connection lost")},
 			},
 		}
 
 		_, err := probe.Remoteproc(context.Background(), r)
 
-		assert.ErrorContains(t, err, "no such file")
+		assert.ErrorContains(t, err, "connection lost")
 	})
 
 	t.Run("returns empty when remoteproc directory is empty", func(t *testing.T) {
 		r := &runner.Fake{
 			Commands: map[string]runner.FakeResult{
-				"ls /sys/class/remoteproc": {Output: ""},
+				"ls /sys/class/remoteproc 2>/dev/null || true": {Output: ""},
 			},
 		}
 
@@ -58,8 +58,8 @@ func TestProbeRemoteproc(t *testing.T) {
 	t.Run("returns error when reading names fails", func(t *testing.T) {
 		r := &runner.Fake{
 			Commands: map[string]runner.FakeResult{
-				"ls /sys/class/remoteproc":         {Output: "remoteproc0"},
-				"cat /sys/class/remoteproc/*/name": {Err: errors.New("permission denied")},
+				"ls /sys/class/remoteproc 2>/dev/null || true": {Output: "remoteproc0"},
+				"cat /sys/class/remoteproc/*/name":             {Err: errors.New("permission denied")},
 			},
 		}
 

--- a/internal/probe/remoteproc_test.go
+++ b/internal/probe/remoteproc_test.go
@@ -67,5 +67,4 @@ func TestProbeRemoteproc(t *testing.T) {
 
 		assert.ErrorContains(t, err, "permission denied")
 	})
-
 }

--- a/internal/probe/remoteproc_test.go
+++ b/internal/probe/remoteproc_test.go
@@ -30,17 +30,16 @@ func TestProbeRemoteproc(t *testing.T) {
 		assert.Equal(t, want, got)
 	})
 
-	t.Run("returns empty when no remoteproc directory", func(t *testing.T) {
+	t.Run("returns error when listing remoteproc directory fails", func(t *testing.T) {
 		r := &runner.Fake{
 			Commands: map[string]runner.FakeResult{
 				"ls /sys/class/remoteproc": {Output: "", Err: errors.New("no such file")},
 			},
 		}
 
-		got, err := probe.Remoteproc(context.Background(), r)
+		_, err := probe.Remoteproc(context.Background(), r)
 
-		require.NoError(t, err)
-		assert.Empty(t, got)
+		assert.ErrorContains(t, err, "no such file")
 	})
 
 	t.Run("returns empty when remoteproc directory is empty", func(t *testing.T) {
@@ -68,4 +67,5 @@ func TestProbeRemoteproc(t *testing.T) {
 
 		assert.ErrorContains(t, err, "permission denied")
 	})
+
 }


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- Propagate probe errors instead of swallowing them.
- Carry the probe error through to the report layer.
- Display the probe error instead of "no remoteproc devices found".
- Tests for error propagation and reporting.

Before:

```sh
$ ./topo health --target imx93 --timeout 200ms 
Host
----
SSH: ✅ (ssh)
Container Engine: ✅ (docker)

Target
------
Connectivity: ✅
Container Engine: ❌ (timed out)
Hardware Info: ❌ (timed out)
Subsystem Driver (remoteproc): ℹ️ (no remoteproc devices found)
```
After


```sh
$ ./topo health --target imx93 --timeout 200ms 
Host
----
SSH: ✅ (ssh)
Container Engine: ✅ (docker)

Target
------
Connectivity: ✅
Container Engine: ❌ (timed out)
Hardware Info: ❌ (timed out)
Subsystem Driver (remoteproc): ❌ (timed out)
```
