### PR TITLE
fix: accurate `topo --version`

### DIFF
--- a/cmd/topo/version_test.go
+++ b/cmd/topo/version_test.go
@@ -1,0 +1,43 @@
+package main_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVersionFlagReportsLinkedVersion(t *testing.T) {
+	workingDirectory, err := os.Getwd()
+	require.NoError(t, err)
+
+	binaryName := "topo"
+	if runtime.GOOS == "windows" {
+		binaryName += ".exe"
+	}
+	binaryPath := filepath.Join(t.TempDir(), binaryName)
+
+	buildCommand := exec.Command(
+		"go",
+		"build",
+		"-ldflags",
+		"-X github.com/arm/topo/internal/version.Version=4.1.0 -X github.com/arm/topo/internal/version.GitCommit=deadbeef",
+		"-o",
+		binaryPath,
+		".",
+	)
+	buildCommand.Dir = workingDirectory
+
+	buildOutput, err := buildCommand.CombinedOutput()
+	require.NoError(t, err, string(buildOutput))
+
+	versionCommand := exec.Command(binaryPath, "--version")
+	versionOutput, err := versionCommand.CombinedOutput()
+	require.NoError(t, err, string(versionOutput))
+
+	assert.Equal(t, "topo version 4.1.0 (commit: deadbeef)\n", string(versionOutput))
+}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,8 +1,8 @@
 package version
 
-var (
-	Dev = "dev"
+const Dev = "dev"
 
+var (
 	// Version holds the complete version number. Filled in at linking time via -ldflags.
 	Version = Dev
 


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- topo version made overridable
