### PR TITLE
fix: use correct known_hosts format for targets in fix command

### DIFF
--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -171,9 +171,10 @@ func connectivityCheck(status ConnectionStatus) HealthCheck {
 			Command:     fmt.Sprintf("topo health --target %s --accept-new-host-keys", status.Destination),
 		}
 	case errors.Is(status.Error, probe.ErrHostKeyChanged):
+		sshConfig := ssh.NewConfig(status.Destination)
 		check.Fix = &Fix{
 			Description: "Remove the old SSH host key from known_hosts, then retry",
-			Command:     fmt.Sprintf("ssh-keygen -R %s", status.Destination.Host),
+			Command:     fmt.Sprintf("ssh-keygen -R %q", sshConfig.AsKnownHostsEntry()),
 		}
 	}
 	return check

--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -124,7 +124,7 @@ func TestGenerateTargetReport(t *testing.T) {
 	t.Run("when host key has changed, Connectivity includes a known_hosts fix", func(t *testing.T) {
 		ts := health.Status{
 			Connection: health.ConnectionStatus{
-				Destination: ssh.NewDestination("user@my-target"),
+				Destination: ssh.NewDestination("ssh://user@my-target:2222"),
 				Error:       probe.ErrHostKeyChanged,
 			},
 		}
@@ -133,7 +133,7 @@ func TestGenerateTargetReport(t *testing.T) {
 
 		assert.Equal(t, health.CheckStatusError, got.Connectivity.Status)
 		assert.Equal(t, "Remove the old SSH host key from known_hosts, then retry", got.Connectivity.Fix.Description)
-		assert.Equal(t, "ssh-keygen -R my-target", got.Connectivity.Fix.Command)
+		assert.Equal(t, "ssh-keygen -R \"[my-target]:2222\"", got.Connectivity.Fix.Command)
 	})
 }
 

--- a/internal/ssh/config.go
+++ b/internal/ssh/config.go
@@ -11,6 +11,7 @@ import (
 type Config struct {
 	HostName string
 	User     string
+	Port     string
 }
 
 func NewConfig(dest Destination) Config {
@@ -19,6 +20,14 @@ func NewConfig(dest Destination) Config {
 		return Config{}
 	}
 	return NewConfigFromBytes(output)
+}
+
+func (c Config) AsKnownHostsEntry() string {
+	if c.Port == "" || c.Port == "22" {
+		return c.HostName
+	}
+
+	return fmt.Sprintf("[%s]:%s", c.HostName, c.Port)
 }
 
 func NewConfigFromBytes(data []byte) Config {
@@ -36,6 +45,8 @@ func NewConfigFromBytes(data []byte) Config {
 			config.HostName = fields[1]
 		case "user":
 			config.User = fields[1]
+		case "port":
+			config.Port = fields[1]
 		}
 	}
 	return config

--- a/internal/ssh/config.go
+++ b/internal/ssh/config.go
@@ -22,14 +22,6 @@ func NewConfig(dest Destination) Config {
 	return NewConfigFromBytes(output)
 }
 
-func (c Config) AsKnownHostsEntry() string {
-	if c.Port == "" || c.Port == "22" {
-		return c.HostName
-	}
-
-	return fmt.Sprintf("[%s]:%s", c.HostName, c.Port)
-}
-
 func NewConfigFromBytes(data []byte) Config {
 	var config Config
 	scanner := bufio.NewScanner(bytes.NewReader(data))
@@ -50,6 +42,14 @@ func NewConfigFromBytes(data []byte) Config {
 		}
 	}
 	return config
+}
+
+func (c Config) AsKnownHostsEntry() string {
+	if c.Port == "" || c.Port == "22" {
+		return c.HostName
+	}
+
+	return fmt.Sprintf("[%s]:%s", c.HostName, c.Port)
 }
 
 func GetUserFromConfig(dest Destination) (string, error) {

--- a/internal/ssh/config_test.go
+++ b/internal/ssh/config_test.go
@@ -11,6 +11,7 @@ func TestNewConfigFromBytes(t *testing.T) {
 	t.Run("parses basic config fields", func(t *testing.T) {
 		input := []byte(`hostname springfield.nuclear.gov
 user homer
+port 1234
 `)
 
 		got := ssh.NewConfigFromBytes(input)
@@ -18,6 +19,7 @@ user homer
 		want := ssh.Config{
 			HostName: "springfield.nuclear.gov",
 			User:     "homer",
+			Port:     "1234",
 		}
 		assert.Equal(t, want, got)
 	})
@@ -54,6 +56,38 @@ user homer
 		}
 		assert.Equal(t, want, got)
 	})
+}
+
+func TestAsKnownHostsEntry(t *testing.T) {
+	cases := []struct {
+		desc string
+		cfg  ssh.Config
+		want string
+	}{
+		{
+			desc: "hostname without port",
+			cfg:  ssh.Config{HostName: "my-target"},
+			want: "my-target",
+		},
+		{
+			desc: "hostname with default ssh port",
+			cfg:  ssh.Config{HostName: "my-target", Port: "22"},
+			want: "my-target",
+		},
+		{
+			desc: "hostname with non-standard port",
+			cfg:  ssh.Config{HostName: "my-target", Port: "2222"},
+			want: "[my-target]:2222",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			got := tc.cfg.AsKnownHostsEntry()
+
+			assert.Equal(t, tc.want, got)
+		})
+	}
 }
 
 func TestResolveConfiguredUser(t *testing.T) {


### PR DESCRIPTION
## Background

<!-- List the changes this PR introduces -->

Our current "host keys have changed" fix in `topo health` suggests a command that doesn't work for:
  - Targets with non-default ssh ports
  - Most SSH config aliases

This is because `.ssh/known_hosts` entries are stored against resolved hostnames, with ports (when 22 is not used) in a slightly different format.

## Changes

- Uses `ssh -G`-based resolution to fix for aliases and resolve if a non-default port is in use
- Adds a method to format an `ssh.Config` as a known hosts entry key for use by the suggested fix command
- Quotes the known hosts entry in the suggested fix command so shells don't misinterpret the `[]` that the hostname is wrapped in
