### PR TITLE
ci: Generate release notes in topo

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -63,7 +63,7 @@ jobs:
         with:
           distribution: goreleaser
           version: '~> v2'
-          args: release --clean --draft
+          args: release --clean --skip=publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_CURRENT_TAG: ${{ steps.calculate_next_version.outputs.next_version }}
@@ -211,3 +211,26 @@ jobs:
           name: release-links
           path: publisher-artifacts/release_links.md
           if-no-files-found: error
+
+      - name: Update and publish release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: arm/topo
+          RELEASE_TAG: ${{ steps.calculate_next_version.outputs.next_version }}
+          PRE_RELEASE: ${{ inputs.pre-release }}
+        run: |
+          gh api repos/{owner}/{repo}/releases/generate-notes \
+            -f tag_name="$RELEASE_TAG" \
+            --jq .body > existing_body.md
+
+          {
+            cat existing_body.md
+            printf '\n\n'
+            cat publisher-artifacts/release_links.md
+          } > combined_notes.md
+
+          if [ "$PRE_RELEASE" = "true" ]; then
+            gh release create "$RELEASE_TAG" --title "$RELEASE_TAG" --prerelease --notes-file combined_notes.md
+          else
+            gh release create "$RELEASE_TAG" --title "$RELEASE_TAG" --notes-file combined_notes.md
+          fi

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -133,7 +133,6 @@ jobs:
             --ref v7 \
             --field source-run-id=${{ github.run_id }} \
             --field release-version=${VERSION} \
-            --field release-tag=${VERSION} \
             --field pre-release=${{ inputs.pre-release }}
 
           echo "Waiting for topo-publisher sign-and-release run to be created"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -205,13 +205,6 @@ jobs:
           echo "::error::Timed out waiting for $ARTIFACT_NAME artifact from topo-publisher run $PUBLISHER_RUN_ID"
           exit 1
 
-      - name: Upload release links artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: release-links
-          path: publisher-artifacts/release_links.md
-          if-no-files-found: error
-
       - name: Update and publish release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -130,7 +130,7 @@ jobs:
         run: |
           gh workflow run sign-and-release.yml \
             --repo Arm-Debug/topo-publisher \
-            --ref v7 \
+            --ref v8 \
             --field source-run-id=${{ github.run_id }} \
             --field release-version=${VERSION} \
             --field pre-release=${{ inputs.pre-release }}
@@ -142,7 +142,7 @@ jobs:
             publisher_run_id="$(gh run list \
               --repo Arm-Debug/topo-publisher \
               --workflow sign-and-release.yml \
-              --branch v7 \
+              --branch v8 \
               --event workflow_dispatch \
               --limit 5 \
               --json createdAt,databaseId,displayTitle \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -217,7 +217,7 @@ jobs:
 
           {
             cat publisher-artifacts/release_links.md
-            printf '\n\n'
+            printf '\n\n## Changelog\n'
             cat existing_body.md
           } > combined_notes.md
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -206,3 +206,10 @@ jobs:
 
           echo "::error::Timed out waiting for $ARTIFACT_NAME artifact from topo-publisher run $PUBLISHER_RUN_ID"
           exit 1
+
+      - name: Upload release links artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-links
+          path: publisher-artifacts/release_links.md
+          if-no-files-found: error

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -128,8 +128,6 @@ jobs:
           GH_TOKEN: ${{ steps.publisher-token.outputs.token }}
           VERSION: ${{ steps.calculate_next_version.outputs.next_version }}
         run: |
-          dispatched_at="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
-
           gh workflow run sign-and-release.yml \
             --repo Arm-Debug/topo-publisher \
             --ref v7 \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -216,9 +216,9 @@ jobs:
             --jq .body > existing_body.md
 
           {
-            cat existing_body.md
-            printf '\n\n'
             cat publisher-artifacts/release_links.md
+            printf '\n\n'
+            cat existing_body.md
           } > combined_notes.md
 
           if [ "$PRE_RELEASE" = "true" ]; then

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -128,6 +128,8 @@ jobs:
           GH_TOKEN: ${{ steps.publisher-token.outputs.token }}
           VERSION: ${{ steps.calculate_next_version.outputs.next_version }}
         run: |
+          dispatched_at="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+
           gh workflow run sign-and-release.yml \
             --repo Arm-Debug/topo-publisher \
             --ref v7 \
@@ -204,10 +206,3 @@ jobs:
 
           echo "::error::Timed out waiting for $ARTIFACT_NAME artifact from topo-publisher run $PUBLISHER_RUN_ID"
           exit 1
-
-      - name: Upload release links artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: release-links
-          path: publisher-artifacts/release_links.md
-          if-no-files-found: error


### PR DESCRIPTION
## Changes
- remove unnecessary artifacts upload for release links file
- generate the binaries using goreleaser, but don't make the draft release with it
- use gh api to generate release notes
