### PR TITLE
fix: Fix incorrect matching of container IDs with topo PS

### DIFF
--- a/internal/deploy/ps.go
+++ b/internal/deploy/ps.go
@@ -148,10 +148,10 @@ func BuildProcessingDomainLookup(inspected []InspectedContainer) map[string]stri
 		}
 
 		if id := strings.TrimSpace(container.ID); id != "" {
-			lookup[id] = processingDomain
 			if len(id) > dockerShortIDLength {
-				lookup[id[:dockerShortIDLength]] = processingDomain
+				id = id[:dockerShortIDLength]
 			}
+			lookup[id] = processingDomain
 		}
 	}
 

--- a/internal/deploy/ps.go
+++ b/internal/deploy/ps.go
@@ -13,6 +13,7 @@ const (
 	remoteprocRuntimeName    = "io.containerd.remoteproc.v1"
 	remoteprocNameAnnotation = "remoteproc.name"
 	hostProcessingDomain     = "Linux Host"
+	dockerShortIDLength      = 12
 )
 
 type PSContainer struct {
@@ -148,6 +149,9 @@ func BuildProcessingDomainLookup(inspected []InspectedContainer) map[string]stri
 
 		if id := strings.TrimSpace(container.ID); id != "" {
 			lookup[id] = processingDomain
+			if len(id) > dockerShortIDLength {
+				lookup[id[:dockerShortIDLength]] = processingDomain
+			}
 		}
 	}
 

--- a/internal/deploy/ps_test.go
+++ b/internal/deploy/ps_test.go
@@ -104,6 +104,28 @@ func TestBuildProcessingDomainLookup(t *testing.T) {
 		assert.Equal(t, want, got)
 	})
 
+	t.Run("indexes remoteproc containers by short docker id", func(t *testing.T) {
+		input := []deploy.InspectedContainer{
+			{
+				ID: "0ccbbb5c98961db4e650d8db70b0154c3cf5bbfcd4a44450b019fea11a6afb9a",
+				HostConfig: deploy.InspectedHostConfig{
+					Runtime: "io.containerd.remoteproc.v1",
+					Annotations: map[string]string{
+						"remoteproc.name": "m33",
+					},
+				},
+			},
+		}
+
+		got := deploy.BuildProcessingDomainLookup(input)
+
+		want := map[string]string{
+			"0ccbbb5c98961db4e650d8db70b0154c3cf5bbfcd4a44450b019fea11a6afb9a": "m33",
+			"0ccbbb5c9896": "m33",
+		}
+		assert.Equal(t, want, got)
+	})
+
 	t.Run("skips non remoteproc containers", func(t *testing.T) {
 		input := []deploy.InspectedContainer{
 			{

--- a/internal/deploy/ps_test.go
+++ b/internal/deploy/ps_test.go
@@ -120,7 +120,6 @@ func TestBuildProcessingDomainLookup(t *testing.T) {
 		got := deploy.BuildProcessingDomainLookup(input)
 
 		want := map[string]string{
-			"0ccbbb5c98961db4e650d8db70b0154c3cf5bbfcd4a44450b019fea11a6afb9a": "m33",
 			"0ccbbb5c9896": "m33",
 		}
 		assert.Equal(t, want, got)


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- Docker inspect returns full container IDs, compose ps --format json can return short IDs. 
- This can lead to a mismatch, where the remoteproc services would fall back and incorrectly report as Linux Host.

This PR adds a regression test and a fix- using the short ID only. 
