### PR TITLE
fix: Support cloning Git object IDs

### DIFF
--- a/internal/template/source.go
+++ b/internal/template/source.go
@@ -126,8 +126,7 @@ func cloneCommitTo(url, commit, destDir string) error {
 	if err := runGit(destDir, "fetch", "--depth", "1", "origin", commit); err != nil {
 		return fmt.Errorf("failed to fetch git commit: %w", err)
 	}
-	branchName := "topo-" + shortGitObjectID(commit)
-	if err := runGit(destDir, "checkout", "--quiet", "-B", branchName, "FETCH_HEAD"); err != nil {
+	if err := runGit(destDir, "checkout", "--quiet", "--detach", "FETCH_HEAD"); err != nil {
 		return fmt.Errorf("failed to check out git commit: %w", err)
 	}
 
@@ -158,14 +157,6 @@ func isFullGitObjectID(ref string) bool {
 		}
 	}
 	return true
-}
-
-func shortGitObjectID(ref string) string {
-	const shortObjectIDLength = 7
-	if len(ref) <= shortObjectIDLength {
-		return ref
-	}
-	return ref[:shortObjectIDLength]
 }
 
 func isHexDigit(r rune) bool {

--- a/internal/template/source.go
+++ b/internal/template/source.go
@@ -88,16 +88,90 @@ func (g GitSource) CopyTo(destDir string) error {
 		return DestDirExistsError{Dir: destDir}
 	}
 
-	args := []string{"clone", "--depth", "1"}
-	if g.Ref != "" {
-		args = append(args, "--branch", g.Ref)
+	if isFullGitObjectID(g.Ref) {
+		return cloneCommitTo(g.URL, g.Ref, destDir)
 	}
-	args = append(args, g.URL, destDir)
+
+	return cloneRefTo(g.URL, g.Ref, destDir)
+}
+
+func cloneRefTo(url, ref, destDir string) error {
+	args := []string{"clone", "--depth", "1"}
+	if ref != "" {
+		args = append(args, "--branch", ref)
+	}
+	args = append(args, url, destDir)
+
+	if err := runGit("", args...); err != nil {
+		return fmt.Errorf("failed to clone git repository: %w", err)
+	}
+	return nil
+}
+
+func cloneCommitTo(url, commit, destDir string) error {
+	if err := runGit("", "init", "--quiet", destDir); err != nil {
+		return fmt.Errorf("failed to initialize git repository: %w", err)
+	}
+
+	success := false
+	defer func() {
+		if !success {
+			_ = os.RemoveAll(destDir)
+		}
+	}()
+
+	if err := runGit(destDir, "remote", "add", "origin", url); err != nil {
+		return fmt.Errorf("failed to add git remote: %w", err)
+	}
+	if err := runGit(destDir, "fetch", "--depth", "1", "origin", commit); err != nil {
+		return fmt.Errorf("failed to fetch git commit: %w", err)
+	}
+	branchName := "topo-" + shortGitObjectID(commit)
+	if err := runGit(destDir, "checkout", "--quiet", "-B", branchName, "FETCH_HEAD"); err != nil {
+		return fmt.Errorf("failed to check out git commit: %w", err)
+	}
+
+	success = true
+	return nil
+}
+
+func runGit(dir string, args ...string) error {
 	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
 	cmd.Env = os.Environ()
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
+}
+
+func isFullGitObjectID(ref string) bool {
+	// Git object IDs are full-length hex strings: 40 chars for SHA-1 repos,
+	// or 64 chars for SHA-256 repos. Only these need the commit checkout path;
+	// branches, tags, and short SHAs should use normal ref cloning semantics.
+	if len(ref) != 40 && len(ref) != 64 {
+		return false
+	}
+
+	for _, r := range ref {
+		if !isHexDigit(r) {
+			return false
+		}
+	}
+	return true
+}
+
+func shortGitObjectID(ref string) string {
+	const shortObjectIDLength = 7
+	if len(ref) <= shortObjectIDLength {
+		return ref
+	}
+	return ref[:shortObjectIDLength]
+}
+
+func isHexDigit(r rune) bool {
+	return (r >= '0' && r <= '9') ||
+		(r >= 'a' && r <= 'f') ||
+		(r >= 'A' && r <= 'F')
 }
 
 func (g GitSource) String() string {

--- a/internal/template/source_test.go
+++ b/internal/template/source_test.go
@@ -174,7 +174,7 @@ func TestGitSource(t *testing.T) {
 			assert.ErrorIs(t, err, template.DestDirExistsError{Dir: dstDir})
 		})
 
-		t.Run("checks out a commit SHA ref", func(t *testing.T) {
+		t.Run("checks out a commit object ID as detached HEAD", func(t *testing.T) {
 			repoDir, firstCommit := createGitRepoWithTwoCommits(t)
 			dstDir := filepath.Join(t.TempDir(), "dest")
 			src := template.GitSource{URL: repoDir, Ref: firstCommit}
@@ -183,7 +183,6 @@ func TestGitSource(t *testing.T) {
 
 			require.NoError(t, err)
 			assert.Equal(t, firstCommit, gitOutput(t, dstDir, "rev-parse", "HEAD"))
-			assert.Equal(t, "topo-"+firstCommit[:7], gitOutput(t, dstDir, "branch", "--show-current"))
 		})
 	})
 

--- a/internal/template/source_test.go
+++ b/internal/template/source_test.go
@@ -2,8 +2,10 @@ package template_test
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/arm/topo/internal/template"
@@ -163,12 +165,26 @@ func TestNewSource(t *testing.T) {
 
 func TestGitSource(t *testing.T) {
 	t.Run("CopyTo", func(t *testing.T) {
-		dstDir := t.TempDir()
-		src := template.GitSource{URL: "https://github.com/example/repo.git"}
+		t.Run("errors when destination already exists", func(t *testing.T) {
+			dstDir := t.TempDir()
+			src := template.GitSource{URL: "https://github.com/example/repo.git"}
 
-		err := src.CopyTo(dstDir)
+			err := src.CopyTo(dstDir)
 
-		assert.ErrorIs(t, err, template.DestDirExistsError{Dir: dstDir})
+			assert.ErrorIs(t, err, template.DestDirExistsError{Dir: dstDir})
+		})
+
+		t.Run("checks out a commit SHA ref", func(t *testing.T) {
+			repoDir, firstCommit := createGitRepoWithTwoCommits(t)
+			dstDir := filepath.Join(t.TempDir(), "dest")
+			src := template.GitSource{URL: repoDir, Ref: firstCommit}
+
+			err := src.CopyTo(dstDir)
+
+			require.NoError(t, err)
+			assert.Equal(t, firstCommit, gitOutput(t, dstDir, "rev-parse", "HEAD"))
+			assert.Equal(t, "topo-"+firstCommit[:7], gitOutput(t, dstDir, "branch", "--show-current"))
+		})
 	})
 
 	t.Run("String", func(t *testing.T) {
@@ -360,6 +376,44 @@ func TestDirSource(t *testing.T) {
 			assert.Equal(t, "template", name)
 		})
 	})
+}
+
+func createGitRepoWithTwoCommits(t *testing.T) (string, string) {
+	t.Helper()
+
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "config", "user.name", "Topo Test")
+	runGit(t, repoDir, "config", "user.email", "topo@example.com")
+	testutil.RequireWriteFile(t, filepath.Join(repoDir, "content.txt"), "first")
+	runGit(t, repoDir, "add", ".")
+	runGit(t, repoDir, "commit", "-m", "first")
+	firstCommit := gitOutput(t, repoDir, "rev-parse", "HEAD")
+
+	testutil.RequireWriteFile(t, filepath.Join(repoDir, "content.txt"), "second")
+	runGit(t, repoDir, "add", ".")
+	runGit(t, repoDir, "commit", "-m", "second")
+
+	return repoDir, firstCommit
+}
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, "git %s failed:\n%s", strings.Join(args, " "), string(output))
+}
+
+func gitOutput(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, "git %s failed:\n%s", strings.Join(args, " "), string(output))
+	return strings.TrimSpace(string(output))
 }
 
 func windowsFilePermissions(original os.FileMode) os.FileMode {


### PR DESCRIPTION
## Changes

- Support Git template sources pinned to full object IDs by fetching and checking out the commit directly
  - ~Avoid detached head state by creating a branch at the commit called `topo-<short-id>`~
- Keep normal branch/tag refs on the existing shallow clone path