### PR TITLE
ci: Pre release tag management

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,10 +36,44 @@ jobs:
       - name: Calculate next version
         id: calculate_next_version
         run: |
-          if ! next="$(svu next)"; then
+          open_pre_base="$(
+            git tag --list 'v*-pre.*' |
+              sed -n 's/^\(v[0-9][^-]*\)-pre\.[0-9][0-9]*$/\1/p' |
+              sort -u -V |
+              while IFS= read -r candidate; do
+                if ! git rev-parse -q --verify "refs/tags/${candidate}" >/dev/null; then
+                  echo "$candidate"
+                fi
+              done |
+              tail -n1
+          )"
+
+          if ! base="$(svu next)"; then
             echo "svu failed" >&2
             exit 1
           fi
+          base="${base%%-pre.*}"
+
+          if [ -n "$open_pre_base" ]; then
+            base="$open_pre_base"
+          fi
+
+          if [ "${{ inputs.pre-release }}" = "true" ]; then
+            next_pre=1
+            for tag in $(git tag --list "${base}-pre.*"); do
+              suffix="${tag#"${base}-pre."}"
+              case "$suffix" in
+                ''|*[!0-9]*) continue ;;
+              esac
+              if [ "$suffix" -ge "$next_pre" ]; then
+                next_pre=$((suffix + 1))
+              fi
+            done
+            next="${base}-pre.${next_pre}"
+          else
+            next="$base"
+          fi
+
           echo "next_version=$next" >> "$GITHUB_OUTPUT"
 
       - name: Set git config

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,6 +2,12 @@ name: Release
 
 on:
   workflow_dispatch:
+    inputs:
+      pre-release:
+        description: Publish signed artifacts under the pre-release Artifactory layout.
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -122,7 +128,8 @@ jobs:
         run: |
           gh workflow run sign-and-release.yml \
             --repo Arm-Debug/topo-publisher \
-            --ref v4 \
+            --ref v5 \
             --field run-id=${{ github.run_id }} \
             --field release-version=${VERSION} \
             --field release-tag=${VERSION} \
+            --field pre-release=${{ inputs.pre-release }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,44 +36,11 @@ jobs:
       - name: Calculate next version
         id: calculate_next_version
         run: |
-          open_pre_base="$(
-            git tag --list 'v*-pre.*' |
-              sed -n 's/^\(v[0-9][^-]*\)-pre\.[0-9][0-9]*$/\1/p' |
-              sort -u -V |
-              while IFS= read -r candidate; do
-                if ! git rev-parse -q --verify "refs/tags/${candidate}" >/dev/null; then
-                  echo "$candidate"
-                fi
-              done |
-              tail -n1
-          )"
-
-          if ! base="$(svu next)"; then
-            echo "svu failed" >&2
-            exit 1
-          fi
-          base="${base%%-pre.*}"
-
-          if [ -n "$open_pre_base" ]; then
-            base="$open_pre_base"
-          fi
-
           if [ "${{ inputs.pre-release }}" = "true" ]; then
-            next_pre=1
-            for tag in $(git tag --list "${base}-pre.*"); do
-              suffix="${tag#"${base}-pre."}"
-              case "$suffix" in
-                ''|*[!0-9]*) continue ;;
-              esac
-              if [ "$suffix" -ge "$next_pre" ]; then
-                next_pre=$((suffix + 1))
-              fi
-            done
-            next="${base}-pre.${next_pre}"
+            next="$(svu prerelease --prerelease pre)"
           else
-            next="$base"
+            next="$(svu next)"
           fi
-
           echo "next_version=$next" >> "$GITHUB_OUTPUT"
 
       - name: Set git config

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       pre-release:
-        description: Publish signed artifacts under the pre-release Artifactory layout.
+        description: Pre-release
         required: false
         type: boolean
         default: false


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

This adds support for pre-release tags into the workload. Resulting in this behaviour:

- Make a Normal release: `v1.3.0`
- Make a first pre-release: `v1.4.0-pre.1`
- Make Second pre-release: `v1.4.0-pre.2`
- Make a normal release: `v1.4.0`
- Make Second pre-release: `v1.5.0-pre.1`
