### PR TITLE
feat: add `-a`/`--all` flag to `topo ps`

### DIFF
--- a/cmd/topo/ps.go
+++ b/cmd/topo/ps.go
@@ -12,8 +12,8 @@ import (
 
 var topoPsCmd = &cobra.Command{
 	Use:   "ps",
-	Short: "List running containers on the target for the current Compose project.",
-	Long: `List running containers on the target for the current Compose project.
+	Short: "List containers on the target for the current Compose project.",
+	Long: `List containers on the target for the current Compose project.
 
 The compose.yaml must be in the current working directory, as this is used to select containers to be viewed.
 `,
@@ -34,7 +34,13 @@ The compose.yaml must be in the current working directory, as this is used to se
 
 		dest := ssh.NewDestination(targetArg)
 		hostName := ssh.NewConfig(dest).HostName
-		containers, err := deploy.ListRunningContainers(composeFile, command.NewHostFromDestination(dest), hostName)
+		allContainers, err := cmd.Flags().GetBool("all")
+		if err != nil {
+			panic("internal error: all flag not registered: " + err.Error())
+		}
+
+		host := command.NewHostFromDestination(dest)
+		containers, err := deploy.ListContainers(composeFile, host, hostName, allContainers)
 		if err != nil {
 			return err
 		}
@@ -45,5 +51,6 @@ The compose.yaml must be in the current working directory, as this is used to se
 
 func init() {
 	addTargetFlag(topoPsCmd)
+	topoPsCmd.Flags().BoolP("all", "a", false, "show all containers, including stopped")
 	rootCmd.AddCommand(topoPsCmd)
 }

--- a/e2e/deploy_test.go
+++ b/e2e/deploy_test.go
@@ -37,7 +37,7 @@ func TestDeploy(t *testing.T) {
 		require.NoError(t, err)
 		assertResponseBody(t, fmt.Sprintf("http://localhost:%s/", port), expectedResponse)
 
-		requirePS(t, topo, projectDir, container.SSHDestination, "hello-server", "8080")
+		requirePS(t, topo, projectDir, container.SSHDestination, nil, "hello-server", "8080")
 	})
 
 	t.Run("Clone and deploy", func(t *testing.T) {
@@ -56,7 +56,26 @@ func TestDeploy(t *testing.T) {
 		require.NoError(t, err)
 		assertResponseBody(t, fmt.Sprintf("http://localhost:%s/", port), expectedResponse)
 
-		requirePS(t, topo, cloneDir, container.SSHDestination, "hello-server", "8080")
+		requirePS(t, topo, cloneDir, container.SSHDestination, nil, "hello-server", "8080")
+	})
+
+	t.Run("ps -a shows stopped containers", func(t *testing.T) {
+		projectDir := t.TempDir()
+		composeFile := testutil.WriteComposeFile(t, projectDir, `services:
+  sleeper:
+    image: busybox
+    command: ["sleep", "300"]
+`)
+		t.Cleanup(func() {
+			composeDown(t, composeFile, container.SSHDestination)
+		})
+
+		requireDeploy(t, topo, projectDir, container.SSHDestination)
+		requireStop(t, topo, projectDir, container.SSHDestination)
+		psOut := requirePS(t, topo, projectDir, container.SSHDestination, nil)
+		assert.NotContains(t, psOut, "busybox")
+
+		requirePS(t, topo, projectDir, container.SSHDestination, []string{"-a"}, "busybox", "Exited")
 	})
 }
 
@@ -109,17 +128,31 @@ func requireDeploy(t *testing.T, topo, projectDir, sshDestination string, extraA
 	require.NoErrorf(t, err, "deploy failed: %s", out)
 }
 
-func requirePS(t *testing.T, topo, projectDir, sshDestination string, expectedOutputs ...string) {
+func requirePS(t *testing.T, topo, projectDir, sshDestination string, extraArgs []string, expectedOutputs ...string) string {
 	t.Helper()
-	psCmd := exec.Command(topo, "ps", "--target", sshDestination)
+	args := []string{"ps", "--target", sshDestination}
+	args = append(args, extraArgs...)
+	psCmd := exec.Command(topo, args...)
 	psCmd.Dir = projectDir
 
 	out, err := psCmd.CombinedOutput()
 
 	require.NoErrorf(t, err, "ps failed: %s", out)
+	output := string(out)
 	for _, expected := range expectedOutputs {
-		assert.Contains(t, string(out), expected)
+		assert.Contains(t, output, expected)
 	}
+	return output
+}
+
+func requireStop(t *testing.T, topo, projectDir, sshDestination string) {
+	t.Helper()
+	stopCmd := exec.Command(topo, "stop", "--target", sshDestination)
+	stopCmd.Dir = projectDir
+
+	out, err := stopCmd.CombinedOutput()
+
+	require.NoErrorf(t, err, "stop failed: %s", out)
 }
 
 func assertResponseBody(t *testing.T, url, wantBody string) {

--- a/internal/deploy/ps.go
+++ b/internal/deploy/ps.go
@@ -42,12 +42,12 @@ type InspectedHostConfig struct {
 	Annotations map[string]string `json:"Annotations"`
 }
 
-func ListRunningContainers(composeFile string, h command.Host, hostName string) ([]Container, error) {
-	rawJSON, err := getRunningContainers(composeFile, h)
+func ListContainers(composeFile string, h command.Host, hostName string, all bool) ([]Container, error) {
+	rawJSON, err := getContainers(composeFile, h, all)
 	if err != nil {
 		return nil, err
 	}
-	raws, err := ParseRunningContainers(rawJSON)
+	raws, err := ParseContainers(rawJSON)
 	if err != nil {
 		return nil, err
 	}
@@ -64,9 +64,9 @@ func ListRunningContainers(composeFile string, h command.Host, hostName string) 
 	return containers, nil
 }
 
-func getRunningContainers(composeFile string, h command.Host) (string, error) {
+func getContainers(composeFile string, h command.Host, all bool) (string, error) {
 	var stdout, stderr bytes.Buffer
-	cmd := command.DockerCompose(h, composeFile, "ps", "--format", "json")
+	cmd := command.DockerCompose(h, composeFile, composePSArgs(all)...)
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
@@ -75,7 +75,15 @@ func getRunningContainers(composeFile string, h command.Host) (string, error) {
 	return stdout.String(), nil
 }
 
-func ParseRunningContainers(rawJSON string) ([]PSContainer, error) {
+func composePSArgs(all bool) []string {
+	args := []string{"ps", "--format", "json"}
+	if all {
+		args = append(args, "--all")
+	}
+	return args
+}
+
+func ParseContainers(rawJSON string) ([]PSContainer, error) {
 	raws := []PSContainer{}
 	decoder := json.NewDecoder(strings.NewReader(rawJSON))
 	for decoder.More() {

--- a/internal/deploy/ps_test.go
+++ b/internal/deploy/ps_test.go
@@ -8,12 +8,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestParseRunningContainers(t *testing.T) {
+func TestParseContainers(t *testing.T) {
 	t.Run("decodes the NDJSON stream emitted by docker compose ps", func(t *testing.T) {
 		input := `{"ID":"abc123","Image":"web","Status":"Up 5 minutes","Ports":"0.0.0.0:8080->80/tcp"}
 {"ID":"def456","Image":"db","Status":"Up 5 minutes","Ports":""}`
 
-		got, err := deploy.ParseRunningContainers(input)
+		got, err := deploy.ParseContainers(input)
 
 		require.NoError(t, err)
 		want := []deploy.PSContainer{
@@ -24,14 +24,14 @@ func TestParseRunningContainers(t *testing.T) {
 	})
 
 	t.Run("returns an empty slice for empty input", func(t *testing.T) {
-		got, err := deploy.ParseRunningContainers("")
+		got, err := deploy.ParseContainers("")
 
 		require.NoError(t, err)
 		assert.Equal(t, []deploy.PSContainer{}, got)
 	})
 
 	t.Run("returns an error on malformed JSON", func(t *testing.T) {
-		_, err := deploy.ParseRunningContainers("{not json")
+		_, err := deploy.ParseContainers("{not json")
 
 		assert.Error(t, err)
 	})

--- a/internal/output/views/container_list.go
+++ b/internal/output/views/container_list.go
@@ -14,10 +14,10 @@ type ContainerList struct {
 	Containers []deploy.Container `json:"containers"`
 }
 
-const containerListTemplate = `{{if .}}Container ID	Image	Status	Processing Domain	Address
+const containerListTemplate = `Container ID	Image	Status	Processing Domain	Address
 {{- range .}}
 {{.Id}}	{{.Image}}	{{.Status}}	{{.ProcessingDomain}}	{{.Address}}
-{{- end }}{{else}}No containers deployed from this project are running.{{end}}`
+{{- end }}`
 
 func (r ContainerList) AsPlain(isTTY bool) (string, error) {
 	tmpl, err := template.

--- a/internal/output/views/container_list_test.go
+++ b/internal/output/views/container_list_test.go
@@ -54,14 +54,14 @@ func TestContainerList(t *testing.T) {
 			assert.Contains(t, out.String(), "Linux Host")
 		})
 
-		t.Run("renders empty message when no containers", func(t *testing.T) {
+		t.Run("renders only the header when no containers", func(t *testing.T) {
 			toPrint := views.ContainerList{Containers: nil}
 			var out bytes.Buffer
 
 			err := views.Print(toPrint, &out, term.Plain)
 
 			require.NoError(t, err)
-			assert.Contains(t, out.String(), "No containers deployed from this project are running.")
+			assert.Equal(t, "Container ID   Image   Status   Processing Domain   Address", out.String())
 		})
 	})
 


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- Adds an `-a`/`--all` flag to `topo ps` which is just passed through to `docker compose ps` directly
   - Just adds an e2e test for this since the seam it lives on atm is hard to unit test as-is and refactoring didn't feel worth it
- Removes the special case human message we displayed if no containers were running when `topo ps` was invoked - it felt weird to me to deviate from the behaviour `docker ps`/`docker compose ps`. Happy to revert this change specifically if it's disagreeable though it would need re-wording depending on the presence of the `-a` flag which is a bit annoying.

The medium-term goal here is to making `topo ps` usable for determining/rendering the state of a project's containers without extra docker commands for things like the VS Code extension project view. 
