### PR TITLE
feat: skip-version-checks flag in topo health

### DIFF
--- a/cmd/topo/health.go
+++ b/cmd/topo/health.go
@@ -12,7 +12,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const acceptNewHostFlag = "accept-new-host-keys"
+const (
+	acceptNewHostFlag     = "accept-new-host-keys"
+	skipVersionChecksFlag = "skip-version-checks"
+)
 
 var healthCmd = &cobra.Command{
 	Use:   "health",
@@ -27,13 +30,19 @@ var healthCmd = &cobra.Command{
 		if err != nil {
 			panic(fmt.Sprintf("internal error: %s flag not registered: %v", acceptNewHostFlag, err))
 		}
+
+		skipVersionCheck, err := cmd.Flags().GetBool(skipVersionChecksFlag)
+		if err != nil {
+			panic(fmt.Sprintf("internal error: %s flag not registered: %v", skipVersionChecksFlag, err))
+		}
+
 		var spinner *term.Spinner
 		if outputFormat == term.Plain {
 			spinner = term.StartSpinner(os.Stderr, "Checking health...")
 		}
 
 		toPrint := templates.PrintableHealthReport{
-			Host: health.CheckHost(),
+			Host: health.CheckHost(health.CheckHostOptions{SkipVersionChecks: skipVersionCheck}),
 		}
 
 		if targetArg, ok := lookupTarget(cmd); ok {
@@ -63,5 +72,6 @@ func init() {
 	addTargetFlag(healthCmd)
 	addTimeoutFlag(healthCmd, defaultTimeout)
 	healthCmd.Flags().Bool(acceptNewHostFlag, false, "automatically trust and add new SSH host keys for the target")
+	healthCmd.Flags().Bool(skipVersionChecksFlag, false, "skip version checks for dependencies")
 	rootCmd.AddCommand(healthCmd)
 }

--- a/cmd/topo/health.go
+++ b/cmd/topo/health.go
@@ -17,6 +17,21 @@ const (
 	skipVersionChecksFlag = "skip-version-checks"
 )
 
+const skipVersionChecksEnvVar = "TOPO_SKIP_VERSION_CHECKS"
+
+func resolveSkipVersionChecks(cmd *cobra.Command) bool {
+	skipVersionCheck, err := cmd.Flags().GetBool(skipVersionChecksFlag)
+	if err != nil {
+		panic(fmt.Sprintf("internal error: %s flag not registered: %v", skipVersionChecksFlag, err))
+	}
+
+	if !skipVersionCheck {
+		skipVersionCheck = os.Getenv(skipVersionChecksEnvVar) != ""
+	}
+
+	return skipVersionCheck
+}
+
 var healthCmd = &cobra.Command{
 	Use:   "health",
 	Short: "Check the target host environment",
@@ -31,10 +46,7 @@ var healthCmd = &cobra.Command{
 			panic(fmt.Sprintf("internal error: %s flag not registered: %v", acceptNewHostFlag, err))
 		}
 
-		skipVersionCheck, err := cmd.Flags().GetBool(skipVersionChecksFlag)
-		if err != nil {
-			panic(fmt.Sprintf("internal error: %s flag not registered: %v", skipVersionChecksFlag, err))
-		}
+		skipVersionCheck := resolveSkipVersionChecks(cmd)
 
 		var spinner *term.Spinner
 		if outputFormat == term.Plain {
@@ -72,6 +84,6 @@ func init() {
 	addTargetFlag(healthCmd)
 	addTimeoutFlag(healthCmd, defaultTimeout)
 	healthCmd.Flags().Bool(acceptNewHostFlag, false, "automatically trust and add new SSH host keys for the target")
-	healthCmd.Flags().Bool(skipVersionChecksFlag, false, "skip version checks for dependencies")
+	healthCmd.Flags().Bool(skipVersionChecksFlag, false, fmt.Sprintf("skip version checks for dependencies (can also be set via %s env var)", skipVersionChecksEnvVar))
 	rootCmd.AddCommand(healthCmd)
 }

--- a/cmd/topo/health.go
+++ b/cmd/topo/health.go
@@ -19,19 +19,6 @@ const (
 
 const skipVersionChecksEnvVar = "TOPO_SKIP_VERSION_CHECKS"
 
-func resolveSkipVersionChecks(cmd *cobra.Command) bool {
-	skipVersionCheck, err := cmd.Flags().GetBool(skipVersionChecksFlag)
-	if err != nil {
-		panic(fmt.Sprintf("internal error: %s flag not registered: %v", skipVersionChecksFlag, err))
-	}
-
-	if !skipVersionCheck {
-		skipVersionCheck = os.Getenv(skipVersionChecksEnvVar) != ""
-	}
-
-	return skipVersionCheck
-}
-
 var healthCmd = &cobra.Command{
 	Use:   "health",
 	Short: "Check the target host environment",
@@ -86,4 +73,17 @@ func init() {
 	healthCmd.Flags().Bool(acceptNewHostFlag, false, "automatically trust and add new SSH host keys for the target")
 	healthCmd.Flags().Bool(skipVersionChecksFlag, false, fmt.Sprintf("skip version checks for dependencies (can also be set via %s env var)", skipVersionChecksEnvVar))
 	rootCmd.AddCommand(healthCmd)
+}
+
+func resolveSkipVersionChecks(cmd *cobra.Command) bool {
+	skipVersionCheck, err := cmd.Flags().GetBool(skipVersionChecksFlag)
+	if err != nil {
+		panic(fmt.Sprintf("internal error: %s flag not registered: %v", skipVersionChecksFlag, err))
+	}
+
+	if !skipVersionCheck {
+		skipVersionCheck = os.Getenv(skipVersionChecksEnvVar) != ""
+	}
+
+	return skipVersionCheck
 }

--- a/internal/health/check.go
+++ b/internal/health/check.go
@@ -68,7 +68,7 @@ func (v VersionMatches) Run(ctx context.Context, _ runner.Runner, _ Dependency) 
 	return v.Fix, InfoError{Err: fmt.Errorf("out of date - current: %s, latest version: %s", v.CurrentVersion, latest)}
 }
 
-func FilterVersionChecks(deps []Dependency) []Dependency {
+func RemoveVersionChecks(deps []Dependency) []Dependency {
 	deps = slices.Clone(deps)
 	for i, dep := range deps {
 		deps[i].Checks = slices.DeleteFunc(dep.Checks, func(c Check) bool {

--- a/internal/health/check.go
+++ b/internal/health/check.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/arm/topo/internal/output/logger"
 	"github.com/arm/topo/internal/runner"
@@ -65,4 +66,15 @@ func (v VersionMatches) Run(ctx context.Context, _ runner.Runner, _ Dependency) 
 	}
 
 	return v.Fix, InfoError{Err: fmt.Errorf("out of date - current: %s, latest version: %s", v.CurrentVersion, latest)}
+}
+
+func FilterVersionChecks(deps []Dependency) []Dependency {
+	deps = slices.Clone(deps)
+	for i, dep := range deps {
+		deps[i].Checks = slices.DeleteFunc(dep.Checks, func(c Check) bool {
+			_, ok := c.(VersionMatches)
+			return ok
+		})
+	}
+	return deps
 }

--- a/internal/health/check_test.go
+++ b/internal/health/check_test.go
@@ -27,6 +27,21 @@ func TestBinaryExists(t *testing.T) {
 	})
 }
 
+func TestFilterVersionChecks(t *testing.T) {
+	t.Run("removes checks of type VersionMatches", func(t *testing.T) {
+		dep := health.Dependency{
+			Binary: "mixed",
+			Label:  "Mixed",
+			Checks: []health.Check{health.BinaryExists{}, health.VersionMatches{}},
+		}
+
+		got := health.FilterVersionChecks([]health.Dependency{dep})
+
+		assert.Len(t, got, 1)
+		assert.Equal(t, got[0].Checks, []health.Check{health.BinaryExists{}})
+	})
+}
+
 func TestVersionMatches(t *testing.T) {
 	ctx := context.Background()
 	dep := health.Dependency{}

--- a/internal/health/check_test.go
+++ b/internal/health/check_test.go
@@ -27,7 +27,7 @@ func TestBinaryExists(t *testing.T) {
 	})
 }
 
-func TestFilterVersionChecks(t *testing.T) {
+func TestRemoveVersionChecks(t *testing.T) {
 	t.Run("removes checks of type VersionMatches", func(t *testing.T) {
 		dep := health.Dependency{
 			Binary: "mixed",
@@ -35,7 +35,7 @@ func TestFilterVersionChecks(t *testing.T) {
 			Checks: []health.Check{health.BinaryExists{}, health.VersionMatches{}},
 		}
 
-		got := health.FilterVersionChecks([]health.Dependency{dep})
+		got := health.RemoveVersionChecks([]health.Dependency{dep})
 
 		assert.Len(t, got, 1)
 		assert.Equal(t, got[0].Checks, []health.Check{health.BinaryExists{}})

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -70,7 +70,7 @@ func CheckHost(opts CheckHostOptions) HostReport {
 	r := runner.NewLocal()
 	deps := HostRequiredDependencies
 	if opts.SkipVersionChecks {
-		deps = FilterVersionChecks(deps)
+		deps = RemoveVersionChecks(deps)
 	}
 	dependencyStatuses := PerformChecks(context.Background(), deps, r)
 	return GenerateHostReport(dependencyStatuses)

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -62,9 +62,17 @@ func (r TargetReport) MarshalJSON() ([]byte, error) {
 	return json.Marshal(Alias(r))
 }
 
-func CheckHost() HostReport {
+type CheckHostOptions struct {
+	SkipVersionChecks bool
+}
+
+func CheckHost(opts CheckHostOptions) HostReport {
 	r := runner.NewLocal()
-	dependencyStatuses := PerformChecks(context.Background(), HostRequiredDependencies, r)
+	deps := HostRequiredDependencies
+	if opts.SkipVersionChecks {
+		deps = FilterVersionChecks(deps)
+	}
+	dependencyStatuses := PerformChecks(context.Background(), deps, r)
 	return GenerateHostReport(dependencyStatuses)
 }
 


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- Adds a `--skip-version-checks` to `topo health` for use by consumers that don't want to hit artifactory every time health is checked
  - Opted to pluralise this in case we add other version checks to `topo health` in the future. Maybe too pre-emptive?
- Adds util to filter all version checks from a list of dependencies that is used when this flag is set :)

Importantly I opted not to filter out dependencies whose only check is of type `VersionMatches` to keep the list of dependencies consistent.
