### PR TITLE
fix: handle ssh's too many authentication failures in health check

### DIFF
--- a/internal/ssh/errors.go
+++ b/internal/ssh/errors.go
@@ -28,7 +28,7 @@ func ClassifyStderr(stderr string) error {
 	if strings.Contains(lower, "timed out") {
 		return ErrConnectionTimeout
 	}
-	if strings.Contains(lower, "permission denied") {
+	if strings.Contains(lower, "permission denied") || strings.Contains(lower, "too many authentication failures") {
 		return ErrAuthFailed
 	}
 	if strings.Contains(lower, "connection refused") {

--- a/internal/ssh/errors_test.go
+++ b/internal/ssh/errors_test.go
@@ -13,6 +13,7 @@ func TestClassifyStderr(t *testing.T) {
 		want   error
 	}{
 		{name: "auth failure", stderr: "user@host: Permission denied (publickey).", want: ErrAuthFailed},
+		{name: "too many authentication failures", stderr: "Received disconnect from 192.0.2.10 port 22:2: Too many authentication failures", want: ErrAuthFailed},
 		{name: "connection refused", stderr: "ssh: connect to host example.com port 22: Connection refused", want: ErrConnectionFailed},
 		{name: "hostname not resolved", stderr: "ssh: Could not resolve hostname not-valid: Temporary failure in name resolution", want: ErrConnectionFailed},
 		{name: "operation timed out (macOS)", stderr: "ssh: connect to host example.com port 22: Operation timed out", want: ErrConnectionTimeout},


### PR DESCRIPTION
## Description

We are currently only suggesting `setup-keys` when we try to authenticate via SSH and we get a `permission denied` error. We categorize this error as an Authentication Error.

We could, however, also get a `too many authentication failures` error when trying to connect, which should also be an Authentication Error, but we are failing to categorize it as such.

`too many authentication failures` suggests that we haven't setup the keys for that target, although this is not always the case:

It could be that keys for that target are already setup but there are too many keys in the SSH agent (so it attempts several keys before attempting the correct one). This can happen if the user has not added the key for that target in their .ssh/config , which is a configuration mistake from behalf of the user.

In any case, running setup-keys will resolve the issue, as the newly created key is also added to the topo_config.

## Changes

- fail the health check on SSH's `too many authentication failures` and suggest `setup-keys` to resolve the issue.
