### PR TITLE
ci: Add support for pre-release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,6 +2,12 @@ name: Release
 
 on:
   workflow_dispatch:
+    inputs:
+      pre-release:
+        description: Publish signed artifacts under the pre-release Artifactory layout.
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -122,7 +128,8 @@ jobs:
         run: |
           gh workflow run sign-and-release.yml \
             --repo Arm-Debug/topo-publisher \
-            --ref v4 \
+            --ref v5 \
             --field run-id=${{ github.run_id }} \
             --field release-version=${VERSION} \
             --field release-tag=${VERSION} \
+            --field pre-release=${{ inputs.pre-release }}


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

Dependant on: https://github.com/Arm-Debug/topo-publisher/pull/35

- Adds an input for `pre-release` which threads through the publish sign and release workflow.
