### PR TITLE
refactor: Template updater file handling

### DIFF
--- a/scripts/update_templates/files.go
+++ b/scripts/update_templates/files.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// TODO: Move files out of internal when we extract this to a separate repo
+const relativeCatalogOutputPath = "internal/catalog/data/catalog.json"
+
+const relativeSourcesPath = "scripts/update_templates/sources.json"
+
+func catalogOutputPath() (string, error) {
+	repoRoot, err := findRepoRoot()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(repoRoot, filepath.FromSlash(relativeCatalogOutputPath)), nil
+}
+
+func openGitHubSources() (*os.File, error) {
+	repoRoot, err := findRepoRoot()
+	if err != nil {
+		return nil, err
+	}
+
+	return os.Open(filepath.Join(repoRoot, filepath.FromSlash(relativeSourcesPath)))
+}
+
+func findRepoRoot() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir, nil
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", os.ErrNotExist
+		}
+		dir = parent
+	}
+}

--- a/scripts/update_templates/files.go
+++ b/scripts/update_templates/files.go
@@ -11,7 +11,7 @@ const relativeCatalogOutputPath = "internal/catalog/data/catalog.json"
 const relativeSourcesPath = "scripts/update_templates/sources.json"
 
 func catalogOutputPath() (string, error) {
-	repoRoot, err := findRepoRoot()
+	repoRoot, err := findModuleRoot()
 	if err != nil {
 		return "", err
 	}
@@ -34,7 +34,7 @@ func createCatalogOutput() (*os.File, string, error) {
 }
 
 func openGitHubSources() (*os.File, error) {
-	repoRoot, err := findRepoRoot()
+	repoRoot, err := findModuleRoot()
 	if err != nil {
 		return nil, err
 	}
@@ -42,7 +42,7 @@ func openGitHubSources() (*os.File, error) {
 	return os.Open(filepath.Join(repoRoot, filepath.FromSlash(relativeSourcesPath)))
 }
 
-func findRepoRoot() (string, error) {
+func findModuleRoot() (string, error) {
 	dir, err := os.Getwd()
 	if err != nil {
 		return "", err

--- a/scripts/update_templates/files.go
+++ b/scripts/update_templates/files.go
@@ -19,6 +19,20 @@ func catalogOutputPath() (string, error) {
 	return filepath.Join(repoRoot, filepath.FromSlash(relativeCatalogOutputPath)), nil
 }
 
+func createCatalogOutput() (*os.File, string, error) {
+	path, err := catalogOutputPath()
+	if err != nil {
+		return nil, "", err
+	}
+
+	file, err := os.Create(path)
+	if err != nil {
+		return nil, "", err
+	}
+
+	return file, path, nil
+}
+
 func openGitHubSources() (*os.File, error) {
 	repoRoot, err := findRepoRoot()
 	if err != nil {

--- a/scripts/update_templates/github_source.go
+++ b/scripts/update_templates/github_source.go
@@ -6,13 +6,6 @@ import (
 	"io"
 )
 
-var sourcesJSON = `[
-	{"repo": "Arm-Examples/topo-welcome", "sha": "8303e66db59a7a11e64877121f3db1b688d2011f"},
-	{"repo": "Arm-Examples/topo-lightbulb-moment", "sha": "c2b2e4a672cda67832372f77aeb1d1f71beee9a7"},
-	{"repo": "Arm-Examples/topo-cpu-ai-chat", "sha": "c06f343b9c753231714ac1cdbee7c7be5108e6b7"},
-	{"repo": "Arm-Examples/topo-simd-visual-benchmark", "sha": "f0cd31621ce79b4643df7e9bdd8eff26c20b338c"}
-]`
-
 type GitHubSource struct {
 	Repo string `json:"repo"`
 	SHA  string `json:"sha"`

--- a/scripts/update_templates/main.go
+++ b/scripts/update_templates/main.go
@@ -30,13 +30,19 @@ func main() {
 		templates = append(templates, template)
 	}
 
-	outputPath, err := catalogOutputPath()
+	outputFile, outputPath, err := createCatalogOutput()
 	if err != nil {
-		log.Fatalf("failed to calculate catalog output path: %v\n", err)
+		log.Fatalf("failed to create catalog output: %v\n", err)
 	}
 
-	if err := WriteTemplates(outputPath, templates); err != nil {
-		log.Printf("failed to write templates: %v\n", err)
+	writeErr := WriteTemplates(outputFile, templates)
+	closeErr := outputFile.Close()
+	if writeErr != nil {
+		log.Printf("failed to write templates: %v\n", writeErr)
+		os.Exit(1)
+	}
+	if closeErr != nil {
+		log.Printf("failed to close catalog output: %v\n", closeErr)
 		os.Exit(1)
 	}
 	log.Printf("written catalog to %s\n", outputPath)

--- a/scripts/update_templates/main.go
+++ b/scripts/update_templates/main.go
@@ -4,11 +4,12 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"strings"
 )
 
 // TODO: Move files out of internal when we extract this to a separate repo
 const relativeCatalogOutputPath = "internal/catalog/data/catalog.json"
+
+const relativeSourcesPath = "scripts/update_templates/sources.json"
 
 func main() {
 	githubToken := os.Getenv("GITHUB_TOKEN")
@@ -18,8 +19,14 @@ func main() {
 
 	githubClient := NewGitHubClient(githubToken)
 
+	sourcesFile, err := openGitHubSources()
+	if err != nil {
+		log.Fatalf("failed to open GitHub sources: %v\n", err)
+	}
+	defer sourcesFile.Close()
+
 	var templates []Template
-	for _, source := range ListGitHubSources(strings.NewReader(sourcesJSON)) {
+	for _, source := range ListGitHubSources(sourcesFile) {
 		template, err := FetchTemplate(githubClient, source)
 		if err != nil {
 			log.Printf("failed to fetch %s (%v)\n", source, err)
@@ -48,6 +55,15 @@ func catalogOutputPath() (string, error) {
 	}
 
 	return filepath.Join(repoRoot, filepath.FromSlash(relativeCatalogOutputPath)), nil
+}
+
+func openGitHubSources() (*os.File, error) {
+	repoRoot, err := findRepoRoot()
+	if err != nil {
+		return nil, err
+	}
+
+	return os.Open(filepath.Join(repoRoot, filepath.FromSlash(relativeSourcesPath)))
 }
 
 func findRepoRoot() (string, error) {

--- a/scripts/update_templates/main.go
+++ b/scripts/update_templates/main.go
@@ -38,12 +38,10 @@ func main() {
 	writeErr := WriteTemplates(outputFile, templates)
 	closeErr := outputFile.Close()
 	if writeErr != nil {
-		log.Printf("failed to write templates: %v\n", writeErr)
-		os.Exit(1)
+		log.Fatalf("failed to write templates: %v\n", writeErr)
 	}
 	if closeErr != nil {
-		log.Printf("failed to close catalog output: %v\n", closeErr)
-		os.Exit(1)
+		log.Fatalf("failed to close catalog output: %v\n", closeErr)
 	}
 	log.Printf("written catalog to %s\n", outputPath)
 }

--- a/scripts/update_templates/main.go
+++ b/scripts/update_templates/main.go
@@ -3,13 +3,7 @@ package main
 import (
 	"log"
 	"os"
-	"path/filepath"
 )
-
-// TODO: Move files out of internal when we extract this to a separate repo
-const relativeCatalogOutputPath = "internal/catalog/data/catalog.json"
-
-const relativeSourcesPath = "scripts/update_templates/sources.json"
 
 func main() {
 	githubToken := os.Getenv("GITHUB_TOKEN")
@@ -46,41 +40,4 @@ func main() {
 		os.Exit(1)
 	}
 	log.Printf("written catalog to %s\n", outputPath)
-}
-
-func catalogOutputPath() (string, error) {
-	repoRoot, err := findRepoRoot()
-	if err != nil {
-		return "", err
-	}
-
-	return filepath.Join(repoRoot, filepath.FromSlash(relativeCatalogOutputPath)), nil
-}
-
-func openGitHubSources() (*os.File, error) {
-	repoRoot, err := findRepoRoot()
-	if err != nil {
-		return nil, err
-	}
-
-	return os.Open(filepath.Join(repoRoot, filepath.FromSlash(relativeSourcesPath)))
-}
-
-func findRepoRoot() (string, error) {
-	dir, err := os.Getwd()
-	if err != nil {
-		return "", err
-	}
-
-	for {
-		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
-			return dir, nil
-		}
-
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			return "", os.ErrNotExist
-		}
-		dir = parent
-	}
 }

--- a/scripts/update_templates/main.go
+++ b/scripts/update_templates/main.go
@@ -7,6 +7,9 @@ import (
 	"strings"
 )
 
+// TODO: Move files out of internal when we extract this to a separate repo
+const relativeCatalogOutputPath = "internal/catalog/data/catalog.json"
+
 func main() {
 	githubToken := os.Getenv("GITHUB_TOKEN")
 	if githubToken == "" {
@@ -28,7 +31,7 @@ func main() {
 
 	outputPath, err := catalogOutputPath()
 	if err != nil {
-		log.Fatalf("failed to find catalog output path: %v\n", err)
+		log.Fatalf("failed to calculate catalog output path: %v\n", err)
 	}
 
 	if err := WriteTemplates(outputPath, templates); err != nil {
@@ -44,7 +47,7 @@ func catalogOutputPath() (string, error) {
 		return "", err
 	}
 
-	return filepath.Join(repoRoot, "internal", "catalog", "data", "catalog.json"), nil
+	return filepath.Join(repoRoot, filepath.FromSlash(relativeCatalogOutputPath)), nil
 }
 
 func findRepoRoot() (string, error) {

--- a/scripts/update_templates/main.go
+++ b/scripts/update_templates/main.go
@@ -17,7 +17,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("failed to open GitHub sources: %v\n", err)
 	}
-	defer sourcesFile.Close()
+	defer sourcesFile.Close() //nolint:errcheck // Closing a read-only file cannot affect catalog generation.
 
 	var templates []Template
 	for _, source := range ListGitHubSources(sourcesFile) {

--- a/scripts/update_templates/sources.json
+++ b/scripts/update_templates/sources.json
@@ -1,0 +1,6 @@
+[
+	{"repo": "Arm-Examples/topo-welcome", "sha": "8303e66db59a7a11e64877121f3db1b688d2011f"},
+	{"repo": "Arm-Examples/topo-lightbulb-moment", "sha": "c2b2e4a672cda67832372f77aeb1d1f71beee9a7"},
+	{"repo": "Arm-Examples/topo-cpu-ai-chat", "sha": "c06f343b9c753231714ac1cdbee7c7be5108e6b7"},
+	{"repo": "Arm-Examples/topo-simd-visual-benchmark", "sha": "f0cd31621ce79b4643df7e9bdd8eff26c20b338c"}
+]

--- a/scripts/update_templates/write.go
+++ b/scripts/update_templates/write.go
@@ -2,8 +2,7 @@ package main
 
 import (
 	"encoding/json"
-	"os"
-	"path/filepath"
+	"io"
 )
 
 const catalogSchemaURL = "https://raw.githubusercontent.com/arm/topo/main/internal/catalog/data/catalog.schema.json"
@@ -13,25 +12,13 @@ type CatalogDocument struct {
 	Templates []Template `json:"templates"`
 }
 
-func WriteTemplates(path string, templates []Template) (err error) {
-	path = filepath.Clean(path)
-	f, err := os.Create(path)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		cerr := f.Close()
-		if err == nil {
-			err = cerr
-		}
-	}()
-
+func WriteTemplates(w io.Writer, templates []Template) error {
 	document := CatalogDocument{
 		Schema:    catalogSchemaURL,
 		Templates: templates,
 	}
 
-	enc := json.NewEncoder(f)
+	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
 	return enc.Encode(document)
 }

--- a/scripts/update_templates/write_test.go
+++ b/scripts/update_templates/write_test.go
@@ -1,8 +1,7 @@
 package main
 
 import (
-	"os"
-	"path/filepath"
+	"bytes"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,7 +10,7 @@ import (
 
 func TestWriteTemplates(t *testing.T) {
 	t.Run("writes expected json", func(t *testing.T) {
-		writeTo := filepath.Join(t.TempDir(), "templates.json")
+		var output bytes.Buffer
 		input := []Template{
 			{
 				XTopo: XTopo{
@@ -24,7 +23,7 @@ func TestWriteTemplates(t *testing.T) {
 			},
 		}
 
-		err := WriteTemplates(writeTo, input)
+		err := WriteTemplates(&output, input)
 		require.NoError(t, err)
 
 		want := `
@@ -41,13 +40,6 @@ func TestWriteTemplates(t *testing.T) {
 	]
 }
 `
-		assert.JSONEq(t, want, requireReadFile(t, writeTo))
+		assert.JSONEq(t, want, output.String())
 	})
-}
-
-func requireReadFile(t testing.TB, path string) string {
-	t.Helper()
-	data, err := os.ReadFile(path)
-	require.NoError(t, err)
-	return string(data)
 }


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- Move hard-coded template source entries into `scripts/update_templates/sources.json`
- Extract repository-relative file path helpers into `files.go`
- Change `WriteTemplates` to write to an `io.Writer` instead of creating files directly
