### PR TITLE
fix: Improve confusing tunnel security messaging

### DIFF
--- a/internal/ssh/ssh_tunnel.go
+++ b/internal/ssh/ssh_tunnel.go
@@ -122,11 +122,12 @@ func (ct *CheckRemoteForwardNotExposed) Run(w io.Writer) error {
 
 	hostName := NewConfig(ct.TargetDest).HostName
 	cmd := exec.Command("curl", fmt.Sprintf("%s:%s", hostName, ct.Port), "--max-time", "1")
-	cmd.Stdout = w
-	cmd.Stderr = w
+	// curl failing is the success path here; suppress its output so a
+	// "Failed to connect" line doesn't appear in the deployment log.
+	cmd.Stdout = io.Discard
+	cmd.Stderr = io.Discard
 
-	err := cmd.Run()
-	if err == nil {
+	if err := cmd.Run(); err == nil {
 		return fmt.Errorf("remote sshd is exposing the forwarded port %s on its network (likely GatewayPorts=yes); the local registry is reachable without SSH auth", ct.Port)
 	}
 

--- a/internal/ssh/ssh_tunnel.go
+++ b/internal/ssh/ssh_tunnel.go
@@ -104,9 +104,9 @@ type CheckRemoteForwardNotExposed struct {
 	Port       string
 }
 
-// Detects a remote sshd with GatewayPorts enabled, which would bind the -R
-// forward to 0.0.0.0 on the target instead of its loopback, exposing the
-// local registry to the target's network.
+// Checks whether the RemoteForward port exposes the registry to the target's
+// network, rather than being limited to target loopback. This can happen when
+// sshd permits non-loopback remote forwards, such as GatewayPorts.
 func NewCheckRemoteForwardNotExposed(targetDest Destination, port string) *CheckRemoteForwardNotExposed {
 	return &CheckRemoteForwardNotExposed{TargetDest: targetDest, Port: port}
 }

--- a/internal/ssh/ssh_tunnel.go
+++ b/internal/ssh/ssh_tunnel.go
@@ -34,7 +34,7 @@ func ControlSocketPath(targetHost string) string {
 
 func NewSSHTunnel(targetDest Destination, port string, useControlSockets bool) (operation.Operation, operation.Operation, operation.Operation) {
 	start := NewSSHTunnelStart(targetDest, port, useControlSockets)
-	securityCheck := NewCheckSSHTunnelSecurity(targetDest, port)
+	securityCheck := NewCheckRemoteForwardNotExposed(targetDest, port)
 
 	var stop operation.Operation
 	if useControlSockets {
@@ -99,39 +99,39 @@ func (s *SSHTunnelStart) Run(w io.Writer) error {
 	return nil
 }
 
-type CheckSSHTunnelSecurity struct {
+type CheckRemoteForwardNotExposed struct {
 	TargetDest Destination
 	Port       string
 }
 
-func NewCheckSSHTunnelSecurity(targetDest Destination, port string) *CheckSSHTunnelSecurity {
-	return &CheckSSHTunnelSecurity{TargetDest: targetDest, Port: port}
+// Detects a remote sshd with GatewayPorts enabled, which would bind the -R
+// forward to 0.0.0.0 on the target instead of its loopback, exposing the
+// local registry to the target's network.
+func NewCheckRemoteForwardNotExposed(targetDest Destination, port string) *CheckRemoteForwardNotExposed {
+	return &CheckRemoteForwardNotExposed{TargetDest: targetDest, Port: port}
 }
 
-func (ct *CheckSSHTunnelSecurity) Description() string {
-	return "Check SSH tunnel security"
+func (ct *CheckRemoteForwardNotExposed) Description() string {
+	return "Check tunnel port is not exposed on remote network"
 }
 
-func (ct *CheckSSHTunnelSecurity) Run(w io.Writer) error {
+func (ct *CheckRemoteForwardNotExposed) Run(w io.Writer) error {
 	if ct.TargetDest.IsLocalhost() {
 		return nil
 	}
-	cmd := ct.command()
+
+	hostName := NewConfig(ct.TargetDest).HostName
+	cmd := exec.Command("curl", fmt.Sprintf("%s:%s", hostName, ct.Port), "--max-time", "1")
 	cmd.Stdout = w
 	cmd.Stderr = w
 
 	err := cmd.Run()
 	if err == nil {
-		return fmt.Errorf("ssh tunnel to %s is not secure: able to access registry port without authentication", ct.TargetDest)
+		return fmt.Errorf("remote sshd is exposing the forwarded port %s on its network (likely GatewayPorts=yes); the local registry is reachable without SSH auth", ct.Port)
 	}
 
-	_, _ = fmt.Fprintf(w, "Port %s is not exposed on target to local network\n", ct.Port)
+	_, _ = fmt.Fprintf(w, "Port %s is bound to remote loopback only\n", ct.Port)
 	return nil
-}
-
-func (ct *CheckSSHTunnelSecurity) command() *exec.Cmd {
-	hostName := NewConfig(ct.TargetDest).HostName
-	return exec.Command("curl", fmt.Sprintf("%s:%s", hostName, ct.Port), "--max-time", "1")
 }
 
 type SSHTunnelStop struct {

--- a/internal/ssh/ssh_tunnel_test.go
+++ b/internal/ssh/ssh_tunnel_test.go
@@ -54,8 +54,8 @@ func TestSSHTunnel(t *testing.T) {
 
 			_, securityCheck, _ := ssh.NewSSHTunnel(dest, "44553", true)
 
-			_, ok := securityCheck.(*ssh.CheckSSHTunnelSecurity)
-			assert.True(t, ok, "security check operation is not of type CheckSSHTunnelSecurity")
+			_, ok := securityCheck.(*ssh.CheckRemoteForwardNotExposed)
+			assert.True(t, ok, "security check operation is not of type CheckRemoteForwardNotExposed")
 		})
 	})
 }
@@ -124,14 +124,14 @@ func TestSSHTunnelStart(t *testing.T) {
 	})
 }
 
-func TestCheckSSHTunnelSecurity(t *testing.T) {
+func TestCheckRemoteForwardNotExposed(t *testing.T) {
 	t.Run("Description", func(t *testing.T) {
 		t.Run("it returns the expected string", func(t *testing.T) {
-			cs := ssh.NewCheckSSHTunnelSecurity(ssh.NewDestination("user@remote"), "12345")
+			cs := ssh.NewCheckRemoteForwardNotExposed(ssh.NewDestination("user@remote"), "12345")
 
 			got := cs.Description()
 
-			assert.Equal(t, "Check SSH tunnel security", got)
+			assert.Equal(t, "Check tunnel port is not exposed on remote network", got)
 		})
 	})
 }


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- Stop displaying curl failures in the logs, because failing curl is actually good in this case
- Explain the purpose of the check
- Make error/success messages more meaningful and potentially actionable 
