### PR TITLE
chore: use `main` for all embedded templates

### DIFF
--- a/internal/catalog/data/catalog.json
+++ b/internal/catalog/data/catalog.json
@@ -14,7 +14,7 @@
         }
       },
       "url": "https://github.com/Arm-Examples/topo-welcome.git",
-      "ref": "8303e66db59a7a11e64877121f3db1b688d2011f"
+      "ref": "main"
     },
     {
       "name": "Lightbulb Moment",
@@ -39,7 +39,7 @@
         }
       },
       "url": "https://github.com/Arm-Examples/topo-lightbulb-moment.git",
-      "ref": "9bb2b0b42b39178afcb225319f989ba85afd68b1"
+      "ref": "main"
     },
     {
       "name": "Topo llama.cpp WebUI Chat",
@@ -57,7 +57,7 @@
         }
       },
       "url": "https://github.com/Arm-Examples/topo-llama-web-ui.git",
-      "ref": "99561df2838081fc7f7af9229b8e677b898bbd88"
+      "ref": "main"
     },
     {
       "name": "SIMD Visual Benchmark",
@@ -72,7 +72,7 @@
         }
       },
       "url": "https://github.com/Arm-Examples/topo-simd-visual-benchmark.git",
-      "ref": "f0cd31621ce79b4643df7e9bdd8eff26c20b338c"
+      "ref": "main"
     }
   ]
 }

--- a/scripts/update_templates/github_sources.json
+++ b/scripts/update_templates/github_sources.json
@@ -1,6 +1,6 @@
 [
-	{"repo": "Arm-Examples/topo-welcome", "sha": "8303e66db59a7a11e64877121f3db1b688d2011f"},
-	{"repo": "Arm-Examples/topo-lightbulb-moment", "sha": "9bb2b0b42b39178afcb225319f989ba85afd68b1"},
-	{"repo": "Arm-Examples/topo-llama-web-ui", "sha": "99561df2838081fc7f7af9229b8e677b898bbd88"},
-	{"repo": "Arm-Examples/topo-simd-visual-benchmark", "sha": "f0cd31621ce79b4643df7e9bdd8eff26c20b338c"}
+	{"repo": "Arm-Examples/topo-welcome", "sha": "main"},
+	{"repo": "Arm-Examples/topo-lightbulb-moment", "sha": "main"},
+	{"repo": "Arm-Examples/topo-llama-web-ui", "sha": "main"},
+	{"repo": "Arm-Examples/topo-simd-visual-benchmark", "sha": "main"}
 ]


### PR DESCRIPTION
## Details

Pinning templates to specific sha's as part of catalog extraction work was done prematurely in `topo`. It is now annoying to update templates - a `topo` release is required to bump a template version in `topo templates`. While this is a valid approach for external catalogue, the embedded catalogue should still use `main`.

## Changes

<!-- List the changes this PR introduces -->

- Revert the embedded catalog to use `main` for every template we own.
