### PR TITLE
feat: Add support for topo ps returning processing domains

### DIFF
--- a/internal/deploy/ps.go
+++ b/internal/deploy/ps.go
@@ -9,16 +9,35 @@ import (
 	"github.com/arm/topo/internal/deploy/command"
 )
 
-type RawContainer struct {
+const (
+	remoteprocRuntimeName    = "io.containerd.remoteproc.v1"
+	remoteprocNameAnnotation = "remoteproc.name"
+	hostProcessingDomain     = "Linux Host"
+)
+
+type PSContainer struct {
+	ID     string `json:"ID"`
 	Image  string `json:"Image"`
 	Status string `json:"Status"`
 	Ports  string `json:"Ports"`
 }
 
 type Container struct {
-	Image   string `json:"image"`
-	Status  string `json:"status"`
-	Address string `json:"address"`
+	Image            string `json:"image"`
+	Status           string `json:"status"`
+	ProcessingDomain string `json:"processingDomain"`
+	Address          string `json:"address"`
+}
+
+type InspectedContainer struct {
+	ID         string              `json:"Id"`
+	Name       string              `json:"Name"`
+	HostConfig InspectedHostConfig `json:"HostConfig"`
+}
+
+type InspectedHostConfig struct {
+	Runtime     string            `json:"Runtime"`
+	Annotations map[string]string `json:"Annotations"`
 }
 
 func ListRunningContainers(composeFile string, h command.Host, hostName string) ([]Container, error) {
@@ -30,7 +49,17 @@ func ListRunningContainers(composeFile string, h command.Host, hostName string) 
 	if err != nil {
 		return nil, err
 	}
-	return RemapAddresses(raws, hostName), nil
+	containers := RemapAddresses(raws, hostName)
+
+	domains, err := getProcessingDomains(raws, h)
+	if err != nil {
+		return nil, err
+	}
+
+	for i, raw := range raws {
+		containers[i].ProcessingDomain = processingDomainFromLookup(raw, domains)
+	}
+	return containers, nil
 }
 
 func getRunningContainers(composeFile string, h command.Host) (string, error) {
@@ -44,11 +73,11 @@ func getRunningContainers(composeFile string, h command.Host) (string, error) {
 	return stdout.String(), nil
 }
 
-func ParseRunningContainers(rawJSON string) ([]RawContainer, error) {
-	raws := []RawContainer{}
+func ParseRunningContainers(rawJSON string) ([]PSContainer, error) {
+	raws := []PSContainer{}
 	decoder := json.NewDecoder(strings.NewReader(rawJSON))
 	for decoder.More() {
-		var raw RawContainer
+		var raw PSContainer
 		if err := decoder.Decode(&raw); err != nil {
 			return nil, err
 		}
@@ -57,7 +86,75 @@ func ParseRunningContainers(rawJSON string) ([]RawContainer, error) {
 	return raws, nil
 }
 
-func RemapAddresses(raws []RawContainer, hostName string) []Container {
+func getProcessingDomains(raws []PSContainer, h command.Host) (map[string]string, error) {
+	targets := make([]string, 0, len(raws))
+	for _, raw := range raws {
+		if raw.ID != "" {
+			targets = append(targets, raw.ID)
+		}
+	}
+	if len(targets) == 0 {
+		return map[string]string{}, nil
+	}
+
+	rawJSON, err := inspectContainers(targets, h)
+	if err != nil {
+		return nil, err
+	}
+
+	inspected, err := ParseInspectedContainers(rawJSON)
+	if err != nil {
+		return nil, err
+	}
+
+	return BuildProcessingDomainLookup(inspected), nil
+}
+
+func inspectContainers(targets []string, h command.Host) (string, error) {
+	var stdout, stderr bytes.Buffer
+	cmd := command.Docker(h, append([]string{"inspect"}, targets...)...)
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("docker inspect: %w: %s", err, strings.TrimSpace(stderr.String()))
+	}
+	return stdout.String(), nil
+}
+
+func ParseInspectedContainers(rawJSON string) ([]InspectedContainer, error) {
+	if strings.TrimSpace(rawJSON) == "" {
+		return []InspectedContainer{}, nil
+	}
+
+	inspected := []InspectedContainer{}
+	if err := json.Unmarshal([]byte(rawJSON), &inspected); err != nil {
+		return nil, err
+	}
+	return inspected, nil
+}
+
+func BuildProcessingDomainLookup(inspected []InspectedContainer) map[string]string {
+	lookup := map[string]string{}
+
+	for _, container := range inspected {
+		if container.HostConfig.Runtime != remoteprocRuntimeName {
+			continue
+		}
+
+		processingDomain := strings.TrimSpace(container.HostConfig.Annotations[remoteprocNameAnnotation])
+		if processingDomain == "" {
+			continue
+		}
+
+		if id := strings.TrimSpace(container.ID); id != "" {
+			lookup[id] = processingDomain
+		}
+	}
+
+	return lookup
+}
+
+func RemapAddresses(raws []PSContainer, hostName string) []Container {
 	containers := make([]Container, len(raws))
 	for i, raw := range raws {
 		containers[i] = Container{
@@ -67,6 +164,13 @@ func RemapAddresses(raws []RawContainer, hostName string) []Container {
 		}
 	}
 	return containers
+}
+
+func processingDomainFromLookup(raw PSContainer, lookup map[string]string) string {
+	if domain, ok := lookup[raw.ID]; ok {
+		return domain
+	}
+	return hostProcessingDomain
 }
 
 func publishedAddress(rawPorts, hostName string) string {

--- a/internal/deploy/ps_test.go
+++ b/internal/deploy/ps_test.go
@@ -10,15 +10,15 @@ import (
 
 func TestParseRunningContainers(t *testing.T) {
 	t.Run("decodes the NDJSON stream emitted by docker compose ps", func(t *testing.T) {
-		input := `{"Image":"web","Status":"Up 5 minutes","Ports":"0.0.0.0:8080->80/tcp"}
-{"Image":"db","Status":"Up 5 minutes","Ports":""}`
+		input := `{"ID":"abc123","Image":"web","Status":"Up 5 minutes","Ports":"0.0.0.0:8080->80/tcp"}
+{"ID":"def456","Image":"db","Status":"Up 5 minutes","Ports":""}`
 
 		got, err := deploy.ParseRunningContainers(input)
 
 		require.NoError(t, err)
-		want := []deploy.RawContainer{
-			{Image: "web", Status: "Up 5 minutes", Ports: "0.0.0.0:8080->80/tcp"},
-			{Image: "db", Status: "Up 5 minutes", Ports: ""},
+		want := []deploy.PSContainer{
+			{ID: "abc123", Image: "web", Status: "Up 5 minutes", Ports: "0.0.0.0:8080->80/tcp"},
+			{ID: "def456", Image: "db", Status: "Up 5 minutes", Ports: ""},
 		}
 		assert.Equal(t, want, got)
 	})
@@ -27,7 +27,7 @@ func TestParseRunningContainers(t *testing.T) {
 		got, err := deploy.ParseRunningContainers("")
 
 		require.NoError(t, err)
-		assert.Equal(t, []deploy.RawContainer{}, got)
+		assert.Equal(t, []deploy.PSContainer{}, got)
 	})
 
 	t.Run("returns an error on malformed JSON", func(t *testing.T) {
@@ -37,9 +37,111 @@ func TestParseRunningContainers(t *testing.T) {
 	})
 }
 
+func TestParseInspectedContainers(t *testing.T) {
+	t.Run("decodes docker inspect output", func(t *testing.T) {
+		input := `[
+			{
+				"Id": "abc123",
+				"Name": "/project-web-1",
+				"HostConfig": {
+					"Runtime": "io.containerd.remoteproc.v1",
+					"Annotations": {
+						"remoteproc.name": "m0"
+					}
+				}
+			}
+		]`
+
+		got, err := deploy.ParseInspectedContainers(input)
+
+		require.NoError(t, err)
+		want := []deploy.InspectedContainer{
+			{
+				ID:   "abc123",
+				Name: "/project-web-1",
+				HostConfig: deploy.InspectedHostConfig{
+					Runtime: "io.containerd.remoteproc.v1",
+					Annotations: map[string]string{
+						"remoteproc.name": "m0",
+					},
+				},
+			},
+		}
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("returns empty slice for empty input", func(t *testing.T) {
+		got, err := deploy.ParseInspectedContainers("")
+
+		require.NoError(t, err)
+		assert.Equal(t, []deploy.InspectedContainer{}, got)
+	})
+
+	t.Run("returns error on malformed JSON", func(t *testing.T) {
+		_, err := deploy.ParseInspectedContainers("{not json")
+
+		assert.Error(t, err)
+	})
+}
+
+func TestBuildProcessingDomainLookup(t *testing.T) {
+	t.Run("indexes remoteproc containers by id", func(t *testing.T) {
+		input := []deploy.InspectedContainer{
+			{
+				ID: "abc123",
+				HostConfig: deploy.InspectedHostConfig{
+					Runtime: "io.containerd.remoteproc.v1",
+					Annotations: map[string]string{
+						"remoteproc.name": "m0",
+					},
+				},
+			},
+		}
+
+		got := deploy.BuildProcessingDomainLookup(input)
+
+		want := map[string]string{"abc123": "m0"}
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("skips non remoteproc containers", func(t *testing.T) {
+		input := []deploy.InspectedContainer{
+			{
+				ID: "abc123",
+				HostConfig: deploy.InspectedHostConfig{
+					Runtime: "runc",
+					Annotations: map[string]string{
+						"remoteproc.name": "m0",
+					},
+				},
+			},
+		}
+
+		got := deploy.BuildProcessingDomainLookup(input)
+
+		assert.Empty(t, got)
+	})
+
+	t.Run("skips remoteproc containers without a processing domain annotation", func(t *testing.T) {
+		input := []deploy.InspectedContainer{
+			{
+				ID: "abc123",
+				HostConfig: deploy.InspectedHostConfig{
+					Runtime:     "io.containerd.remoteproc.v1",
+					Annotations: map[string]string{},
+				},
+			},
+		}
+
+		got := deploy.BuildProcessingDomainLookup(input)
+
+		assert.Empty(t, got)
+	})
+}
+
 func TestRemapAddresses(t *testing.T) {
 	t.Run("strips the container-side port mapping and substitutes the hostname", func(t *testing.T) {
-		input := []deploy.RawContainer{{Ports: "0.0.0.0:8080->80/tcp"}}
+		input := []deploy.PSContainer{{Ports: "0.0.0.0:8080->80/tcp"}}
 
 		got := deploy.RemapAddresses(input, "myhost")
 
@@ -48,7 +150,7 @@ func TestRemapAddresses(t *testing.T) {
 	})
 
 	t.Run("retains image and status fields", func(t *testing.T) {
-		input := []deploy.RawContainer{{Image: "web", Status: "Up", Ports: ""}}
+		input := []deploy.PSContainer{{Image: "web", Status: "Up"}}
 
 		got := deploy.RemapAddresses(input, "myhost")
 
@@ -57,7 +159,7 @@ func TestRemapAddresses(t *testing.T) {
 	})
 
 	t.Run("leaves ports untouched when hostname is empty", func(t *testing.T) {
-		input := []deploy.RawContainer{{Ports: "0.0.0.0:8080->80/tcp"}}
+		input := []deploy.PSContainer{{Ports: "0.0.0.0:8080->80/tcp"}}
 
 		got := deploy.RemapAddresses(input, "")
 
@@ -66,7 +168,7 @@ func TestRemapAddresses(t *testing.T) {
 	})
 
 	t.Run("leaves addresses without 0.0.0.0 untouched", func(t *testing.T) {
-		input := []deploy.RawContainer{{Ports: "127.0.0.1:8080"}}
+		input := []deploy.PSContainer{{Ports: "127.0.0.1:8080"}}
 
 		got := deploy.RemapAddresses(input, "myhost")
 
@@ -75,7 +177,7 @@ func TestRemapAddresses(t *testing.T) {
 	})
 
 	t.Run("remaps all published ports", func(t *testing.T) {
-		input := []deploy.RawContainer{{Ports: "0.0.0.0:8080->80/tcp, 0.0.0.0:8443->443/tcp"}}
+		input := []deploy.PSContainer{{Ports: "0.0.0.0:8080->80/tcp, 0.0.0.0:8443->443/tcp"}}
 
 		got := deploy.RemapAddresses(input, "myhost")
 

--- a/internal/output/templates/ps.go
+++ b/internal/output/templates/ps.go
@@ -14,9 +14,9 @@ type PrintablePSReport struct {
 	Containers []deploy.Container `json:"containers"`
 }
 
-const PSTemplate = `{{if .}}Image	Status	Address
+const PSTemplate = `{{if .}}Image	Status	Processing Domain	Address
 {{- range .}}
-{{.Image}}	{{.Status}}	{{.Address}}
+{{.Image}}	{{.Status}}	{{.ProcessingDomain}}	{{.Address}}
 {{- end }}{{else}}No containers deployed from this project are running.{{end}}`
 
 func (r PrintablePSReport) AsPlain(isTTY bool) (string, error) {

--- a/internal/output/templates/ps_test.go
+++ b/internal/output/templates/ps_test.go
@@ -15,13 +15,14 @@ import (
 
 func TestPrintPSReport(t *testing.T) {
 	t.Run("PlainFormat", func(t *testing.T) {
-		t.Run("renders container image, status, and address", func(t *testing.T) {
+		t.Run("renders container image, status, processing domain, and address", func(t *testing.T) {
 			toPrint := templates.PrintablePSReport{
 				Containers: []deploy.Container{
 					{
-						Image:   "my-app",
-						Status:  "Up 5 minutes",
-						Address: "localhost:8080",
+						Image:            "my-app",
+						Status:           "Up 5 minutes",
+						ProcessingDomain: "m0",
+						Address:          "localhost:8080",
 					},
 				},
 			}
@@ -32,14 +33,16 @@ func TestPrintPSReport(t *testing.T) {
 			require.NoError(t, err)
 			assert.Contains(t, out.String(), "my-app")
 			assert.Contains(t, out.String(), "Up 5 minutes")
+			assert.Contains(t, out.String(), "m0")
 			assert.Contains(t, out.String(), "localhost:8080")
+			assert.Contains(t, out.String(), "Processing Domain")
 		})
 
 		t.Run("renders multiple containers", func(t *testing.T) {
 			toPrint := templates.PrintablePSReport{
 				Containers: []deploy.Container{
-					{Image: "web"},
-					{Image: "db"},
+					{Image: "web", ProcessingDomain: "Linux Host"},
+					{Image: "db", ProcessingDomain: "Linux Host"},
 				},
 			}
 			var out bytes.Buffer
@@ -49,6 +52,7 @@ func TestPrintPSReport(t *testing.T) {
 			require.NoError(t, err)
 			assert.Contains(t, out.String(), "web")
 			assert.Contains(t, out.String(), "db")
+			assert.Contains(t, out.String(), "Linux Host")
 		})
 
 		t.Run("renders empty message when no containers", func(t *testing.T) {
@@ -67,9 +71,10 @@ func TestPrintPSReport(t *testing.T) {
 			toPrint := templates.PrintablePSReport{
 				Containers: []deploy.Container{
 					{
-						Image:   "my-app",
-						Status:  "Up 5 minutes",
-						Address: "localhost:8080",
+						Image:            "my-app",
+						Status:           "Up 5 minutes",
+						ProcessingDomain: "m0",
+						Address:          "localhost:8080",
 					},
 				},
 			}
@@ -79,7 +84,7 @@ func TestPrintPSReport(t *testing.T) {
 
 			require.NoError(t, err)
 			want := `{
-				"containers": [{"image": "my-app", "status": "Up 5 minutes", "address": "localhost:8080"}]
+				"containers": [{"image": "my-app", "status": "Up 5 minutes", "processingDomain": "m0", "address": "localhost:8080"}]
 			}`
 			assert.JSONEq(t, want, out.String())
 		})


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- Topo has many examples which deploy to heterogenous devices using remoteproc runtime
- This PR adds support to topo ps for displaying which processing domain each container is deployed to.
- 