### PR TITLE
feat: Incremental catalog update plan

### DIFF
--- a/internal/catalog/data/catalog.schema.json
+++ b/internal/catalog/data/catalog.schema.json
@@ -99,7 +99,7 @@
           }
         },
         "url": {
-          "description": "Repository URL containing the template.",
+          "description": "Repository URL containing the template. This URL is the stable source identifier used to match catalog entries to configured sources.",
           "type": "string",
           "format": "uri"
         },

--- a/scripts/update_templates/catalog.go
+++ b/scripts/update_templates/catalog.go
@@ -18,22 +18,26 @@ type Catalog struct {
 	Templates []Template `json:"templates"`
 }
 
-func ReadCatalogFile() (Catalog, error) {
+func ReadTemplates() ([]Template, error) {
 	path, err := catalogOutputPath()
 	if err != nil {
-		return Catalog{}, err
+		return nil, err
 	}
 
 	file, err := os.Open(path)
 	if err != nil {
-		return Catalog{}, err
+		return nil, err
 	}
 	defer file.Close() //nolint:errcheck // Closing a read-only file cannot affect catalog generation.
 
-	return ReadCatalog(file)
+	catalog, err := ReadCatalogFile(file)
+	if err != nil {
+		return nil, err
+	}
+	return catalog.Templates, nil
 }
 
-func ReadCatalog(r io.Reader) (Catalog, error) {
+func ReadCatalogFile(r io.Reader) (Catalog, error) {
 	var document Catalog
 	if err := json.NewDecoder(r).Decode(&document); err != nil {
 		return Catalog{}, err
@@ -41,12 +45,12 @@ func ReadCatalog(r io.Reader) (Catalog, error) {
 	return document, nil
 }
 
-func WriteCatalogFile(templates []Template) (string, error) {
+func WriteTemplates(templates []Template) (string, error) {
 	outputFile, outputFilePath, err := createCatalogOutput()
 	if err != nil {
 		return "", fmt.Errorf("failed to create catalog output: %w", err)
 	}
-	writeErr := WriteCatalog(outputFile, templates)
+	writeErr := WriteTemplatesToCatalogFile(outputFile, templates)
 	closeErr := outputFile.Close()
 	if writeErr != nil {
 		return "", fmt.Errorf("failed to write templates: %w", writeErr)
@@ -57,7 +61,7 @@ func WriteCatalogFile(templates []Template) (string, error) {
 	return outputFilePath, nil
 }
 
-func WriteCatalog(w io.Writer, templates []Template) error {
+func WriteTemplatesToCatalogFile(w io.Writer, templates []Template) error {
 	document := Catalog{
 		Schema:    catalogSchemaURL,
 		Templates: templates,

--- a/scripts/update_templates/catalog.go
+++ b/scripts/update_templates/catalog.go
@@ -13,9 +13,32 @@ const (
 	catalogSchemaURL          = "https://raw.githubusercontent.com/arm/topo/main/internal/catalog/data/catalog.schema.json"
 )
 
-type CatalogDocument struct {
+type Catalog struct {
 	Schema    string     `json:"$schema"`
 	Templates []Template `json:"templates"`
+}
+
+func ReadCatalogFile() (Catalog, error) {
+	path, err := catalogOutputPath()
+	if err != nil {
+		return Catalog{}, err
+	}
+
+	file, err := os.Open(path)
+	if err != nil {
+		return Catalog{}, err
+	}
+	defer file.Close() //nolint:errcheck // Closing a read-only file cannot affect catalog generation.
+
+	return ReadCatalog(file)
+}
+
+func ReadCatalog(r io.Reader) (Catalog, error) {
+	var document Catalog
+	if err := json.NewDecoder(r).Decode(&document); err != nil {
+		return Catalog{}, err
+	}
+	return document, nil
 }
 
 func WriteCatalogFile(templates []Template) (string, error) {
@@ -35,7 +58,7 @@ func WriteCatalogFile(templates []Template) (string, error) {
 }
 
 func WriteCatalog(w io.Writer, templates []Template) error {
-	document := CatalogDocument{
+	document := Catalog{
 		Schema:    catalogSchemaURL,
 		Templates: templates,
 	}

--- a/scripts/update_templates/catalog_test.go
+++ b/scripts/update_templates/catalog_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestReadCatalog(t *testing.T) {
+func TestReadCatalogFile(t *testing.T) {
 	t.Run("reads templates from catalog input", func(t *testing.T) {
 		input := bytes.NewBufferString(`
 {
@@ -25,7 +25,7 @@ func TestReadCatalog(t *testing.T) {
 }
 `)
 
-		got, err := ReadCatalog(input)
+		got, err := ReadCatalogFile(input)
 
 		require.NoError(t, err)
 		want := Catalog{
@@ -46,7 +46,7 @@ func TestReadCatalog(t *testing.T) {
 	})
 }
 
-func TestWriteCatalog(t *testing.T) {
+func TestWriteTemplatesToCatalogFile(t *testing.T) {
 	t.Run("writes templates to catalog file", func(t *testing.T) {
 		var output bytes.Buffer
 		input := []Template{
@@ -61,7 +61,7 @@ func TestWriteCatalog(t *testing.T) {
 			},
 		}
 
-		err := WriteCatalog(&output, input)
+		err := WriteTemplatesToCatalogFile(&output, input)
 		require.NoError(t, err)
 
 		want := `

--- a/scripts/update_templates/catalog_test.go
+++ b/scripts/update_templates/catalog_test.go
@@ -8,6 +8,44 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestReadCatalog(t *testing.T) {
+	t.Run("reads templates from catalog input", func(t *testing.T) {
+		input := bytes.NewBufferString(`
+{
+	"$schema": "https://raw.githubusercontent.com/arm/topo/main/internal/catalog/data/catalog.schema.json",
+	"templates": [
+		{
+			"name": "death-star-trench-run",
+			"description": "Use the Force to benchmark impossible shots",
+			"features": ["X-wing", "Astromech", "Proton torpedoes"],
+			"url": "ssh://death-star.example",
+			"ref": "rebellion"
+		}
+	]
+}
+`)
+
+		got, err := ReadCatalog(input)
+
+		require.NoError(t, err)
+		want := Catalog{
+			Schema: catalogSchemaURL,
+			Templates: []Template{
+				{
+					XTopo: XTopo{
+						Name:        "death-star-trench-run",
+						Description: "Use the Force to benchmark impossible shots",
+						Features:    []string{"X-wing", "Astromech", "Proton torpedoes"},
+					},
+					URL: "ssh://death-star.example",
+					Ref: "rebellion",
+				},
+			},
+		}
+		assert.Equal(t, want, got)
+	})
+}
+
 func TestWriteCatalog(t *testing.T) {
 	t.Run("writes templates to catalog file", func(t *testing.T) {
 		var output bytes.Buffer

--- a/scripts/update_templates/github_source.go
+++ b/scripts/update_templates/github_source.go
@@ -26,8 +26,8 @@ func (s GitHubSource) URL() string {
 	return fmt.Sprintf("https://github.com/%s.git", s.Repo)
 }
 
-func ListGitHubSources() ([]GitHubSource, error) {
-	sourcesFile, err := openGitHubSources()
+func ListGithubSources(path string) ([]GitHubSource, error) {
+	sourcesFile, err := os.Open(path)
 	if err != nil {
 		return nil, err
 	}
@@ -35,16 +35,32 @@ func ListGitHubSources() ([]GitHubSource, error) {
 
 	var sources []GitHubSource
 	if err := json.NewDecoder(sourcesFile).Decode(&sources); err != nil {
-		panic(fmt.Errorf("failed to decode sources: %w", err))
+		return nil, fmt.Errorf("failed to decode sources: %w", err)
+	}
+	if err := validateUniqueGitHubSourceIDs(sources); err != nil {
+		return nil, err
 	}
 	return sources, nil
 }
 
-func openGitHubSources() (*os.File, error) {
+func GithubSourcesFilePath() (string, error) {
 	repoRoot, err := findModuleRoot()
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 
-	return os.Open(filepath.Join(repoRoot, filepath.FromSlash(relativeSourcesPath)))
+	return filepath.Join(repoRoot, filepath.FromSlash(relativeSourcesPath)), nil
+}
+
+func validateUniqueGitHubSourceIDs(sources []GitHubSource) error {
+	seen := make(map[TemplateSourceID]GitHubSource, len(sources))
+	for _, source := range sources {
+		id := source.ID()
+		previous, exists := seen[id]
+		if exists {
+			return fmt.Errorf("duplicate source ID %s for %s and %s", id, previous, source)
+		}
+		seen[id] = source
+	}
+	return nil
 }

--- a/scripts/update_templates/github_source.go
+++ b/scripts/update_templates/github_source.go
@@ -18,7 +18,11 @@ func (s GitHubSource) String() string {
 	return fmt.Sprintf("%s@%s", s.Repo, s.SHA)
 }
 
-func (s GitHubSource) CloneURL() string {
+func (s GitHubSource) ID() TemplateSourceID {
+	return TemplateSourceID(s.URL())
+}
+
+func (s GitHubSource) URL() string {
 	return fmt.Sprintf("https://github.com/%s.git", s.Repo)
 }
 

--- a/scripts/update_templates/github_source_test.go
+++ b/scripts/update_templates/github_source_test.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListGithubSources(t *testing.T) {
+	t.Run("disallows sources with duplicate ids", func(t *testing.T) {
+		sourcesJSON := `[
+			{"repo":"example/repo","sha":"first-sha"},
+			{"repo":"example/repo","sha":"second-sha"}
+		]`
+		sourcesFilePath := filepath.Join(t.TempDir(), "github_sources.json")
+		require.NoError(t, os.WriteFile(sourcesFilePath, []byte(sourcesJSON), 0o600))
+
+		_, err := ListGithubSources(sourcesFilePath)
+
+		assert.EqualError(t, err, "duplicate source ID https://github.com/example/repo.git for example/repo@first-sha and example/repo@second-sha")
+	})
+}

--- a/scripts/update_templates/main.go
+++ b/scripts/update_templates/main.go
@@ -14,7 +14,12 @@ func main() {
 
 	githubClient := NewGitHubClient(githubToken)
 
-	sources, err := ListGitHubSources()
+	sourcesFilePath, err := GithubSourcesFilePath()
+	if err != nil {
+		log.Fatalf("failed to find sources file: %v\n", err)
+	}
+
+	sources, err := ListGithubSources(sourcesFilePath)
 	if err != nil {
 		log.Fatalf("failed to list sources: %v\n", err)
 	}

--- a/scripts/update_templates/main.go
+++ b/scripts/update_templates/main.go
@@ -41,6 +41,7 @@ func main() {
 		log.Printf("fetched %s\n", source)
 		templates = append(templates, template)
 	}
+	templates = TemplatesInSourceOrder(sources, templates)
 
 	filePath, err := WriteCatalogFile(templates)
 	if err != nil {

--- a/scripts/update_templates/main.go
+++ b/scripts/update_templates/main.go
@@ -7,6 +7,13 @@ import (
 )
 
 func main() {
+	githubToken := os.Getenv("GITHUB_TOKEN")
+	if githubToken == "" {
+		log.Println("⚠️ GITHUB_TOKEN is not set: you might get rate limited")
+	}
+
+	githubClient := NewGitHubClient(githubToken)
+
 	sources, err := ListGitHubSources()
 	if err != nil {
 		log.Fatalf("failed to list sources: %v\n", err)
@@ -23,12 +30,6 @@ func main() {
 		log.Println("catalog already up to date")
 		return
 	}
-
-	githubToken := os.Getenv("GITHUB_TOKEN")
-	if githubToken == "" {
-		log.Println("⚠️ GITHUB_TOKEN is not set: you might get rate limited")
-	}
-	githubClient := NewGitHubClient(githubToken)
 
 	templates := append([]Template{}, plan.Unchanged...)
 	for _, source := range append(plan.ToAdd, plan.ToUpdate...) {

--- a/scripts/update_templates/main.go
+++ b/scripts/update_templates/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"log"
 	"os"
+	"strings"
 )
 
 func main() {
@@ -17,17 +18,11 @@ func main() {
 	}
 
 	plan := PlanUpdate(sources, currentTemplates)
+	log.Printf("update plan:\n%s", indent(plan.String()))
 	if !plan.HasChanges() {
 		log.Println("catalog already up to date")
 		return
 	}
-	log.Printf(
-		"template update plan:\n  🆕 %d to add\n  🔄 %d to update\n  🗑️ %d to remove\n  ☑️ %d unchanged",
-		len(plan.ToAdd),
-		len(plan.ToUpdate),
-		len(plan.ToRemove),
-		len(plan.Unchanged),
-	)
 
 	githubToken := os.Getenv("GITHUB_TOKEN")
 	if githubToken == "" {
@@ -51,4 +46,8 @@ func main() {
 		log.Fatalf("failed to write catalog file: %v\n", err)
 	}
 	log.Printf("written catalog to %s\n", filePath)
+}
+
+func indent(text string) string {
+	return "  " + strings.ReplaceAll(text, "\n", "\n  ")
 }

--- a/scripts/update_templates/main.go
+++ b/scripts/update_templates/main.go
@@ -11,12 +11,12 @@ func main() {
 		log.Fatalf("failed to list sources: %v\n", err)
 	}
 
-	catalog, err := ReadCatalogFile()
+	currentTemplates, err := ReadTemplates()
 	if err != nil {
 		log.Fatalf("failed to read catalog file: %v\n", err)
 	}
 
-	plan := PlanUpdate(sources, catalog.Templates)
+	plan := PlanUpdate(sources, currentTemplates)
 	if !plan.HasChanges() {
 		log.Println("catalog already up to date")
 		return
@@ -46,7 +46,7 @@ func main() {
 	}
 	templates = TemplatesInSourceOrder(sources, templates)
 
-	filePath, err := WriteCatalogFile(templates)
+	filePath, err := WriteTemplates(templates)
 	if err != nil {
 		log.Fatalf("failed to write catalog file: %v\n", err)
 	}

--- a/scripts/update_templates/main.go
+++ b/scripts/update_templates/main.go
@@ -6,13 +6,6 @@ import (
 )
 
 func main() {
-	githubToken := os.Getenv("GITHUB_TOKEN")
-	if githubToken == "" {
-		log.Println("⚠️ GITHUB_TOKEN is not set: you might get rate limited")
-	}
-
-	githubClient := NewGitHubClient(githubToken)
-
 	sources, err := ListGitHubSources()
 	if err != nil {
 		log.Fatalf("failed to list sources: %v\n", err)
@@ -35,6 +28,12 @@ func main() {
 		len(plan.ToRemove),
 		len(plan.Unchanged),
 	)
+
+	githubToken := os.Getenv("GITHUB_TOKEN")
+	if githubToken == "" {
+		log.Println("⚠️ GITHUB_TOKEN is not set: you might get rate limited")
+	}
+	githubClient := NewGitHubClient(githubToken)
 
 	templates := append([]Template{}, plan.Unchanged...)
 	for _, source := range append(plan.ToAdd, plan.ToUpdate...) {

--- a/scripts/update_templates/main.go
+++ b/scripts/update_templates/main.go
@@ -18,12 +18,25 @@ func main() {
 		log.Fatalf("failed to list sources: %v\n", err)
 	}
 
-	var templates []Template
-	for _, source := range sources {
+	catalog, err := ReadCatalogFile()
+	if err != nil {
+		log.Fatalf("failed to read catalog file: %v\n", err)
+	}
+
+	plan := PlanUpdate(sources, catalog.Templates)
+	log.Printf(
+		"template update plan: %d add, %d update, %d remove, %d unchanged",
+		len(plan.ToAdd),
+		len(plan.ToUpdate),
+		len(plan.ToRemove),
+		len(plan.Unchanged),
+	)
+
+	templates := append([]Template{}, plan.Unchanged...)
+	for _, source := range append(plan.ToAdd, plan.ToUpdate...) {
 		template, err := FetchTemplate(githubClient, source)
 		if err != nil {
-			log.Printf("failed to fetch %s (%v)\n", source, err)
-			continue
+			log.Fatalf("failed to fetch %s: %v\n", source, err)
 		}
 		log.Printf("fetched %s\n", source)
 		templates = append(templates, template)

--- a/scripts/update_templates/main.go
+++ b/scripts/update_templates/main.go
@@ -24,6 +24,10 @@ func main() {
 	}
 
 	plan := PlanUpdate(sources, catalog.Templates)
+	if !plan.HasChanges() {
+		log.Println("catalog already up to date")
+		return
+	}
 	log.Printf(
 		"template update plan:\n  🆕 %d to add\n  🔄 %d to update\n  🗑️ %d to remove\n  ☑️ %d unchanged",
 		len(plan.ToAdd),

--- a/scripts/update_templates/main.go
+++ b/scripts/update_templates/main.go
@@ -25,7 +25,7 @@ func main() {
 
 	plan := PlanUpdate(sources, catalog.Templates)
 	log.Printf(
-		"template update plan: %d add, %d update, %d remove, %d unchanged",
+		"template update plan:\n  🆕 %d to add\n  🔄 %d to update\n  🗑️ %d to remove\n  ☑️ %d unchanged",
 		len(plan.ToAdd),
 		len(plan.ToUpdate),
 		len(plan.ToRemove),

--- a/scripts/update_templates/template.go
+++ b/scripts/update_templates/template.go
@@ -8,10 +8,16 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+type TemplateSourceID string
+
 type Template struct {
 	XTopo
 	URL string `json:"url"`
 	Ref string `json:"ref"`
+}
+
+func (t Template) SourceID() TemplateSourceID {
+	return TemplateSourceID(t.URL)
 }
 
 type XTopo struct {
@@ -42,7 +48,7 @@ func NewTemplate(source GitHubSource, composeFile io.Reader) (Template, error) {
 
 	return Template{
 		XTopo: parsed.XTopo,
-		URL:   source.CloneURL(),
+		URL:   source.URL(),
 		Ref:   source.SHA,
 	}, nil
 }

--- a/scripts/update_templates/template.go
+++ b/scripts/update_templates/template.go
@@ -16,10 +16,6 @@ type Template struct {
 	Ref string `json:"ref"`
 }
 
-func (t Template) SourceID() TemplateSourceID {
-	return TemplateSourceID(t.URL)
-}
-
 type XTopo struct {
 	Name        string         `json:"name"`
 	Description string         `json:"description"`
@@ -59,4 +55,8 @@ func FetchTemplate(client GitHubClient, source GitHubSource) (Template, error) {
 		return Template{}, err
 	}
 	return NewTemplate(source, bytes.NewReader(yamlBytes))
+}
+
+func (t Template) SourceID() TemplateSourceID {
+	return TemplateSourceID(t.URL)
 }

--- a/scripts/update_templates/template_sort.go
+++ b/scripts/update_templates/template_sort.go
@@ -1,0 +1,19 @@
+package main
+
+func TemplatesInSourceOrder(sources []GitHubSource, templates []Template) []Template {
+	templateByID := make(map[TemplateSourceID]Template, len(templates))
+	for _, template := range templates {
+		templateByID[template.SourceID()] = template
+	}
+
+	ordered := make([]Template, 0, len(sources))
+	for _, source := range sources {
+		template, exists := templateByID[source.ID()]
+		if !exists {
+			continue
+		}
+		ordered = append(ordered, template)
+	}
+
+	return ordered
+}

--- a/scripts/update_templates/template_sort.go
+++ b/scripts/update_templates/template_sort.go
@@ -1,5 +1,7 @@
 package main
 
+import "fmt"
+
 func TemplatesInSourceOrder(sources []GitHubSource, templates []Template) []Template {
 	templateByID := make(map[TemplateSourceID]Template, len(templates))
 	for _, template := range templates {
@@ -10,7 +12,7 @@ func TemplatesInSourceOrder(sources []GitHubSource, templates []Template) []Temp
 	for _, source := range sources {
 		template, exists := templateByID[source.ID()]
 		if !exists {
-			continue
+			panic(fmt.Sprintf("missing template for source %s", source))
 		}
 		ordered = append(ordered, template)
 	}

--- a/scripts/update_templates/template_sort_test.go
+++ b/scripts/update_templates/template_sort_test.go
@@ -29,4 +29,15 @@ func TestTemplatesInSourceOrder(t *testing.T) {
 		}
 		assert.Equal(t, want, got)
 	})
+
+	t.Run("panics when source has no matching template", func(t *testing.T) {
+		sources := []GitHubSource{
+			{Repo: "example/missing", SHA: "missing-sha"},
+		}
+		templates := []Template{}
+
+		assert.PanicsWithValue(t, "missing template for source example/missing@missing-sha", func() {
+			TemplatesInSourceOrder(sources, templates)
+		})
+	})
 }

--- a/scripts/update_templates/template_sort_test.go
+++ b/scripts/update_templates/template_sort_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTemplatesInSourceOrder(t *testing.T) {
+	t.Run("returns templates ordered to match sources", func(t *testing.T) {
+		sources := []GitHubSource{
+			{Repo: "example/first", SHA: "first-sha"},
+			{Repo: "example/second", SHA: "second-sha"},
+			{Repo: "example/third", SHA: "third-sha"},
+		}
+		templates := []Template{
+			{URL: "https://github.com/example/third.git", Ref: "third-sha"},
+			{URL: "https://github.com/example/orphan.git", Ref: "orphan-sha"},
+			{URL: "https://github.com/example/second.git", Ref: "second-sha"},
+			{URL: "https://github.com/example/first.git", Ref: "first-sha"},
+		}
+
+		got := TemplatesInSourceOrder(sources, templates)
+
+		want := []Template{
+			{URL: "https://github.com/example/first.git", Ref: "first-sha"},
+			{URL: "https://github.com/example/second.git", Ref: "second-sha"},
+			{URL: "https://github.com/example/third.git", Ref: "third-sha"},
+		}
+		assert.Equal(t, want, got)
+	})
+}

--- a/scripts/update_templates/update_plan.go
+++ b/scripts/update_templates/update_plan.go
@@ -1,0 +1,48 @@
+package main
+
+type UpdatePlan struct {
+	ToAdd     []GitHubSource
+	ToUpdate  []GitHubSource
+	ToRemove  []Template
+	Unchanged []Template
+}
+
+// TODO: codify the fact CloneURL and URL are the foreign key id
+
+func PlanUpdate(sources []GitHubSource, current []Template) UpdatePlan {
+	currentByURL := make(map[string]Template, len(current))
+	for _, template := range current {
+		currentByURL[template.URL] = template
+	}
+
+	sourceByURL := make(map[string]GitHubSource, len(sources))
+	for _, source := range sources {
+		url := source.CloneURL()
+		sourceByURL[url] = source
+	}
+
+	var plan UpdatePlan
+	for _, source := range sources {
+		url := source.CloneURL()
+		template, exists := currentByURL[url]
+		if !exists {
+			plan.ToAdd = append(plan.ToAdd, source)
+			continue
+		}
+
+		if template.Ref != source.SHA {
+			plan.ToUpdate = append(plan.ToUpdate, source)
+			continue
+		}
+
+		plan.Unchanged = append(plan.Unchanged, template)
+	}
+
+	for _, template := range current {
+		if _, exists := sourceByURL[template.URL]; !exists {
+			plan.ToRemove = append(plan.ToRemove, template)
+		}
+	}
+
+	return plan
+}

--- a/scripts/update_templates/update_plan.go
+++ b/scripts/update_templates/update_plan.go
@@ -1,5 +1,10 @@
 package main
 
+import (
+	"fmt"
+	"strings"
+)
+
 type UpdatePlan struct {
 	ToAdd     []GitHubSource
 	ToUpdate  []GitHubSource
@@ -9,6 +14,32 @@ type UpdatePlan struct {
 
 func (p UpdatePlan) HasChanges() bool {
 	return len(p.ToAdd) > 0 || len(p.ToUpdate) > 0 || len(p.ToRemove) > 0
+}
+
+func (p UpdatePlan) String() string {
+	var lines []string
+	lines = append(lines, fmt.Sprintf("🆕 %d to add", len(p.ToAdd)))
+	lines = appendSourceURLs(lines, p.ToAdd)
+	lines = append(lines, fmt.Sprintf("🔄 %d to update", len(p.ToUpdate)))
+	lines = appendSourceURLs(lines, p.ToUpdate)
+	lines = append(lines, fmt.Sprintf("🗑️ %d to remove", len(p.ToRemove)))
+	lines = appendTemplateURLs(lines, p.ToRemove)
+	lines = append(lines, fmt.Sprintf("☑️ %d unchanged", len(p.Unchanged)))
+	return strings.Join(lines, "\n")
+}
+
+func appendSourceURLs(lines []string, sources []GitHubSource) []string {
+	for _, source := range sources {
+		lines = append(lines, fmt.Sprintf("  - %s", source.URL()))
+	}
+	return lines
+}
+
+func appendTemplateURLs(lines []string, templates []Template) []string {
+	for _, template := range templates {
+		lines = append(lines, fmt.Sprintf("  - %s", template.URL))
+	}
+	return lines
 }
 
 func PlanUpdate(sources []GitHubSource, current []Template) UpdatePlan {

--- a/scripts/update_templates/update_plan.go
+++ b/scripts/update_templates/update_plan.go
@@ -43,14 +43,14 @@ func appendTemplateURLs(lines []string, templates []Template) []string {
 }
 
 func PlanUpdate(sources []GitHubSource, current []Template) UpdatePlan {
-	currentByID := make(map[TemplateSourceID]Template, len(current))
-	for _, template := range current {
-		currentByID[template.SourceID()] = template
-	}
-
 	sourceByID := make(map[TemplateSourceID]GitHubSource, len(sources))
 	for _, source := range sources {
 		sourceByID[source.ID()] = source
+	}
+
+	currentByID := make(map[TemplateSourceID]Template, len(current))
+	for _, template := range current {
+		currentByID[template.SourceID()] = template
 	}
 
 	var plan UpdatePlan

--- a/scripts/update_templates/update_plan.go
+++ b/scripts/update_templates/update_plan.go
@@ -7,6 +7,10 @@ type UpdatePlan struct {
 	Unchanged []Template
 }
 
+func (p UpdatePlan) HasChanges() bool {
+	return len(p.ToAdd) > 0 || len(p.ToUpdate) > 0 || len(p.ToRemove) > 0
+}
+
 func PlanUpdate(sources []GitHubSource, current []Template) UpdatePlan {
 	currentByID := make(map[TemplateSourceID]Template, len(current))
 	for _, template := range current {

--- a/scripts/update_templates/update_plan.go
+++ b/scripts/update_templates/update_plan.go
@@ -7,24 +7,20 @@ type UpdatePlan struct {
 	Unchanged []Template
 }
 
-// TODO: codify the fact CloneURL and URL are the foreign key id
-
 func PlanUpdate(sources []GitHubSource, current []Template) UpdatePlan {
-	currentByURL := make(map[string]Template, len(current))
+	currentByID := make(map[TemplateSourceID]Template, len(current))
 	for _, template := range current {
-		currentByURL[template.URL] = template
+		currentByID[template.SourceID()] = template
 	}
 
-	sourceByURL := make(map[string]GitHubSource, len(sources))
+	sourceByID := make(map[TemplateSourceID]GitHubSource, len(sources))
 	for _, source := range sources {
-		url := source.CloneURL()
-		sourceByURL[url] = source
+		sourceByID[source.ID()] = source
 	}
 
 	var plan UpdatePlan
 	for _, source := range sources {
-		url := source.CloneURL()
-		template, exists := currentByURL[url]
+		template, exists := currentByID[source.ID()]
 		if !exists {
 			plan.ToAdd = append(plan.ToAdd, source)
 			continue
@@ -39,7 +35,7 @@ func PlanUpdate(sources []GitHubSource, current []Template) UpdatePlan {
 	}
 
 	for _, template := range current {
-		if _, exists := sourceByURL[template.URL]; !exists {
+		if _, exists := sourceByID[template.SourceID()]; !exists {
 			plan.ToRemove = append(plan.ToRemove, template)
 		}
 	}

--- a/scripts/update_templates/update_plan_test.go
+++ b/scripts/update_templates/update_plan_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPlanUpdate(t *testing.T) {
+	t.Run("classifies added, updated and removed templates", func(t *testing.T) {
+		sources := []GitHubSource{
+			{Repo: "example/unchanged", SHA: "same-sha"},
+			{Repo: "example/updated", SHA: "new-sha"},
+			{Repo: "example/added", SHA: "added-sha"},
+		}
+		current := []Template{
+			{URL: "https://github.com/example/removed.git", Ref: "removed-sha"},
+			{URL: "https://github.com/example/unchanged.git", Ref: "same-sha"},
+			{URL: "https://github.com/example/updated.git", Ref: "old-sha"},
+		}
+
+		got := PlanUpdate(sources, current)
+
+		want := UpdatePlan{
+			ToAdd:     []GitHubSource{{Repo: "example/added", SHA: "added-sha"}},
+			ToUpdate:  []GitHubSource{{Repo: "example/updated", SHA: "new-sha"}},
+			ToRemove:  []Template{{URL: "https://github.com/example/removed.git", Ref: "removed-sha"}},
+			Unchanged: []Template{{URL: "https://github.com/example/unchanged.git", Ref: "same-sha"}},
+		}
+		assert.Equal(t, want, got)
+	})
+}

--- a/scripts/update_templates/update_plan_test.go
+++ b/scripts/update_templates/update_plan_test.go
@@ -30,3 +30,47 @@ func TestPlanUpdate(t *testing.T) {
 		assert.Equal(t, want, got)
 	})
 }
+
+func TestUpdatePlan(t *testing.T) {
+	t.Run("HasChanges", func(t *testing.T) {
+		t.Run("returns false when only templates are unchanged", func(t *testing.T) {
+			plan := UpdatePlan{
+				Unchanged: []Template{{URL: "https://github.com/example/unchanged.git", Ref: "same-sha"}},
+			}
+
+			got := plan.HasChanges()
+
+			assert.False(t, got)
+		})
+
+		t.Run("returns true when templates will be added", func(t *testing.T) {
+			plan := UpdatePlan{
+				ToAdd: []GitHubSource{{Repo: "example/added", SHA: "added-sha"}},
+			}
+
+			got := plan.HasChanges()
+
+			assert.True(t, got)
+		})
+
+		t.Run("returns true when templates will be updated", func(t *testing.T) {
+			plan := UpdatePlan{
+				ToUpdate: []GitHubSource{{Repo: "example/updated", SHA: "new-sha"}},
+			}
+
+			got := plan.HasChanges()
+
+			assert.True(t, got)
+		})
+
+		t.Run("returns true when templates will be removed", func(t *testing.T) {
+			plan := UpdatePlan{
+				ToRemove: []Template{{URL: "https://github.com/example/removed.git", Ref: "removed-sha"}},
+			}
+
+			got := plan.HasChanges()
+
+			assert.True(t, got)
+		})
+	})
+}


### PR DESCRIPTION
## Changes

- Update template catalog generation to read the existing catalog and build an incremental update plan before fetching templates
- Only fetch templates that need to be added or updated, remove stale entries, and exit early when the catalog is already up to date
- Preserve configured template source order and use repository URLs as stable source identifiers
- Improve update logging with add/update/remove/unchanged plan details