### PR TITLE
feat: upgrade command

### DIFF
--- a/cmd/topo/upgrade.go
+++ b/cmd/topo/upgrade.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"runtime"
+	"os"
 
 	"github.com/arm/topo/internal/output/term"
 	"github.com/arm/topo/internal/upgrade"
@@ -19,40 +19,26 @@ var upgradeCmd = &cobra.Command{
 		cmd.SilenceUsage = true
 		outputFormat := resolveOutput(cmd)
 
+		var spinner *term.Spinner
+		if outputFormat == term.Plain {
+			spinner = term.StartSpinner(os.Stderr, "Upgrading topo...")
+		}
+
 		ctx, cancel := contextWithTimeout(cmd)
 		defer cancel()
 
-		current := version.Version
-		var latest string
-		err := term.WithSpinner(outputFormat, "Checking for updates...", func() (err error) {
-			latest, err = version.FetchLatest(ctx, version.ArtifactoryBaseURL)
-			return err
-		})
+		newVersion, err := upgrade.Upgrade(ctx, spinner)
+		spinner.Stop()
 		if err != nil {
 			return err
 		}
 
-		if current == latest || current == version.Dev {
-			fmt.Printf("topo %s is already up to date\n", current)
+		if newVersion == version.Version {
+			fmt.Printf("Already running the latest version of topo (%s)\n", newVersion)
 			return nil
 		}
 
-		fmt.Printf("Upgrading topo from %s to %s\n", current, latest)
-
-		binPath, err := upgrade.CurrentBinaryPath()
-		if err != nil {
-			return fmt.Errorf("failed to determine current binary path: %w", err)
-		}
-
-		err = term.WithSpinner(outputFormat, fmt.Sprintf("Downloading topo %s...", latest), func() error {
-			downloadURL := upgrade.ArtifactoryDownloadURL(runtime.GOOS, runtime.GOARCH, latest)
-			return upgrade.Install(ctx, binPath, downloadURL)
-		})
-		if err != nil {
-			return err
-		}
-
-		fmt.Printf("Upgraded topo to %s\n", latest)
+		fmt.Printf("Upgraded topo to %s\n", newVersion)
 		return nil
 	},
 }

--- a/cmd/topo/upgrade.go
+++ b/cmd/topo/upgrade.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/arm/topo/internal/output/term"
 	"github.com/arm/topo/internal/upgrade"
