### PR TITLE
feat: opinionated default install dir + shell-specific command to add to PATH in install script 

### DIFF
--- a/e2e/install_script_posix_test.go
+++ b/e2e/install_script_posix_test.go
@@ -21,10 +21,20 @@ func scriptPath(t *testing.T) string {
 
 func runInstallScript(t *testing.T, args ...string) (string, error) {
 	t.Helper()
+	return runInstallScriptWithEnv(t, nil, args...)
+}
+
+func runInstallScriptWithEnv(t *testing.T, env []string, args ...string) (string, error) {
+	t.Helper()
 	cmdArgs := append([]string{scriptPath(t)}, args...)
 	cmd := exec.Command("sh", cmdArgs...)
+	cmd.Env = append(os.Environ(), env...)
 	out, err := cmd.CombinedOutput()
 	return string(out), err
+}
+
+func installBinDir(home string) string {
+	return filepath.Join(home, ".local", "bin")
 }
 
 func TestInstallScript(t *testing.T) {
@@ -32,16 +42,18 @@ func TestInstallScript(t *testing.T) {
 		t.Skip("skipping install script e2e tests in short mode")
 	}
 
-	t.Run("installs latest version", func(t *testing.T) {
-		dir := t.TempDir()
-		bin := filepath.Join(dir, "topo")
+	t.Run("installs latest version to $HOME/.local/bin", func(t *testing.T) {
+		home := t.TempDir()
 
-		out, err := runInstallScript(t, "--path", dir)
+		out, err := runInstallScriptWithEnv(t, []string{
+			"HOME=" + home,
+		})
 
+		wantBin := filepath.Join(installBinDir(home), "topo")
 		require.NoError(t, err, "script failed: %s", out)
 		assert.Contains(t, out, "Installed topo")
-		assert.FileExists(t, bin)
-		info, err := os.Stat(bin)
+		assert.FileExists(t, wantBin)
+		info, err := os.Stat(wantBin)
 		require.NoError(t, err)
 		assert.NotZero(t, info.Mode()&0o111, "binary should be executable")
 	})
@@ -52,20 +64,48 @@ func TestInstallScript(t *testing.T) {
 
 		out, err := runInstallScript(t, "--version", version, "--path", dir)
 
+		wantBin := filepath.Join(dir, "topo")
 		require.NoError(t, err, "script failed: %s", out)
 		assert.Contains(t, out, version)
+		assert.FileExists(t, wantBin)
+		// TODO assert that the version of the installed binary matches the requested version
+	})
+
+	t.Run("installs to custom path when requested", func(t *testing.T) {
+		dir := t.TempDir()
+
+		out, err := runInstallScript(t, "--path", dir)
+
+		require.NoError(t, err, "script failed: %s", out)
 		assert.FileExists(t, filepath.Join(dir, "topo"))
 	})
 
 	t.Run("can reinstall in-place", func(t *testing.T) {
-		dir := t.TempDir()
-		_, err := runInstallScript(t, "--path", dir)
+		home := t.TempDir()
+		installDir := installBinDir(home)
+		env := []string{
+			"HOME=" + home,
+		}
+		_, err := runInstallScriptWithEnv(t, env, "--version", "v4.0.0")
 		require.NoError(t, err)
 
-		_, err = runInstallScript(t, "--path", dir)
+		_, err = runInstallScriptWithEnv(t, env)
+
+		wantBin := filepath.Join(installDir, "topo")
+		require.NoError(t, err)
+		assert.FileExists(t, wantBin)
+	})
+
+	t.Run("does not prompt to add to PATH when install directory is already on PATH", func(t *testing.T) {
+		home := t.TempDir()
+		env := []string{
+			"HOME=" + home,
+			"PATH=" + installBinDir(home) + string(os.PathListSeparator) + os.Getenv("PATH"),
+		}
+		out, err := runInstallScriptWithEnv(t, env)
 
 		require.NoError(t, err)
-		assert.FileExists(t, filepath.Join(dir, "topo"))
+		assert.NotContains(t, out, "is not on your PATH")
 	})
 
 	t.Run("fails on unknown flag", func(t *testing.T) {

--- a/e2e/install_script_posix_test.go
+++ b/e2e/install_script_posix_test.go
@@ -52,7 +52,6 @@ func TestInstallScript(t *testing.T) {
 
 		wantBin := filepath.Join(installBinDir(home), "topo")
 		require.NoError(t, err, "script failed: %s", out)
-		assert.Contains(t, out, "Installed topo")
 		assert.FileExists(t, wantBin)
 		assert.Contains(t, out, "~/.zshrc")
 		info, err := os.Stat(wantBin)
@@ -94,10 +93,10 @@ func TestInstallScript(t *testing.T) {
 		_, err := runInstallScriptWithEnv(t, env, "--version", "v4.0.0")
 		require.NoError(t, err)
 
-		_, err = runInstallScriptWithEnv(t, env)
+		out, err := runInstallScriptWithEnv(t, env)
 
 		wantBin := filepath.Join(installDir, "topo")
-		require.NoError(t, err)
+		require.NoError(t, err, "script failed: %s", out)
 		assert.FileExists(t, wantBin)
 	})
 
@@ -110,7 +109,7 @@ func TestInstallScript(t *testing.T) {
 
 		out, err := runInstallScriptWithEnv(t, env)
 
-		require.NoError(t, err)
+		require.NoError(t, err, "script failed: %s", out)
 		assert.NotContains(t, out, "is not on your PATH")
 	})
 

--- a/e2e/install_script_posix_test.go
+++ b/e2e/install_script_posix_test.go
@@ -47,19 +47,21 @@ func TestInstallScript(t *testing.T) {
 
 		out, err := runInstallScriptWithEnv(t, []string{
 			"HOME=" + home,
+			"SHELL=/bin/zsh",
 		})
 
 		wantBin := filepath.Join(installBinDir(home), "topo")
 		require.NoError(t, err, "script failed: %s", out)
 		assert.Contains(t, out, "Installed topo")
 		assert.FileExists(t, wantBin)
+		assert.Contains(t, out, "~/.zshrc")
 		info, err := os.Stat(wantBin)
 		require.NoError(t, err)
 		assert.NotZero(t, info.Mode()&0o111, "binary should be executable")
 	})
 
 	t.Run("installs a specific version", func(t *testing.T) {
-		version := "v4.0.0"
+		version := "4.0.0"
 		dir := t.TempDir()
 
 		out, err := runInstallScript(t, "--version", version, "--path", dir)
@@ -68,7 +70,10 @@ func TestInstallScript(t *testing.T) {
 		require.NoError(t, err, "script failed: %s", out)
 		assert.Contains(t, out, version)
 		assert.FileExists(t, wantBin)
-		// TODO assert that the version of the installed binary matches the requested version
+		cmd := exec.Command(wantBin, "--version")
+		output, err := cmd.CombinedOutput()
+		require.NoError(t, err)
+		assert.Contains(t, string(output), version)
 	})
 
 	t.Run("installs to custom path when requested", func(t *testing.T) {
@@ -102,6 +107,7 @@ func TestInstallScript(t *testing.T) {
 			"HOME=" + home,
 			"PATH=" + installBinDir(home) + string(os.PathListSeparator) + os.Getenv("PATH"),
 		}
+
 		out, err := runInstallScriptWithEnv(t, env)
 
 		require.NoError(t, err)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,7 +3,7 @@
 set -eu
 
 USAGE="POSIX-portable idempotent installer for topo.
-Downloads a release from the Arm artifactory server and installs the application.
+Downloads and installs a topo release from the Arm Artifactory server.
 
 Usage:
   sh install.sh [--version VERSION] [--path DIRECTORY]

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,15 +3,14 @@
 set -eu
 
 USAGE="POSIX-portable idempotent installer for topo.
-Downloads a release from the Arm artifactory server and installs the binary
-to \$HOME/.local/bin.
+Downloads a release from the Arm artifactory server and installs the application.
 
 Usage:
   sh install.sh [--version VERSION] [--path DIRECTORY]
 
 Options:
   --version VERSION   Install a specific version (e.g. v4.0.0). Default: latest.
-  --path DIRECTORY    Install the binary into DIRECTORY instead of \$HOME/.local/bin."
+  --path DIRECTORY    Install to a custom directory. Default: \$HOME/.local/bin."
 
 BASE_URL="https://artifacts.tools.arm.com/topo"
 BINARY_NAME="topo"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,15 +3,15 @@
 set -eu
 
 USAGE="POSIX-portable idempotent installer for topo.
-Downloads a release from the Arm artifactory server and places the binary
-on the current user's PATH.
+Downloads a release from the Arm artifactory server and installs the binary
+to \$HOME/.local/bin.
 
 Usage:
   sh install.sh [--version VERSION] [--path DIRECTORY]
 
 Options:
   --version VERSION   Install a specific version (e.g. v4.0.0). Default: latest.
-  --path DIRECTORY    Install the binary into DIRECTORY instead of auto-detecting."
+  --path DIRECTORY    Install the binary into DIRECTORY instead of \$HOME/.local/bin."
 
 BASE_URL="https://artifacts.tools.arm.com/topo"
 BINARY_NAME="topo"
@@ -112,40 +112,41 @@ build_download_url() {
 resolve_install_dir() {
   install_dir="$1"
 
-  if [ -n "$install_dir" ]; then
-    mkdir -p "$install_dir" 2>/dev/null || {
-      echo "Error: cannot create directory: ${install_dir}" >&2
-      exit 1
-    }
-    echo "$install_dir"
-    return
+  if [ -z "$install_dir" ]; then
+    install_dir="$HOME/.local/bin"
   fi
 
-  existing="$(command -v "$BINARY_NAME" 2>/dev/null || true)"
-  if [ -n "$existing" ]; then
-    dir="$(dirname "$existing")"
-    version="$("$existing" --version 2>/dev/null || true)"
-    echo "Existing installation found at ${dir} (${version}), will update in-place" >&2
-    echo "$dir"
-    return
-  fi
+  mkdir -p "$install_dir" 2>/dev/null || {
+    echo "Error: cannot create directory: ${install_dir}" >&2
+    exit 1
+  }
+  echo "$install_dir"
+}
 
-  preferred_dir="$HOME/.local/bin"
+is_dir_on_path() {
+  install_dir="$1"
 
-  # try conventional user-local directories already on PATH.
-  for candidate in "$preferred_dir" "$HOME/bin"; do
-    case ":${PATH}:" in
-      *":${candidate}:"*)
-        mkdir -p "$candidate" 2>/dev/null && echo "$candidate" && return
-        ;;
-    esac
-  done
+  case ":${PATH:-}:" in
+    *":${install_dir}:"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
 
-  echo "Error: could not find a user-writable directory on PATH." >&2
-  echo "Provide one explicitly with --path, or add $preferred_dir to your PATH with the following command:" >&2
-  echo "  export PATH=\"\$PATH:$preferred_dir\"" >&2
-  echo "To persist across terminal restarts, add the export line to your shell's configuration file (e.g. ~/.bashrc, ~/.zshrc)" >&2
-  exit 1
+path_setup_command() {
+  case "${SHELL:-}" in
+    */zsh)
+      echo "export PATH=\"\$PATH:\$HOME/.local/bin\"; grep -qxF 'export PATH=\"\$PATH:\$HOME/.local/bin\"' ~/.zshrc 2>/dev/null || printf '\\nexport PATH=\"\$PATH:\$HOME/.local/bin\"\\n' >> ~/.zshrc"
+      ;;
+    */bash)
+      echo "export PATH=\"\$PATH:\$HOME/.local/bin\"; grep -qxF 'export PATH=\"\$PATH:\$HOME/.local/bin\"' ~/.bashrc 2>/dev/null || printf '\\nexport PATH=\"\$PATH:\$HOME/.local/bin\"\\n' >> ~/.bashrc"
+      ;;
+    */fish)
+      echo "fish_add_path -U \"\$HOME/.local/bin\""
+      ;;
+    *)
+      echo "export PATH=\"\$PATH:\$HOME/.local/bin\"; grep -qxF 'export PATH=\"\$PATH:\$HOME/.local/bin\"' ~/.profile 2>/dev/null || printf '\\nexport PATH=\"\$PATH:\$HOME/.local/bin\"\\n' >> ~/.profile"
+      ;;
+  esac
 }
 
 download_and_extract() {
@@ -174,15 +175,14 @@ install_binary() {
   install -m 0755 "$src" "${install_dir}/${BINARY_NAME}"
   echo "Installed ${BINARY_NAME} ${version} to ${install_dir}/${BINARY_NAME}"
 
-  if has_cmd "$BINARY_NAME"; then
+  if is_dir_on_path "$install_dir"; then
     echo "Run '${BINARY_NAME} --help' to get started"
   else
     abs_dir=$(cd "$install_dir" && pwd -L)
     echo ""
     echo "Warning: ${abs_dir} is not on your PATH"
-    echo "Add it to your current session with:"
-    echo "  export PATH=\"\$PATH:${abs_dir}\""
-    echo "To persist across terminal restarts, add the export line to your shell's configuration file (e.g. ~/.bashrc, ~/.zshrc)"
+    echo "Add it for the current session and future sessions with:"
+    echo "  $(path_setup_command)"
     echo ""
   fi
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -110,16 +110,15 @@ build_download_url() {
 }
 
 resolve_install_dir() {
-  install_dir="$1"
-
-  if [ -z "$install_dir" ]; then
-    install_dir="$HOME/.local/bin"
-  fi
-
-  mkdir -p "$install_dir" 2>/dev/null || {
+  install_dir="${1:-$HOME/.local/bin}"
+  if ! mkdir -p "$install_dir" 2>/dev/null; then
     echo "Error: cannot create directory: ${install_dir}" >&2
     exit 1
-  }
+  fi
+  if ! install_dir="$(cd "$install_dir" && pwd -L)"; then
+    echo "Error: cannot resolve directory: ${install_dir}" >&2
+    exit 1
+  fi
   echo "$install_dir"
 }
 
@@ -133,18 +132,20 @@ is_dir_on_path() {
 }
 
 path_setup_command() {
+  install_dir="$1"
+
   case "${SHELL:-}" in
     */zsh)
-      echo "export PATH=\"\$PATH:\$HOME/.local/bin\"; grep -qxF 'export PATH=\"\$PATH:\$HOME/.local/bin\"' ~/.zshrc 2>/dev/null || printf '\\nexport PATH=\"\$PATH:\$HOME/.local/bin\"\\n' >> ~/.zshrc"
+      echo "echo 'export PATH=\"\$PATH:${install_dir}\"' >> ~/.zshrc; export PATH=\"\$PATH:${install_dir}\""
       ;;
     */bash)
-      echo "export PATH=\"\$PATH:\$HOME/.local/bin\"; grep -qxF 'export PATH=\"\$PATH:\$HOME/.local/bin\"' ~/.bashrc 2>/dev/null || printf '\\nexport PATH=\"\$PATH:\$HOME/.local/bin\"\\n' >> ~/.bashrc"
+      echo "echo 'export PATH=\"\$PATH:${install_dir}\"' >> ~/.bashrc; export PATH=\"\$PATH:${install_dir}\""
       ;;
     */fish)
-      echo "fish_add_path -U \"\$HOME/.local/bin\""
+      echo "fish_add_path -U \"${install_dir}\""
       ;;
     *)
-      echo "export PATH=\"\$PATH:\$HOME/.local/bin\"; grep -qxF 'export PATH=\"\$PATH:\$HOME/.local/bin\"' ~/.profile 2>/dev/null || printf '\\nexport PATH=\"\$PATH:\$HOME/.local/bin\"\\n' >> ~/.profile"
+      echo "echo 'export PATH=\"\$PATH:${install_dir}\"' >> ~/.profile; export PATH=\"\$PATH:${install_dir}\""
       ;;
   esac
 }
@@ -173,16 +174,15 @@ install_binary() {
   version="$3"
 
   install -m 0755 "$src" "${install_dir}/${BINARY_NAME}"
-  echo "Installed ${BINARY_NAME} ${version} to ${install_dir}/${BINARY_NAME}"
+  echo "Downloaded ${BINARY_NAME} ${version} to ${install_dir}/${BINARY_NAME}"
 
   if is_dir_on_path "$install_dir"; then
     echo "Run '${BINARY_NAME} --help' to get started"
   else
-    abs_dir=$(cd "$install_dir" && pwd -L)
     echo ""
-    echo "Warning: ${abs_dir} is not on your PATH"
+    echo "Warning: ${install_dir} is not on your PATH"
     echo "Add it for the current session and future sessions with:"
-    echo "  $(path_setup_command)"
+    echo "  $(path_setup_command "$install_dir")"
     echo ""
   fi
 }


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- Moves away from the "let's find a dir already on the PATH to shove topo into and tell the user to add it if we can't find one" and replaces it with "always install to `~/.local/bin`, then check if its on the PATH and if not give the user a one-liner to do it"
- Minor test changes to:
  - Assert the correct version is downloaded when passing `--version`
  - Shell-specific instructions are included to add to PATH based on the users' default shell
  - Does not prompt to add to PATH if install dir is already on it

Have tested on all the included shells and works for me - not too familiar with fish idioms. The add path utility I've used seemed neat but not sure if this is standard.
