### PR TITLE
feat: add `topo configure` for re-configuration of project parameters

### DIFF
--- a/cmd/topo/configure.go
+++ b/cmd/topo/configure.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"os"
+
+	"github.com/arm/topo/internal/arguments"
+	"github.com/arm/topo/internal/output/term"
+	"github.com/arm/topo/internal/project"
+	"github.com/spf13/cobra"
+)
+
+var configureCmd = &cobra.Command{
+	Use:   "configure [PARAMETER=VALUE ...]",
+	Short: "Configure project parameters",
+	Long: `Configure project parameters for the Topo project in the current directory.
+
+The compose file (compose.yaml or compose.yml) must be in the current working directory.
+
+Some projects require parameters. Supply them on the command line or answer
+interactive prompts.`,
+	Example: `  # Will prompt for required parameters
+  topo configure
+
+  # Provide parameters explicitly
+  topo configure GREETING_NAME="World"`,
+	Args: cobra.ArbitraryArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+
+		composeFile, err := getComposeFileName()
+		if err != nil {
+			return err
+		}
+
+		var providers []arguments.Provider
+		if len(args) > 0 {
+			cliProvider, err := arguments.NewCLIProvider(args)
+			if err != nil {
+				return err
+			}
+			providers = append(providers, cliProvider)
+		}
+		if term.IsTTY(os.Stdout) && term.IsTTY(os.Stdin) {
+			providers = append(providers, arguments.NewInteractiveProvider(os.Stdin, os.Stdout))
+		}
+
+		parameterProvider := arguments.NewStrictProviderChain(providers...)
+
+		return project.ResolveAndApplyArgs(composeFile, parameterProvider)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(configureCmd)
+}

--- a/e2e/configure_test.go
+++ b/e2e/configure_test.go
@@ -1,0 +1,80 @@
+package e2e
+
+import (
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/arm/topo/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigure(t *testing.T) {
+	topo := buildBinary(t)
+
+	t.Run("updates compose yaml parameters", func(t *testing.T) {
+		projectDir := t.TempDir()
+		composePath := filepath.Join(projectDir, "compose.yaml")
+		testutil.RequireWriteFile(t, composePath, configurableCompose("Original"))
+
+		cmd := exec.Command(topo, "configure", "GREETING_NAME=World")
+		cmd.Dir = projectDir
+		out, err := cmd.CombinedOutput()
+
+		require.NoErrorf(t, err, "configure failed: %s", out)
+		assert.Empty(t, string(out))
+		want := configurableCompose("World")
+		got := testutil.RequireReadFile(t, composePath)
+		assert.YAMLEq(t, want, got)
+	})
+
+	t.Run("uses compose yml when compose yaml is absent", func(t *testing.T) {
+		projectDir := t.TempDir()
+		composePath := filepath.Join(projectDir, "compose.yml")
+		testutil.RequireWriteFile(t, composePath, configurableCompose("Original"))
+
+		cmd := exec.Command(topo, "configure", "GREETING_NAME=Yml")
+		cmd.Dir = projectDir
+		out, err := cmd.CombinedOutput()
+
+		require.NoErrorf(t, err, "configure failed: %s", out)
+		assert.Empty(t, string(out))
+		want := configurableCompose("Yml")
+		got := testutil.RequireReadFile(t, composePath)
+		assert.YAMLEq(t, want, got)
+	})
+
+	t.Run("rejects undeclared parameters without changing the compose file", func(t *testing.T) {
+		projectDir := t.TempDir()
+		composePath := filepath.Join(projectDir, "compose.yaml")
+		original := configurableCompose("Original")
+		testutil.RequireWriteFile(t, composePath, original)
+
+		cmd := exec.Command(topo, "configure", "UNKNOWN=value")
+		cmd.Dir = projectDir
+		out, err := cmd.CombinedOutput()
+
+		require.Error(t, err)
+		assert.Contains(t, string(out), "unknown argument: UNKNOWN")
+		got := testutil.RequireReadFile(t, composePath)
+		assert.Equal(t, original, got)
+	})
+}
+
+func configurableCompose(greetingName string) string {
+	return `services:
+  app:
+    build:
+      context: .
+      args:
+        GREETING_NAME: ` + greetingName + `
+
+x-topo:
+  name: Welcome
+  args:
+    GREETING_NAME:
+      description: Name to greet
+      required: true
+`
+}

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -282,7 +282,7 @@ type resolveArgsOperation struct {
 }
 
 func (o resolveArgsOperation) Description() string {
-	return "Input args"
+	return "Configure project"
 }
 
 func (o resolveArgsOperation) Run(_ io.Writer) error {


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- Adds a `topo configure` command which allows for the complete re-configuration of a Topo Project's parameters 
  - Note this command introduces a third place where a parameter provider chain is constructed from CLI args + TTY input (`clone`, `extend` and `configure`) so potentially worth commonising these though I've not done that here for simplicity's sake.
- Replaces 'Input args' in cloning project configuration with 'Configure project' to define a neater link between the two concepts

Note this PR explicitly does not update the README, glossary or clone/extend help strings as it feels like that should be done as part of a wider language update that spans across all "templates" as they're known currently.