### PR TITLE
fix(security): bump golang to 1.26.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/arm/topo
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/compose-spec/compose-go/v2 v2.10.2


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- Address https://pkg.go.dev/vuln/GO-2026-4918
