### PR TITLE
feat: Populate catalog templates with args

### DIFF
--- a/internal/catalog/data/catalog.json
+++ b/internal/catalog/data/catalog.json
@@ -5,6 +5,14 @@
       "name": "Hello World",
       "description": "A minimal \"Hello, World\" web app for validating a Topo setup and deployment.\nIt runs a single service that exposes a web page on the target,\nwith the greeting text customizable via the GREETING_NAME parameter.\n",
       "features": null,
+      "args": {
+        "GREETING_NAME": {
+          "description": "The text to use in the greeting message",
+          "required": true,
+          "default": "World",
+          "example": "Markus"
+        }
+      },
       "url": "https://github.com/Arm-Examples/topo-welcome.git",
       "ref": "main"
     },
@@ -14,6 +22,22 @@
       "features": [
         "remoteproc-runtime"
       ],
+      "args": {
+        "LLM_PROMPT_PRESET": {
+          "description": "The writing style for the LLM to use when generating messages about the light bulb state. Can be any style description (e.g., \"shakespearean english\", \"pirate\", \"haiku\", \"detective noir\").\n",
+          "required": true,
+          "default": "shakespearean english",
+          "example": "shakespearean english"
+        },
+        "PLATFORM": {
+          "description": "The platform to build for. Must be either `stm32mp257` or `imx93`.",
+          "required": true
+        },
+        "REMOTEPROC": {
+          "description": "The remoteproc device to use. Must be `m33` if the stm32 board is used, or `imx-rproc` if the imx93 board is used.",
+          "required": true
+        }
+      },
       "url": "https://github.com/Arm-Examples/topo-lightbulb-moment.git",
       "ref": "main"
     },
@@ -24,6 +48,22 @@
         "SVE",
         "NEON"
       ],
+      "args": {
+        "ENABLE_SVE": {
+          "description": "Enables building with SVE instructions (OFF/ON)",
+          "default": "OFF",
+          "example": "ON"
+        },
+        "HF_MODEL": {
+          "description": "Hugging Face model repo ID containing a supported single-file GGUF model",
+          "default": "bartowski/Qwen_Qwen3.5-0.8B-GGUF",
+          "example": "unsloth/SmolLM2-135M-Instruct-GGUF"
+        },
+        "HF_MODEL_FILE": {
+          "description": "Exact supported GGUF filename to download; sharded and mmproj files are rejected",
+          "example": "Qwen_Qwen3.5-0.8B-Q4_0.gguf"
+        }
+      },
       "url": "https://github.com/Arm-Examples/topo-cpu-ai-chat.git",
       "ref": "main"
     },
@@ -33,6 +73,12 @@
       "features": [
         "SVE"
       ],
+      "args": {
+        "PROCESSOR_CLIENT_TIMEOUT_S": {
+          "description": "HTTP timeout in seconds that the dashboard uses when contacting the\nprocessor services. Increase when running very large workloads.\n",
+          "default": "30"
+        }
+      },
       "url": "https://github.com/Arm-Examples/topo-simd-visual-benchmark.git",
       "ref": "main"
     }

