### PR TITLE
fix: explicitly bind tunnel to ipv4 loopback on target

### DIFF
--- a/internal/ssh/ssh_tunnel.go
+++ b/internal/ssh/ssh_tunnel.go
@@ -4,27 +4,16 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io"
-	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
-	"time"
 
 	"github.com/arm/topo/internal/command"
 	"github.com/arm/topo/internal/operation"
 )
 
 const TunnelPIDPlaceholder = "<ssh tunnel pid>"
-
-func isPortTaken(port string) bool {
-	conn, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%s", port), 2*time.Second)
-	if err != nil {
-		return false
-	}
-	conn.Close() // nolint:errcheck
-	return true
-}
 
 func ControlSocketPath(targetHost string) string {
 	hash := sha256.Sum256([]byte(targetHost))
@@ -70,7 +59,7 @@ func (s *SSHTunnelStart) Command() *exec.Cmd {
 		)
 	}
 	args = append(args,
-		"-R", fmt.Sprintf("%s:127.0.0.1:%s", s.Port, s.Port),
+		"-R", fmt.Sprintf("127.0.0.1:%s:127.0.0.1:%s", s.Port, s.Port),
 		s.TargetDest.String(),
 	)
 	// #nosec -- arguments are validated
@@ -86,12 +75,8 @@ func (s *SSHTunnelStart) Run(w io.Writer) error {
 		run = cmd.Run
 	}
 	if err := run(); err != nil {
-		if isPortTaken(s.Port) {
-			return fmt.Errorf("port already in use: %s - specify a different port or stop the existing process", s.Port)
-		}
-
 		formattedError := command.FormatError(cmd.Args, err)
-		return fmt.Errorf("failed to open ssh tunnel: %w", formattedError)
+		return fmt.Errorf("failed to open ssh tunnel: %w - ensure port %s is free or specify a different one with `--registry-port`", formattedError, s.Port)
 	}
 	if cmd.Process != nil {
 		s.Process = cmd.Process

--- a/internal/ssh/ssh_tunnel_test.go
+++ b/internal/ssh/ssh_tunnel_test.go
@@ -69,7 +69,7 @@ func TestSSHTunnelStart(t *testing.T) {
 			st := ssh.NewSSHTunnelStart(dest, port, true)
 			got := strings.Join(st.Command().Args, " ")
 
-			want := fmt.Sprintf("ssh -N -o ExitOnForwardFailure=yes -fMS %s -R %s:127.0.0.1:%s ssh://user@remote", ssh.ControlSocketPath(dest.String()), port, port)
+			want := fmt.Sprintf("ssh -N -o ExitOnForwardFailure=yes -fMS %s -R 127.0.0.1:%s:127.0.0.1:%s ssh://user@remote", ssh.ControlSocketPath(dest.String()), port, port)
 			assert.Equal(t, want, got)
 		})
 
@@ -80,7 +80,7 @@ func TestSSHTunnelStart(t *testing.T) {
 			st := ssh.NewSSHTunnelStart(dest, port, false)
 			got := strings.Join(st.Command().Args, " ")
 
-			want := fmt.Sprintf("ssh -N -o ExitOnForwardFailure=yes -R %s:127.0.0.1:%s ssh://user@remote", port, port)
+			want := fmt.Sprintf("ssh -N -o ExitOnForwardFailure=yes -R 127.0.0.1:%s:127.0.0.1:%s ssh://user@remote", port, port)
 			assert.Equal(t, want, got)
 		})
 	})

--- a/internal/ssh/ssh_tunnel_test.go
+++ b/internal/ssh/ssh_tunnel_test.go
@@ -85,34 +85,6 @@ func TestSSHTunnelStart(t *testing.T) {
 		})
 	})
 
-	t.Run("Run", func(t *testing.T) {
-		t.Run("it returns port in use error when port is taken", func(t *testing.T) {
-			listener, err := net.Listen("tcp", "127.0.0.1:0")
-			require.NoError(t, err)
-			defer listener.Close() //nolint:errcheck
-			_, port, err := net.SplitHostPort(listener.Addr().String())
-			require.NoError(t, err)
-			var buf strings.Builder
-			st := ssh.NewSSHTunnelStart(ssh.NewDestination("user@remote"), port, true)
-
-			err = st.Run(&buf)
-
-			require.Error(t, err)
-			assert.Contains(t, err.Error(), "port already in use: "+port)
-		})
-
-		t.Run("it returns generic tunnel error when port is free", func(t *testing.T) {
-			st := ssh.NewSSHTunnelStart(ssh.NewDestination("user@remote"), "99010", true)
-			var buf strings.Builder
-
-			err := st.Run(&buf)
-
-			require.Error(t, err)
-			assert.Contains(t, err.Error(), "failed to open ssh tunnel:")
-			assert.NotContains(t, err.Error(), "port already in use")
-		})
-	})
-
 	t.Run("Description", func(t *testing.T) {
 		t.Run("it returns expected string", func(t *testing.T) {
 			st := ssh.NewSSHTunnelStart(ssh.NewDestination("user@remote"), "12345", true)


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- Explicitly binds to ipv4 loopback (127.0.0.1:PORT) on the target side when creating the reverse tunnel. On some systems, just specifying the port will fallback to binding it to the ipv6 loopback if ipv4 one is taken silently. This is particularly annoying if you happen to be deploying to a target which is also running a topo registry (e.g. our DGX spark) as it means the deploy continues until the pull step where it fails since it will pull from the on-target registry running on the ipv4 loopback, not your local one available on the ipv6 loopback. 🙄 
- Removes the `isPortTaken` check when ssh tunnel creation fails - since the tunnel is always spawned after the registry is created on the host machine, the port will always be taken so the check is misleading and overly aggressive. Instead replaces it with some guidance in the generic error message.
- Removes some low value tests which were mainly built for the `isPortTaken` check

These changes together would've saved me an hour or two or debugging this afternoon.

