### PR TITLE
feat: add container ID to `topo ps`

### DIFF
--- a/internal/deploy/ps.go
+++ b/internal/deploy/ps.go
@@ -24,6 +24,7 @@ type PSContainer struct {
 }
 
 type Container struct {
+	Id               string `json:"id"`
 	Image            string `json:"image"`
 	Status           string `json:"status"`
 	ProcessingDomain string `json:"processingDomain"`
@@ -162,6 +163,7 @@ func RemapAddresses(raws []PSContainer, hostName string) []Container {
 	containers := make([]Container, len(raws))
 	for i, raw := range raws {
 		containers[i] = Container{
+			Id:      raw.ID,
 			Image:   raw.Image,
 			Status:  raw.Status,
 			Address: publishedAddress(raw.Ports, hostName),

--- a/internal/deploy/ps_test.go
+++ b/internal/deploy/ps_test.go
@@ -170,12 +170,12 @@ func TestRemapAddresses(t *testing.T) {
 		assert.Equal(t, want, got)
 	})
 
-	t.Run("retains image and status fields", func(t *testing.T) {
-		input := []deploy.PSContainer{{Image: "web", Status: "Up"}}
+	t.Run("retains unmapped fields", func(t *testing.T) {
+		input := []deploy.PSContainer{{Image: "web", Status: "Up", ID: "such-a-cool-id"}}
 
 		got := deploy.RemapAddresses(input, "myhost")
 
-		want := []deploy.Container{{Image: "web", Status: "Up"}}
+		want := []deploy.Container{{Image: "web", Status: "Up", Id: "such-a-cool-id"}}
 		assert.Equal(t, want, got)
 	})
 

--- a/internal/output/views/container_list.go
+++ b/internal/output/views/container_list.go
@@ -14,9 +14,9 @@ type ContainerList struct {
 	Containers []deploy.Container `json:"containers"`
 }
 
-const containerListTemplate = `{{if .}}Image	Status	Processing Domain	Address
+const containerListTemplate = `{{if .}}Container ID	Image	Status	Processing Domain	Address
 {{- range .}}
-{{.Image}}	{{.Status}}	{{.ProcessingDomain}}	{{.Address}}
+{{.Id}}	{{.Image}}	{{.Status}}	{{.ProcessingDomain}}	{{.Address}}
 {{- end }}{{else}}No containers deployed from this project are running.{{end}}`
 
 func (r ContainerList) AsPlain(isTTY bool) (string, error) {

--- a/internal/output/views/container_list_test.go
+++ b/internal/output/views/container_list_test.go
@@ -70,6 +70,7 @@ func TestContainerList(t *testing.T) {
 			toPrint := views.ContainerList{
 				Containers: []deploy.Container{
 					{
+						Id:               "abcdef123456",
 						Image:            "my-app",
 						Status:           "Up 5 minutes",
 						ProcessingDomain: "m0",
@@ -83,7 +84,7 @@ func TestContainerList(t *testing.T) {
 
 			require.NoError(t, err)
 			want := `{
-				"containers": [{"image": "my-app", "status": "Up 5 minutes", "processingDomain": "m0", "address": "localhost:8080"}]
+				"containers": [{"id": "abcdef123456", "image": "my-app", "status": "Up 5 minutes", "processingDomain": "m0", "address": "localhost:8080"}]
 			}`
 			assert.JSONEq(t, want, out.String())
 		})


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- Adds container IDs to `topo ps` output to avoid hiding information that is useful for things like `docker logs` et al, also useful for the VS Code extension to be able to identify unique containers across `ps` executions, deploys etc

Sample output:

```
Container ID   Image              Status          Processing Domain   Address
d8f4fffba9f5   topo-welcome-app   Up 21 minutes   Linux Host          imx93-lionel.cambridge.arm.com:8000, [::]:8000
```

```json
{
  "containers": [
    {
      "id": "d8f4fffba9f5",
      "image": "topo-welcome-app",
      "status": "Up 22 minutes",
      "processingDomain": "Linux Host",
      "address": "myboard:8000, [::]:8000"
    }
  ]
}
```