--- a/internal/catalog/data/catalog.schema.json
+++ b/internal/catalog/data/catalog.schema.json
@@ -20,6 +20,49 @@
     }
   },
   "$defs": {
+    "arg": {
+      "type": "object",
+      "description": "Build argument definition.",
+      "additionalProperties": false,
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "Context displayed in user prompts."
+        },
+        "required": {
+          "type": "boolean",
+          "description": "If true, implementations must enforce input or error."
+        },
+        "default": {
+          "type": "string",
+          "description": "Value used if user skips input (only valid when not required)."
+        },
+        "example": {
+          "type": "string",
+          "description": "Hint text displayed in help and prompts."
+        },
+        "hints": {
+          "type": "object",
+          "description": "Advisory metadata that implementations may use to discover, filter, or suggest suitable argument values. Unknown hint keys should be ignored.",
+          "patternProperties": {
+            "^[a-z][a-z0-9-]*(\\.[a-z][a-z0-9-]*)+$": {
+              "oneOf": [
+                {
+                  "type": ["string", "number", "boolean"]
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": ["string", "number", "boolean"]
+                  }
+                }
+              ]
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
     "template": {
       "type": "object",
       "additionalProperties": false,
@@ -47,6 +90,13 @@
               "type": "null"
             }
           ]
+        },
+        "args": {
+          "description": "Optional dictionary of build argument definitions used for parameterized templates.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/arg"
+          }
         },
         "url": {
           "description": "Repository URL containing the template.",

--- a/scripts/update_templates/main.go
+++ b/scripts/update_templates/main.go
@@ -16,11 +16,20 @@ var repoList = []string{
 }
 
 type Template struct {
-	Name        string   `json:"name"`
-	Description string   `json:"description"`
-	Features    []string `json:"features"`
-	URL         string   `json:"url"`
-	Ref         string   `json:"ref"`
+	Name        string         `json:"name"`
+	Description string         `json:"description"`
+	Features    []string       `json:"features"`
+	Args        map[string]Arg `json:"args,omitempty"`
+	URL         string         `json:"url"`
+	Ref         string         `json:"ref"`
+}
+
+type Arg struct {
+	Description string         `json:"description,omitempty"`
+	Required    bool           `json:"required,omitempty"`
+	Default     string         `json:"default,omitempty"`
+	Example     string         `json:"example,omitempty"`
+	Hints       map[string]any `json:"hints,omitempty"`
 }
 
 func main() {

--- a/scripts/update_templates/parse.go
+++ b/scripts/update_templates/parse.go
@@ -41,16 +41,9 @@ func BuildTemplate(repoURL string, compose io.Reader) (Template, error) {
 }
 
 func parseArgs(compose []byte) (map[string]Arg, error) {
-	type rawArg struct {
-		Description string         `yaml:"description"`
-		Required    bool           `yaml:"required"`
-		Default     string         `yaml:"default"`
-		Example     string         `yaml:"example"`
-		Hints       map[string]any `yaml:"hints"`
-	}
 	type rawCompose struct {
 		XTopo struct {
-			Args map[string]rawArg `yaml:"args"`
+			Args map[string]Arg `yaml:"args"`
 		} `yaml:"x-topo"`
 	}
 
@@ -62,17 +55,7 @@ func parseArgs(compose []byte) (map[string]Arg, error) {
 		return nil, nil
 	}
 
-	args := make(map[string]Arg, len(parsed.XTopo.Args))
-	for name, arg := range parsed.XTopo.Args {
-		args[name] = Arg{
-			Description: arg.Description,
-			Required:    arg.Required,
-			Default:     arg.Default,
-			Example:     arg.Example,
-			Hints:       arg.Hints,
-		}
-	}
-	return args, nil
+	return parsed.XTopo.Args, nil
 }
 
 func parseRepoSpec(spec string) (repo, ref string) {

--- a/scripts/update_templates/parse.go
+++ b/scripts/update_templates/parse.go
@@ -1,15 +1,22 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"strings"
 
 	"github.com/arm/topo/internal/template"
+	"gopkg.in/yaml.v3"
 )
 
 func BuildTemplate(repoURL string, compose io.Reader) (Template, error) {
-	tmpl, err := template.FromContent(compose)
+	content, err := io.ReadAll(compose)
+	if err != nil {
+		return Template{}, fmt.Errorf("failed to read compose definition: %w", err)
+	}
+
+	tmpl, err := template.FromContent(bytes.NewReader(content))
 	if err != nil {
 		return Template{}, fmt.Errorf("failed to parse compose definition: %w", err)
 	}
@@ -19,12 +26,53 @@ func BuildTemplate(repoURL string, compose io.Reader) (Template, error) {
 		return Template{}, fmt.Errorf("no valid x-topo name in compose definition")
 	}
 
+	args, err := parseArgs(content)
+	if err != nil {
+		return Template{}, fmt.Errorf("failed to parse args: %w", err)
+	}
+
 	return Template{
 		Name:        metadata.Name,
 		Description: metadata.Description,
 		Features:    metadata.Features,
+		Args:        args,
 		URL:         repoURL,
 	}, nil
+}
+
+func parseArgs(compose []byte) (map[string]Arg, error) {
+	type rawArg struct {
+		Description string         `yaml:"description"`
+		Required    bool           `yaml:"required"`
+		Default     string         `yaml:"default"`
+		Example     string         `yaml:"example"`
+		Hints       map[string]any `yaml:"hints"`
+	}
+	type rawCompose struct {
+		XTopo struct {
+			Args map[string]rawArg `yaml:"args"`
+		} `yaml:"x-topo"`
+	}
+
+	var parsed rawCompose
+	if err := yaml.Unmarshal(compose, &parsed); err != nil {
+		return nil, err
+	}
+	if len(parsed.XTopo.Args) == 0 {
+		return nil, nil
+	}
+
+	args := make(map[string]Arg, len(parsed.XTopo.Args))
+	for name, arg := range parsed.XTopo.Args {
+		args[name] = Arg{
+			Description: arg.Description,
+			Required:    arg.Required,
+			Default:     arg.Default,
+			Example:     arg.Example,
+			Hints:       arg.Hints,
+		}
+	}
+	return args, nil
 }
 
 func parseRepoSpec(spec string) (repo, ref string) {

--- a/scripts/update_templates/parse_test.go
+++ b/scripts/update_templates/parse_test.go
@@ -16,6 +16,15 @@ func TestBuildTemplate(t *testing.T) {
   features:
     - SME
     - NEON
+  args:
+    MODEL:
+      description: Model ID
+      required: true
+      default: qwen3:7B
+      example: qwen3:0.6B
+      hints:
+        org.example.kind: model
+        org.example.tags: [llm, cpu]
 `
 		compose := strings.NewReader(composeContent)
 
@@ -26,7 +35,19 @@ func TestBuildTemplate(t *testing.T) {
 			Name:        "Example Template",
 			Description: "Example description",
 			Features:    []string{"SME", "NEON"},
-			URL:         "git@github.com:Arm-Debug/example.git",
+			Args: map[string]Arg{
+				"MODEL": {
+					Description: "Model ID",
+					Required:    true,
+					Default:     "qwen3:7B",
+					Example:     "qwen3:0.6B",
+					Hints: map[string]any{
+						"org.example.kind": "model",
+						"org.example.tags": []any{"llm", "cpu"},
+					},
+				},
+			},
+			URL: "git@github.com:Arm-Debug/example.git",
 		}, tpl)
 	})
 


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- Add catalog schema support for template args, including advisory hints
- Update `scripts/update_templates` to populate args from template `x-topo.args` metadata
- Regenerate `internal/catalog/data/catalog.json`

ℹ️ Subsequently I'd like to take a holistic look at the data structures we use for parsing and writing data, as there's some historically shared bits that shouldn't be shared in order to make catalog updating truly separate from topo itself.