### PR TITLE
refactor: manually calculate image names instead of using `docker compose`

### DIFF
--- a/internal/compose/compose.go
+++ b/internal/compose/compose.go
@@ -177,6 +177,23 @@ func RegisterVolumes(targetProject *types.Project, volumes []types.ServiceVolume
 	}
 }
 
+func ImageNames(composeFilePath string) ([]string, error) {
+	project, err := ReadProject(composeFilePath)
+	if err != nil {
+		return nil, err
+	}
+	var names []string
+	for name, svc := range project.Services {
+		if svc.Image != "" {
+			names = append(names, svc.Image)
+		} else {
+			names = append(names, fmt.Sprintf("%s-%s", project.Name, name))
+		}
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
 func PullableServices(composeFilePath string) ([]string, error) {
 	project, err := ReadProject(composeFilePath)
 	if err != nil {

--- a/internal/compose/compose_test.go
+++ b/internal/compose/compose_test.go
@@ -2,6 +2,7 @@ package compose_test
 
 import (
 	"path/filepath"
+	"sort"
 	"testing"
 
 	"github.com/arm/topo/internal/compose"
@@ -185,6 +186,76 @@ func TestRegisterVolumes(t *testing.T) {
 			"existing": types.VolumeConfig{Name: "existing", Driver: "local"},
 			"new":      types.VolumeConfig{},
 		}, project.Volumes)
+	})
+}
+
+func TestImageNames(t *testing.T) {
+	t.Run("returns explicit and generated image names in sorted order", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "compose.yaml")
+		testutil.RequireWriteFile(t, path, `
+name: springfield
+services:
+  api:
+    build: .
+  web:
+    image: nginx:1.27
+  worker:
+    build: .
+    image: worker:dev
+`)
+
+		got, err := compose.ImageNames(path)
+
+		require.NoError(t, err)
+		assert.Equal(t, []string{"nginx:1.27", "springfield-api", "worker:dev"}, got)
+	})
+
+	t.Run("uses the compose file directory when project name is omitted", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "compose.yaml")
+		testutil.RequireWriteFile(t, path, `
+services:
+  api:
+    build: .
+  web:
+    image: nginx:1.27
+`)
+
+		got, err := compose.ImageNames(path)
+
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{filepath.Base(dir) + "-api", "nginx:1.27"}, got)
+	})
+
+	t.Run("returns sorted output", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "compose.yaml")
+		testutil.RequireWriteFile(t, path, `
+name: springfield
+services:
+  zulu:
+    build: .
+  alpha:
+    image: alpine:3.20
+  mike:
+    build: .
+    image: mike:dev
+  beta:
+    image: busybox:1.36
+`)
+
+		got, err := compose.ImageNames(path)
+
+		require.NoError(t, err)
+		assert.True(t, sort.StringsAreSorted(got))
+	})
+
+	t.Run("returns error for invalid yaml", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "compose.yaml")
+		testutil.RequireWriteFile(t, path, `{invalid`)
+
+		_, err := compose.ImageNames(path)
+
+		assert.Error(t, err)
 	})
 }
 

--- a/internal/compose/compose_test.go
+++ b/internal/compose/compose_test.go
@@ -227,6 +227,36 @@ services:
 		assert.ElementsMatch(t, []string{filepath.Base(dir) + "-api", "nginx:1.27"}, got)
 	})
 
