### PR TITLE
fix!: Skip version checks argument precedence and truthiness

### DIFF
--- a/cmd/topo/health.go
+++ b/cmd/topo/health.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/arm/topo/internal/env"
 	"github.com/arm/topo/internal/health"
 	"github.com/arm/topo/internal/output/printable"
 	"github.com/arm/topo/internal/output/templates"
@@ -76,14 +77,20 @@ func init() {
 }
 
 func resolveSkipVersionChecks(cmd *cobra.Command) bool {
-	skipVersionCheck, err := cmd.Flags().GetBool(skipVersionChecksFlag)
+	if skipVersionChecks, wasArgProvided := getSkipVersionChecksFlagValue(cmd); wasArgProvided {
+		return skipVersionChecks
+	}
+	return env.IsVarTruthy(skipVersionChecksEnvVar)
+}
+
+func getSkipVersionChecksFlagValue(cmd *cobra.Command) (bool, bool) {
+	if !cmd.Flags().Changed(skipVersionChecksFlag) {
+		return false, false
+	}
+
+	skipVersionChecks, err := cmd.Flags().GetBool(skipVersionChecksFlag)
 	if err != nil {
 		panic(fmt.Sprintf("internal error: %s flag not registered: %v", skipVersionChecksFlag, err))
 	}
-
-	if !skipVersionCheck {
-		skipVersionCheck = os.Getenv(skipVersionChecksEnvVar) != ""
-	}
-
-	return skipVersionCheck
+	return skipVersionChecks, true
 }

--- a/cmd/topo/health.go
+++ b/cmd/topo/health.go
@@ -77,20 +77,13 @@ func init() {
 }
 
 func resolveSkipVersionChecks(cmd *cobra.Command) bool {
-	if skipVersionChecks, wasArgProvided := getSkipVersionChecksFlagValue(cmd); wasArgProvided {
-		return skipVersionChecks
-	}
-	return env.IsVarTruthy(skipVersionChecksEnvVar)
-}
-
-func getSkipVersionChecksFlagValue(cmd *cobra.Command) (bool, bool) {
 	if !cmd.Flags().Changed(skipVersionChecksFlag) {
-		return false, false
+		return env.IsVarTruthy(skipVersionChecksEnvVar)
 	}
 
 	skipVersionChecks, err := cmd.Flags().GetBool(skipVersionChecksFlag)
 	if err != nil {
 		panic(fmt.Sprintf("internal error: %s flag not registered: %v", skipVersionChecksFlag, err))
 	}
-	return skipVersionChecks, true
+	return skipVersionChecks
 }

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -1,0 +1,21 @@
+package env
+
+import (
+	"os"
+	"slices"
+	"strings"
+)
+
+func IsVarTruthy(name string) bool {
+	return slices.Contains(
+		[]string{
+			"1",
+			"true",
+			"yes",
+			"on",
+			"y",
+			"enabled",
+		},
+		strings.ToLower(os.Getenv(name)),
+	)
+}

--- a/internal/env/env_test.go
+++ b/internal/env/env_test.go
@@ -1,0 +1,43 @@
+package env_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/arm/topo/internal/env"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsEnvVarTruthy(t *testing.T) {
+	t.Run("returns true if env variable is set to truthy value", func(t *testing.T) {
+		truthy_values := []string{
+			"1",
+			"On",
+			"TRUE",
+			"Yes",
+			"enabled",
+			"tRuE",
+			"true",
+			"y",
+			"yes",
+		}
+
+		for _, value := range truthy_values {
+			description := fmt.Sprintf("%q is considered truthy", value)
+			env_var := "SOME_VAR"
+			t.Run(description, func(t *testing.T) {
+				t.Setenv(env_var, value)
+
+				assert.True(t, env.IsVarTruthy(env_var))
+			})
+		}
+	})
+
+	t.Run("returns false if env variable is not set", func(t *testing.T) {
+		assert.False(t, env.IsVarTruthy("NOT_SET"))
+	})
+
+	t.Run("returns false if env variable is set to falsy value", func(t *testing.T) {
+		assert.False(t, env.IsVarTruthy("false"))
+	})
+}


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- `SKIP_VERSION_CHECKS` must now be set to truthy value to be considered enabled (`1`, `yes`, `on`, `true`, `enabled`)
- Fixed a bug where explicit false value provided in cli could be overridden by `SKIP_VERSION_CHECKS` env variable being non-empty 
