### PR TITLE
refactor: remove unnecessary dir existence check for remoteproc

### DIFF
--- a/internal/probe/remoteproc.go
+++ b/internal/probe/remoteproc.go
@@ -14,14 +14,6 @@ type RemoteprocCPU struct {
 
 func Remoteproc(ctx context.Context, r runner.Runner) ([]RemoteprocCPU, error) {
 	var remoteProcs []RemoteprocCPU
-	_, err := r.Run(ctx, "test -d /sys/class/remoteproc")
-	if err != nil {
-		if errors.Is(err, runner.ErrTimeout) {
-			return remoteProcs, err
-		}
-		return remoteProcs, nil
-	}
-
 	out, err := r.Run(ctx, "cat /sys/class/remoteproc/*/name")
 	if err != nil {
 		if errors.Is(err, runner.ErrTimeout) {

--- a/internal/probe/remoteproc_test.go
+++ b/internal/probe/remoteproc_test.go
@@ -15,7 +15,6 @@ func TestProbeRemoteproc(t *testing.T) {
 	t.Run("returns remote processors", func(t *testing.T) {
 		r := &runner.Fake{
 			Commands: map[string]runner.FakeResult{
-				"test -d /sys/class/remoteproc":    {},
 				"cat /sys/class/remoteproc/*/name": {Output: "virtio0\nvirtio1"},
 			},
 		}
@@ -33,7 +32,7 @@ func TestProbeRemoteproc(t *testing.T) {
 	t.Run("returns empty when remoteproc directory does not exist", func(t *testing.T) {
 		r := &runner.Fake{
 			Commands: map[string]runner.FakeResult{
-				"test -d /sys/class/remoteproc": {Output: "", Err: errors.New("exit status 1")},
+				"cat /sys/class/remoteproc/*/name": {Err: errors.New("No such file or directory")},
 			},
 		}
 
@@ -41,39 +40,12 @@ func TestProbeRemoteproc(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.Empty(t, got)
-	})
-
-	t.Run("returns error when listing remoteproc directory fails", func(t *testing.T) {
-		r := &runner.Fake{
-			Commands: map[string]runner.FakeResult{
-				"test -d /sys/class/remoteproc": {Output: "", Err: runner.ErrTimeout},
-			},
-		}
-
-		_, err := probe.Remoteproc(context.Background(), r)
-
-		assert.ErrorIs(t, err, runner.ErrTimeout)
 	})
 
 	t.Run("returns empty when no remoteproc names found", func(t *testing.T) {
 		r := &runner.Fake{
 			Commands: map[string]runner.FakeResult{
-				"test -d /sys/class/remoteproc":    {},
 				"cat /sys/class/remoteproc/*/name": {Output: ""},
-			},
-		}
-
-		got, err := probe.Remoteproc(context.Background(), r)
-
-		require.NoError(t, err)
-		assert.Empty(t, got)
-	})
-
-	t.Run("returns empty when reading names fails with non-timeout error", func(t *testing.T) {
-		r := &runner.Fake{
-			Commands: map[string]runner.FakeResult{
-				"test -d /sys/class/remoteproc":    {},
-				"cat /sys/class/remoteproc/*/name": {Err: errors.New("No such file or directory")},
 			},
 		}
 
@@ -86,7 +58,6 @@ func TestProbeRemoteproc(t *testing.T) {
 	t.Run("returns error when reading names times out", func(t *testing.T) {
 		r := &runner.Fake{
 			Commands: map[string]runner.FakeResult{
-				"test -d /sys/class/remoteproc":    {},
 				"cat /sys/class/remoteproc/*/name": {Err: runner.ErrTimeout},
 			},
 		}


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- As the tytle says, checking for the existence of `/sys/class/remoteproc` is unnecessary. Check removed.
