### PR TITLE
feat: Improve `topo health` fix output

### DIFF
--- a/e2e/setup_keys_test.go
+++ b/e2e/setup_keys_test.go
@@ -20,14 +20,14 @@ func TestSetupKeysJourney(t *testing.T) {
 	Step(t, "health reports unknown host key and suggests accept-new-host-keys")
 	out := runTopo(t, topo, "health", "--target", container.SSHDestination)
 	assert.Contains(t, out, "Connectivity: ❌ (ssh host key is unknown)")
-	assert.Contains(t, out, "Fix: Trust the target's SSH host key")
-	assert.Contains(t, out, fmt.Sprintf("Cmd: topo health --target %s --accept-new-host-keys", container.SSHDestination))
+	assert.Contains(t, out, "Trust the target's SSH host key")
+	assert.Contains(t, out, fmt.Sprintf("topo health --target %s --accept-new-host-keys", container.SSHDestination))
 
 	Step(t, "health with accept-new-host-keys trusts host and suggests setup-keys")
 	out = runTopo(t, topo, "health", "--target", container.SSHDestination, "--accept-new-host-keys")
 	assert.Contains(t, out, "Connectivity: ❌ (ssh authentication failed)")
-	assert.Contains(t, out, "Fix: Configure SSH keys on remote target")
-	assert.Contains(t, out, fmt.Sprintf("Cmd: topo setup-keys --target %s", container.SSHDestination))
+	assert.Contains(t, out, "Configure SSH keys on remote target")
+	assert.Contains(t, out, fmt.Sprintf("topo setup-keys --target %s", container.SSHDestination))
 
 	Step(t, "setup-keys generates keys and installs them on the target")
 	askpass := writeAskPassScript(t, sshRootPassword)

--- a/internal/output/views/health.go
+++ b/internal/output/views/health.go
@@ -19,9 +19,11 @@ const healthReportTemplate = `
 {{- define "checkRow" -}}
 {{ .Name }}:{{ statusIcon .Status }}{{- if .Value }} ({{ .Value }}){{- end }}
 {{- if .Fix }}
-  Fix: {{ .Fix.Description }}
+  Fix:
+    {{ .Fix.Description }}
   {{- if .Fix.Command }}
-  Cmd: {{ .Fix.Command }}
+  Command:
+    {{ .Fix.Command }}
   {{- end }}
 {{- end -}}
 {{- end -}}

--- a/internal/output/views/health_test.go
+++ b/internal/output/views/health_test.go
@@ -170,8 +170,8 @@ func TestHealthReport(t *testing.T) {
 
 			require.NoError(t, err)
 			assert.Contains(t, out.String(), "Skin Care: ⚠️")
-			assert.Contains(t, out.String(), "  Fix: Apply Working Hands Cream")
-			assert.Contains(t, out.String(), "  Cmd: topo moisturise")
+			assert.Contains(t, out.String(), "  Fix:\n    Apply Working Hands Cream")
+			assert.Contains(t, out.String(), "  Command:\n    topo moisturise")
 		})
 
 		t.Run("when no target is specified, prints the hint", func(t *testing.T) {


### PR DESCRIPTION
## Changes

- Keep commands on their own line for easier triple-click / terminal hint selection

### Screenshot

<img width="501" height="235" alt="Screenshot 2026-06-11 at 14 02 29" src="https://github.com/user-attachments/assets/fc72a8e3-f9a2-4945-9677-44f1ff52fe9e" />
