### PR TITLE
docs: add Topo glossary

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Discover and deploy containerised software to Arm hardware over SSH.
 
-Point Topo at any Arm-based Linux device to discover software templates which showcase its capabilities. Pick one and Topo helps you configure it for your use case, then deploys it in minutes. The result? A standard Docker Compose project to learn from, modify, or use as a starting point for your own work.
+Point Topo at any Arm-based Linux device to discover software Templates which showcase its capabilities. Pick one and Topo helps you configure it for your use case, then deploys it in minutes. The result? A standard Docker Compose project to learn from, modify, or use as a starting point for your own work.
 
 Already have a Compose project? Topo gives you a fast, incremental build-deploy loop over SSH.
 
@@ -14,7 +14,9 @@ Already have a Compose project? Topo gives you a fast, incremental build-deploy 
 
 **You want a faster edit-build-deploy loop.** Build on your laptop and deploy to a Pi or Jetson over SSH. Rebuilds are incremental, so after the first deploy you're often iterating in seconds.
 
-**You have a heterogeneous device and want to use all of it.** Your board has coprocessors like a Cortex-M that normally need separate toolchains and manual firmware loading. Topo and [remoteproc-runtime](https://github.com/arm/remoteproc-runtime) let you orchestrate the whole device as one Docker Compose project.
+**You have a heterogeneous device and want to use all of it.** Your board has remote processors like a Cortex-M that normally need separate toolchains and manual firmware loading. Topo and [Remoteproc Runtime](https://github.com/arm/remoteproc-runtime) let you orchestrate the whole device as one Docker Compose project.
+
+Not sure what these terms mean? The [glossary](docs/glossary.md) defines Topo's core concepts.
 
 ## What does it look like?
 
@@ -22,7 +24,7 @@ Already have a Compose project? Topo gives you a fast, incremental build-deploy 
 # Check your target is ready
 topo health --target pi@raspberrypi
 
-# See which templates match your hardware
+# See which Templates match your hardware
 topo templates --target pi@raspberrypi
 
 # Clone one and configure it for your target
@@ -34,9 +36,9 @@ topo deploy --target pi@raspberrypi
 ## Highlights
 
 - **Fast, incremental deploys** over SSH, with layer caching to keep rebuilds quick
-- **Hardware-aware template discovery** that matches your target's actual capabilities
+- **Hardware-aware Template discovery** that matches your target's actual capabilities
 - **Standard tooling throughout**: Docker Compose, container images, and OCI registries
-- **Whole-device orchestration** of Linux services and coprocessor firmware in a single Compose project
+- **Whole-device orchestration** of Linux services and remote processor firmware in a single Compose project
 
 ## Installation
 
@@ -77,21 +79,21 @@ Alternatively, manually add the appropriate binary from [GitHub Releases](https:
 topo health --target [user@]host
 ```
 
-### 2. Find a template
+### 2. Find a Template
 
 ```sh
 topo templates --target [user@]host
 ```
 
-### 3. Clone your chosen template
+### 3. Clone your chosen Template
 
-Choose a template you wish to try, then clone it:
+Choose a Template you wish to try, then clone it:
 
 ```sh
 topo clone https://github.com/Arm-Examples/topo-welcome.git
 ```
 
-If the template requires build arguments, Topo will prompt you for them.
+If the Template requires build arguments, Topo will prompt you for them.
 
 ### 4. Deploy to your target
 
@@ -104,7 +106,7 @@ Topo builds the container images on your host, transfers them to the target over
 
 ### 5. Review the deployment
 
-Your project is now running on your target. See the template README for details.
+Your project is now running on your target. See the Template README for details.
 
 ### 6. Stop the deployment
 

--- a/cmd/topo/clone.go
+++ b/cmd/topo/clone.go
@@ -29,7 +29,7 @@ interactive prompts.`,
   topo clone git:ubuntu@example.com:repo.git
   topo clone git:builder@host:tools/platform.git#v2
 
-  # Local directory (must contain a Topo template)
+  # Local directory (must contain a Topo Template)
   topo clone dir:/path/to/template/folder
   topo clone dir:./relative/path
 

--- a/cmd/topo/deploy.go
+++ b/cmd/topo/deploy.go
@@ -30,13 +30,13 @@ var deployOpts deploy.DeployOptions
 var deployCmd = &cobra.Command{
 	Use:   "deploy",
 	Short: "Deploy services using the compose file",
-	Long: `Deploy services to the target host using definitions in the compose file.
+	Long: `Deploy services to the target using definitions in the compose file.
 
 This command performs the following operations in sequence:
-  1. Build - Builds container images defined in the compose file on the local host
-  2. Pull - Pulls any required images from registries to the local host
-  3. Transfer - Transfers built and pulled images and compose file to the target host
-  4. Run - Runs docker compose up on the target host
+  1. Build - Builds container images defined in the compose file on the host
+  2. Pull - Pulls any required images from registries to the host
+  3. Transfer - Transfers built and pulled images and compose file to the target
+  4. Run - Runs docker compose up on the target
 
 The compose file (compose.yaml) must be in the current working directory, as this is used to select the containers to be deployed.`,
 	Args: cobra.ExactArgs(0),

--- a/cmd/topo/extend.go
+++ b/cmd/topo/extend.go
@@ -12,13 +12,13 @@ import (
 
 var extendCmd = &cobra.Command{
 	Use:   "extend <compose-filepath> <source> [flags] [-- ARG=VALUE ...]",
-	Short: "Add services from a template to the compose file",
+	Short: "Add services from a Template to the compose file",
 	Long: `Add all services from a source to the compose file.
 
 The source argument uses scheme prefixes to specify the source type.
 The git: prefix is optional for git@host and https:// URLs.
 
-Service templates may require build arguments. You can provide them after --
+Topo Templates may require build arguments. You can provide them after --
 or answer interactive prompts.`,
 	Example: `  # Git repository
   topo extend compose.yaml git:https://github.com/user/repo.git

--- a/cmd/topo/health.go
+++ b/cmd/topo/health.go
@@ -21,8 +21,8 @@ const skipVersionChecksEnvVar = "TOPO_SKIP_VERSION_CHECKS"
 
 var healthCmd = &cobra.Command{
 	Use:   "health",
-	Short: "Check the target host environment",
-	Long:  "Check the target host environment, including container engines and SSH availability.",
+	Short: "Check the target environment",
+	Long:  "Check the target environment, including container engines and SSH availability.",
 	Args:  cobra.ExactArgs(0),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true

--- a/cmd/topo/setup_keys.go
+++ b/cmd/topo/setup_keys.go
@@ -16,7 +16,7 @@ var (
 
 var setupKeysCmd = &cobra.Command{
 	Use:   "setup-keys",
-	Short: "Generate SSH keys for the target and install the public key on the target host",
+	Short: "Generate SSH keys for the target and install the public key on the target",
 	Args:  cobra.ExactArgs(0),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true

--- a/cmd/topo/stop.go
+++ b/cmd/topo/stop.go
@@ -12,7 +12,7 @@ import (
 var topoStopCmd = &cobra.Command{
 	Use:   "stop",
 	Short: "Stop a currently running deployment",
-	Long: `Stop services that are already running on the target host using definitions in the compose file.
+	Long: `Stop services that are already running on the target using definitions in the compose file.
 
 Executing this command does not remove the containers.
 

--- a/cmd/topo/templates.go
+++ b/cmd/topo/templates.go
@@ -14,7 +14,7 @@ import (
 
 var templatesCmd = &cobra.Command{
 	Use:   "templates",
-	Short: "List available service templates",
+	Short: "List available Topo Templates",
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		cmd.SilenceUsage = true
 		outputFormat := resolveOutput(cmd)

--- a/cmd/topo/vscode.go
+++ b/cmd/topo/vscode.go
@@ -26,8 +26,8 @@ var getProjectCmd = &cobra.Command{
 
 var describeCmd = &cobra.Command{
 	Use:    "describe",
-	Short:  "Describe the hardware characteristics of the target host",
-	Long:   "Print a description of the hardware characteristics of the target host including CPU ISA features and remoteproc capabilities.",
+	Short:  "Describe the hardware characteristics of the target",
+	Long:   "Print a description of the hardware characteristics of the target, including CPU ISA features and remoteproc capabilities.",
 	Hidden: true,
 	Args:   cobra.ExactArgs(0),
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,0 +1,71 @@
+# Topo Glossary
+
+This glossary defines the core terms used in Topo documentation and command output.
+
+## Host
+
+A general-purpose system used to configure, **deploy** to, or communicate with one or more **targets**. A **host** may also act as a **target** in cases where the same system runs the deployed application.
+
+## Target
+
+Where **deployments** run. A **target** may be a **heterogeneous device** containing one or more **processing domains**, such as a **primary processor**, **remote processors**, and **accelerators**. A **target** may be distinct from the **host** or may reside on the same system. Currently, this must be, at minimum, a computer running Linux on AArch64 (linux/arm64) on the **primary processor**.
+
+## Processing Domain
+
+Logical groupings of related components (usually on the **target**). **Processing domains** organize applications and services in containers by where they are on a device and what they can run.
+
+## Heterogeneous Device
+
+A device that contains multiple kinds of processing capabilities, such as a **primary processor**, **remote processors**, and **accelerators**, across one or more **processing domains**.
+
+## Primary Processor
+
+The main general-purpose **processing domain** running the Linux operating system. It manages system resources, runs user-space applications and containers, and coordinates **remote processors** via frameworks such as **Remoteproc Runtime**.
+
+## Primary OS
+
+The primary operating system of the **target**. For Topo, the target's **primary OS** is the Linux environment accessed by SSH from the **host** to run containers and coordinate with **remote processors** and other **processing domains**.
+
+## Remote Processor
+
+A peer execution environment on a **target** with an independent firmware lifecycle, typically managed from the **primary OS** through Linux remoteproc.
+
+## Accelerator
+
+A workload-specific component, such as a GPU or NPU, accessed through drivers, runtimes, or APIs. Unlike a **remote processor**, an **accelerator** is not typically managed as an independent firmware lifecycle through Linux remoteproc.
+
+## Dependency
+
+A required component (library, service, or another app) that must be available for an application to function. Often also described as a prerequisite, can relate to **target** or **host**.
+
+## Template
+
+A containerised sample project that provides a starting point for development. It includes application code, build configuration, and an **x-topo** metadata block describing required hardware **features** and configurable parameters. **Templates** are configured when cloned. Topo allows the discovery and **deployment** of **Templates** for validation.
+
+## X-Topo
+
+A metadata extension defined within a Compose file that describes a **Template**'s purpose, hardware requirements, **features**, and configurable arguments. Enables tooling (such as Topo) to provide validation, filtering, and interactive setup.
+
+## Feature
+
+A declared hardware capability required or utilised by a **Template** (e.g., NEON support, GPU compute capability, specific **accelerator** support). Used for matching **Templates** to compatible **targets**.
+
+## Deploy
+
+The process of building container images on the **host**, transferring them to the **target**, and starting services, typically via Docker Compose. If a service is configured to run on a **remote processor**, a runtime such as **Remoteproc Runtime** may be used.
+
+## Deployment
+
+The outcome of a successful **deploy** operation. A **deployment** includes all active services, containers, and (where applicable) firmware executing across one or more **processing domains**, and reflects the system as it is currently provisioned and operating.
+
+## Incremental Build/Deploy
+
+A **build** approach where only changed layers are rebuilt, and a **deploy** approach where only rebuilt layers are transferred to the **target**, reducing iteration time.
+
+## Remoteproc Runtime
+
+An Open Container Initiative (OCI) compliant container runtime that deploys firmware to **remote processors** via the Linux remoteproc framework. Allows firmware to be packaged, distributed, and executed using standard container tools (e.g., Docker, containerd, Podman).
+
+## Firmware Container
+
+A container image that packages a firmware binary. When run with **Remoteproc Runtime**, the firmware is loaded onto a **target**'s **remote processor** and then started, instead of executed as a typical Linux process.

--- a/internal/deploy/project_checks/project_checks_test.go
+++ b/internal/deploy/project_checks/project_checks_test.go
@@ -53,7 +53,7 @@ services:
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "linux/amd64")
 	})
-	t.Run("skips remoteproc runtime without platform", func(t *testing.T) {
+	t.Run("skips remoteproc-runtime without platform", func(t *testing.T) {
 		composeFile := writeComposeFile(t, `
 services:
   firmware:
@@ -63,7 +63,7 @@ services:
 
 		require.NoError(t, checks.EnsureProjectIsLinuxArm64Ready(composeFile))
 	})
-	t.Run("succeeds with valid remoteproc runtime", func(t *testing.T) {
+	t.Run("succeeds with valid remoteproc-runtime", func(t *testing.T) {
 		composeFile := writeComposeFile(t, `
 services:
   rtos-firmware:

--- a/internal/health/dependencies.go
+++ b/internal/health/dependencies.go
@@ -108,7 +108,7 @@ func TargetRequiredDependencies(target ssh.Destination) []Dependency {
 				BinaryExists{
 					Severity: SeverityWarning,
 					Fix: &Fix{
-						Description: "Install the remoteproc runtime",
+						Description: "Install the Remoteproc Runtime",
 						Command:     fmt.Sprintf("topo install remoteproc-runtime --target %s", target),
 					},
 				},
@@ -123,7 +123,7 @@ func TargetRequiredDependencies(target ssh.Destination) []Dependency {
 				BinaryExists{
 					Severity: SeverityWarning,
 					Fix: &Fix{
-						Description: "Install the remoteproc runtime",
+						Description: "Install the Remoteproc Runtime",
 						Command:     fmt.Sprintf("topo install remoteproc-runtime --target %s", target),
 					},
 				},

--- a/internal/health/dependencies_test.go
+++ b/internal/health/dependencies_test.go
@@ -60,7 +60,7 @@ func TestTargetRequiredDependencies(t *testing.T) {
 		wantBinaryExistsCheck := health.BinaryExists{
 			Severity: health.SeverityWarning,
 			Fix: &health.Fix{
-				Description: "Install the remoteproc runtime",
+				Description: "Install the Remoteproc Runtime",
 				Command:     "topo install remoteproc-runtime --target ssh://user@my-target",
 			},
 		}
@@ -164,7 +164,7 @@ func TestPerformChecks(t *testing.T) {
 				health.BinaryExists{
 					Severity: health.SeverityWarning,
 					Fix: &health.Fix{
-						Description: "Install the remoteproc runtime",
+						Description: "Install the Remoteproc Runtime",
 						Command:     "topo install remoteproc-runtime",
 					},
 				},
@@ -176,7 +176,7 @@ func TestPerformChecks(t *testing.T) {
 
 		assert.Len(t, got, 1)
 		want := &health.Fix{
-			Description: "Install the remoteproc runtime",
+			Description: "Install the Remoteproc Runtime",
 			Command:     "topo install remoteproc-runtime",
 		}
 		assert.Equal(t, want, got[0].Fix)

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -90,10 +90,10 @@ func Extend(targetComposeFile string, src template.Source, argProvider arguments
 		}
 	}()
 
-	logger.Info(fmt.Sprintf("copying service template to %q", destDir))
+	logger.Info(fmt.Sprintf("copying topo template to %q", destDir))
 
 	if err := src.CopyTo(destDir); err != nil {
-		return fmt.Errorf("failed to copy Service Template: %w", err)
+		return fmt.Errorf("failed to copy topo template: %w", err)
 	}
 
 	if info, err := os.Stat(destDir); err != nil || !info.IsDir() {

--- a/scripts/update_templates/README.md
+++ b/scripts/update_templates/README.md
@@ -1,10 +1,10 @@
 # Update Templates Script
 
-This repository includes a Go script used to keep the templates list JSON up to date.
+This repository includes a Go script used to keep the Templates list JSON up to date.
 
 ## Overview
 
-The script regenerates the templates list JSON from a fixed set of repositories. It should be run whenever repositories are added, removed, or changed. Template definitions are sourced from each repository’s x-Topo metadata.
+The script regenerates the Templates list JSON from a fixed set of repositories. It should be run whenever repositories are added, removed, or changed. Template definitions are sourced from each repository’s x-Topo metadata.
 
 ## Usage
 
@@ -14,12 +14,12 @@ Run the script from the root of the repository:
 
 When executed, this command will:
 - Iterate over the configured repository list
-- Collect template metadata
-- Regenerate and update the templates list JSON file
+- Collect Template metadata
+- Regenerate and update the Templates list JSON file
 
 ## Adding a Repository
 
-To include a new repository in the templates list, update the `repoList` variable in the main:
+To include a new repository in the Templates list, update the `repoList` variable in the main:
 
     var repoList = []string{
         "topo-cortexa-welcome#main",
@@ -42,4 +42,3 @@ Example:
 After modifying the list, re-run the script to apply the changes.
 
 Note that this only supports the arm-debug org right now
-


### PR DESCRIPTION
## Changes

- Add `docs/glossary.md` with definitions for core Topo concepts.
- Link to the glossary from the README after the "Who is this for?" section.

## Validation

- Documentation-only change; no code tests run.