+	t.Run("resolves image names from extended services", func(t *testing.T) {
+		dir := t.TempDir()
+		basePath := filepath.Join(dir, "base.yaml")
+		path := filepath.Join(dir, "compose.yaml")
+		testutil.RequireWriteFile(t, basePath, `
+services:
+  image-base:
+    image: duff:latest
+  build-base:
+    build: .
+`)
+		testutil.RequireWriteFile(t, path, `
+name: springfield
+services:
+  duff:
+    extends:
+      file: base.yaml
+      service: image-base
+  api:
+    extends:
+      file: base.yaml
+      service: build-base
+`)
+
+		got, err := compose.ImageNames(path)
+
+		require.NoError(t, err)
+		assert.Equal(t, []string{"duff:latest", "springfield-api"}, got)
+	})
+
 	t.Run("returns sorted output", func(t *testing.T) {
 		path := filepath.Join(t.TempDir(), "compose.yaml")
 		testutil.RequireWriteFile(t, path, `

--- a/internal/compose/compose_test.go
+++ b/internal/compose/compose_test.go
@@ -190,7 +190,7 @@ func TestRegisterVolumes(t *testing.T) {
 }
 
 func TestImageNames(t *testing.T) {
-	t.Run("returns explicit and generated image names in sorted order", func(t *testing.T) {
+	t.Run("returns explicit and generated image names", func(t *testing.T) {
 		path := filepath.Join(t.TempDir(), "compose.yaml")
 		testutil.RequireWriteFile(t, path, `
 name: springfield
@@ -207,7 +207,7 @@ services:
 		got, err := compose.ImageNames(path)
 
 		require.NoError(t, err)
-		assert.Equal(t, []string{"nginx:1.27", "springfield-api", "worker:dev"}, got)
+		assert.ElementsMatch(t, []string{"nginx:1.27", "springfield-api", "worker:dev"}, got)
 	})
 
 	t.Run("uses the compose file directory when project name is omitted", func(t *testing.T) {
@@ -254,7 +254,7 @@ services:
 		got, err := compose.ImageNames(path)
 
 		require.NoError(t, err)
-		assert.Equal(t, []string{"duff:latest", "springfield-api"}, got)
+		assert.ElementsMatch(t, []string{"duff:latest", "springfield-api"}, got)
 	})
 
 	t.Run("returns sorted output", func(t *testing.T) {

--- a/internal/deploy/operation/docker_compose_transfer.go
+++ b/internal/deploy/operation/docker_compose_transfer.go
@@ -4,9 +4,8 @@ import (
 	"fmt"
 	"io"
 	"os/exec"
-	"sort"
-	"strings"
 
+	"github.com/arm/topo/internal/compose"
 	"github.com/arm/topo/internal/deploy/command"
 	"golang.org/x/sync/errgroup"
 )
@@ -30,7 +29,7 @@ func (t *DockerComposePipeTransfer) Description() string {
 }
 
 func (t *DockerComposePipeTransfer) Run(cmdOutput io.Writer) error {
-	images, err := t.getImagesFromCompose(cmdOutput)
+	images, err := compose.ImageNames(t.composeFile)
 	if err != nil {
 		return err
 	}
@@ -47,25 +46,6 @@ func (t *DockerComposePipeTransfer) buildTransferCommands(imageName string) (*ex
 	saveCmd := command.Docker(t.source, "save", imageName)
 	loadCmd := command.Docker(t.dest, "load")
 	return saveCmd, loadCmd
-}
-
-func (t *DockerComposePipeTransfer) getImagesFromCompose(cmdOutput io.Writer) ([]string, error) {
-	cmd := command.DockerCompose(t.source, t.composeFile, "config", "--images")
-	cmd.Stderr = cmdOutput
-	output, err := cmd.Output()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get image names from compose file: %w", err)
-	}
-	var imageNames []string
-	lines := strings.SplitSeq(strings.TrimSpace(string(output)), "\n")
-	for line := range lines {
-		line = strings.TrimSpace(line)
-		if line != "" {
-			imageNames = append(imageNames, line)
-		}
-	}
-	sort.Strings(imageNames)
-	return imageNames, nil
 }
 
 func (t *DockerComposePipeTransfer) transferImage(cmdOutput io.Writer, imageName string) error {

--- a/internal/deploy/operation/registry_transfer.go
+++ b/internal/deploy/operation/registry_transfer.go
@@ -6,9 +6,9 @@ import (
 	"io"
 	"os/exec"
 	"regexp"
-	"sort"
 	"strings"
 
+	"github.com/arm/topo/internal/compose"
 	"github.com/arm/topo/internal/deploy/command"
 )
 
@@ -30,7 +30,7 @@ func (r *RegistryTransfer) Description() string {
 }
 
 func (r *RegistryTransfer) Run(w io.Writer) error {
-	images, err := r.getImagesFromCompose(w)
+	images, err := compose.ImageNames(r.composeFile)
 	if err != nil {
 		return err
 	}
@@ -40,21 +40,6 @@ func (r *RegistryTransfer) Run(w io.Writer) error {
 		}
 	}
 	return nil
-}
-
-func (r *RegistryTransfer) getImagesFromCompose(w io.Writer) ([]string, error) {
-	cmd := command.DockerCompose(r.source, r.composeFile, "config", "--images")
-	cmd.Stderr = w
-	out, err := cmd.Output()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get image names: %w", err)
-	}
-	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
-	for i := range lines {
-		lines[i] = strings.TrimSpace(lines[i])
-	}
-	sort.Strings(lines)
-	return lines, nil
 }
 
 func (r *RegistryTransfer) transferImage(w io.Writer, image string) error {


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- Calculate image names using data from compose file instead of relying on `docker compose config --images`
   - Enables support for container engines that follow different image name semantics
