### PR TITLE
feat: Success message

### DIFF
--- a/cmd/topo/deploy.go
+++ b/cmd/topo/deploy.go
@@ -102,6 +102,7 @@ The compose file (compose.yaml) must be in the current working directory, as thi
 		if err != nil {
 			return fmt.Errorf("deployment failed; ensure topo health is passing: %w", err)
 		}
+
 		return nil
 	},
 }

--- a/cmd/topo/deploy.go
+++ b/cmd/topo/deploy.go
@@ -102,7 +102,6 @@ The compose file (compose.yaml) must be in the current working directory, as thi
 		if err != nil {
 			return fmt.Errorf("deployment failed; ensure topo health is passing: %w", err)
 		}
-
 		return nil
 	},
 }

--- a/internal/deploy/deploy.go
+++ b/internal/deploy/deploy.go
@@ -54,6 +54,6 @@ func NewDeployment(composeFile string, opts DeployOptions) (goperation.Sequence,
 		}
 	}
 	ops = append(ops, operation.NewDockerComposeUp(composeFile, targetHost, opts.RecreateMode))
-	ops = append(ops, post_deploy.NewPostDeployMessage(composeFile, targetHost))
+	ops = append(ops, post_deploy.NewDeploySuccess(composeFile, targetHost, "Run `topo ps` to see deployed containers"))
 	return goperation.NewSequence(ops...), cleanup
 }

--- a/internal/deploy/deploy.go
+++ b/internal/deploy/deploy.go
@@ -3,6 +3,7 @@ package deploy
 import (
 	"github.com/arm/topo/internal/deploy/command"
 	"github.com/arm/topo/internal/deploy/operation"
+	"github.com/arm/topo/internal/deploy/post_deploy"
 	goperation "github.com/arm/topo/internal/operation"
 	"github.com/arm/topo/internal/ssh"
 )
@@ -53,5 +54,6 @@ func NewDeployment(composeFile string, opts DeployOptions) (goperation.Sequence,
 		}
 	}
 	ops = append(ops, operation.NewDockerComposeUp(composeFile, targetHost, opts.RecreateMode))
+	ops = append(ops, post_deploy.NewPostDeployMessage(composeFile, targetHost))
 	return goperation.NewSequence(ops...), cleanup
 }

--- a/internal/deploy/deploy_test.go
+++ b/internal/deploy/deploy_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/arm/topo/internal/deploy"
 	"github.com/arm/topo/internal/deploy/command"
 	"github.com/arm/topo/internal/deploy/operation"
+	"github.com/arm/topo/internal/deploy/post_deploy"
 	"github.com/arm/topo/internal/deploy/testutil"
 	goperation "github.com/arm/topo/internal/operation"
 	"github.com/arm/topo/internal/ssh"
@@ -32,6 +33,7 @@ func TestNewDeployment(t *testing.T) {
 			operation.NewDockerComposePull(composeFile, localHost),
 			operation.NewDockerComposePipeTransfer(composeFile, localHost, remoteHost),
 			operation.NewDockerComposeUp(composeFile, remoteHost, operation.RecreateModeDefault),
+			post_deploy.NewPostDeployMessage(composeFile, remoteHost),
 		}
 		assert.Equal(t, want, got)
 	})
@@ -57,6 +59,7 @@ func TestNewDeployment(t *testing.T) {
 			operation.NewRegistryTransfer(composeFile, localHost, remoteHost, port),
 			wantTunnelStop,
 			operation.NewDockerComposeUp(composeFile, remoteHost, operation.RecreateModeDefault),
+			post_deploy.NewPostDeployMessage(composeFile, remoteHost),
 		)
 		assert.Equal(t, want, got)
 	})
@@ -93,6 +96,7 @@ func TestNewDeployment(t *testing.T) {
 					operation.NewDockerComposeBuild(composeFile, localHost),
 					operation.NewDockerComposePull(composeFile, localHost),
 					operation.NewDockerComposeUp(composeFile, localHost, tt.recreateMode),
+					post_deploy.NewPostDeployMessage(composeFile, localHost),
 				}
 				assert.Equal(t, want, got)
 			})
