### PR TITLE
fix: distinguish SSH auth exhaustion from invalid credentials

### DIFF
--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -160,7 +160,7 @@ func connectivityCheck(status ConnectionStatus) HealthCheck {
 
 	check.Value = status.Error.Error()
 	switch {
-	case errors.Is(status.Error, probe.ErrAuthFailed):
+	case errors.Is(status.Error, probe.ErrAuthFailed) || errors.Is(status.Error, probe.ErrTooManyAuthFails):
 		check.Fix = &Fix{
 			Description: "Configure SSH keys on remote target",
 			Command:     fmt.Sprintf("topo setup-keys --target %s", status.Destination),

--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -91,6 +91,21 @@ func TestGenerateTargetReport(t *testing.T) {
 		assert.Equal(t, "topo setup-keys --target ssh://user@my-target", got.Connectivity.Fix.Command)
 	})
 
+	t.Run("when too many authentication failures occur, Connectivity includes a setup-keys fix", func(t *testing.T) {
+		ts := health.Status{
+			Connection: health.ConnectionStatus{
+				Destination: ssh.NewDestination("user@my-target"),
+				Error:       probe.ErrTooManyAuthFails,
+			},
+		}
+
+		got := health.GenerateTargetReport(ts)
+
+		assert.Equal(t, health.CheckStatusError, got.Connectivity.Status)
+		assert.Equal(t, "Configure SSH keys on remote target", got.Connectivity.Fix.Description)
+		assert.Equal(t, "topo setup-keys --target ssh://user@my-target", got.Connectivity.Fix.Command)
+	})
+
 	t.Run("when host key is new, Connectivity includes an accept-new-host-keys fix", func(t *testing.T) {
 		ts := health.Status{
 			Connection: health.ConnectionStatus{

--- a/internal/probe/ssh_authentication.go
+++ b/internal/probe/ssh_authentication.go
@@ -9,9 +9,10 @@ import (
 )
 
 var (
-	ErrHostKeyUnknown = errors.New("ssh host key is unknown")
-	ErrHostKeyChanged = errors.New("ssh host key has changed")
-	ErrAuthFailed     = errors.New("ssh authentication failed")
+	ErrHostKeyUnknown   = errors.New("ssh host key is unknown")
+	ErrHostKeyChanged   = errors.New("ssh host key has changed")
+	ErrAuthFailed       = errors.New("ssh authentication failed")
+	ErrTooManyAuthFails = errors.New("ssh too many authentication failures")
 )
 
 // SSHAuthentication verifies SSH connectivity by attempting public key authentication.
@@ -27,6 +28,8 @@ func SSHAuthentication(ctx context.Context, r *runner.SSH, acceptNewHostKeys boo
 		return ErrHostKeyUnknown
 	case errors.Is(err, ssh.ErrAuthFailed):
 		return ErrAuthFailed
+	case errors.Is(err, ssh.ErrTooManyAuthFails):
+		return ErrTooManyAuthFails
 	default:
 		return err
 	}

--- a/internal/ssh/errors.go
+++ b/internal/ssh/errors.go
@@ -9,6 +9,7 @@ import (
 var (
 	ErrSSH               = errors.New("ssh failed")
 	ErrAuthFailed        = fmt.Errorf("%w: authentication failed", ErrSSH)
+	ErrTooManyAuthFails  = fmt.Errorf("%w: too many authentication failures", ErrSSH)
 	ErrConnectionFailed  = fmt.Errorf("%w: connection failed", ErrSSH)
 	ErrConnectionTimeout = fmt.Errorf("%w: connection timed out", ErrSSH)
 	ErrHostKeyUnknown    = fmt.Errorf("%w: host key is not known", ErrSSH)
@@ -28,8 +29,11 @@ func ClassifyStderr(stderr string) error {
 	if strings.Contains(lower, "timed out") {
 		return ErrConnectionTimeout
 	}
-	if strings.Contains(lower, "permission denied") || strings.Contains(lower, "too many authentication failures") {
+	if strings.Contains(lower, "permission denied") {
 		return ErrAuthFailed
+	}
+	if strings.Contains(lower, "too many authentication failures") {
+		return ErrTooManyAuthFails
 	}
 	if strings.Contains(lower, "connection refused") {
 		return ErrConnectionFailed

--- a/internal/ssh/errors_test.go
+++ b/internal/ssh/errors_test.go
@@ -13,7 +13,7 @@ func TestClassifyStderr(t *testing.T) {
 		want   error
 	}{
 		{name: "auth failure", stderr: "user@host: Permission denied (publickey).", want: ErrAuthFailed},
-		{name: "too many authentication failures", stderr: "Received disconnect from 192.0.2.10 port 22:2: Too many authentication failures", want: ErrAuthFailed},
+		{name: "too many authentication failures", stderr: "Received disconnect from 192.0.2.10 port 22:2: Too many authentication failures", want: ErrTooManyAuthFails},
 		{name: "connection refused", stderr: "ssh: connect to host example.com port 22: Connection refused", want: ErrConnectionFailed},
 		{name: "hostname not resolved", stderr: "ssh: Could not resolve hostname not-valid: Temporary failure in name resolution", want: ErrConnectionFailed},
 		{name: "operation timed out (macOS)", stderr: "ssh: connect to host example.com port 22: Operation timed out", want: ErrConnectionTimeout},
@@ -49,7 +49,7 @@ Host key verification failed.`,
 }
 
 func TestSentinelErrors(t *testing.T) {
-	sentinels := []error{ErrAuthFailed, ErrConnectionFailed, ErrConnectionTimeout, ErrHostKeyUnknown, ErrHostKeyChanged}
+	sentinels := []error{ErrAuthFailed, ErrTooManyAuthFails, ErrConnectionFailed, ErrConnectionTimeout, ErrHostKeyUnknown, ErrHostKeyChanged}
 	for _, err := range sentinels {
 		t.Run(err.Error(), func(t *testing.T) {
 			assert.ErrorIs(t, err, ErrSSH)


### PR DESCRIPTION
## Description
   
We already classify `too many authentication failures` as a distinct SSH error, but the health report is still treating it like a generic auth failure.

## Changes

Handle this case explicitly in the probe and health layers so the user gets a more accurate diagnostic of the failure's cause:
- map ssh `too many authentication failures` to a dedicated probe error

This keeps `permission denied` and `too many authentication failures` separate, which better reflects the likely cause of the failure.