### PR TITLE
feat: direct install script users to topo upgrade

### DIFF
--- a/e2e/install_script_posix_test.go
+++ b/e2e/install_script_posix_test.go
@@ -84,8 +84,6 @@ func TestInstallScript(t *testing.T) {
 		require.NoError(t, err, "script failed: %s", out)
 		assert.Contains(t, out, "topo is already installed")
 		assert.Contains(t, out, "topo upgrade")
-		assert.NotContains(t, out, "Installing topo")
-		assert.NotContains(t, out, "Installed topo")
 	})
 
 	t.Run("fails on unknown flag", func(t *testing.T) {

--- a/e2e/install_script_posix_test.go
+++ b/e2e/install_script_posix_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/arm/topo/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -19,12 +20,18 @@ func scriptPath(t *testing.T) string {
 	return path
 }
 
-func runInstallScript(t *testing.T, args ...string) (string, error) {
+func runInstallScriptWithEnv(t *testing.T, env []string, args ...string) (string, error) {
 	t.Helper()
 	cmdArgs := append([]string{scriptPath(t)}, args...)
 	cmd := exec.Command("sh", cmdArgs...)
+	cmd.Env = append(os.Environ(), env...)
 	out, err := cmd.CombinedOutput()
 	return string(out), err
+}
+
+func runInstallScript(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	return runInstallScriptWithEnv(t, nil, args...)
 }
 
 func TestInstallScript(t *testing.T) {
@@ -57,7 +64,7 @@ func TestInstallScript(t *testing.T) {
 		assert.FileExists(t, filepath.Join(dir, "topo"))
 	})
 
-	t.Run("can reinstall in-place", func(t *testing.T) {
+	t.Run("can override existing binary with --path", func(t *testing.T) {
 		dir := t.TempDir()
 		_, err := runInstallScript(t, "--path", dir)
 		require.NoError(t, err)
@@ -66,6 +73,20 @@ func TestInstallScript(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.FileExists(t, filepath.Join(dir, "topo"))
+	})
+
+	t.Run("tells user to use upgrade when topo is already installed", func(t *testing.T) {
+		dir := t.TempDir()
+		testutil.RequireWriteFile(t, filepath.Join(dir, "topo"), "")
+		pathWithTopo := dir + string(os.PathListSeparator) + os.Getenv("PATH")
+
+		out, err := runInstallScriptWithEnv(t, []string{"PATH=" + pathWithTopo})
+
+		require.NoError(t, err, "script failed: %s", out)
+		assert.Contains(t, out, "topo is already installed")
+		assert.Contains(t, out, "topo upgrade")
+		assert.NotContains(t, out, "Installing topo")
+		assert.NotContains(t, out, "Installed topo")
 	})
 
 	t.Run("fails on unknown flag", func(t *testing.T) {

--- a/e2e/install_script_posix_test.go
+++ b/e2e/install_script_posix_test.go
@@ -75,9 +75,9 @@ func TestInstallScript(t *testing.T) {
 	})
 
 	t.Run("tells user to use upgrade when topo is already installed", func(t *testing.T) {
-		dir := t.TempDir()
-		requireWriteDummyExecutable(t, filepath.Join(dir, "topo"))
-		pathWithTopo := dir + string(os.PathListSeparator) + os.Getenv("PATH")
+		topoInstallDir := t.TempDir()
+		requireWriteDummyExecutable(t, filepath.Join(topoInstallDir, "topo"))
+		pathWithTopo := topoInstallDir + string(os.PathListSeparator) + os.Getenv("PATH")
 
 		out, err := runInstallScriptWithEnv(t, []string{"PATH=" + pathWithTopo})
 

--- a/e2e/install_script_posix_test.go
+++ b/e2e/install_script_posix_test.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/arm/topo/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -77,7 +76,7 @@ func TestInstallScript(t *testing.T) {
 
 	t.Run("tells user to use upgrade when topo is already installed", func(t *testing.T) {
 		dir := t.TempDir()
-		testutil.RequireWriteFile(t, filepath.Join(dir, "topo"), "")
+		requireWriteDummyExecutable(t, filepath.Join(dir, "topo"))
 		pathWithTopo := dir + string(os.PathListSeparator) + os.Getenv("PATH")
 
 		out, err := runInstallScriptWithEnv(t, []string{"PATH=" + pathWithTopo})

--- a/e2e/install_script_windows_test.go
+++ b/e2e/install_script_windows_test.go
@@ -79,9 +79,9 @@ func TestInstallScriptWindows(t *testing.T) {
 	})
 
 	t.Run("tells user to use upgrade when topo is already installed", func(t *testing.T) {
-		dir := t.TempDir()
-		requireWriteDummyExecutable(t, filepath.Join(dir, "topo.exe"))
-		pathWithTopo := dir + string(os.PathListSeparator) + os.Getenv("PATH")
+		topoInstallDir := t.TempDir()
+		requireWriteDummyExecutable(t, filepath.Join(topoInstallDir, "topo.exe"))
+		pathWithTopo := topoInstallDir + string(os.PathListSeparator) + os.Getenv("PATH")
 
 		out, err := runInstallScriptWithEnv(t, []string{"PATH=" + pathWithTopo})
 

--- a/e2e/install_script_windows_test.go
+++ b/e2e/install_script_windows_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func runInstallScript(t *testing.T, args ...string) (string, error) {
+func runInstallScriptWithEnv(t *testing.T, env []string, args ...string) (string, error) {
 	t.Helper()
 
 	path, err := filepath.Abs("../scripts/install.ps1")
@@ -29,10 +29,15 @@ func runInstallScript(t *testing.T, args ...string) (string, error) {
 		"-File", path,
 	}, args...)
 	cmd := exec.Command("powershell", cmdArgs...)
-	cmd.Env = append(os.Environ(), "LOCALAPPDATA="+localAppDataDir)
+	cmd.Env = append(os.Environ(), env...)
 
 	out, err := cmd.CombinedOutput()
 	return string(out), err
+}
+
+func runInstallScript(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	return runInstallScriptWithEnv(t, nil, args...)
 }
 
 func TestInstallScriptWindows(t *testing.T) {
@@ -62,7 +67,7 @@ func TestInstallScriptWindows(t *testing.T) {
 		assert.FileExists(t, filepath.Join(dir, "topo.exe"))
 	})
 
-	t.Run("can reinstall in place", func(t *testing.T) {
+	t.Run("can override existing binary with -Path", func(t *testing.T) {
 		dir := t.TempDir()
 		_, err := runInstallScript(t, "-Path", dir)
 		require.NoError(t, err)
@@ -71,6 +76,20 @@ func TestInstallScriptWindows(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.FileExists(t, filepath.Join(dir, "topo.exe"))
+	})
+
+	t.Run("tells user to use upgrade when topo is already installed", func(t *testing.T) {
+		dir := t.TempDir()
+		testutil.RequireWriteFile(t, filepath.Join(dir, "topo.exe"), "")
+		pathWithTopo := dir + string(os.PathListSeparator) + os.Getenv("PATH")
+
+		out, err := runInstallScriptWithEnv(t, []string{"PATH=" + pathWithTopo})
+
+		require.NoError(t, err, "script failed: %s", out)
+		assert.Contains(t, out, "topo is already installed")
+		assert.Contains(t, out, "topo upgrade")
+		assert.NotContains(t, out, "Installing topo")
+		assert.NotContains(t, out, "Installed topo")
 	})
 
 	t.Run("fails on unknown flag", func(t *testing.T) {

--- a/e2e/install_script_windows_test.go
+++ b/e2e/install_script_windows_test.go
@@ -88,8 +88,6 @@ func TestInstallScriptWindows(t *testing.T) {
 		require.NoError(t, err, "script failed: %s", out)
 		assert.Contains(t, out, "topo is already installed")
 		assert.Contains(t, out, "topo upgrade")
-		assert.NotContains(t, out, "Installing topo")
-		assert.NotContains(t, out, "Installed topo")
 	})
 
 	t.Run("fails on unknown flag", func(t *testing.T) {

--- a/e2e/install_script_windows_test.go
+++ b/e2e/install_script_windows_test.go
@@ -80,7 +80,7 @@ func TestInstallScriptWindows(t *testing.T) {
 
 	t.Run("tells user to use upgrade when topo is already installed", func(t *testing.T) {
 		dir := t.TempDir()
-		testutil.RequireWriteFile(t, filepath.Join(dir, "topo.exe"), "")
+		requireWriteDummyExecutable(t, filepath.Join(dir, "topo.exe"))
 		pathWithTopo := dir + string(os.PathListSeparator) + os.Getenv("PATH")
 
 		out, err := runInstallScriptWithEnv(t, []string{"PATH=" + pathWithTopo})

--- a/e2e/testutil.go
+++ b/e2e/testutil.go
@@ -1,0 +1,14 @@
+package e2e
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func requireWriteDummyExecutable(t testing.TB, path string) {
+	t.Helper()
+	err := os.WriteFile(path, nil, 0o755)
+	require.NoError(t, err)
+}

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -65,12 +65,6 @@ function Build-DownloadUrl {
 }
 
 function Exit-IfTopoAlreadyInstalled {
-    param([string]$Requested)
-
-    if (-not [string]::IsNullOrWhiteSpace($Requested)) {
-        return
-    }
-
     $existing = Get-Command $ExeName -CommandType Application -ErrorAction SilentlyContinue | Select-Object -First 1
     if (-not $existing) {
         return
@@ -153,7 +147,9 @@ if ($Help) {
 }
 
 $installDir = $null
-Exit-IfTopoAlreadyInstalled -Requested $Path
+if ([string]::IsNullOrWhiteSpace($Path)) {
+    Exit-IfTopoAlreadyInstalled -Requested $Path
+}
 $installDir = Resolve-InstallDir -Requested $Path
 $resolvedVersion = Resolve-Version -Requested $Version
 Write-Host "Installing $BinaryName $resolvedVersion"

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -148,7 +148,7 @@ if ($Help) {
 
 $installDir = $null
 if ([string]::IsNullOrWhiteSpace($Path)) {
-    Exit-IfTopoAlreadyInstalled -Requested $Path
+    Exit-IfTopoAlreadyInstalled
 }
 $installDir = Resolve-InstallDir -Requested $Path
 $resolvedVersion = Resolve-Version -Requested $Version

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -10,7 +10,7 @@ $ErrorActionPreference = 'Stop'
 $ProgressPreference    = 'SilentlyContinue'
 
 $Usage = @'
-PowerShell installer for topo on Windows.
+PowerShell bootstrap installer for topo on Windows.
 Downloads a release from the Arm artifactory server, installs it under the
 current user, and ensures the install directory is on your PATH.
 
@@ -64,21 +64,29 @@ function Build-DownloadUrl {
     return "$BaseUrl/$Version/windows/$archive"
 }
 
+function Exit-IfTopoAlreadyInstalled {
+    param([string]$Requested)
+
+    if (-not [string]::IsNullOrWhiteSpace($Requested)) {
+        return
+    }
+
+    $existing = Get-Command $ExeName -CommandType Application -ErrorAction SilentlyContinue | Select-Object -First 1
+    if (-not $existing) {
+        return
+    }
+
+    Write-Host "$BinaryName is already installed at $($existing.Source)."
+    Write-Host "Use '$BinaryName upgrade' to update the existing installation, or pass -Path to download to somewhere else."
+    exit 0
+}
+
 function Resolve-InstallDir {
     param([string]$Requested)
 
     if (-not [string]::IsNullOrWhiteSpace($Requested)) {
         New-Item -ItemType Directory -Path $Requested -Force | Out-Null
         return (Resolve-Path -LiteralPath $Requested).ProviderPath
-    }
-
-    $existing = Get-Command $ExeName -CommandType Application -ErrorAction SilentlyContinue | Select-Object -First 1
-    if ($existing) {
-        $dir = Split-Path -Parent $existing.Source
-        $currentVersion = ''
-        try { $currentVersion = (& $existing.Source --version 2>$null) -join ' ' } catch { }
-        Write-Host "Existing installation found at $dir ($currentVersion), will update in-place"
-        return $dir
     }
 
     # windows convention is to install user-local binaries under %LOCALAPPDATA%\Programs\$BinaryName
@@ -144,11 +152,13 @@ if ($Help) {
     return
 }
 
+$installDir = $null
+Exit-IfTopoAlreadyInstalled -Requested $Path
+$installDir = Resolve-InstallDir -Requested $Path
 $resolvedVersion = Resolve-Version -Requested $Version
 Write-Host "Installing $BinaryName $resolvedVersion"
 
 $url        = Build-DownloadUrl -Version $resolvedVersion
-$installDir = Resolve-InstallDir -Requested $Path
 
 Install-Binary -Url $url -InstallDir $installDir -Version $resolvedVersion
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -110,12 +110,6 @@ build_download_url() {
 }
 
 exit_if_topo_already_installed() {
-  requested_install_dir="$1"
-
-  if [ -n "$requested_install_dir" ]; then
-    return
-  fi
-
   existing="$(command -v "$BINARY_NAME" 2>/dev/null || true)"
   if [ -z "$existing" ]; then
     return
@@ -198,7 +192,9 @@ install_binary() {
 main() {
   parse_args "$@"
 
-  exit_if_topo_already_installed "$ARG_INSTALL_DIR"
+  if [ -z "$ARG_INSTALL_DIR" ]; then
+    exit_if_topo_already_installed "$ARG_INSTALL_DIR"
+  fi  
 
   install_dir="$(resolve_install_dir "$ARG_INSTALL_DIR")"
   version="$(resolve_version "$ARG_VERSION")"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,7 +2,7 @@
 {
 set -eu
 
-USAGE="POSIX-portable idempotent installer for topo.
+USAGE="POSIX-portable bootstrap installer for topo.
 Downloads a release from the Arm artifactory server and places the binary
 on the current user's PATH.
 
@@ -109,6 +109,23 @@ build_download_url() {
   echo "${BASE_URL}/${version}/${os}/${archive}"
 }
 
+exit_if_topo_already_installed() {
+  requested_install_dir="$1"
+
+  if [ -n "$requested_install_dir" ]; then
+    return
+  fi
+
+  existing="$(command -v "$BINARY_NAME" 2>/dev/null || true)"
+  if [ -z "$existing" ]; then
+    return
+  fi
+
+  echo "${BINARY_NAME} is already installed at ${existing}." >&2
+  echo "Use '${BINARY_NAME} upgrade' to update the existing installation, or pass --path to download to somewhere else." >&2
+  exit 0
+}
+
 resolve_install_dir() {
   install_dir="$1"
 
@@ -118,15 +135,6 @@ resolve_install_dir() {
       exit 1
     }
     echo "$install_dir"
-    return
-  fi
-
-  existing="$(command -v "$BINARY_NAME" 2>/dev/null || true)"
-  if [ -n "$existing" ]; then
-    dir="$(dirname "$existing")"
-    version="$("$existing" --version 2>/dev/null || true)"
-    echo "Existing installation found at ${dir} (${version}), will update in-place" >&2
-    echo "$dir"
     return
   fi
 
@@ -190,11 +198,13 @@ install_binary() {
 main() {
   parse_args "$@"
 
+  exit_if_topo_already_installed "$ARG_INSTALL_DIR"
+
+  install_dir="$(resolve_install_dir "$ARG_INSTALL_DIR")"
   version="$(resolve_version "$ARG_VERSION")"
   echo "Installing ${BINARY_NAME} ${version}"
 
   url="$(build_download_url "$version")"
-  install_dir="$(resolve_install_dir "$ARG_INSTALL_DIR")"
 
   tmpdir="$(mktemp -d)"
   trap 'rm -rf "$tmpdir"' EXIT

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -193,7 +193,7 @@ main() {
   parse_args "$@"
 
   if [ -z "$ARG_INSTALL_DIR" ]; then
-    exit_if_topo_already_installed "$ARG_INSTALL_DIR"
+    exit_if_topo_already_installed
   fi  
 
   install_dir="$(resolve_install_dir "$ARG_INSTALL_DIR")"


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- Removes the ability of the install scripts to replace `topo` binaries already on the PATH in-place and directs them towards `topo upgrade`
- Overriding existing binaries when using the `--path` flag continues to function as normal
- Technically a breaking change to the install scripts but didn't mark as such in the PR title since it's not breaking to the CLI