@@ -140,6 +144,7 @@ func TestNewDeployment(t *testing.T) {
 			operation.NewRegistryTransfer(composeFile, localHost, remoteHost, port),
 			wantTunnelEnd,
 			operation.NewDockerComposeUp(composeFile, remoteHost, operation.RecreateModeDefault),
+			post_deploy.NewPostDeployMessage(composeFile, remoteHost),
 		)
 		assert.Equal(t, want, got)
 	})

--- a/internal/deploy/deploy_test.go
+++ b/internal/deploy/deploy_test.go
@@ -33,7 +33,7 @@ func TestNewDeployment(t *testing.T) {
 			operation.NewDockerComposePull(composeFile, localHost),
 			operation.NewDockerComposePipeTransfer(composeFile, localHost, remoteHost),
 			operation.NewDockerComposeUp(composeFile, remoteHost, operation.RecreateModeDefault),
-			post_deploy.NewPostDeployMessage(composeFile, remoteHost),
+			post_deploy.NewDeploySuccess(composeFile, remoteHost, "Run `topo ps` to see deployed containers"),
 		}
 		assert.Equal(t, want, got)
 	})
@@ -59,7 +59,7 @@ func TestNewDeployment(t *testing.T) {
 			operation.NewRegistryTransfer(composeFile, localHost, remoteHost, port),
 			wantTunnelStop,
 			operation.NewDockerComposeUp(composeFile, remoteHost, operation.RecreateModeDefault),
-			post_deploy.NewPostDeployMessage(composeFile, remoteHost),
+			post_deploy.NewDeploySuccess(composeFile, remoteHost, "Run `topo ps` to see deployed containers"),
 		)
 		assert.Equal(t, want, got)
 	})
@@ -96,7 +96,7 @@ func TestNewDeployment(t *testing.T) {
 					operation.NewDockerComposeBuild(composeFile, localHost),
 					operation.NewDockerComposePull(composeFile, localHost),
 					operation.NewDockerComposeUp(composeFile, localHost, tt.recreateMode),
-					post_deploy.NewPostDeployMessage(composeFile, localHost),
+					post_deploy.NewDeploySuccess(composeFile, localHost, "Run `topo ps` to see deployed containers"),
 				}
 				assert.Equal(t, want, got)
 			})
@@ -144,7 +144,7 @@ func TestNewDeployment(t *testing.T) {
 			operation.NewRegistryTransfer(composeFile, localHost, remoteHost, port),
 			wantTunnelEnd,
 			operation.NewDockerComposeUp(composeFile, remoteHost, operation.RecreateModeDefault),
-			post_deploy.NewPostDeployMessage(composeFile, remoteHost),
+			post_deploy.NewDeploySuccess(composeFile, remoteHost, "Run `topo ps` to see deployed containers"),
 		)
 		assert.Equal(t, want, got)
 	})

--- a/internal/deploy/post_deploy/post_deploy.go
+++ b/internal/deploy/post_deploy/post_deploy.go
@@ -9,20 +9,22 @@ import (
 	"github.com/arm/topo/internal/template"
 )
 
