### PR TITLE
chore: Remove redundant localhost check

### DIFF
--- a/internal/ssh/ssh_tunnel.go
+++ b/internal/ssh/ssh_tunnel.go
@@ -112,23 +112,11 @@ func (ct *CheckSSHTunnelSecurity) Description() string {
 	return "Check SSH tunnel security"
 }
 
-func (ct *CheckSSHTunnelSecurity) Command() *exec.Cmd {
-	if !ct.TargetDest.IsLocalhost() {
-		hostName := NewConfig(ct.TargetDest).HostName
-		return exec.Command("curl", fmt.Sprintf("%s:%s", hostName, ct.Port), "--max-time", "1")
-	}
-	return nil
-}
-
 func (ct *CheckSSHTunnelSecurity) Run(w io.Writer) error {
 	if ct.TargetDest.IsLocalhost() {
 		return nil
 	}
-	cmd := ct.Command()
-	if cmd == nil {
-		panic(fmt.Sprintf("BUG: security check called for unresolvable host %q; caller must validate host before invoking", ct.TargetDest))
-	}
-
+	cmd := ct.command()
 	cmd.Stdout = w
 	cmd.Stderr = w
 
@@ -139,6 +127,11 @@ func (ct *CheckSSHTunnelSecurity) Run(w io.Writer) error {
 
 	_, _ = fmt.Fprintf(w, "Port %s is not exposed on target to local network\n", ct.Port)
 	return nil
+}
+
+func (ct *CheckSSHTunnelSecurity) command() *exec.Cmd {
+	hostName := NewConfig(ct.TargetDest).HostName
+	return exec.Command("curl", fmt.Sprintf("%s:%s", hostName, ct.Port), "--max-time", "1")
 }
 
 type SSHTunnelStop struct {

--- a/internal/ssh/ssh_tunnel_test.go
+++ b/internal/ssh/ssh_tunnel_test.go
@@ -137,28 +137,6 @@ func TestSSHTunnelStart(t *testing.T) {
 }
 
 func TestCheckSSHTunnelSecurity(t *testing.T) {
-	t.Run("Command", func(t *testing.T) {
-		t.Run("it generates correct curl command", func(t *testing.T) {
-			dest := ssh.NewDestination("user@remote")
-			port := operation.DefaultRegistryPort
-
-			cs := ssh.NewCheckSSHTunnelSecurity(dest, port)
-			got := strings.Join(cs.Command().Args, " ")
-
-			want := fmt.Sprintf("curl remote:%s --max-time 1", port)
-			assert.Equal(t, want, got)
-		})
-
-		t.Run("it returns nil when target is localhost", func(t *testing.T) {
-			dest := ssh.NewDestination("root@localhost")
-			port := operation.DefaultRegistryPort
-
-			cs := ssh.NewCheckSSHTunnelSecurity(dest, port)
-			got := cs.Command()
-			assert.Nil(t, got)
-		})
-	})
-
 	t.Run("Description", func(t *testing.T) {
 		t.Run("it returns the expected string", func(t *testing.T) {
 			cs := ssh.NewCheckSSHTunnelSecurity(ssh.NewDestination("user@remote"), operation.DefaultRegistryPort)


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- Remove redundant check for localhost (already gated by a pre-flight check) 
    - Eliminate a `panic`
- Remove uninteresting test case (unexport `Command()`)  
