### PR TITLE
refactor: pluralise HW profile  properties

### DIFF
--- a/internal/catalog/compatibility.go
+++ b/internal/catalog/compatibility.go
@@ -58,7 +58,7 @@ func extractSupportedFeatures(profile probe.HardwareProfile) map[string]struct{}
 			supportedFeatures[strings.ToLower(feature)] = struct{}{}
 		}
 	}
-	if len(profile.RemoteCPUs) > 0 {
+	if len(profile.RemoteProcessors) > 0 {
 		supportedFeatures["remoteproc"] = struct{}{}
 		supportedFeatures["remoteproc-runtime"] = struct{}{}
 	}

--- a/internal/catalog/compatibility.go
+++ b/internal/catalog/compatibility.go
@@ -53,12 +53,12 @@ func compatibilityStatus(profile probe.HardwareProfile, supportedFeatures map[st
 
 func extractSupportedFeatures(profile probe.HardwareProfile) map[string]struct{} {
 	supportedFeatures := map[string]struct{}{}
-	for _, proc := range profile.HostProcessor {
+	for _, proc := range profile.HostProcessors {
 		for _, feature := range proc.ExtractArmFeatures() {
 			supportedFeatures[strings.ToLower(feature)] = struct{}{}
 		}
 	}
-	if len(profile.RemoteCPU) > 0 {
+	if len(profile.RemoteCPUs) > 0 {
 		supportedFeatures["remoteproc"] = struct{}{}
 		supportedFeatures["remoteproc-runtime"] = struct{}{}
 	}

--- a/internal/catalog/compatibility_test.go
+++ b/internal/catalog/compatibility_test.go
@@ -89,7 +89,7 @@ func TestAnnotateCompatibility(t *testing.T) {
 		repo := catalog.Repo{Name: "rp-template", Features: []string{"remoteproc"}}
 		repos := []catalog.Repo{repo}
 		profile := probe.HardwareProfile{
-			RemoteCPUs: []probe.RemoteprocCPU{
+			RemoteProcessors: []probe.RemoteProc{
 				{Name: "m3"},
 			},
 		}

--- a/internal/catalog/compatibility_test.go
+++ b/internal/catalog/compatibility_test.go
@@ -13,7 +13,7 @@ func TestAnnotateCompatibility(t *testing.T) {
 		repo := catalog.Repo{Name: "sve-template", Features: []string{"SVE"}}
 		repos := []catalog.Repo{repo}
 		profile := probe.HardwareProfile{
-			HostProcessor: []probe.HostProcessor{
+			HostProcessors: []probe.HostProcessor{
 				{Features: []string{"asimd", "sve"}},
 			},
 		}
@@ -29,7 +29,7 @@ func TestAnnotateCompatibility(t *testing.T) {
 		repo := catalog.Repo{Name: "sve-template", Features: []string{"SVE"}}
 		repos := []catalog.Repo{repo}
 		profile := probe.HardwareProfile{
-			HostProcessor: []probe.HostProcessor{
+			HostProcessors: []probe.HostProcessor{
 				{Features: []string{"asimd"}},
 			},
 		}
@@ -45,7 +45,7 @@ func TestAnnotateCompatibility(t *testing.T) {
 		repo := catalog.Repo{Name: "neon-template", Features: []string{"NEON"}}
 		repos := []catalog.Repo{repo}
 		profile := probe.HardwareProfile{
-			HostProcessor: []probe.HostProcessor{
+			HostProcessors: []probe.HostProcessor{
 				{Features: []string{"asimd"}},
 			},
 		}
@@ -61,7 +61,7 @@ func TestAnnotateCompatibility(t *testing.T) {
 		repo := catalog.Repo{Name: "neon-template", Features: []string{"NEON"}}
 		repos := []catalog.Repo{repo}
 		profile := probe.HardwareProfile{
-			HostProcessor: []probe.HostProcessor{
+			HostProcessors: []probe.HostProcessor{
 				{Features: []string{"sve"}},
 			},
 		}
@@ -89,7 +89,7 @@ func TestAnnotateCompatibility(t *testing.T) {
 		repo := catalog.Repo{Name: "rp-template", Features: []string{"remoteproc"}}
 		repos := []catalog.Repo{repo}
 		profile := probe.HardwareProfile{
-			RemoteCPU: []probe.RemoteprocCPU{
+			RemoteCPUs: []probe.RemoteprocCPU{
 				{Name: "m3"},
 			},
 		}
@@ -105,7 +105,7 @@ func TestAnnotateCompatibility(t *testing.T) {
 		repo := catalog.Repo{Name: "multi-feature-template", Features: []string{"SVE", "remoteproc"}}
 		repos := []catalog.Repo{repo}
 		profile := probe.HardwareProfile{
-			HostProcessor: []probe.HostProcessor{
+			HostProcessors: []probe.HostProcessor{
 				{Features: []string{"asimd", "sve"}},
 			},
 		}
@@ -121,7 +121,7 @@ func TestAnnotateCompatibility(t *testing.T) {
 		repo := catalog.Repo{Name: "multi-feature-template", Features: []string{"SVE", "remoteproc"}}
 		repos := []catalog.Repo{repo}
 		profile := probe.HardwareProfile{
-			HostProcessor: []probe.HostProcessor{
+			HostProcessors: []probe.HostProcessor{
 				{Features: []string{"asimd"}},
 			},
 		}

--- a/internal/catalog/compatibility_test.go
+++ b/internal/catalog/compatibility_test.go
@@ -89,7 +89,7 @@ func TestAnnotateCompatibility(t *testing.T) {
 		repo := catalog.Repo{Name: "rp-template", Features: []string{"remoteproc"}}
 		repos := []catalog.Repo{repo}
 		profile := probe.HardwareProfile{
-			RemoteProcessors: []probe.RemoteProc{
+			RemoteProcessors: []probe.RemoteProcessor{
 				{Name: "m3"},
 			},
 		}

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -125,7 +125,7 @@ func GenerateTargetReport(targetStatus Status) TargetReport {
 	report.Connectivity = connectivityCheck(targetStatus.Connection)
 
 	report.SubsystemDriver.Name = "Subsystem Driver (remoteproc)"
-	remoteCPUs := targetStatus.Hardware.RemoteCPU
+	remoteCPUs := targetStatus.Hardware.RemoteCPUs
 	switch {
 	case targetStatus.Hardware.Err != nil:
 		report.SubsystemDriver.Status = CheckStatusError

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -125,14 +125,14 @@ func GenerateTargetReport(targetStatus Status) TargetReport {
 	report.Connectivity = connectivityCheck(targetStatus.Connection)
 
 	report.SubsystemDriver.Name = "Subsystem Driver (remoteproc)"
-	remoteCPUs := targetStatus.Hardware.RemoteCPUs
+	remoteProcessors := targetStatus.Hardware.RemoteProcessors
 	switch {
 	case targetStatus.Hardware.Err != nil:
 		report.SubsystemDriver.Status = CheckStatusError
 		report.SubsystemDriver.Value = targetStatus.Hardware.Err.Error()
-	case len(remoteCPUs) > 0:
-		names := make([]string, len(remoteCPUs))
-		for i, remoteProc := range remoteCPUs {
+	case len(remoteProcessors) > 0:
+		names := make([]string, len(remoteProcessors))
+		for i, remoteProc := range remoteProcessors {
 			names[i] = remoteProc.Name
 		}
 		report.SubsystemDriver.Status = CheckStatusOK

--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -49,7 +49,7 @@ func TestGenerateTargetReport(t *testing.T) {
 	t.Run("when remoteproc devices are found, SubsystemDriver status is ok and includes device names", func(t *testing.T) {
 		ts := health.Status{
 			Hardware: health.HardwareProfile{
-				RemoteCPU: []probe.RemoteprocCPU{{Name: "m4_0"}, {Name: "m4_1"}},
+				RemoteCPUs: []probe.RemoteprocCPU{{Name: "m4_0"}, {Name: "m4_1"}},
 			},
 		}
 

--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -49,7 +49,7 @@ func TestGenerateTargetReport(t *testing.T) {
 	t.Run("when remoteproc devices are found, SubsystemDriver status is ok and includes device names", func(t *testing.T) {
 		ts := health.Status{
 			Hardware: health.HardwareProfile{
-				RemoteProcessors: []probe.RemoteProc{{Name: "m4_0"}, {Name: "m4_1"}},
+				RemoteProcessors: []probe.RemoteProcessor{{Name: "m4_0"}, {Name: "m4_1"}},
 			},
 		}
 

--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -49,7 +49,7 @@ func TestGenerateTargetReport(t *testing.T) {
 	t.Run("when remoteproc devices are found, SubsystemDriver status is ok and includes device names", func(t *testing.T) {
 		ts := health.Status{
 			Hardware: health.HardwareProfile{
-				RemoteCPUs: []probe.RemoteprocCPU{{Name: "m4_0"}, {Name: "m4_1"}},
+				RemoteProcessors: []probe.RemoteProc{{Name: "m4_0"}, {Name: "m4_1"}},
 			},
 		}
 

--- a/internal/health/status.go
+++ b/internal/health/status.go
@@ -8,7 +8,7 @@ import (
 )
 
 type HardwareProfile struct {
-	RemoteProcessors []probe.RemoteProc
+	RemoteProcessors []probe.RemoteProcessor
 	Err              error
 }
 
@@ -28,7 +28,7 @@ type HealthStatus struct {
 func ProbeHealthStatus(ctx context.Context, r runner.Runner) HealthStatus {
 	var hs HealthStatus
 
-	remoteProcessors, err := probe.Remoteprocs(ctx, r)
+	remoteProcessors, err := probe.Remoteproc(ctx, r)
 	hs.Hardware.RemoteProcessors = remoteProcessors
 	hs.Hardware.Err = err
 

--- a/internal/health/status.go
+++ b/internal/health/status.go
@@ -8,13 +8,13 @@ import (
 )
 
 type HardwareProfile struct {
-	RemoteCPUs []probe.RemoteprocCPU
-	Err        error
+	RemoteProcessors []probe.RemoteProc
+	Err              error
 }
 
 func (h HardwareProfile) Capabilities() map[HardwareCapability]struct{} {
 	capabilities := make(map[HardwareCapability]struct{})
-	if len(h.RemoteCPUs) > 0 {
+	if len(h.RemoteProcessors) > 0 {
 		capabilities[Remoteproc] = struct{}{}
 	}
 	return capabilities
@@ -28,8 +28,8 @@ type HealthStatus struct {
 func ProbeHealthStatus(ctx context.Context, r runner.Runner) HealthStatus {
 	var hs HealthStatus
 
-	remoteprocs, err := probe.Remoteproc(ctx, r)
-	hs.Hardware.RemoteCPUs = remoteprocs
+	remoteProcessors, err := probe.Remoteprocs(ctx, r)
+	hs.Hardware.RemoteProcessors = remoteProcessors
 	hs.Hardware.Err = err
 
 	dependenciesToCheck := FilterByHardware(TargetRequiredDependencies, hs.Hardware.Capabilities())

--- a/internal/health/status.go
+++ b/internal/health/status.go
@@ -8,13 +8,13 @@ import (
 )
 
 type HardwareProfile struct {
-	RemoteCPU []probe.RemoteprocCPU
-	Err       error
+	RemoteCPUs []probe.RemoteprocCPU
+	Err        error
 }
 
 func (h HardwareProfile) Capabilities() map[HardwareCapability]struct{} {
 	capabilities := make(map[HardwareCapability]struct{})
-	if len(h.RemoteCPU) > 0 {
+	if len(h.RemoteCPUs) > 0 {
 		capabilities[Remoteproc] = struct{}{}
 	}
 	return capabilities
@@ -29,7 +29,7 @@ func ProbeHealthStatus(ctx context.Context, r runner.Runner) HealthStatus {
 	var hs HealthStatus
 
 	remoteprocs, err := probe.Remoteproc(ctx, r)
-	hs.Hardware.RemoteCPU = remoteprocs
+	hs.Hardware.RemoteCPUs = remoteprocs
 	hs.Hardware.Err = err
 
 	dependenciesToCheck := FilterByHardware(TargetRequiredDependencies, hs.Hardware.Capabilities())

--- a/internal/output/templates/describe_test.go
+++ b/internal/output/templates/describe_test.go
@@ -38,7 +38,7 @@ hostProcessors:
       - sve
 remoteProcessors:
   - name: remoteproc0
-totalmemory_kb: 16384
+totalMemoryKb: 16384
 `
 			require.NoError(t, err)
 			assert.YAMLEq(t, want, out.String())
@@ -73,7 +73,7 @@ totalmemory_kb: 16384
 				"remoteProcessors": [
 					{"name": "remoteproc0"}
 				],
-				"totalmemory_kb": 16384
+				"totalMemoryKb": 16384
 			}`
 			require.NoError(t, err)
 			assert.JSONEq(t, want, out.String())

--- a/internal/output/templates/describe_test.go
+++ b/internal/output/templates/describe_test.go
@@ -19,7 +19,7 @@ func TestPrintTargetDescription(t *testing.T) {
 				HostProcessors: []probe.HostProcessor{
 					{Model: "Cortex-A55", Cores: 4, Features: []string{"asimd", "sve"}},
 				},
-				RemoteProcessors: []probe.RemoteProc{
+				RemoteProcessors: []probe.RemoteProcessor{
 					{Name: "remoteproc0"},
 				},
 				TotalMemoryKb: 16384,
@@ -52,7 +52,7 @@ totalMemoryKb: 16384
 					HostProcessors: []probe.HostProcessor{
 						{Model: "Cortex-A55", Cores: 4, Features: []string{"asimd", "sve"}},
 					},
-					RemoteProcessors: []probe.RemoteProc{
+					RemoteProcessors: []probe.RemoteProcessor{
 						{Name: "remoteproc0"},
 					},
 					TotalMemoryKb: 16384,

--- a/internal/output/templates/describe_test.go
+++ b/internal/output/templates/describe_test.go
@@ -16,10 +16,10 @@ func TestPrintTargetDescription(t *testing.T) {
 	t.Run("PlainFormat", func(t *testing.T) {
 		t.Run("outputs valid yaml that round-trips back to the hardware profile", func(t *testing.T) {
 			profile := probe.HardwareProfile{
-				HostProcessor: []probe.HostProcessor{
+				HostProcessors: []probe.HostProcessor{
 					{Model: "Cortex-A55", Cores: 4, Features: []string{"asimd", "sve"}},
 				},
-				RemoteCPU: []probe.RemoteprocCPU{
+				RemoteCPUs: []probe.RemoteprocCPU{
 					{Name: "remoteproc0"},
 				},
 				TotalMemoryKb: 16384,
@@ -30,7 +30,7 @@ func TestPrintTargetDescription(t *testing.T) {
 			err := printable.Print(toPrint, &out, term.Plain)
 
 			want := `
-host:
+hosts:
   - model: Cortex-A55
     cores: 4
     features:
@@ -49,10 +49,10 @@ totalmemory_kb: 16384
 		t.Run("renders valid JSON with all fields", func(t *testing.T) {
 			toPrint := templates.PrintableTargetDescription{
 				HardwareProfile: probe.HardwareProfile{
-					HostProcessor: []probe.HostProcessor{
+					HostProcessors: []probe.HostProcessor{
 						{Model: "Cortex-A55", Cores: 4, Features: []string{"asimd", "sve"}},
 					},
-					RemoteCPU: []probe.RemoteprocCPU{
+					RemoteCPUs: []probe.RemoteprocCPU{
 						{Name: "remoteproc0"},
 					},
 					TotalMemoryKb: 16384,
@@ -63,7 +63,7 @@ totalmemory_kb: 16384
 			err := printable.Print(toPrint, &out, term.JSON)
 
 			want := `{
-				"host": [
+				"hosts": [
 					{
 						"model": "Cortex-A55",
 						"cores": 4,

--- a/internal/output/templates/describe_test.go
+++ b/internal/output/templates/describe_test.go
@@ -19,7 +19,7 @@ func TestPrintTargetDescription(t *testing.T) {
 				HostProcessors: []probe.HostProcessor{
 					{Model: "Cortex-A55", Cores: 4, Features: []string{"asimd", "sve"}},
 				},
-				RemoteCPUs: []probe.RemoteprocCPU{
+				RemoteProcessors: []probe.RemoteProc{
 					{Name: "remoteproc0"},
 				},
 				TotalMemoryKb: 16384,
@@ -30,13 +30,13 @@ func TestPrintTargetDescription(t *testing.T) {
 			err := printable.Print(toPrint, &out, term.Plain)
 
 			want := `
-hosts:
+hostProcessors:
   - model: Cortex-A55
     cores: 4
     features:
       - asimd
       - sve
-remoteprocs:
+remoteProcessors:
   - name: remoteproc0
 totalmemory_kb: 16384
 `
@@ -52,7 +52,7 @@ totalmemory_kb: 16384
 					HostProcessors: []probe.HostProcessor{
 						{Model: "Cortex-A55", Cores: 4, Features: []string{"asimd", "sve"}},
 					},
-					RemoteCPUs: []probe.RemoteprocCPU{
+					RemoteProcessors: []probe.RemoteProc{
 						{Name: "remoteproc0"},
 					},
 					TotalMemoryKb: 16384,
@@ -63,14 +63,14 @@ totalmemory_kb: 16384
 			err := printable.Print(toPrint, &out, term.JSON)
 
 			want := `{
-				"hosts": [
+				"hostProcessors": [
 					{
 						"model": "Cortex-A55",
 						"cores": 4,
 						"features": ["asimd", "sve"]
 					}
 				],
-				"remoteprocs": [
+				"remoteProcessors": [
 					{"name": "remoteproc0"}
 				],
 				"totalmemory_kb": 16384

--- a/internal/probe/hardware.go
+++ b/internal/probe/hardware.go
@@ -10,7 +10,7 @@ import (
 type HardwareProfile struct {
 	HostProcessors   []HostProcessor `yaml:"hostProcessors" json:"hostProcessors"`
 	RemoteProcessors []RemoteProc    `yaml:"remoteProcessors" json:"remoteProcessors,omitempty"`
-	TotalMemoryKb    int64           `yaml:"totalmemory_kb" json:"totalmemory_kb"`
+	TotalMemoryKb    int64           `yaml:"totalMemoryKb" json:"totalMemoryKb"`
 }
 
 func Hardware(ctx context.Context, r runner.Runner) (HardwareProfile, error) {

--- a/internal/probe/hardware.go
+++ b/internal/probe/hardware.go
@@ -8,25 +8,25 @@ import (
 )
 
 type HardwareProfile struct {
-	HostProcessor []HostProcessor `yaml:"host" json:"host"`
-	RemoteCPU     []RemoteprocCPU `yaml:"remoteprocs" json:"remoteprocs,omitempty"`
-	TotalMemoryKb int64           `yaml:"totalmemory_kb" json:"totalmemory_kb"`
+	HostProcessors []HostProcessor `yaml:"hosts" json:"hosts"`
+	RemoteCPUs     []RemoteprocCPU `yaml:"remoteprocs" json:"remoteprocs,omitempty"`
+	TotalMemoryKb  int64           `yaml:"totalmemory_kb" json:"totalmemory_kb"`
 }
 
 func Hardware(ctx context.Context, r runner.Runner) (HardwareProfile, error) {
 	var hp HardwareProfile
 
-	cpuProfile, err := CPU(ctx, r)
+	hostProcessors, err := CPU(ctx, r)
 	if err != nil {
 		return hp, fmt.Errorf("collecting CPU info: %w", err)
 	}
-	hp.HostProcessor = cpuProfile
+	hp.HostProcessors = hostProcessors
 
-	cpus, err := Remoteproc(ctx, r)
+	remoteCPUs, err := Remoteproc(ctx, r)
 	if err != nil {
 		return hp, fmt.Errorf("collecting remote CPUs: %w", err)
 	}
-	hp.RemoteCPU = cpus
+	hp.RemoteCPUs = remoteCPUs
 
 	memTotal, err := Memory(ctx, r)
 	if err != nil {

--- a/internal/probe/hardware.go
+++ b/internal/probe/hardware.go
@@ -8,9 +8,9 @@ import (
 )
 
 type HardwareProfile struct {
-	HostProcessors   []HostProcessor `yaml:"hostProcessors" json:"hostProcessors"`
-	RemoteProcessors []RemoteProc    `yaml:"remoteProcessors" json:"remoteProcessors,omitempty"`
-	TotalMemoryKb    int64           `yaml:"totalMemoryKb" json:"totalMemoryKb"`
+	HostProcessors   []HostProcessor   `yaml:"hostProcessors" json:"hostProcessors"`
+	RemoteProcessors []RemoteProcessor `yaml:"remoteProcessors" json:"remoteProcessors,omitempty"`
+	TotalMemoryKb    int64             `yaml:"totalMemoryKb" json:"totalMemoryKb"`
 }
 
 func Hardware(ctx context.Context, r runner.Runner) (HardwareProfile, error) {
@@ -22,7 +22,7 @@ func Hardware(ctx context.Context, r runner.Runner) (HardwareProfile, error) {
 	}
 	hp.HostProcessors = hostProcessors
 
-	remoteProcessors, err := Remoteprocs(ctx, r)
+	remoteProcessors, err := Remoteproc(ctx, r)
 	if err != nil {
 		return hp, fmt.Errorf("collecting remote processors: %w", err)
 	}

--- a/internal/probe/hardware.go
+++ b/internal/probe/hardware.go
@@ -8,25 +8,25 @@ import (
 )
 
 type HardwareProfile struct {
-	HostProcessors []HostProcessor `yaml:"hosts" json:"hosts"`
-	RemoteCPUs     []RemoteprocCPU `yaml:"remoteprocs" json:"remoteprocs,omitempty"`
-	TotalMemoryKb  int64           `yaml:"totalmemory_kb" json:"totalmemory_kb"`
+	HostProcessors   []HostProcessor `yaml:"hostProcessors" json:"hostProcessors"`
+	RemoteProcessors []RemoteProc    `yaml:"remoteProcessors" json:"remoteProcessors,omitempty"`
+	TotalMemoryKb    int64           `yaml:"totalmemory_kb" json:"totalmemory_kb"`
 }
 
 func Hardware(ctx context.Context, r runner.Runner) (HardwareProfile, error) {
 	var hp HardwareProfile
 
-	hostProcessors, err := CPU(ctx, r)
+	hostProcessors, err := HostProcessors(ctx, r)
 	if err != nil {
 		return hp, fmt.Errorf("collecting CPU info: %w", err)
 	}
 	hp.HostProcessors = hostProcessors
 
-	remoteCPUs, err := Remoteproc(ctx, r)
+	remoteProcessors, err := Remoteprocs(ctx, r)
 	if err != nil {
-		return hp, fmt.Errorf("collecting remote CPUs: %w", err)
+		return hp, fmt.Errorf("collecting remote processors: %w", err)
 	}
-	hp.RemoteCPUs = remoteCPUs
+	hp.RemoteProcessors = remoteProcessors
 
 	memTotal, err := Memory(ctx, r)
 	if err != nil {

--- a/internal/probe/host_processors.go
+++ b/internal/probe/host_processors.go
@@ -38,7 +38,7 @@ func (proc *HostProcessor) ExtractArmFeatures() []string {
 	return res
 }
 
-func CPU(ctx context.Context, r runner.Runner) ([]HostProcessor, error) {
+func HostProcessors(ctx context.Context, r runner.Runner) ([]HostProcessor, error) {
 	if err := r.BinaryExists(ctx, "lscpu"); err != nil {
 		return nil, err
 	}

--- a/internal/probe/host_processors_test.go
+++ b/internal/probe/host_processors_test.go
@@ -14,7 +14,7 @@ func lscpuJSON(fields string) string {
 	return `{"lscpu": [` + fields + `]}`
 }
 
-func TestProbeCPU(t *testing.T) {
+func TestHostProcessors(t *testing.T) {
 	t.Run("parses lscpu with clusters", func(t *testing.T) {
 		r := &runner.Fake{
 			Binaries: []string{"lscpu"},

--- a/internal/probe/host_processors_test.go
+++ b/internal/probe/host_processors_test.go
@@ -30,7 +30,7 @@ func TestProbeCPU(t *testing.T) {
 			},
 		}
 
-		got, err := probe.CPU(context.Background(), r)
+		got, err := probe.HostProcessors(context.Background(), r)
 
 		require.NoError(t, err)
 		want := []probe.HostProcessor{
@@ -57,7 +57,7 @@ func TestProbeCPU(t *testing.T) {
 			},
 		}
 
-		got, err := probe.CPU(context.Background(), r)
+		got, err := probe.HostProcessors(context.Background(), r)
 
 		require.NoError(t, err)
 		require.Len(t, got, 1)
@@ -87,7 +87,7 @@ func TestProbeCPU(t *testing.T) {
 			},
 		}
 
-		got, err := probe.CPU(context.Background(), r)
+		got, err := probe.HostProcessors(context.Background(), r)
 
 		require.NoError(t, err)
 		require.Len(t, got, 2)
@@ -107,7 +107,7 @@ func TestProbeCPU(t *testing.T) {
 			},
 		}
 
-		got, err := probe.CPU(context.Background(), r)
+		got, err := probe.HostProcessors(context.Background(), r)
 
 		require.NoError(t, err)
 		assert.Empty(t, got)
@@ -125,7 +125,7 @@ func TestProbeCPU(t *testing.T) {
 			},
 		}
 
-		_, err := probe.CPU(context.Background(), r)
+		_, err := probe.HostProcessors(context.Background(), r)
 
 		assert.Error(t, err)
 	})
@@ -133,7 +133,7 @@ func TestProbeCPU(t *testing.T) {
 	t.Run("returns error when lscpu not found", func(t *testing.T) {
 		r := &runner.Fake{}
 
-		_, err := probe.CPU(context.Background(), r)
+		_, err := probe.HostProcessors(context.Background(), r)
 
 		assert.ErrorContains(t, err, `"lscpu" not found in $PATH`)
 	})
@@ -146,7 +146,7 @@ func TestProbeCPU(t *testing.T) {
 			},
 		}
 
-		_, err := probe.CPU(context.Background(), r)
+		_, err := probe.HostProcessors(context.Background(), r)
 
 		assert.Error(t, err)
 	})

--- a/internal/probe/remoteproc.go
+++ b/internal/probe/remoteproc.go
@@ -8,12 +8,12 @@ import (
 	"github.com/arm/topo/internal/runner"
 )
 
-type RemoteprocCPU struct {
+type RemoteProc struct {
 	Name string `yaml:"name" json:"name"`
 }
 
-func Remoteproc(ctx context.Context, r runner.Runner) ([]RemoteprocCPU, error) {
-	var remoteProcs []RemoteprocCPU
+func Remoteprocs(ctx context.Context, r runner.Runner) ([]RemoteProc, error) {
+	var remoteProcs []RemoteProc
 	out, err := r.Run(ctx, "cat /sys/class/remoteproc/*/name")
 	if err != nil {
 		if errors.Is(err, runner.ErrTimeout) {
@@ -22,9 +22,9 @@ func Remoteproc(ctx context.Context, r runner.Runner) ([]RemoteprocCPU, error) {
 		return remoteProcs, nil
 	}
 
-	remoteCPU := strings.FieldsSeq(out)
-	for cpu := range remoteCPU {
-		remoteProcs = append(remoteProcs, RemoteprocCPU{Name: cpu})
+	procs := strings.FieldsSeq(out)
+	for proc := range procs {
+		remoteProcs = append(remoteProcs, RemoteProc{Name: proc})
 	}
 	return remoteProcs, nil
 }

--- a/internal/probe/remoteproc.go
+++ b/internal/probe/remoteproc.go
@@ -8,12 +8,12 @@ import (
 	"github.com/arm/topo/internal/runner"
 )
 
-type RemoteProc struct {
+type RemoteProcessor struct {
 	Name string `yaml:"name" json:"name"`
 }
 
-func Remoteprocs(ctx context.Context, r runner.Runner) ([]RemoteProc, error) {
-	var remoteProcs []RemoteProc
+func Remoteproc(ctx context.Context, r runner.Runner) ([]RemoteProcessor, error) {
+	var remoteProcs []RemoteProcessor
 	out, err := r.Run(ctx, "cat /sys/class/remoteproc/*/name")
 	if err != nil {
 		if errors.Is(err, runner.ErrTimeout) {
@@ -24,7 +24,7 @@ func Remoteprocs(ctx context.Context, r runner.Runner) ([]RemoteProc, error) {
 
 	procs := strings.FieldsSeq(out)
 	for proc := range procs {
-		remoteProcs = append(remoteProcs, RemoteProc{Name: proc})
+		remoteProcs = append(remoteProcs, RemoteProcessor{Name: proc})
 	}
 	return remoteProcs, nil
 }

--- a/internal/probe/remoteproc_test.go
+++ b/internal/probe/remoteproc_test.go
@@ -19,10 +19,10 @@ func TestProbeRemoteproc(t *testing.T) {
 			},
 		}
 
-		got, err := probe.Remoteprocs(context.Background(), r)
+		got, err := probe.Remoteproc(context.Background(), r)
 
 		require.NoError(t, err)
-		want := []probe.RemoteProc{
+		want := []probe.RemoteProcessor{
 			{Name: "virtio0"},
 			{Name: "virtio1"},
 		}
@@ -36,7 +36,7 @@ func TestProbeRemoteproc(t *testing.T) {
 			},
 		}
 
-		got, err := probe.Remoteprocs(context.Background(), r)
+		got, err := probe.Remoteproc(context.Background(), r)
 
 		require.NoError(t, err)
 		assert.Empty(t, got)
@@ -49,7 +49,7 @@ func TestProbeRemoteproc(t *testing.T) {
 			},
 		}
 
-		got, err := probe.Remoteprocs(context.Background(), r)
+		got, err := probe.Remoteproc(context.Background(), r)
 
 		require.NoError(t, err)
 		assert.Empty(t, got)
@@ -62,7 +62,7 @@ func TestProbeRemoteproc(t *testing.T) {
 			},
 		}
 
-		_, err := probe.Remoteprocs(context.Background(), r)
+		_, err := probe.Remoteproc(context.Background(), r)
 
 		assert.ErrorIs(t, err, runner.ErrTimeout)
 	})

--- a/internal/probe/remoteproc_test.go
+++ b/internal/probe/remoteproc_test.go
@@ -19,10 +19,10 @@ func TestProbeRemoteproc(t *testing.T) {
 			},
 		}
 
-		got, err := probe.Remoteproc(context.Background(), r)
+		got, err := probe.Remoteprocs(context.Background(), r)
 
 		require.NoError(t, err)
-		want := []probe.RemoteprocCPU{
+		want := []probe.RemoteProc{
 			{Name: "virtio0"},
 			{Name: "virtio1"},
 		}
@@ -36,7 +36,7 @@ func TestProbeRemoteproc(t *testing.T) {
 			},
 		}
 
-		got, err := probe.Remoteproc(context.Background(), r)
+		got, err := probe.Remoteprocs(context.Background(), r)
 
 		require.NoError(t, err)
 		assert.Empty(t, got)
@@ -49,7 +49,7 @@ func TestProbeRemoteproc(t *testing.T) {
 			},
 		}
 
-		got, err := probe.Remoteproc(context.Background(), r)
+		got, err := probe.Remoteprocs(context.Background(), r)
 
 		require.NoError(t, err)
 		assert.Empty(t, got)
@@ -62,7 +62,7 @@ func TestProbeRemoteproc(t *testing.T) {
 			},
 		}
 
-		_, err := probe.Remoteproc(context.Background(), r)
+		_, err := probe.Remoteprocs(context.Background(), r)
 
 		assert.ErrorIs(t, err, runner.ErrTimeout)
 	})


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- `host` renamed to `hosts` in `topo describe` output
- internal renaming to make sure properties are pluralised correctly
- tagged as refactor because `topo describe` is not part of the public API