-type PostDeployMessage struct {
-	composeFile string
-	host        command.Host
+type DeploySuccess struct {
+	composeFile    string
+	host           command.Host
+	defaultMessage string
 }
 
-func NewPostDeployMessage(composeFile string, h command.Host) *PostDeployMessage {
-	return &PostDeployMessage{
-		composeFile: composeFile,
-		host:        h,
+func NewDeploySuccess(composeFile string, h command.Host, defaultMessage string) *DeploySuccess {
+	return &DeploySuccess{
+		composeFile:    composeFile,
+		host:           h,
+		defaultMessage: defaultMessage,
 	}
 }
 
-func (t *PostDeployMessage) Description() string {
-	return "Deploy Success"
+func (t *DeploySuccess) Description() string {
+	return "Deployment Success"
 }
 
 func getSuccessMessage(composeFile string) (string, error) {
@@ -39,13 +41,13 @@ func getSuccessMessage(composeFile string) (string, error) {
 	return tpl.Metadata.SuccessMessage, nil
 }
 
-func (p *PostDeployMessage) Run(w io.Writer) error {
+func (p *DeploySuccess) Run(w io.Writer) error {
 	successMessage, err := getSuccessMessage(p.composeFile)
 	if err != nil {
 		return err
 	}
 	if successMessage == "" {
-		successMessage = "Run `topo ps` to see deployed containers"
+		successMessage = p.defaultMessage
 	}
 
 	_, err = fmt.Fprintln(w, successMessage)

--- a/internal/deploy/post_deploy/post_deploy.go
+++ b/internal/deploy/post_deploy/post_deploy.go
@@ -1,0 +1,61 @@
+package post_deploy
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/arm/topo/internal/deploy/command"
+	"github.com/arm/topo/internal/operation"
+	"github.com/arm/topo/internal/template"
+)
+
+type PostDeployMessage struct {
+	composeFile string
+	host        command.Host
+}
+
+func NewPostDeployMessage(composeFile string, h command.Host) operation.Operation {
+	return &PostDeployMessage{
+		composeFile: composeFile,
+		host:        h,
+	}
+}
+
+func (t *PostDeployMessage) Description() string {
+	return "Deploy Success"
+}
+
+func getSuccessMessage(composeFile string) (string, error) {
+	f, err := os.Open(composeFile)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = f.Close() }()
+
+	tpl, err := template.FromContent(f)
+	if err != nil {
+		return "", err
+	}
+	return tpl.Metadata.SuccessMessage, nil
+}
+
+func (p *PostDeployMessage) Run(w io.Writer) error {
+	if w == nil {
+		return nil
+	}
+	successMessage, err := getSuccessMessage(p.composeFile)
+	if err != nil {
+		return err
+	}
+	if successMessage == "" {
+		successMessage = "Run `topo ps` to see deployed containers"
+	}
+
+	_, err = fmt.Fprintln(w, successMessage)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/deploy/post_deploy/post_deploy.go
+++ b/internal/deploy/post_deploy/post_deploy.go
@@ -40,9 +40,6 @@ func getSuccessMessage(composeFile string) (string, error) {
 }
 
 func (p *PostDeployMessage) Run(w io.Writer) error {
-	if w == nil {
-		return nil
-	}
 	successMessage, err := getSuccessMessage(p.composeFile)
 	if err != nil {
 		return err

--- a/internal/deploy/post_deploy/post_deploy.go
+++ b/internal/deploy/post_deploy/post_deploy.go
@@ -38,7 +38,7 @@ func getSuccessMessage(composeFile string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return tpl.Metadata.SuccessMessage, nil
+	return tpl.Metadata.DeploymentSuccessMessage, nil
 }
 
 func (p *DeploySuccess) Run(w io.Writer) error {

--- a/internal/deploy/post_deploy/post_deploy.go
+++ b/internal/deploy/post_deploy/post_deploy.go
@@ -6,7 +6,6 @@ import (
 	"os"
 
 	"github.com/arm/topo/internal/deploy/command"
-	"github.com/arm/topo/internal/operation"
 	"github.com/arm/topo/internal/template"
 )
 
@@ -15,7 +14,7 @@ type PostDeployMessage struct {
 	host        command.Host
 }
 
-func NewPostDeployMessage(composeFile string, h command.Host) operation.Operation {
+func NewPostDeployMessage(composeFile string, h command.Host) *PostDeployMessage {
 	return &PostDeployMessage{
 		composeFile: composeFile,
 		host:        h,

--- a/internal/deploy/post_deploy/post_deploy_test.go
+++ b/internal/deploy/post_deploy/post_deploy_test.go
@@ -13,12 +13,12 @@ import (
 )
 
 func TestDeploySuccess(t *testing.T) {
-	t.Run("Run writes success_message from compose file", func(t *testing.T) {
+	t.Run("Run writes deployment_success_message from compose file", func(t *testing.T) {
 		dir := t.TempDir()
 		composeFile := filepath.Join(dir, "compose.yaml")
 		testutil.RequireWriteFile(t, composeFile, `
 x-topo:
-  success_message: "Deployment complete!"
+  deployment_success_message: "Deployment complete!"
 services:
   app:
     image: nginx
@@ -32,7 +32,7 @@ services:
 		assert.Equal(t, "Deployment complete!\n", buf.String())
 	})
 
-	t.Run("Run writes default message when success_message is absent", func(t *testing.T) {
+	t.Run("Run writes default message when deployment_success_message is absent", func(t *testing.T) {
 		dir := t.TempDir()
 		composeFile := filepath.Join(dir, "compose.yaml")
 		testutil.RequireWriteFile(t, composeFile, `

--- a/internal/deploy/post_deploy/post_deploy_test.go
+++ b/internal/deploy/post_deploy/post_deploy_test.go
@@ -12,18 +12,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestPostDeployMessage(t *testing.T) {
-	t.Run("Run writes deploy_success_message from compose file", func(t *testing.T) {
+func TestDeploySuccess(t *testing.T) {
+	t.Run("Run writes success_message from compose file", func(t *testing.T) {
 		dir := t.TempDir()
 		composeFile := filepath.Join(dir, "compose.yaml")
 		testutil.RequireWriteFile(t, composeFile, `
 x-topo:
-  deploy_success_message: "Deployment complete!"
+  success_message: "Deployment complete!"
 services:
   app:
     image: nginx
 `)
-		op := post_deploy.NewPostDeployMessage(composeFile, command.LocalHost)
+		op := post_deploy.NewDeploySuccess(composeFile, command.LocalHost, "Run `topo ps` to see deployed containers")
 		var buf bytes.Buffer
 
 		err := op.Run(&buf)
@@ -32,7 +32,7 @@ services:
 		assert.Equal(t, "Deployment complete!\n", buf.String())
 	})
 
-	t.Run("Run writes default message when deploy_success_message is absent", func(t *testing.T) {
+	t.Run("Run writes default message when success_message is absent", func(t *testing.T) {
 		dir := t.TempDir()
 		composeFile := filepath.Join(dir, "compose.yaml")
 		testutil.RequireWriteFile(t, composeFile, `
@@ -40,7 +40,7 @@ services:
   app:
     image: nginx
 `)
-		op := post_deploy.NewPostDeployMessage(composeFile, command.LocalHost)
+		op := post_deploy.NewDeploySuccess(composeFile, command.LocalHost, "Run `topo ps` to see deployed containers")
 		var buf bytes.Buffer
 
 		err := op.Run(&buf)
@@ -50,7 +50,7 @@ services:
 	})
 
 	t.Run("Run returns error when compose file does not exist", func(t *testing.T) {
-		op := post_deploy.NewPostDeployMessage("nonexistent.yaml", command.LocalHost)
+		op := post_deploy.NewDeploySuccess("nonexistent.yaml", command.LocalHost, "Run `topo ps` to see deployed containers")
 		var buf bytes.Buffer
 
 		err := op.Run(&buf)

--- a/internal/deploy/post_deploy/post_deploy_test.go
+++ b/internal/deploy/post_deploy/post_deploy_test.go
@@ -13,12 +13,12 @@ import (
 )
 
 func TestPostDeployMessage(t *testing.T) {
-	t.Run("Run writes success_message from compose file", func(t *testing.T) {
+	t.Run("Run writes deploy_success_message from compose file", func(t *testing.T) {
 		dir := t.TempDir()
 		composeFile := filepath.Join(dir, "compose.yaml")
 		testutil.RequireWriteFile(t, composeFile, `
 x-topo:
-  success_message: "Deployment complete!"
+  deploy_success_message: "Deployment complete!"
 services:
   app:
     image: nginx
@@ -32,7 +32,7 @@ services:
 		assert.Equal(t, "Deployment complete!\n", buf.String())
 	})
 
-	t.Run("Run writes default message when success_message is absent", func(t *testing.T) {
+	t.Run("Run writes default message when deploy_success_message is absent", func(t *testing.T) {
 		dir := t.TempDir()
 		composeFile := filepath.Join(dir, "compose.yaml")
 		testutil.RequireWriteFile(t, composeFile, `

--- a/internal/deploy/post_deploy/post_deploy_test.go
+++ b/internal/deploy/post_deploy/post_deploy_test.go
@@ -1,0 +1,60 @@
+package post_deploy_test
+
+import (
+	"bytes"
+	"path/filepath"
+	"testing"
+
+	"github.com/arm/topo/internal/deploy/command"
+	"github.com/arm/topo/internal/deploy/post_deploy"
+	"github.com/arm/topo/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPostDeployMessage(t *testing.T) {
+	t.Run("Run writes success_message from compose file", func(t *testing.T) {
+		dir := t.TempDir()
+		composeFile := filepath.Join(dir, "compose.yaml")
+		testutil.RequireWriteFile(t, composeFile, `
+x-topo:
+  success_message: "Deployment complete!"
+services:
+  app:
+    image: nginx
+`)
+		op := post_deploy.NewPostDeployMessage(composeFile, command.LocalHost)
+		var buf bytes.Buffer
+
+		err := op.Run(&buf)
+
+		require.NoError(t, err)
+		assert.Equal(t, "Deployment complete!\n", buf.String())
+	})
+
+	t.Run("Run writes default message when success_message is absent", func(t *testing.T) {
+		dir := t.TempDir()
+		composeFile := filepath.Join(dir, "compose.yaml")
+		testutil.RequireWriteFile(t, composeFile, `
+services:
+  app:
+    image: nginx
+`)
+		op := post_deploy.NewPostDeployMessage(composeFile, command.LocalHost)
+		var buf bytes.Buffer
+
+		err := op.Run(&buf)
+
+		require.NoError(t, err)
+		assert.Equal(t, "Run `topo ps` to see deployed containers\n", buf.String())
+	})
+
+	t.Run("Run returns error when compose file does not exist", func(t *testing.T) {
+		op := post_deploy.NewPostDeployMessage("nonexistent.yaml", command.LocalHost)
+		var buf bytes.Buffer
+
+		err := op.Run(&buf)
+
+		require.Error(t, err)
+	})
+}

--- a/internal/template/definition.go
+++ b/internal/template/definition.go
@@ -78,7 +78,7 @@ func FromDir(destDir string) (Template, error) {
 type rawMetadata struct {
 	Name           string            `yaml:"name"`
 	Description    string            `yaml:"description"`
-	SuccessMessage string            `yaml:"success_message"`
+	SuccessMessage string            `yaml:"deploy_success_message"`
 	Features       []string          `yaml:"features,omitempty"`
 	Args           map[string]rawArg `yaml:"args,omitempty"`
 }

--- a/internal/template/definition.go
+++ b/internal/template/definition.go
@@ -76,11 +76,11 @@ func FromDir(destDir string) (Template, error) {
 }
 
 type rawMetadata struct {
-	Name          string            `yaml:"name"`
-	Description   string            `yaml:"description"`
+	Name           string            `yaml:"name"`
+	Description    string            `yaml:"description"`
 	SuccessMessage string            `yaml:"success_message"`
-	Features      []string          `yaml:"features,omitempty"`
-	Args          map[string]rawArg `yaml:"args,omitempty"`
+	Features       []string          `yaml:"features,omitempty"`
+	Args           map[string]rawArg `yaml:"args,omitempty"`
 }
 
 type rawArg struct {

--- a/internal/template/definition.go
+++ b/internal/template/definition.go
@@ -22,11 +22,11 @@ type Service struct {
 }
 
 type Metadata struct {
-	Name           string
-	Description    string
+	Name                     string
+	Description              string
 	DeploymentSuccessMessage string
-	Features       []string
-	Args           []Arg
+	Features                 []string
+	Args                     []Arg
 }
 
 type Arg struct {
@@ -76,11 +76,11 @@ func FromDir(destDir string) (Template, error) {
 }
 
 type rawMetadata struct {
-	Name           string            `yaml:"name"`
-	Description    string            `yaml:"description"`
-	DeploymentSuccessMessage string   `yaml:"deployment_success_message"`
-	Features       []string          `yaml:"features,omitempty"`
-	Args           map[string]rawArg `yaml:"args,omitempty"`
+	Name                     string            `yaml:"name"`
+	Description              string            `yaml:"description"`
+	DeploymentSuccessMessage string            `yaml:"deployment_success_message"`
+	Features                 []string          `yaml:"features,omitempty"`
+	Args                     map[string]rawArg `yaml:"args,omitempty"`
 }
 
 type rawArg struct {

--- a/internal/template/definition.go
+++ b/internal/template/definition.go
@@ -24,7 +24,7 @@ type Service struct {
 type Metadata struct {
 	Name           string
 	Description    string
-	SuccessMessage string
+	DeploymentSuccessMessage string
 	Features       []string
 	Args           []Arg
 }
@@ -78,7 +78,7 @@ func FromDir(destDir string) (Template, error) {
 type rawMetadata struct {
 	Name           string            `yaml:"name"`
 	Description    string            `yaml:"description"`
-	SuccessMessage string            `yaml:"deployment_success_message"`
+	DeploymentSuccessMessage string   `yaml:"deployment_success_message"`
 	Features       []string          `yaml:"features,omitempty"`
 	Args           map[string]rawArg `yaml:"args,omitempty"`
 }
@@ -98,7 +98,7 @@ func (t *Metadata) UnmarshalYAML(node *yaml.Node) error {
 
 	t.Name = raw.Name
 	t.Description = raw.Description
-	t.SuccessMessage = raw.SuccessMessage
+	t.DeploymentSuccessMessage = raw.DeploymentSuccessMessage
 	t.Features = raw.Features
 	t.Args = parseArgsInOrder(node, raw.Args)
 

--- a/internal/template/definition.go
+++ b/internal/template/definition.go
@@ -78,7 +78,7 @@ func FromDir(destDir string) (Template, error) {
 type rawMetadata struct {
 	Name          string            `yaml:"name"`
 	Description   string            `yaml:"description"`
-	SuccessMesage string            `yaml:"success_message"`
+	SuccessMessage string            `yaml:"success_message"`
 	Features      []string          `yaml:"features,omitempty"`
 	Args          map[string]rawArg `yaml:"args,omitempty"`
 }
@@ -98,7 +98,7 @@ func (t *Metadata) UnmarshalYAML(node *yaml.Node) error {
 
 	t.Name = raw.Name
 	t.Description = raw.Description
-	t.SuccessMessage = raw.SuccessMesage
+	t.SuccessMessage = raw.SuccessMessage
 	t.Features = raw.Features
 	t.Args = parseArgsInOrder(node, raw.Args)
 

--- a/internal/template/definition.go
+++ b/internal/template/definition.go
@@ -78,7 +78,7 @@ func FromDir(destDir string) (Template, error) {
 type rawMetadata struct {
 	Name           string            `yaml:"name"`
 	Description    string            `yaml:"description"`
-	SuccessMessage string            `yaml:"deploy_success_message"`
+	SuccessMessage string            `yaml:"success_message"`
 	Features       []string          `yaml:"features,omitempty"`
 	Args           map[string]rawArg `yaml:"args,omitempty"`
 }

--- a/internal/template/definition.go
+++ b/internal/template/definition.go
@@ -22,10 +22,11 @@ type Service struct {
 }
 
 type Metadata struct {
-	Name        string
-	Description string
-	Features    []string
-	Args        []Arg
+	Name           string
+	Description    string
+	SuccessMessage string
+	Features       []string
+	Args           []Arg
 }
 
 type Arg struct {
@@ -75,10 +76,11 @@ func FromDir(destDir string) (Template, error) {
 }
 
 type rawMetadata struct {
-	Name        string            `yaml:"name"`
-	Description string            `yaml:"description"`
-	Features    []string          `yaml:"features,omitempty"`
-	Args        map[string]rawArg `yaml:"args,omitempty"`
+	Name          string            `yaml:"name"`
+	Description   string            `yaml:"description"`
+	SuccessMesage string            `yaml:"success_message"`
+	Features      []string          `yaml:"features,omitempty"`
+	Args          map[string]rawArg `yaml:"args,omitempty"`
 }
 
 type rawArg struct {
@@ -96,6 +98,7 @@ func (t *Metadata) UnmarshalYAML(node *yaml.Node) error {
 
 	t.Name = raw.Name
 	t.Description = raw.Description
+	t.SuccessMessage = raw.SuccessMesage
 	t.Features = raw.Features
 	t.Args = parseArgsInOrder(node, raw.Args)
 

--- a/internal/template/definition.go
+++ b/internal/template/definition.go
@@ -78,7 +78,7 @@ func FromDir(destDir string) (Template, error) {
 type rawMetadata struct {
 	Name           string            `yaml:"name"`
 	Description    string            `yaml:"description"`
-	SuccessMessage string            `yaml:"success_message"`
+	SuccessMessage string            `yaml:"deployment_success_message"`
 	Features       []string          `yaml:"features,omitempty"`
 	Args           map[string]rawArg `yaml:"args,omitempty"`
 }

--- a/internal/template/definition_test.go
+++ b/internal/template/definition_test.go
@@ -94,11 +94,11 @@ services:
 		assert.Equal(t, want, got)
 	})
 
-	t.Run("parses deploy_success_message from x-topo metadata", func(t *testing.T) {
+	t.Run("parses success_message from x-topo metadata", func(t *testing.T) {
 		composeFileContents := `
 x-topo:
   name: "test-service"
-  deploy_success_message: "Deployment complete!"
+  success_message: "Deployment complete!"
 `
 		tpl, err := template.FromContent(strings.NewReader(composeFileContents))
 		got := tpl.Metadata
@@ -111,7 +111,7 @@ x-topo:
 		assert.Equal(t, want, got)
 	})
 
-	t.Run("leaves SuccessMessage empty when deploy_success_message absent from x-topo", func(t *testing.T) {
+	t.Run("leaves SuccessMessage empty when success_message absent from x-topo", func(t *testing.T) {
 		composeFileContents := `
 x-topo:
   name: "test-service"

--- a/internal/template/definition_test.go
+++ b/internal/template/definition_test.go
@@ -94,11 +94,11 @@ services:
 		assert.Equal(t, want, got)
 	})
 
-	t.Run("parses success_message from x-topo metadata", func(t *testing.T) {
+	t.Run("parses deployment_success_message from x-topo metadata", func(t *testing.T) {
 		composeFileContents := `
 x-topo:
   name: "test-service"
-  success_message: "Deployment complete!"
+  deployment_success_message: "Deployment complete!"
 `
 		tpl, err := template.FromContent(strings.NewReader(composeFileContents))
 		got := tpl.Metadata
@@ -111,7 +111,7 @@ x-topo:
 		assert.Equal(t, want, got)
 	})
 
-	t.Run("leaves SuccessMessage empty when success_message absent from x-topo", func(t *testing.T) {
+	t.Run("leaves SuccessMessage empty when deployment_success_message absent from x-topo", func(t *testing.T) {
 		composeFileContents := `
 x-topo:
   name: "test-service"

--- a/internal/template/definition_test.go
+++ b/internal/template/definition_test.go
@@ -94,11 +94,11 @@ services:
 		assert.Equal(t, want, got)
 	})
 
-	t.Run("parses success_message from x-topo metadata", func(t *testing.T) {
+	t.Run("parses deploy_success_message from x-topo metadata", func(t *testing.T) {
 		composeFileContents := `
 x-topo:
   name: "test-service"
-  success_message: "Deployment complete!"
+  deploy_success_message: "Deployment complete!"
 `
 		tpl, err := template.FromContent(strings.NewReader(composeFileContents))
 		got := tpl.Metadata
@@ -111,7 +111,7 @@ x-topo:
 		assert.Equal(t, want, got)
 	})
 
-	t.Run("leaves SuccessMessage empty when success_message absent from x-topo", func(t *testing.T) {
+	t.Run("leaves SuccessMessage empty when deploy_success_message absent from x-topo", func(t *testing.T) {
 		composeFileContents := `
 x-topo:
   name: "test-service"

--- a/internal/template/definition_test.go
+++ b/internal/template/definition_test.go
@@ -94,6 +94,35 @@ services:
 		assert.Equal(t, want, got)
 	})
 
+	t.Run("parses success_message from x-topo metadata", func(t *testing.T) {
+		composeFileContents := `
+x-topo:
+  name: "test-service"
+  success_message: "Deployment complete!"
+`
+		tpl, err := template.FromContent(strings.NewReader(composeFileContents))
+		got := tpl.Metadata
+
+		require.NoError(t, err)
+		want := template.Metadata{
+			Name:           "test-service",
+			SuccessMessage: "Deployment complete!",
+		}
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("leaves SuccessMessage empty when success_message absent from x-topo", func(t *testing.T) {
+		composeFileContents := `
+x-topo:
+  name: "test-service"
+`
+		tpl, err := template.FromContent(strings.NewReader(composeFileContents))
+		got := tpl.Metadata
+
+		require.NoError(t, err)
+		assert.Empty(t, got.SuccessMessage)
+	})
+
 	t.Run("errors when compose.yaml missing", func(t *testing.T) {
 		dir := t.TempDir()
 

--- a/internal/template/definition_test.go
+++ b/internal/template/definition_test.go
@@ -106,12 +106,12 @@ x-topo:
 		require.NoError(t, err)
 		want := template.Metadata{
 			Name:           "test-service",
-			SuccessMessage: "Deployment complete!",
+			DeploymentSuccessMessage: "Deployment complete!",
 		}
 		assert.Equal(t, want, got)
 	})
 
-	t.Run("leaves SuccessMessage empty when deployment_success_message absent from x-topo", func(t *testing.T) {
+	t.Run("leaves DeploymentSuccessMessage empty when deployment_success_message absent from x-topo", func(t *testing.T) {
 		composeFileContents := `
 x-topo:
   name: "test-service"
@@ -120,7 +120,7 @@ x-topo:
 		got := tpl.Metadata
 
 		require.NoError(t, err)
-		assert.Empty(t, got.SuccessMessage)
+		assert.Empty(t, got.DeploymentSuccessMessage)
 	})
 
 	t.Run("errors when compose.yaml missing", func(t *testing.T) {

--- a/internal/template/definition_test.go
+++ b/internal/template/definition_test.go
@@ -105,7 +105,7 @@ x-topo:
 
 		require.NoError(t, err)
 		want := template.Metadata{
-			Name:           "test-service",
+			Name:                     "test-service",
 			DeploymentSuccessMessage: "Deployment complete!",
 		}
 		assert.Equal(t, want, got)


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->
Add support for the success_message x-topo attribute. This prints a string (defined by compose.yaml) after a successful deployment.

I've used the deployment operations sequence to leverage the operation heading.
With no success_message
```
┌─ Deploy Success ──────────────────────────────────────
Run `topo ps` to see deployed containers
```
with a success_message:
```
┌─ Deploy Success ──────────────────────────────────────
You did it!!
```