### PR TITLE
feat: add container state to `topo ps` json output

### DIFF
--- a/internal/deploy/ps.go
+++ b/internal/deploy/ps.go
@@ -20,6 +20,7 @@ type PSContainer struct {
 	ID     string `json:"ID"`
 	Names  string `json:"Names"`
 	Image  string `json:"Image"`
+	State  string `json:"State"`
 	Status string `json:"Status"`
 	Ports  string `json:"Ports"`
 }
@@ -28,6 +29,7 @@ type Container struct {
 	Id               string `json:"id"`
 	Names            string `json:"names"`
 	Image            string `json:"image"`
+	State            string `json:"state"`
 	Status           string `json:"status"`
 	ProcessingDomain string `json:"processingDomain"`
 	Address          string `json:"address"`
@@ -168,6 +170,7 @@ func RemapAddresses(raws []PSContainer, hostName string) []Container {
 			Id:      raw.ID,
 			Names:   raw.Names,
 			Image:   raw.Image,
+			State:   raw.State,
 			Status:  raw.Status,
 			Address: publishedAddress(raw.Ports, hostName),
 		}

--- a/internal/deploy/ps_test.go
+++ b/internal/deploy/ps_test.go
@@ -10,15 +10,15 @@ import (
 
 func TestParseRunningContainers(t *testing.T) {
 	t.Run("decodes the NDJSON stream emitted by docker compose ps", func(t *testing.T) {
-		input := `{"ID":"abc123","Names":"project-web-1","Image":"web","Status":"Up 5 minutes","Ports":"0.0.0.0:8080->80/tcp"}
-{"ID":"def456","Names":"project-db-1","Image":"db","Status":"Up 5 minutes","Ports":""}`
+		input := `{"ID":"abc123","Names":"project-web-1","Image":"web","State":"running","Status":"Up 5 minutes","Ports":"0.0.0.0:8080->80/tcp"}
+{"ID":"def456","Names":"project-db-1","Image":"db","State":"running","Status":"Up 5 minutes","Ports":""}`
 
 		got, err := deploy.ParseRunningContainers(input)
 
 		require.NoError(t, err)
 		want := []deploy.PSContainer{
-			{ID: "abc123", Names: "project-web-1", Image: "web", Status: "Up 5 minutes", Ports: "0.0.0.0:8080->80/tcp"},
-			{ID: "def456", Names: "project-db-1", Image: "db", Status: "Up 5 minutes", Ports: ""},
+			{ID: "abc123", Names: "project-web-1", Image: "web", State: "running", Status: "Up 5 minutes", Ports: "0.0.0.0:8080->80/tcp"},
+			{ID: "def456", Names: "project-db-1", Image: "db", State: "running", Status: "Up 5 minutes", Ports: ""},
 		}
 		assert.Equal(t, want, got)
 	})
@@ -171,11 +171,11 @@ func TestRemapAddresses(t *testing.T) {
 	})
 
 	t.Run("retains unmapped fields", func(t *testing.T) {
-		input := []deploy.PSContainer{{Image: "web", Status: "Up", ID: "such-a-cool-id", Names: "project-web-1"}}
+		input := []deploy.PSContainer{{Image: "web", State: "running", Status: "Up", ID: "such-a-cool-id", Names: "project-web-1"}}
 
 		got := deploy.RemapAddresses(input, "myhost")
 
-		want := []deploy.Container{{Image: "web", Status: "Up", Id: "such-a-cool-id", Names: "project-web-1"}}
+		want := []deploy.Container{{Image: "web", State: "running", Status: "Up", Id: "such-a-cool-id", Names: "project-web-1"}}
 		assert.Equal(t, want, got)
 	})
 

--- a/internal/output/views/container_list_test.go
+++ b/internal/output/views/container_list_test.go
@@ -21,6 +21,7 @@ func TestContainerList(t *testing.T) {
 						Id:               "abcdef123456",
 						Names:            "project-web-1",
 						Image:            "my-app",
+						State:            "running",
 						Status:           "Up 5 minutes",
 						ProcessingDomain: "m0",
 						Address:          "localhost:8080",
@@ -40,6 +41,8 @@ func TestContainerList(t *testing.T) {
 			assert.Contains(t, out.String(), "localhost:8080")
 			assert.Contains(t, out.String(), "Container ID")
 			assert.Contains(t, out.String(), "Names")
+			assert.NotContains(t, out.String(), "State")
+			assert.NotContains(t, out.String(), "running")
 			assert.Contains(t, out.String(), "Processing Domain")
 		})
 
@@ -79,6 +82,7 @@ func TestContainerList(t *testing.T) {
 						Id:               "abcdef123456",
 						Names:            "project-web-1",
 						Image:            "my-app",
+						State:            "running",
 						Status:           "Up 5 minutes",
 						ProcessingDomain: "m0",
 						Address:          "localhost:8080",
@@ -91,7 +95,7 @@ func TestContainerList(t *testing.T) {
 
 			require.NoError(t, err)
 			want := `{
-				"containers": [{"id": "abcdef123456", "names": "project-web-1", "image": "my-app", "status": "Up 5 minutes", "processingDomain": "m0", "address": "localhost:8080"}]
+				"containers": [{"id": "abcdef123456", "names": "project-web-1", "image": "my-app", "state": "running", "status": "Up 5 minutes", "processingDomain": "m0", "address": "localhost:8080"}]
 			}`
 			assert.JSONEq(t, want, out.String())
 		})


### PR DESCRIPTION
## Changes

Another tiny change hot off the presses

- Forwards container `state` from `docker compose ps` output to `topo ps` output because `status` alone does not tell a full picture and requires parsing
- Notably, this `state` value is excluded from the human-readable table view and is only presented in the JSON view since it's mostly for programmatic consumers of the CLI. This mimics what `docker compose ps` does by default