@@ -24,7 +23,7 @@ var upgradeCmd = &cobra.Command{
 
 		current := version.Version
 		var latest string
-		err := withSpinner(outputFormat, "Checking for updates...", func() (err error) {
+		err := term.WithSpinner(outputFormat, "Checking for updates...", func() (err error) {
 			latest, err = version.FetchLatest(ctx, version.ArtifactoryBaseURL)
 			return err
 		})
@@ -32,7 +31,7 @@ var upgradeCmd = &cobra.Command{
 			return err
 		}
 
-		if current == latest || current == version.Placeholder {
+		if current == latest || current == version.Dev {
 			fmt.Printf("topo %s is already up to date\n", current)
 			return nil
 		}
@@ -44,7 +43,7 @@ var upgradeCmd = &cobra.Command{
 			return fmt.Errorf("failed to determine current binary path: %w", err)
 		}
 
-		err = withSpinner(outputFormat, fmt.Sprintf("Downloading topo %s...", latest), func() error {
+		err = term.WithSpinner(outputFormat, fmt.Sprintf("Downloading topo %s...", latest), func() error {
 			downloadURL := upgrade.ArtifactoryDownloadURL(latest)
 			return upgrade.Install(ctx, binPath, downloadURL)
 		})
@@ -55,14 +54,6 @@ var upgradeCmd = &cobra.Command{
 		fmt.Printf("Upgraded topo to %s\n", latest)
 		return nil
 	},
-}
-
-func withSpinner(outputFormat term.Format, msg string, fn func() error) error {
-	if outputFormat == term.Plain {
-		s := term.StartSpinner(os.Stderr, msg)
-		defer s.Stop()
-	}
-	return fn()
 }
 
 func init() {

--- a/cmd/topo/upgrade.go
+++ b/cmd/topo/upgrade.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/arm/topo/internal/output/term"
+	"github.com/arm/topo/internal/upgrade"
+	"github.com/arm/topo/internal/version"
+	"github.com/spf13/cobra"
+)
+
+var upgradeCmd = &cobra.Command{
+	Use:   "upgrade",
+	Short: "Upgrade topo to the latest version",
+	Long:  "Download and install the latest version of topo from Artifactory, replacing the current binary in place.",
+	Args:  cobra.ExactArgs(0),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+		outputFormat := resolveOutput(cmd)
+
+		ctx, cancel := contextWithTimeout(cmd)
+		defer cancel()
+
+		current := version.Version
+		var latest string
+		err := withSpinner(outputFormat, "Checking for updates...", func() (err error) {
+			latest, err = version.FetchLatest(ctx, version.ArtifactoryBaseURL)
+			return err
+		})
+		if err != nil {
+			return err
+		}
+
+		if current == latest || current == version.Placeholder {
+			fmt.Printf("topo %s is already up to date\n", current)
+			return nil
+		}
+
+		fmt.Printf("Upgrading topo from %s to %s\n", current, latest)
+
+		binPath, err := upgrade.CurrentBinaryPath()
+		if err != nil {
+			return fmt.Errorf("failed to determine current binary path: %w", err)
+		}
+
+		err = withSpinner(outputFormat, fmt.Sprintf("Downloading topo %s...", latest), func() error {
+			downloadURL := upgrade.ArtifactoryDownloadURL(latest)
+			return upgrade.Install(ctx, binPath, downloadURL)
+		})
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("Upgraded topo to %s\n", latest)
+		return nil
+	},
+}
+
+func withSpinner(outputFormat term.Format, msg string, fn func() error) error {
+	if outputFormat == term.Plain {
+		s := term.StartSpinner(os.Stderr, msg)
+		defer s.Stop()
+	}
+	return fn()
+}
+
+func init() {
+	addTimeoutFlag(upgradeCmd, 0)
+	rootCmd.AddCommand(upgradeCmd)
+}

--- a/cmd/topo/upgrade.go
+++ b/cmd/topo/upgrade.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"runtime"
 
 	"github.com/arm/topo/internal/output/term"
 	"github.com/arm/topo/internal/upgrade"
@@ -44,7 +45,7 @@ var upgradeCmd = &cobra.Command{
 		}
 
 		err = term.WithSpinner(outputFormat, fmt.Sprintf("Downloading topo %s...", latest), func() error {
-			downloadURL := upgrade.ArtifactoryDownloadURL(latest)
+			downloadURL := upgrade.ArtifactoryDownloadURL(runtime.GOOS, runtime.GOARCH, latest)
 			return upgrade.Install(ctx, binPath, downloadURL)
 		})
 		if err != nil {

--- a/internal/health/dependencies.go
+++ b/internal/health/dependencies.go
@@ -2,7 +2,6 @@ package health
 
 import (
 	"context"
-	"runtime"
 
 	"github.com/arm/topo/internal/runner"
 	"github.com/arm/topo/internal/version"
@@ -52,7 +51,7 @@ var HostRequiredDependencies = []Dependency{
 				return version.FetchLatest(ctx, version.ArtifactoryBaseURL)
 			},
 			CurrentVersion: version.Version,
-			Fix:            getTopoInstallCommand(),
+			Fix:            "run `topo upgrade`",
 		}},
 	},
 	{
@@ -182,12 +181,4 @@ func hasAnyInstalledPrerequisite(required []SoftwareDependency, installed map[So
 		}
 	}
 	return false
-}
-
-func getTopoInstallCommand() string {
-	if runtime.GOOS == "windows" {
-		return "run `irm https://raw.githubusercontent.com/arm/topo/refs/heads/main/scripts/install.ps1 | iex`"
-	}
-
-	return "run `curl -fsSL https://raw.githubusercontent.com/arm/topo/refs/heads/main/scripts/install.sh | sh`"
 }

--- a/internal/health/dependencies.go
+++ b/internal/health/dependencies.go
@@ -45,7 +45,7 @@ var HostRequiredDependencies = []Dependency{
 		Label:  "Topo",
 		Checks: []Check{VersionMatches{
 			FetchLatest: func(ctx context.Context) (string, error) {
-				if version.Version == "dev" {
+				if version.Version == version.Placeholder {
 					return version.Version, nil
 				}
 

--- a/internal/health/dependencies.go
+++ b/internal/health/dependencies.go
@@ -44,7 +44,7 @@ var HostRequiredDependencies = []Dependency{
 		Label:  "Topo",
 		Checks: []Check{VersionMatches{
 			FetchLatest: func(ctx context.Context) (string, error) {
-				if version.Version == version.Placeholder {
+				if version.Version == version.Dev {
 					return version.Version, nil
 				}
 

--- a/internal/output/term/spinner.go
+++ b/internal/output/term/spinner.go
@@ -3,6 +3,7 @@ package term
 import (
 	"fmt"
 	"io"
+	"os"
 	"time"
 )
 
@@ -51,4 +52,12 @@ func (s *Spinner) Stop() {
 		close(s.stop)
 	}
 	<-s.done
+}
+
+func WithSpinner(outputFormat Format, msg string, fn func() error) error {
+	if outputFormat == Plain {
+		s := StartSpinner(os.Stderr, msg)
+		defer s.Stop()
+	}
+	return fn()
 }

--- a/internal/output/term/spinner.go
+++ b/internal/output/term/spinner.go
@@ -7,6 +7,10 @@ import (
 	"time"
 )
 
+type ProgressReporter interface {
+	Step(message string)
+}
+
 type Spinner struct {
 	stop chan struct{}
 	done chan struct{}
@@ -54,10 +58,9 @@ func (s *Spinner) Stop() {
 	<-s.done
 }
 
-func WithSpinner(outputFormat Format, msg string, fn func() error) error {
-	if outputFormat == Plain {
-		s := StartSpinner(os.Stderr, msg)
-		defer s.Stop()
+func (s *Spinner) Step(message string) {
+	if s == nil || s.stop == nil {
+		return
 	}
-	return fn()
+	_, _ = fmt.Fprintf(os.Stderr, "\r%s %s\033[K\n", "•", message)
 }

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 	"testing"
 
@@ -33,9 +34,9 @@ func RequireLinuxDockerEngine(t testing.TB) {
 	}
 }
 
-func RequireOS(t testing.TB, os string) {
+func RequireOS(t testing.TB, os ...string) {
 	t.Helper()
-	if runtime.GOOS != os {
+	if !slices.Contains(os, runtime.GOOS) {
 		t.Skipf("skipping test that requires %s", os)
 	}
 }

--- a/internal/upgrade/upgrade.go
+++ b/internal/upgrade/upgrade.go
@@ -148,6 +148,9 @@ func binaryName(name string) string {
 func removeTemporaryFile(path string) {
 	err := os.Remove(path)
 	if err != nil {
-		logger.Warn(fmt.Sprintf("failed to remove temp file %s: %v", path, err))
+		if os.IsNotExist(err) {
+			return
+		}
+		logger.Warn(fmt.Sprintf("failed to remove temporary file %s: %v", path, err))
 	}
 }

--- a/internal/upgrade/upgrade.go
+++ b/internal/upgrade/upgrade.go
@@ -17,27 +17,19 @@ import (
 
 var topoBinaryName = binaryName("topo")
 
-func Install(ctx context.Context, binPath string, downloadURL string) error {
+func Install(ctx context.Context, currentBin string, downloadURL string) error {
 	archiveData, err := downloadArchive(ctx, downloadURL)
 	if err != nil {
 		return err
 	}
 
-	tmpPath, err := extractBinary(ctx, archiveData, filepath.Dir(binPath))
+	newBin, err := extractBinary(ctx, archiveData, filepath.Dir(currentBin))
 	if err != nil {
 		return err
 	}
-	defer removeTemporaryFile(tmpPath)
+	defer removeTemporaryFile(newBin)
 
-	if err := os.Rename(tmpPath, binPath); err != nil {
-		return fmt.Errorf("failed to replace binary: %w", err)
-	}
-
-	if err := os.Chmod(binPath, 0o755); err != nil {
-		return fmt.Errorf("failed to set executable permissions: %w", err)
-	}
-
-	return nil
+	return moveBinary(newBin, currentBin)
 }
 
 func CurrentBinaryPath() (string, error) {
@@ -143,6 +135,35 @@ func binaryName(name string) string {
 		return name + ".exe"
 	}
 	return name
+}
+
+func moveBinary(src, dst string) error {
+	if runtime.GOOS == "windows" {
+		// windows locks running executables, so we can't rename directly over dst
+		old := dst + ".old"
+		if err := os.Rename(dst, old); err != nil {
+			return fmt.Errorf("failed to rename current binary: %w", err)
+		}
+
+		if err := os.Rename(src, dst); err != nil {
+			restoreErr := os.Rename(old, dst)
+			if restoreErr != nil {
+				logger.Error(fmt.Sprintf("failed to restore original binary after failed upgrade: %v", restoreErr))
+			}
+			return fmt.Errorf("failed to replace binary: %w", err)
+		}
+		return nil
+	}
+
+	if err := os.Rename(src, dst); err != nil {
+		return fmt.Errorf("failed to replace binary: %w", err)
+	}
+
+	if err := os.Chmod(dst, 0o755); err != nil {
+		return fmt.Errorf("failed to set executable permissions: %w", err)
+	}
+
+	return nil
 }
 
 func removeTemporaryFile(path string) {

--- a/internal/upgrade/upgrade.go
+++ b/internal/upgrade/upgrade.go
@@ -15,8 +15,6 @@ import (
 	"github.com/mholt/archives"
 )
 
-var topoBinaryName = binaryName("topo")
-
 func Install(ctx context.Context, currentBin string, downloadURL string) error {
 	archiveData, err := downloadArchive(ctx, downloadURL)
 	if err != nil {
@@ -97,7 +95,7 @@ func extractBinary(ctx context.Context, archiveData []byte, destDir string) (str
 	var tmpPath string
 
 	err = extractor.Extract(ctx, stream, func(ctx context.Context, fileInfo archives.FileInfo) error {
-		if filepath.Base(fileInfo.Name()) != topoBinaryName {
+		if filepath.Base(fileInfo.Name()) != binaryName("topo") {
 			return nil
 		}
 

--- a/internal/upgrade/upgrade.go
+++ b/internal/upgrade/upgrade.go
@@ -25,7 +25,7 @@ func Install(ctx context.Context, currentBin string, downloadURL string) error {
 	if err != nil {
 		return err
 	}
-	defer removeTemporaryFile(newBin)
+	defer ensureFileRemoved(newBin)
 
 	return moveBinary(newBin, currentBin)
 }
@@ -127,7 +127,7 @@ func extractBinary(ctx context.Context, archiveData []byte, destDir string) (str
 		return tmp.Close()
 	})
 	if err != nil {
-		removeTemporaryFile(tmpPath)
+		ensureFileRemoved(tmpPath)
 		return "", fmt.Errorf("failed to read archive: %w", err)
 	}
 
@@ -136,7 +136,6 @@ func extractBinary(ctx context.Context, archiveData []byte, destDir string) (str
 
 func moveBinary(src, dst string) error {
 	if runtime.GOOS == "windows" {
-		// windows locks running executables, so we can't rename directly over dst
 		old := dst + ".old"
 		if err := os.Rename(dst, old); err != nil {
 			return fmt.Errorf("failed to rename current binary: %w", err)
@@ -163,7 +162,7 @@ func moveBinary(src, dst string) error {
 	return nil
 }
 
-func removeTemporaryFile(path string) {
+func ensureFileRemoved(path string) {
 	err := os.Remove(path)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/internal/upgrade/upgrade.go
+++ b/internal/upgrade/upgrade.go
@@ -11,9 +11,41 @@ import (
 	"runtime"
 
 	"github.com/arm/topo/internal/output/logger"
+	"github.com/arm/topo/internal/output/term"
 	"github.com/arm/topo/internal/version"
 	"github.com/mholt/archives"
 )
+
+func Upgrade(ctx context.Context, reporter term.ProgressReporter) (string, error) {
+	if reporter != nil {
+		reporter.Step("Checking for latest version...")
+	}
+	latest, err := version.FetchLatest(ctx, version.ArtifactoryBaseURL)
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch latest version: %w", err)
+	}
+
+	if version.Version == version.Dev || latest == version.Version {
+		return version.Version, nil
+	}
+
+	binPath, err := CurrentBinaryPath()
+	if err != nil {
+		return "", fmt.Errorf("failed to determine current binary path: %w", err)
+	}
+
+	downloadURL := ArtifactoryDownloadURL(runtime.GOOS, runtime.GOARCH, latest)
+
+	if reporter != nil {
+		reporter.Step(fmt.Sprintf("Installing topo version %s...", latest))
+	}
+	err = Install(ctx, binPath, downloadURL)
+	if err != nil {
+		return "", fmt.Errorf("failed to install new version: %w", err)
+	}
+
+	return latest, nil
+}
 
 func Install(ctx context.Context, currentBin string, downloadURL string) error {
 	archiveData, err := downloadArchive(ctx, downloadURL)

--- a/internal/upgrade/upgrade.go
+++ b/internal/upgrade/upgrade.go
@@ -42,18 +42,18 @@ func CurrentBinaryPath() (string, error) {
 	return binPath, nil
 }
 
-func ArtifactoryDownloadURL(targetVersion string) string {
+func ArtifactoryDownloadURL(os string, arch string, targetVersion string) string {
 	ext := "tar.gz"
-	if runtime.GOOS == "windows" {
+	if os == "windows" {
 		ext = "zip"
 	}
 
-	urlOS := runtime.GOOS
-	if runtime.GOOS == "darwin" {
+	urlOS := os
+	if os == "darwin" {
 		urlOS = "macos"
 	}
 
-	archiveName := fmt.Sprintf("topo_%s_%s.%s", runtime.GOOS, runtime.GOARCH, ext)
+	archiveName := fmt.Sprintf("topo_%s_%s.%s", os, arch, ext)
 	return fmt.Sprintf("%s/v%s/%s/%s", version.ArtifactoryBaseURL, targetVersion, urlOS, archiveName)
 }
 

--- a/internal/upgrade/upgrade.go
+++ b/internal/upgrade/upgrade.go
@@ -1,6 +1,7 @@
 package upgrade
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -9,6 +10,7 @@ import (
 	"path/filepath"
 	"runtime"
 
+	"github.com/arm/topo/internal/output/logger"
 	"github.com/arm/topo/internal/version"
 	"github.com/mholt/archives"
 )
@@ -16,19 +18,26 @@ import (
 var topoBinaryName = binaryName("topo")
 
 func Install(ctx context.Context, binPath string, downloadURL string) error {
-	archivePath, err := downloadArchive(ctx, downloadURL)
+	archiveData, err := downloadArchive(ctx, downloadURL)
 	if err != nil {
 		return err
 	}
-	defer os.Remove(archivePath) //nolint:errcheck
 
-	newBinaryPath, err := extractBinary(ctx, archivePath)
+	tmpPath, err := extractBinary(ctx, archiveData, filepath.Dir(binPath))
 	if err != nil {
 		return err
 	}
-	defer os.Remove(newBinaryPath) //nolint:errcheck
+	defer removeTemporaryFile(tmpPath)
 
-	return moveBinary(newBinaryPath, binPath)
+	if err := os.Rename(tmpPath, binPath); err != nil {
+		return fmt.Errorf("failed to replace binary: %w", err)
+	}
+
+	if err := os.Chmod(binPath, 0o755); err != nil {
+		return fmt.Errorf("failed to set executable permissions: %w", err)
+	}
+
+	return nil
 }
 
 func CurrentBinaryPath() (string, error) {
@@ -58,49 +67,32 @@ func ArtifactoryDownloadURL(targetVersion string) string {
 	return fmt.Sprintf("%s/v%s/%s/%s", version.ArtifactoryBaseURL, targetVersion, urlOS, archiveName)
 }
 
-func downloadArchive(ctx context.Context, url string) (string, error) {
+func downloadArchive(ctx context.Context, url string) ([]byte, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
-		return "", fmt.Errorf("failed to create download request: %w", err)
+		return nil, fmt.Errorf("failed to create download request: %w", err)
 	}
 	// #nosec G107 -- URL is constructed from a hardcoded, trusted base URL
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return "", fmt.Errorf("failed to download archive: %w", err)
+		return nil, fmt.Errorf("failed to download archive: %w", err)
 	}
 	defer resp.Body.Close() //nolint:errcheck
 
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("failed to download archive from %s: HTTP %d", url, resp.StatusCode)
+		return nil, fmt.Errorf("failed to download archive from %s: HTTP %d", url, resp.StatusCode)
 	}
 
-	archive, err := os.CreateTemp("", "topo-archive-*")
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return "", fmt.Errorf("failed to create temp file: %w", err)
-	}
-	archivePath := archive.Name()
-
-	if _, err := io.Copy(archive, resp.Body); err != nil {
-		_ = archive.Close()
-		_ = os.Remove(archivePath)
-		return "", fmt.Errorf("saving archive: %w", err)
-	}
-	if err := archive.Close(); err != nil {
-		_ = os.Remove(archivePath)
-		return "", fmt.Errorf("flushing archive: %w", err)
+		return nil, fmt.Errorf("failed to read archive: %w", err)
 	}
 
-	return archivePath, nil
+	return data, nil
 }
 
-func extractBinary(ctx context.Context, archivePath string) (string, error) {
-	f, err := os.Open(archivePath)
-	if err != nil {
-		return "", fmt.Errorf("failed to open archive: %w", err)
-	}
-	defer f.Close() //nolint:errcheck
-
-	format, stream, err := archives.Identify(ctx, archivePath, f)
+func extractBinary(ctx context.Context, archiveData []byte, destDir string) (string, error) {
+	format, stream, err := archives.Identify(ctx, "", bytes.NewReader(archiveData))
 	if err != nil {
 		return "", fmt.Errorf("failed to identify archive format: %w", err)
 	}
@@ -110,7 +102,7 @@ func extractBinary(ctx context.Context, archivePath string) (string, error) {
 		return "", fmt.Errorf("archive format does not support extraction")
 	}
 
-	var extractedPath string
+	var tmpPath string
 
 	err = extractor.Extract(ctx, stream, func(ctx context.Context, fileInfo archives.FileInfo) error {
 		if filepath.Base(fileInfo.Name()) != topoBinaryName {
@@ -123,61 +115,27 @@ func extractBinary(ctx context.Context, archivePath string) (string, error) {
 		}
 		defer rc.Close() //nolint:errcheck
 
-		tmp, err := os.CreateTemp("", binaryName("topo-new-*"))
+		// important to create the temp file in the same directory to ensure atomic rename works across filesystems
+		tmp, err := os.CreateTemp(destDir, binaryName(".topo-new-*"))
 		if err != nil {
 			return fmt.Errorf("failed to create temp file: %w", err)
 		}
-		extractedPath = tmp.Name()
+		tmpPath = tmp.Name()
 
 		// #nosec G110 -- archive from a hardcoded, trusted Artifactory URL
 		if _, err := io.Copy(tmp, rc); err != nil {
-			_ = tmp.Close()
-			_ = os.Remove(extractedPath)
-			extractedPath = ""
+			tmp.Close() //nolint:errcheck
 			return fmt.Errorf("failed to extract binary: %w", err)
 		}
 		return tmp.Close()
 	})
+
 	if err != nil {
-		if extractedPath != "" {
-			_ = os.Remove(extractedPath)
-		}
+		removeTemporaryFile(tmpPath)
 		return "", fmt.Errorf("failed to read archive: %w", err)
 	}
 
-	if extractedPath == "" {
-		return "", fmt.Errorf("failed to find %q in archive", topoBinaryName)
-	}
-
-	return extractedPath, nil
-}
-
-func moveBinary(srcPath string, dstPath string) error {
-	if runtime.GOOS == "windows" {
-		oldPath := dstPath + ".old"
-		_ = os.Remove(oldPath)
-		if err := os.Rename(dstPath, oldPath); err != nil {
-			return fmt.Errorf("failed to rename current binary: %w", err)
-		}
-		if err := os.Rename(srcPath, dstPath); err != nil {
-			_ = os.Rename(oldPath, dstPath) // attempt to restore
-			return fmt.Errorf("failed to move new binary: %w", err)
-		}
-		_ = os.Remove(oldPath)
-		return nil
-	}
-
-	err := os.Rename(srcPath, dstPath)
-	if err != nil {
-		return fmt.Errorf("failed to replace binary: %w", err)
-	}
-
-	err = os.Chmod(dstPath, 0o755)
-	if err != nil {
-		return fmt.Errorf("failed to set executable permissions: %w", err)
-	}
-
-	return nil
+	return tmpPath, nil
 }
 
 func binaryName(name string) string {
@@ -185,4 +143,11 @@ func binaryName(name string) string {
 		return name + ".exe"
 	}
 	return name
+}
+
+func removeTemporaryFile(path string) {
+	err := os.Remove(path)
+	if err != nil {
+		logger.Warn(fmt.Sprintf("failed to remove temp file %s: %v", path, err))
+	}
 }

--- a/internal/upgrade/upgrade.go
+++ b/internal/upgrade/upgrade.go
@@ -57,6 +57,13 @@ func ArtifactoryDownloadURL(targetVersion string) string {
 	return fmt.Sprintf("%s/v%s/%s/%s", version.ArtifactoryBaseURL, targetVersion, urlOS, archiveName)
 }
 
+func BinaryName(name string) string {
+	if runtime.GOOS == "windows" {
+		return name + ".exe"
+	}
+	return name
+}
+
 func downloadArchive(ctx context.Context, url string) ([]byte, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
@@ -95,7 +102,7 @@ func extractBinary(ctx context.Context, archiveData []byte, destDir string) (str
 	var tmpPath string
 
 	err = extractor.Extract(ctx, stream, func(ctx context.Context, fileInfo archives.FileInfo) error {
-		if filepath.Base(fileInfo.Name()) != binaryName("topo") {
+		if filepath.Base(fileInfo.Name()) != BinaryName("topo") {
 			return nil
 		}
 
@@ -106,7 +113,7 @@ func extractBinary(ctx context.Context, archiveData []byte, destDir string) (str
 		defer rc.Close() //nolint:errcheck
 
 		// important to create the temp file in the same directory to ensure atomic rename works across filesystems
-		tmp, err := os.CreateTemp(destDir, binaryName(".topo-new-*"))
+		tmp, err := os.CreateTemp(destDir, BinaryName(".topo-new-*"))
 		if err != nil {
 			return fmt.Errorf("failed to create temp file: %w", err)
 		}
@@ -126,13 +133,6 @@ func extractBinary(ctx context.Context, archiveData []byte, destDir string) (str
 	}
 
 	return tmpPath, nil
-}
-
-func binaryName(name string) string {
-	if runtime.GOOS == "windows" {
-		return name + ".exe"
-	}
-	return name
 }
 
 func moveBinary(src, dst string) error {

--- a/internal/upgrade/upgrade.go
+++ b/internal/upgrade/upgrade.go
@@ -69,7 +69,7 @@ func downloadArchive(ctx context.Context, url string) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create download request: %w", err)
 	}
-	// #nosec G107 -- URL is constructed from a hardcoded, trusted base URL
+	// #nosec G704 -- request to a hardcoded, trusted URL
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to download archive: %w", err)
@@ -126,7 +126,6 @@ func extractBinary(ctx context.Context, archiveData []byte, destDir string) (str
 		}
 		return tmp.Close()
 	})
-
 	if err != nil {
 		removeTemporaryFile(tmpPath)
 		return "", fmt.Errorf("failed to read archive: %w", err)

--- a/internal/upgrade/upgrade.go
+++ b/internal/upgrade/upgrade.go
@@ -1,0 +1,174 @@
+package upgrade
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"github.com/arm/topo/internal/version"
+	"github.com/mholt/archives"
+)
+
+var topoBinaryName = binaryName("topo")
+
+func Install(ctx context.Context, binPath string, downloadURL string) error {
+	archivePath, err := downloadArchive(ctx, downloadURL)
+	if err != nil {
+		return err
+	}
+	defer os.Remove(archivePath) //nolint:errcheck
+
+	newBinaryPath, err := extractBinary(ctx, archivePath)
+	if err != nil {
+		return err
+	}
+	defer os.Remove(newBinaryPath) //nolint:errcheck
+
+	return moveBinary(newBinaryPath, binPath)
+}
+
+func CurrentBinaryPath() (string, error) {
+	binPath, err := os.Executable()
+	if err != nil {
+		return "", fmt.Errorf("failed to determine current executable path: %w", err)
+	}
+	binPath, err = filepath.EvalSymlinks(binPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve executable path: %w", err)
+	}
+	return binPath, nil
+}
+
+func ArtifactoryDownloadURL(targetVersion string) string {
+	archiveName := fmt.Sprintf("topo_%s_%s.zip", runtime.GOOS, runtime.GOARCH)
+
+	urlOS := runtime.GOOS
+	if runtime.GOOS == "darwin" {
+		urlOS = "macos"
+	}
+
+	return fmt.Sprintf("%s/v%s/%s/%s", version.ArtifactoryBaseURL, targetVersion, urlOS, archiveName)
+}
+
+func downloadArchive(ctx context.Context, url string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to create download request: %w", err)
+	}
+	// #nosec G107 -- URL is constructed from a hardcoded, trusted base URL
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to download archive: %w", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("failed to download archive: HTTP %d", resp.StatusCode)
+	}
+
+	archive, err := os.CreateTemp("", "topo-archive-*")
+	if err != nil {
+		return "", fmt.Errorf("failed to create temp file: %w", err)
+	}
+	archivePath := archive.Name()
+
+	if _, err := io.Copy(archive, resp.Body); err != nil {
+		_ = archive.Close()
+		_ = os.Remove(archivePath)
+		return "", fmt.Errorf("saving archive: %w", err)
+	}
+	if err := archive.Close(); err != nil {
+		_ = os.Remove(archivePath)
+		return "", fmt.Errorf("flushing archive: %w", err)
+	}
+
+	return archivePath, nil
+}
+
+func extractBinary(ctx context.Context, archivePath string) (string, error) {
+	f, err := os.Open(archivePath)
+	if err != nil {
+		return "", fmt.Errorf("failed to open archive: %w", err)
+	}
+	defer f.Close() //nolint:errcheck
+
+	format, stream, err := archives.Identify(ctx, archivePath, f)
+	if err != nil {
+		return "", fmt.Errorf("failed to identify archive format: %w", err)
+	}
+
+	extractor, ok := format.(archives.Extractor)
+	if !ok {
+		return "", fmt.Errorf("archive format does not support extraction")
+	}
+
+	var extractedPath string
+
+	err = extractor.Extract(ctx, stream, func(ctx context.Context, fileInfo archives.FileInfo) error {
+		if filepath.Base(fileInfo.Name()) != topoBinaryName {
+			return nil
+		}
+
+		rc, err := fileInfo.Open()
+		if err != nil {
+			return fmt.Errorf("failed to open %s in archive: %w", fileInfo.Name(), err)
+		}
+		defer rc.Close() //nolint:errcheck
+
+		tmp, err := os.CreateTemp("", binaryName("topo-new-*"))
+		if err != nil {
+			return fmt.Errorf("failed to create temp file: %w", err)
+		}
+		extractedPath = tmp.Name()
+
+		// #nosec G110 -- archive from a hardcoded, trusted Artifactory URL
+		if _, err := io.Copy(tmp, rc); err != nil {
+			_ = tmp.Close()
+			_ = os.Remove(extractedPath)
+			extractedPath = ""
+			return fmt.Errorf("failed to extract binary: %w", err)
+		}
+		return tmp.Close()
+	})
+	if err != nil {
+		if extractedPath != "" {
+			_ = os.Remove(extractedPath)
+		}
+		return "", fmt.Errorf("failed to read archive: %w", err)
+	}
+
+	if extractedPath == "" {
+		return "", fmt.Errorf("failed to find %q in archive", topoBinaryName)
+	}
+
+	return extractedPath, nil
+}
+
+func moveBinary(srcPath string, dstPath string) error {
+	if runtime.GOOS == "windows" {
+		oldPath := dstPath + ".old"
+		_ = os.Remove(oldPath)
+		if err := os.Rename(dstPath, oldPath); err != nil {
+			return fmt.Errorf("failed to rename current binary: %w", err)
+		}
+		if err := os.Rename(srcPath, dstPath); err != nil {
+			_ = os.Rename(oldPath, dstPath) // attempt to restore
+			return fmt.Errorf("failed to move new binary: %w", err)
+		}
+		_ = os.Remove(oldPath)
+		return nil
+	}
+
+	return os.Rename(srcPath, dstPath)
+}
+
+func binaryName(name string) string {
+	if runtime.GOOS == "windows" {
+		return name + ".exe"
+	}
+	return name
+}

--- a/internal/upgrade/upgrade.go
+++ b/internal/upgrade/upgrade.go
@@ -44,13 +44,17 @@ func CurrentBinaryPath() (string, error) {
 }
 
 func ArtifactoryDownloadURL(targetVersion string) string {
-	archiveName := fmt.Sprintf("topo_%s_%s.zip", runtime.GOOS, runtime.GOARCH)
+	ext := "tar.gz"
+	if runtime.GOOS == "windows" {
+		ext = "zip"
+	}
 
 	urlOS := runtime.GOOS
 	if runtime.GOOS == "darwin" {
 		urlOS = "macos"
 	}
 
+	archiveName := fmt.Sprintf("topo_%s_%s.%s", runtime.GOOS, runtime.GOARCH, ext)
 	return fmt.Sprintf("%s/v%s/%s/%s", version.ArtifactoryBaseURL, targetVersion, urlOS, archiveName)
 }
 
@@ -67,7 +71,7 @@ func downloadArchive(ctx context.Context, url string) (string, error) {
 	defer resp.Body.Close() //nolint:errcheck
 
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("failed to download archive: HTTP %d", resp.StatusCode)
+		return "", fmt.Errorf("failed to download archive from %s: HTTP %d", url, resp.StatusCode)
 	}
 
 	archive, err := os.CreateTemp("", "topo-archive-*")
@@ -163,7 +167,17 @@ func moveBinary(srcPath string, dstPath string) error {
 		return nil
 	}
 
-	return os.Rename(srcPath, dstPath)
+	err := os.Rename(srcPath, dstPath)
+	if err != nil {
+		return fmt.Errorf("failed to replace binary: %w", err)
+	}
+
+	err = os.Chmod(dstPath, 0o755)
+	if err != nil {
+		return fmt.Errorf("failed to set executable permissions: %w", err)
+	}
+
+	return nil
 }
 
 func binaryName(name string) string {

--- a/internal/upgrade/upgrade_test.go
+++ b/internal/upgrade/upgrade_test.go
@@ -38,9 +38,12 @@ func makeTarGz(t *testing.T, files map[string][]byte) []byte {
 	return buf.Bytes()
 }
 
-func createDstFile(t *testing.T) string {
+func createFakeBinary(t *testing.T) string {
 	t.Helper()
-	return filepath.Join(t.TempDir(), upgrade.BinaryName("topo"))
+	path := filepath.Join(t.TempDir(), upgrade.BinaryName("topo"))
+	err := os.WriteFile(path, []byte("old binary"), 0o644)
+	require.NoError(t, err)
+	return path
 }
 
 func serveBytes(t *testing.T, data []byte) *httptest.Server {
@@ -63,7 +66,7 @@ func TestInstall(t *testing.T) {
 
 	t.Run("writes binary to destination", func(t *testing.T) {
 		srv := serveBytes(t, validArchive)
-		dst := createDstFile(t)
+		dst := createFakeBinary(t)
 
 		err := upgrade.Install(context.Background(), dst, srv.URL)
 
@@ -76,7 +79,7 @@ func TestInstall(t *testing.T) {
 	t.Run("sets executable permissions on installed binary", func(t *testing.T) {
 		testutil.RequireOS(t, "linux", "darwin")
 		srv := serveBytes(t, validArchive)
-		dst := createDstFile(t)
+		dst := createFakeBinary(t)
 
 		err := upgrade.Install(context.Background(), dst, srv.URL)
 
@@ -88,7 +91,7 @@ func TestInstall(t *testing.T) {
 
 	t.Run("leaves no temp files in destination directory", func(t *testing.T) {
 		srv := serveBytes(t, validArchive)
-		dst := createDstFile(t)
+		dst := createFakeBinary(t)
 
 		err := upgrade.Install(context.Background(), dst, srv.URL)
 
@@ -104,13 +107,13 @@ func TestInstall(t *testing.T) {
 		}))
 		t.Cleanup(srv.Close)
 
-		err := upgrade.Install(context.Background(), createDstFile(t), srv.URL)
+		err := upgrade.Install(context.Background(), createFakeBinary(t), srv.URL)
 
 		assert.ErrorContains(t, err, "HTTP 404")
 	})
 
 	t.Run("returns error on connection failure", func(t *testing.T) {
-		err := upgrade.Install(context.Background(), createDstFile(t), "something-invalid")
+		err := upgrade.Install(context.Background(), createFakeBinary(t), "something-invalid")
 
 		assert.Error(t, err)
 	})
@@ -121,7 +124,7 @@ func TestInstall(t *testing.T) {
 		})
 		srv := serveBytes(t, archive)
 
-		err := upgrade.Install(context.Background(), createDstFile(t), srv.URL)
+		err := upgrade.Install(context.Background(), createFakeBinary(t), srv.URL)
 
 		assert.Error(t, err)
 	})
@@ -129,7 +132,7 @@ func TestInstall(t *testing.T) {
 	t.Run("returns error on invalid archive body", func(t *testing.T) {
 		srv := serveBytes(t, []byte("this is not a valid archive"))
 
-		err := upgrade.Install(context.Background(), createDstFile(t), srv.URL)
+		err := upgrade.Install(context.Background(), createFakeBinary(t), srv.URL)
 
 		assert.Error(t, err)
 	})
@@ -139,7 +142,7 @@ func TestInstall(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 
-		err := upgrade.Install(ctx, createDstFile(t), srv.URL)
+		err := upgrade.Install(ctx, createFakeBinary(t), srv.URL)
 
 		assert.Error(t, err)
 	})

--- a/internal/upgrade/upgrade_test.go
+++ b/internal/upgrade/upgrade_test.go
@@ -154,39 +154,26 @@ func TestInstall(t *testing.T) {
 }
 
 func TestArtifactoryDownloadURL(t *testing.T) {
-	t.Run("contains the formatted target version", func(t *testing.T) {
-		url := upgrade.ArtifactoryDownloadURL("3.13.37")
+	version := "3.13.37"
+	tests := []struct {
+		os       string
+		arch     string
+		expected string
+	}{
+		{"darwin", "amd64", "https://artifacts.tools.arm.com/topo/v" + version + "/macos/topo_darwin_amd64.tar.gz"},
+		{"darwin", "arm64", "https://artifacts.tools.arm.com/topo/v" + version + "/macos/topo_darwin_arm64.tar.gz"},
+		{"linux", "amd64", "https://artifacts.tools.arm.com/topo/v" + version + "/linux/topo_linux_amd64.tar.gz"},
+		{"linux", "arm64", "https://artifacts.tools.arm.com/topo/v" + version + "/linux/topo_linux_arm64.tar.gz"},
+		{"windows", "amd64", "https://artifacts.tools.arm.com/topo/v" + version + "/windows/topo_windows_amd64.zip"},
+		{"windows", "arm64", "https://artifacts.tools.arm.com/topo/v" + version + "/windows/topo_windows_arm64.zip"},
+	}
 
-		assert.Contains(t, url, "v3.13.37")
-	})
+	for _, tt := range tests {
+		name := tt.os + "/" + tt.arch
+		t.Run(name, func(t *testing.T) {
+			url := upgrade.ArtifactoryDownloadURL(tt.os, tt.arch, version)
 
-	t.Run("contains current architecture", func(t *testing.T) {
-		url := upgrade.ArtifactoryDownloadURL("3.13.37")
-
-		assert.Contains(t, url, runtime.GOARCH)
-	})
-
-	t.Run("maps darwin to macos", func(t *testing.T) {
-		testutil.RequireOS(t, "darwin")
-
-		url := upgrade.ArtifactoryDownloadURL("3.13.37")
-
-		assert.Contains(t, url, "/macos/")
-	})
-
-	t.Run("uses zip extension on windows", func(t *testing.T) {
-		testutil.RequireOS(t, "windows")
-
-		url := upgrade.ArtifactoryDownloadURL("3.13.37")
-
-		assert.Contains(t, url, ".zip")
-	})
-
-	t.Run("uses tar.gz extension on linux and darwin", func(t *testing.T) {
-		testutil.RequireOS(t, "linux", "darwin")
-
-		url := upgrade.ArtifactoryDownloadURL("3.13.37")
-
-		assert.Contains(t, url, ".tar.gz")
-	})
+			assert.Equal(t, url, tt.expected)
+		})
+	}
 }

--- a/internal/upgrade/upgrade_test.go
+++ b/internal/upgrade/upgrade_test.go
@@ -89,7 +89,7 @@ func TestInstall(t *testing.T) {
 		assert.Equal(t, os.FileMode(0o755), info.Mode().Perm())
 	})
 
-	t.Run("leaves no temp files in destination directory", func(t *testing.T) {
+	t.Run("leaves no unexpected temp files in destination directory", func(t *testing.T) {
 		srv := serveBytes(t, validArchive)
 		dst := createFakeBinary(t)
 
@@ -98,7 +98,12 @@ func TestInstall(t *testing.T) {
 		require.NoError(t, err)
 		entries, err := os.ReadDir(filepath.Dir(dst))
 		require.NoError(t, err)
-		assert.Len(t, entries, 1)
+
+		if runtime.GOOS == "windows" {
+			assert.Len(t, entries, 2)
+		} else {
+			assert.Len(t, entries, 1)
+		}
 	})
 
 	t.Run("returns error on non-200 response", func(t *testing.T) {

--- a/internal/upgrade/upgrade_test.go
+++ b/internal/upgrade/upgrade_test.go
@@ -88,12 +88,12 @@ func TestInstall(t *testing.T) {
 
 	t.Run("leaves no temp files in destination directory", func(t *testing.T) {
 		srv := serveBytes(t, validArchive)
-		dir := t.TempDir()
+		dst := createDstFile(t)
 
-		err := upgrade.Install(context.Background(), createDstFile(t), srv.URL)
+		err := upgrade.Install(context.Background(), dst, srv.URL)
 
 		require.NoError(t, err)
-		entries, err := os.ReadDir(dir)
+		entries, err := os.ReadDir(filepath.Dir(dst))
 		require.NoError(t, err)
 		assert.Len(t, entries, 1)
 	})

--- a/internal/upgrade/upgrade_test.go
+++ b/internal/upgrade/upgrade_test.go
@@ -1,0 +1,184 @@
+package upgrade_test
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/arm/topo/internal/testutil"
+	"github.com/arm/topo/internal/upgrade"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func makeTarGz(t *testing.T, files map[string][]byte) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+
+	for name, content := range files {
+		err := tw.WriteHeader(&tar.Header{Name: name, Mode: 0o755, Size: int64(len(content))})
+		require.NoError(t, err)
+		_, err = tw.Write(content)
+		require.NoError(t, err)
+	}
+
+	require.NoError(t, tw.Close())
+	require.NoError(t, gw.Close())
+
+	return buf.Bytes()
+}
+
+func createDstFile(t *testing.T) string {
+	t.Helper()
+	return filepath.Join(t.TempDir(), upgrade.BinaryName("topo"))
+}
+
+func serveBytes(t *testing.T, data []byte) *httptest.Server {
+	t.Helper()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(data)
+	}))
+	t.Cleanup(srv.Close)
+
+	return srv
+}
+
+func TestInstall(t *testing.T) {
+	const fakeContent = "fake topo binary"
+
+	validArchive := makeTarGz(t, map[string][]byte{
+		upgrade.BinaryName("topo"): []byte(fakeContent),
+	})
+
+	t.Run("writes binary to destination", func(t *testing.T) {
+		srv := serveBytes(t, validArchive)
+		dst := createDstFile(t)
+
+		err := upgrade.Install(context.Background(), dst, srv.URL)
+
+		require.NoError(t, err)
+		got, err := os.ReadFile(dst)
+		require.NoError(t, err)
+		assert.Equal(t, fakeContent, string(got))
+	})
+
+	t.Run("sets executable permissions on installed binary", func(t *testing.T) {
+		testutil.RequireOS(t, "linux", "darwin")
+		srv := serveBytes(t, validArchive)
+		dst := createDstFile(t)
+
+		err := upgrade.Install(context.Background(), dst, srv.URL)
+
+		require.NoError(t, err)
+		info, err := os.Stat(dst)
+		require.NoError(t, err)
+		assert.Equal(t, os.FileMode(0o755), info.Mode().Perm())
+	})
+
+	t.Run("leaves no temp files in destination directory", func(t *testing.T) {
+		srv := serveBytes(t, validArchive)
+		dir := t.TempDir()
+
+		err := upgrade.Install(context.Background(), createDstFile(t), srv.URL)
+
+		require.NoError(t, err)
+		entries, err := os.ReadDir(dir)
+		require.NoError(t, err)
+		assert.Len(t, entries, 1)
+	})
+
+	t.Run("returns error on non-200 response", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		t.Cleanup(srv.Close)
+
+		err := upgrade.Install(context.Background(), createDstFile(t), srv.URL)
+
+		assert.ErrorContains(t, err, "HTTP 404")
+	})
+
+	t.Run("returns error on connection failure", func(t *testing.T) {
+		err := upgrade.Install(context.Background(), createDstFile(t), "something-invalid")
+
+		assert.Error(t, err)
+	})
+
+	t.Run("returns error when binary is absent from archive", func(t *testing.T) {
+		archive := makeTarGz(t, map[string][]byte{
+			"some-other-file": []byte("not a topo binary"),
+		})
+		srv := serveBytes(t, archive)
+
+		err := upgrade.Install(context.Background(), createDstFile(t), srv.URL)
+
+		assert.Error(t, err)
+	})
+
+	t.Run("returns error on invalid archive body", func(t *testing.T) {
+		srv := serveBytes(t, []byte("this is not a valid archive"))
+
+		err := upgrade.Install(context.Background(), createDstFile(t), srv.URL)
+
+		assert.Error(t, err)
+	})
+
+	t.Run("respects context cancellation", func(t *testing.T) {
+		srv := serveBytes(t, validArchive)
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		err := upgrade.Install(ctx, createDstFile(t), srv.URL)
+
+		assert.Error(t, err)
+	})
+}
+
+func TestArtifactoryDownloadURL(t *testing.T) {
+	t.Run("contains the formatted target version", func(t *testing.T) {
+		url := upgrade.ArtifactoryDownloadURL("3.13.37")
+
+		assert.Contains(t, url, "v3.13.37")
+	})
+
+	t.Run("contains current architecture", func(t *testing.T) {
+		url := upgrade.ArtifactoryDownloadURL("3.13.37")
+
+		assert.Contains(t, url, runtime.GOARCH)
+	})
+
+	t.Run("maps darwin to macos", func(t *testing.T) {
+		testutil.RequireOS(t, "darwin")
+
+		url := upgrade.ArtifactoryDownloadURL("3.13.37")
+
+		assert.Contains(t, url, "/macos/")
+	})
+
+	t.Run("uses zip extension on windows", func(t *testing.T) {
+		testutil.RequireOS(t, "windows")
+
+		url := upgrade.ArtifactoryDownloadURL("3.13.37")
+
+		assert.Contains(t, url, ".zip")
+	})
+
+	t.Run("uses tar.gz extension on linux and darwin", func(t *testing.T) {
+		testutil.RequireOS(t, "linux", "darwin")
+
+		url := upgrade.ArtifactoryDownloadURL("3.13.37")
+
+		assert.Contains(t, url, ".tar.gz")
+	})
+}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,10 +1,10 @@
 package version
 
 var (
-	Placeholder = "dev"
+	Dev = "dev"
 
 	// Version holds the complete version number. Filled in at linking time via -ldflags.
-	Version = Placeholder
+	Version = Dev
 
 	// GitCommit holds the git revision. Filled in at linking time via -ldflags.
 	GitCommit = "unknown"

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,8 +1,10 @@
 package version
 
 var (
+	Placeholder = "dev"
+
 	// Version holds the complete version number. Filled in at linking time via -ldflags.
-	Version = "dev"
+	Version = Placeholder
 
 	// GitCommit holds the git revision. Filled in at linking time via -ldflags.
 	GitCommit = "unknown"


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- Adds a `topo upgrade` command. General steps are;
  - Check for latest version from artifactory, if already on it then bail
  - If not then construct the archive URL
  - Download the archive into memory
  - Extract the archive into a temp file on disk, in the same directory as the current running `topo` binary. This ensures atomic renames always work as there's no cross-filesystem errors to worry about.
  - On windows; rename current topo to topo.old, rename temp file to topo
    - Windows does not support deleting running programs, so we do this rename dance. This also means we leave a `topo.exe.old` on their disk which we overwrite next time `topo upgrade` is executed
  - Otherwise; rename temp file to `topo`, deleting the current running binary + set execute perms on it
- Adds a `version.Placeholder` constant to avoid hard-coding "dev" all over the place
- Makes a best effort to warn users of any files we created and failed to cleanup and errors if we failed to install and couldn't restore the old version with logging.

## Next Steps

After this PR the plan is to remove the upgrading mechanism from the install scripts and point users towards `topo upgrade` when it's already installed. This makes them more akin to bootstrap scripts rather than idempotent install/update scripts, centralizing update logic in the CLI.

## Testing

Recommend testing this by changing `version.Version` to something like "0.0.1" to avoid hitting the "dev" escape hatch.

---

Apologies for the big diff as well! Couldn't see a clear point to split it aside from things like dropping windows support temporarily which I'm not keen on. Feel free to push back if you think it's not reviewable.