### PR TITLE
feat: add container names to `topo ps`

### DIFF
--- a/internal/deploy/ps.go
+++ b/internal/deploy/ps.go
@@ -18,6 +18,7 @@ const (
 
 type PSContainer struct {
 	ID     string `json:"ID"`
+	Names  string `json:"Names"`
 	Image  string `json:"Image"`
 	Status string `json:"Status"`
 	Ports  string `json:"Ports"`
@@ -25,6 +26,7 @@ type PSContainer struct {
 
 type Container struct {
 	Id               string `json:"id"`
+	Names            string `json:"names"`
 	Image            string `json:"image"`
 	Status           string `json:"status"`
 	ProcessingDomain string `json:"processingDomain"`
@@ -164,6 +166,7 @@ func RemapAddresses(raws []PSContainer, hostName string) []Container {
 	for i, raw := range raws {
 		containers[i] = Container{
 			Id:      raw.ID,
+			Names:   raw.Names,
 			Image:   raw.Image,
 			Status:  raw.Status,
 			Address: publishedAddress(raw.Ports, hostName),

--- a/internal/deploy/ps_test.go
+++ b/internal/deploy/ps_test.go
@@ -10,15 +10,15 @@ import (
 
 func TestParseRunningContainers(t *testing.T) {
 	t.Run("decodes the NDJSON stream emitted by docker compose ps", func(t *testing.T) {
-		input := `{"ID":"abc123","Image":"web","Status":"Up 5 minutes","Ports":"0.0.0.0:8080->80/tcp"}
-{"ID":"def456","Image":"db","Status":"Up 5 minutes","Ports":""}`
+		input := `{"ID":"abc123","Names":"project-web-1","Image":"web","Status":"Up 5 minutes","Ports":"0.0.0.0:8080->80/tcp"}
+{"ID":"def456","Names":"project-db-1","Image":"db","Status":"Up 5 minutes","Ports":""}`
 
 		got, err := deploy.ParseRunningContainers(input)
 
 		require.NoError(t, err)
 		want := []deploy.PSContainer{
-			{ID: "abc123", Image: "web", Status: "Up 5 minutes", Ports: "0.0.0.0:8080->80/tcp"},
-			{ID: "def456", Image: "db", Status: "Up 5 minutes", Ports: ""},
+			{ID: "abc123", Names: "project-web-1", Image: "web", Status: "Up 5 minutes", Ports: "0.0.0.0:8080->80/tcp"},
+			{ID: "def456", Names: "project-db-1", Image: "db", Status: "Up 5 minutes", Ports: ""},
 		}
 		assert.Equal(t, want, got)
 	})
@@ -171,11 +171,11 @@ func TestRemapAddresses(t *testing.T) {
 	})
 
 	t.Run("retains unmapped fields", func(t *testing.T) {
-		input := []deploy.PSContainer{{Image: "web", Status: "Up", ID: "such-a-cool-id"}}
+		input := []deploy.PSContainer{{Image: "web", Status: "Up", ID: "such-a-cool-id", Names: "project-web-1"}}
 
 		got := deploy.RemapAddresses(input, "myhost")
 
-		want := []deploy.Container{{Image: "web", Status: "Up", Id: "such-a-cool-id"}}
+		want := []deploy.Container{{Image: "web", Status: "Up", Id: "such-a-cool-id", Names: "project-web-1"}}
 		assert.Equal(t, want, got)
 	})
 

--- a/internal/output/views/container_list.go
+++ b/internal/output/views/container_list.go
@@ -14,9 +14,9 @@ type ContainerList struct {
 	Containers []deploy.Container `json:"containers"`
 }
 
-const containerListTemplate = `{{if .}}Container ID	Image	Status	Processing Domain	Address
+const containerListTemplate = `{{if .}}Container ID	Names	Image	Status	Processing Domain	Address
 {{- range .}}
-{{.Id}}	{{.Image}}	{{.Status}}	{{.ProcessingDomain}}	{{.Address}}
+{{.Id}}	{{.Names}}	{{.Image}}	{{.Status}}	{{.ProcessingDomain}}	{{.Address}}
 {{- end }}{{else}}No containers deployed from this project are running.{{end}}`
 
 func (r ContainerList) AsPlain(isTTY bool) (string, error) {

--- a/internal/output/views/container_list_test.go
+++ b/internal/output/views/container_list_test.go
@@ -14,10 +14,12 @@ import (
 
 func TestContainerList(t *testing.T) {
 	t.Run("PlainFormat", func(t *testing.T) {
-		t.Run("renders container image, status, processing domain, and address", func(t *testing.T) {
+		t.Run("renders container id, names, image, status, processing domain, and address", func(t *testing.T) {
 			toPrint := views.ContainerList{
 				Containers: []deploy.Container{
 					{
+						Id:               "abcdef123456",
+						Names:            "project-web-1",
 						Image:            "my-app",
 						Status:           "Up 5 minutes",
 						ProcessingDomain: "m0",
@@ -30,10 +32,14 @@ func TestContainerList(t *testing.T) {
 			err := views.Print(toPrint, &out, term.Plain)
 
 			require.NoError(t, err)
+			assert.Contains(t, out.String(), "abcdef123456")
+			assert.Contains(t, out.String(), "project-web-1")
 			assert.Contains(t, out.String(), "my-app")
 			assert.Contains(t, out.String(), "Up 5 minutes")
 			assert.Contains(t, out.String(), "m0")
 			assert.Contains(t, out.String(), "localhost:8080")
+			assert.Contains(t, out.String(), "Container ID")
+			assert.Contains(t, out.String(), "Names")
 			assert.Contains(t, out.String(), "Processing Domain")
 		})
 
@@ -71,6 +77,7 @@ func TestContainerList(t *testing.T) {
 				Containers: []deploy.Container{
 					{
 						Id:               "abcdef123456",
+						Names:            "project-web-1",
 						Image:            "my-app",
 						Status:           "Up 5 minutes",
 						ProcessingDomain: "m0",
@@ -84,7 +91,7 @@ func TestContainerList(t *testing.T) {
 
 			require.NoError(t, err)
 			want := `{
-				"containers": [{"id": "abcdef123456", "image": "my-app", "status": "Up 5 minutes", "processingDomain": "m0", "address": "localhost:8080"}]
+				"containers": [{"id": "abcdef123456", "names": "project-web-1", "image": "my-app", "status": "Up 5 minutes", "processingDomain": "m0", "address": "localhost:8080"}]
 			}`
 			assert.JSONEq(t, want, out.String())
 		})


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- Add the `Names` field from `docker compose ps` to `topo ps` output. Rationale being if you've specified an explicit `container_name`, are using replicas or any other docker or compose features which have an effect on container names then you probably want to see them.

Sample outputs:

```
Container ID   Names                Image              Status         Processing Domain   Address
4e4413f31533   topo-welcome-app-1   topo-welcome-app   Up 8 minutes   Linux Host          my-board:8000, [::]:8000
```

```json
{
  "containers": [
    {
      "id": "4e4413f31533",
      "names": "topo-welcome-app-1",
      "image": "topo-welcome-app",
      "status": "Up 8 minutes",
      "processingDomain": "Linux Host",
      "address": "my-board:8000, [::]:8000"
    }
  ]
}
```
