### PR TITLE
fix: shorten control path

### DIFF
--- a/internal/runner/ssh.go
+++ b/internal/runner/ssh.go
@@ -61,5 +61,5 @@ func multiplexArgs() []string {
 	if runtime.GOOS == "windows" {
 		return nil
 	}
-	return []string{"-o", "ControlMaster=auto", "-o", "ControlPersist=10s", "-o", "ControlPath=~/.ssh/topo-cm-%r@%h:%p"}
+	return []string{"-o", "ControlMaster=auto", "-o", "ControlPersist=10s", "-o", "ControlPath=~/.ssh/topo-cm-%C"}
 }


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- Shorten the control path to include just the hash as including the user and address can become very long depending on the target.
- If the address does become too long, such errors may occur: 
```
yejseo01@CF7PJYX5G9 topo-welcome % topo health --target emulation
Host
----
Topo: ✅ (topo)
SSH: ✅ (ssh)
Curl: ✅ (curl)
Container Engine: ✅ (docker)

Target
------
Destination: ssh://emulation
Connectivity: ❌ (ssh command to ssh://emulation failed: exit status 255 | stderr: unix_listener: path "/Users/yejseo01/.ssh/topo-cm-root@ana-nlb-2-e83cf4f2b8126b63.elb.eu-west-1.amazonaws.com:16049.h4CpVSXx10Gt2m8M" too long for Unix domain socket
)
```
