### PR TITLE
feat: Improve cloning ux when listing templates

### DIFF
--- a/internal/output/views/func_map.go
+++ b/internal/output/views/func_map.go
@@ -16,6 +16,7 @@ func getFuncMap(isTTY bool) template.FuncMap {
 		"blue":              func(s string) string { return s },
 		"yellow":            func(s string) string { return s },
 		"compatibilityMark": plainCompatibilityMark,
+		"cloneCommand":      cloneCommand,
 	}
 
 	if isTTY {
@@ -35,4 +36,12 @@ func plainCompatibilityMark(c catalog.CompatibilityStatus) string {
 		return "❌"
 	}
 	return ""
+}
+
+func cloneCommand(template catalog.TemplateWithCompatibility) string {
+	source := template.URL
+	if template.Ref != "" {
+		source += "#" + template.Ref
+	}
+	return "topo clone " + source
 }

--- a/internal/output/views/template_list.go
+++ b/internal/output/views/template_list.go
@@ -11,22 +11,16 @@ import (
 type TemplateList []catalog.TemplateWithCompatibility
 
 const templateListTemplate = `
-{{- define "featuresRow" -}}
+{{- define "templateRow" }}
+{{- if .Compatibility }}{{ compatibilityMark .Compatibility }} {{ end }}{{ cyan .Name }}
+  {{ blue "Clone:" }}    {{ cloneCommand . }}
 {{- if .Features }}
-  Features: {{ join .Features ", " }}
+  {{ blue "Features:" }} {{ join .Features ", " }}
 {{- end }}
-{{- end }}
-
-{{- define "descriptionRow" -}}
 {{- if .Description }}
+
 {{ wrap .Description }}
 {{- end }}
-{{- end }}
-
-{{- define "templateRow" }}
-{{- if .Compatibility }}{{ compatibilityMark .Compatibility }} {{ end }}{{ cyan .Name }} | {{ blue .URL }} | {{ yellow .Ref }}
-{{- template "featuresRow" . }}
-{{- template "descriptionRow" . }}
 {{- end }}
 
 {{- define "templateList" }}

--- a/internal/output/views/template_list.go
+++ b/internal/output/views/template_list.go
@@ -13,9 +13,13 @@ type TemplateList []catalog.TemplateWithCompatibility
 const templateListTemplate = `
 {{- define "templateRow" }}
 {{- if .Compatibility }}{{ compatibilityMark .Compatibility }} {{ end }}{{ cyan .Name }}
-  {{ blue "Clone:" }}    {{ cloneCommand . }}
+  {{ blue "Clone:" }}
+    {{ cloneCommand . }}
 {{- if .Features }}
-  {{ blue "Features:" }} {{ join .Features ", " }}
+  {{ blue "Features:" }}
+  {{- range .Features }}
+    {{ . }}
+  {{- end }}
 {{- end }}
 {{- if .Description }}
 

--- a/internal/output/views/template_list_test.go
+++ b/internal/output/views/template_list_test.go
@@ -42,10 +42,14 @@ func TestTemplateList(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		want := `name-of-project | url.git | main
+		want := `name-of-project
+  Clone:    topo clone url.git#main
+
   blah blah blah
 
-name-of-other-project | url.git | main
+name-of-other-project
+  Clone:    topo clone url.git#main
+
   blah blah blah
 
 `
@@ -73,7 +77,9 @@ name-of-other-project | url.git | main
 		)
 		require.NoError(t, err)
 
-		want := `name-of-project | url.git | main
+		want := `name-of-project
+  Clone:    topo clone url.git#main
+
   blah blah blah
 
 `
@@ -102,8 +108,10 @@ name-of-other-project | url.git | main
 		)
 		require.NoError(t, err)
 
-		want := `name-of-project | url.git | main
+		want := `name-of-project
+  Clone:    topo clone url.git#main
   Features: walnut, almond
+
   blah blah blah
 
 `
@@ -132,8 +140,10 @@ name-of-other-project | url.git | main
 		)
 		require.NoError(t, err)
 
-		want := `name-of-project | url.git | main
+		want := `name-of-project
+  Clone:    topo clone url.git#main
   Features: walnut, almond
+
   This sentence exists purely to verify that text wrapping behaves correctly
   when the content is long enough to span multiple lines.
 
@@ -163,11 +173,39 @@ name-of-other-project | url.git | main
 		)
 		require.NoError(t, err)
 
-		want := `name-of-project | url.git | main
+		want := `name-of-project
+  Clone:    topo clone url.git#main
   Features: walnut, almond
+
   blah blah blah
 
   blah blah blah
+
+`
+		assert.Equal(t, want, outBuf.String())
+	})
+
+	t.Run("omits ref from clone command when ref is empty", func(t *testing.T) {
+		templates := []catalog.TemplateWithCompatibility{
+			{
+				Template: catalog.Template{
+					Name: "name-of-project",
+					URL:  "url.git",
+				},
+			},
+		}
+
+		var outBuf bytes.Buffer
+
+		err := views.Print(
+			views.TemplateList(templates),
+			&outBuf,
+			term.Plain,
+		)
+		require.NoError(t, err)
+
+		want := `name-of-project
+  Clone:    topo clone url.git
 
 `
 		assert.Equal(t, want, outBuf.String())
@@ -227,7 +265,7 @@ name-of-other-project | url.git | main
 		err := views.Print(views.TemplateList(templates), &outBuf, term.Plain)
 		require.NoError(t, err)
 
-		assert.Equal(t, "✅ name-of-project | url.git | main\n\n", outBuf.String())
+		assert.Equal(t, "✅ name-of-project\n  Clone:    topo clone url.git#main\n\n", outBuf.String())
 	})
 
 	t.Run("prints compatibility marker if project is compatible and vice versa", func(t *testing.T) {

--- a/internal/output/views/template_list_test.go
+++ b/internal/output/views/template_list_test.go
@@ -43,12 +43,14 @@ func TestTemplateList(t *testing.T) {
 		require.NoError(t, err)
 
 		want := `name-of-project
-  Clone:    topo clone url.git#main
+  Clone:
+    topo clone url.git#main
 
   blah blah blah
 
 name-of-other-project
-  Clone:    topo clone url.git#main
+  Clone:
+    topo clone url.git#main
 
   blah blah blah
 
@@ -78,7 +80,8 @@ name-of-other-project
 		require.NoError(t, err)
 
 		want := `name-of-project
-  Clone:    topo clone url.git#main
+  Clone:
+    topo clone url.git#main
 
   blah blah blah
 
@@ -109,8 +112,11 @@ name-of-other-project
 		require.NoError(t, err)
 
 		want := `name-of-project
-  Clone:    topo clone url.git#main
-  Features: walnut, almond
+  Clone:
+    topo clone url.git#main
+  Features:
+    walnut
+    almond
 
   blah blah blah
 
@@ -141,8 +147,11 @@ name-of-other-project
 		require.NoError(t, err)
 
 		want := `name-of-project
-  Clone:    topo clone url.git#main
-  Features: walnut, almond
+  Clone:
+    topo clone url.git#main
+  Features:
+    walnut
+    almond
 
   This sentence exists purely to verify that text wrapping behaves correctly
   when the content is long enough to span multiple lines.
@@ -174,8 +183,11 @@ name-of-other-project
 		require.NoError(t, err)
 
 		want := `name-of-project
-  Clone:    topo clone url.git#main
-  Features: walnut, almond
+  Clone:
+    topo clone url.git#main
+  Features:
+    walnut
+    almond
 
   blah blah blah
 
@@ -205,7 +217,8 @@ name-of-other-project
 		require.NoError(t, err)
 
 		want := `name-of-project
-  Clone:    topo clone url.git
+  Clone:
+    topo clone url.git
 
 `
 		assert.Equal(t, want, outBuf.String())
@@ -265,7 +278,7 @@ name-of-other-project
 		err := views.Print(views.TemplateList(templates), &outBuf, term.Plain)
 		require.NoError(t, err)
 
-		assert.Equal(t, "✅ name-of-project\n  Clone:    topo clone url.git#main\n\n", outBuf.String())
+		assert.Equal(t, "✅ name-of-project\n  Clone:\n    topo clone url.git#main\n\n", outBuf.String())
 	})
 
 	t.Run("prints compatibility marker if project is compatible and vice versa", func(t *testing.T) {


### PR DESCRIPTION
## Changes

- Improve `topo templates` plain output by rendering clone instructions as a nested block:
  ```text
  Clone:
    topo clone url.git#main
  ```
- Render template features as a nested block for better scanability:
  ```text
  Features:
    feature-a
    feature-b
  ```
- Keep template descriptions visually separate from structured metadata

### Screenshot

<img width="600" alt="Screenshot 2026-06-11 at 13 50 14" src="https://github.com/user-attachments/assets/b9e5f23c-364b-44de-8926-2c89fadc6645" />
