### PR TITLE
fix: show full compose file path in deploy message

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -24,6 +24,18 @@ func BinaryLookupCommand(bin string) (string, error) {
 	return fmt.Sprintf("command -v %s", bin), nil
 }
 
+func QuoteArg(s string) string {
+	if s == "" {
+		return "''"
+	}
+
+	if strings.ContainsAny(s, " \t\n\"'\\$`") {
+		return "'" + strings.ReplaceAll(s, "'", `'"'"'`) + "'"
+	}
+
+	return s
+}
+
 func shellEscapeForDoubleQuotes(s string) string {
 	repl := strings.NewReplacer(
 		`\`, `\\`,

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -32,3 +32,44 @@ func TestBinaryLookupCommand(t *testing.T) {
 		assert.Empty(t, got)
 	})
 }
+
+func TestQuoteArg(t *testing.T) {
+	tests := []struct {
+		name string
+		arg  string
+		want string
+	}{
+		{
+			name: "plain arg",
+			arg:  "compose.yml",
+			want: "compose.yml",
+		},
+		{
+			name: "empty arg",
+			arg:  "",
+			want: "''",
+		},
+		{
+			name: "arg with spaces",
+			arg:  "custom compose.yaml",
+			want: "'custom compose.yaml'",
+		},
+		{
+			name: "arg with apostrophe",
+			arg:  "custom's-compose.yaml",
+			want: `'custom'"'"'s-compose.yaml'`,
+		},
+		{
+			name: "windows path",
+			arg:  `C:\Users\runner\AppData\Local\Temp\custom-compose.yaml`,
+			want: `'C:\Users\runner\AppData\Local\Temp\custom-compose.yaml'`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := command.QuoteArg(tt.arg)
+
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/compose/file.go
+++ b/internal/compose/file.go
@@ -13,6 +13,11 @@ var errFileNotFound = errors.New("compose file not found")
 
 var defaultFileNames = []string{"compose.yaml", "compose.yml"}
 
+// DefaultFileName returns the first filename used when resolving a default compose file.
+func DefaultFileName() string {
+	return defaultFileNames[0]
+}
+
 // RequireFile returns the path when it exists and is not a directory.
 func RequireFile(composeFile string) (string, error) {
 	info, err := os.Stat(composeFile)

--- a/internal/deploy/deploy.go
+++ b/internal/deploy/deploy.go
@@ -1,6 +1,9 @@
 package deploy
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/arm/topo/internal/deploy/command"
 	"github.com/arm/topo/internal/deploy/operation"
 	"github.com/arm/topo/internal/deploy/post_deploy"
@@ -54,6 +57,26 @@ func NewDeployment(composeFile string, opts DeployOptions) (goperation.Sequence,
 		}
 	}
 	ops = append(ops, operation.NewDockerComposeUp(composeFile, targetHost, opts.RecreateMode))
-	ops = append(ops, post_deploy.NewDeploySuccess(composeFile, targetHost, "Run `topo ps` to see deployed containers"))
+	ops = append(ops, post_deploy.NewDeploySuccess(composeFile, targetHost, defaultDeploySuccessMessage(composeFile)))
 	return goperation.NewSequence(ops...), cleanup
+}
+
+func defaultDeploySuccessMessage(composeFile string) string {
+	if composeFile == "compose.yaml" {
+		return "Run `topo ps` to see deployed containers"
+	}
+
+	return fmt.Sprintf("Run `topo ps -f %s` to see deployed containers", shellQuote(composeFile))
+}
+
+func shellQuote(arg string) string {
+	if arg == "" {
+		return "''"
+	}
+
+	if strings.ContainsAny(arg, " \t\n\"'\\$`") {
+		return "'" + strings.ReplaceAll(arg, "'", `'"'"'`) + "'"
+	}
+
+	return arg
 }

--- a/internal/deploy/deploy.go
+++ b/internal/deploy/deploy.go
@@ -1,9 +1,6 @@
 package deploy
 
 import (
-	"fmt"
-	"strings"
-
 	"github.com/arm/topo/internal/deploy/command"
 	"github.com/arm/topo/internal/deploy/operation"
 	"github.com/arm/topo/internal/deploy/post_deploy"
@@ -57,26 +54,6 @@ func NewDeployment(composeFile string, opts DeployOptions) (goperation.Sequence,
 		}
 	}
 	ops = append(ops, operation.NewDockerComposeUp(composeFile, targetHost, opts.RecreateMode))
-	ops = append(ops, post_deploy.NewDeploySuccess(composeFile, targetHost, defaultDeploySuccessMessage(composeFile)))
+	ops = append(ops, post_deploy.NewDeploySuccess(composeFile, targetHost, post_deploy.DefaultMessage(composeFile)))
 	return goperation.NewSequence(ops...), cleanup
-}
-
-func defaultDeploySuccessMessage(composeFile string) string {
-	if composeFile == "compose.yaml" {
-		return "Run `topo ps` to see deployed containers"
-	}
-
-	return fmt.Sprintf("Run `topo ps -f %s` to see deployed containers", shellQuote(composeFile))
-}
-
-func shellQuote(arg string) string {
-	if arg == "" {
-		return "''"
-	}
-
-	if strings.ContainsAny(arg, " \t\n\"'\\$`") {
-		return "'" + strings.ReplaceAll(arg, "'", `'"'"'`) + "'"
-	}
-
-	return arg
 }

--- a/internal/deploy/deploy_test.go
+++ b/internal/deploy/deploy_test.go
@@ -38,22 +38,6 @@ func TestNewDeployment(t *testing.T) {
 		assert.Equal(t, want, got)
 	})
 
-	t.Run("includes compose file flag in default success message for non-default compose file", func(t *testing.T) {
-		composeFile := "custom-compose.yaml"
-		deployOpts := deploy.DeployOptions{TargetHost: ssh.PlainLocalhost}
-
-		got, _ := deploy.NewDeployment(composeFile, deployOpts)
-
-		localHost := command.LocalHost
-		want := goperation.Sequence{
-			operation.NewDockerComposeBuild(composeFile, localHost),
-			operation.NewDockerComposePull(composeFile, localHost),
-			operation.NewDockerComposeUp(composeFile, localHost, operation.RecreateModeDefault),
-			post_deploy.NewDeploySuccess(composeFile, localHost, "Run `topo ps -f custom-compose.yaml` to see deployed containers"),
-		}
-		assert.Equal(t, want, got)
-	})
-
 	t.Run("includes registry operations for remote host when enabled", func(t *testing.T) {
 		remoteDest := ssh.NewDestination("user@remote")
 		port := operation.DefaultRegistryPort

--- a/internal/deploy/deploy_test.go
+++ b/internal/deploy/deploy_test.go
@@ -38,6 +38,22 @@ func TestNewDeployment(t *testing.T) {
 		assert.Equal(t, want, got)
 	})
 
+	t.Run("includes compose file flag in default success message for non-default compose file", func(t *testing.T) {
+		composeFile := "custom-compose.yaml"
+		deployOpts := deploy.DeployOptions{TargetHost: ssh.PlainLocalhost}
+
+		got, _ := deploy.NewDeployment(composeFile, deployOpts)
+
+		localHost := command.LocalHost
+		want := goperation.Sequence{
+			operation.NewDockerComposeBuild(composeFile, localHost),
+			operation.NewDockerComposePull(composeFile, localHost),
+			operation.NewDockerComposeUp(composeFile, localHost, operation.RecreateModeDefault),
+			post_deploy.NewDeploySuccess(composeFile, localHost, "Run `topo ps -f custom-compose.yaml` to see deployed containers"),
+		}
+		assert.Equal(t, want, got)
+	})
+
 	t.Run("includes registry operations for remote host when enabled", func(t *testing.T) {
 		remoteDest := ssh.NewDestination("user@remote")
 		port := operation.DefaultRegistryPort

--- a/internal/deploy/post_deploy/post_deploy.go
+++ b/internal/deploy/post_deploy/post_deploy.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/arm/topo/internal/deploy/command"
 	"github.com/arm/topo/internal/template"
@@ -21,6 +22,26 @@ func NewDeploySuccess(composeFile string, h command.Host, defaultMessage string)
 		host:           h,
 		defaultMessage: defaultMessage,
 	}
+}
+
+func DefaultMessage(composeFile string) string {
+	if composeFile == "compose.yaml" {
+		return "Run `topo ps` to see deployed containers"
+	}
+
+	return fmt.Sprintf("Run `topo ps -f %s` to see deployed containers", shellQuote(composeFile))
+}
+
+func shellQuote(arg string) string {
+	if arg == "" {
+		return "''"
+	}
+
+	if strings.ContainsAny(arg, " \t\n\"'\\$`") {
+		return "'" + strings.ReplaceAll(arg, "'", `'"'"'`) + "'"
+	}
+
+	return arg
 }
 
 func (t *DeploySuccess) Description() string {

--- a/internal/deploy/post_deploy/post_deploy.go
+++ b/internal/deploy/post_deploy/post_deploy.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"strings"
 
+	cmdtext "github.com/arm/topo/internal/command"
 	"github.com/arm/topo/internal/deploy/command"
 	"github.com/arm/topo/internal/template"
 )
@@ -29,19 +29,7 @@ func DefaultMessage(composeFile string) string {
 		return "Run `topo ps` to see deployed containers"
 	}
 
-	return fmt.Sprintf("Run `topo ps -f %s` to see deployed containers", shellQuote(composeFile))
-}
-
-func shellQuote(arg string) string {
-	if arg == "" {
-		return "''"
-	}
-
-	if strings.ContainsAny(arg, " \t\n\"'\\$`") {
-		return "'" + strings.ReplaceAll(arg, "'", `'"'"'`) + "'"
-	}
-
-	return arg
+	return fmt.Sprintf("Run `topo ps -f %s` to see deployed containers", cmdtext.QuoteArg(composeFile))
 }
 
 func (t *DeploySuccess) Description() string {

--- a/internal/deploy/post_deploy/post_deploy.go
+++ b/internal/deploy/post_deploy/post_deploy.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	cmdtext "github.com/arm/topo/internal/command"
+	"github.com/arm/topo/internal/compose"
 	"github.com/arm/topo/internal/deploy/command"
 	"github.com/arm/topo/internal/template"
 )
@@ -25,7 +26,7 @@ func NewDeploySuccess(composeFile string, h command.Host, defaultMessage string)
 }
 
 func DefaultMessage(composeFile string) string {
-	if composeFile == "compose.yaml" {
+	if composeFile == compose.DefaultFileName() {
 		return "Run `topo ps` to see deployed containers"
 	}
 

--- a/internal/deploy/post_deploy/post_deploy_test.go
+++ b/internal/deploy/post_deploy/post_deploy_test.go
@@ -49,6 +49,23 @@ services:
 		assert.Equal(t, "Run `topo ps` to see deployed containers\n", buf.String())
 	})
 
+	t.Run("Run writes compose file flag in default message for non-default compose file", func(t *testing.T) {
+		dir := t.TempDir()
+		composeFile := filepath.Join(dir, "custom-compose.yaml")
+		testutil.RequireWriteFile(t, composeFile, `
+services:
+  app:
+    image: nginx
+`)
+		op := post_deploy.NewDeploySuccess(composeFile, command.LocalHost, post_deploy.DefaultMessage(composeFile))
+		var buf bytes.Buffer
+
+		err := op.Run(&buf)
+
+		require.NoError(t, err)
+		assert.Equal(t, "Run `topo ps -f "+composeFile+"` to see deployed containers\n", buf.String())
+	})
+
 	t.Run("Run returns error when compose file does not exist", func(t *testing.T) {
 		op := post_deploy.NewDeploySuccess("nonexistent.yaml", command.LocalHost, "Run `topo ps` to see deployed containers")
 		var buf bytes.Buffer
@@ -57,4 +74,40 @@ services:
 
 		require.Error(t, err)
 	})
+}
+
+func TestDefaultMessage(t *testing.T) {
+	tests := []struct {
+		name        string
+		composeFile string
+		want        string
+	}{
+		{
+			name:        "compose yaml",
+			composeFile: "compose.yaml",
+			want:        "Run `topo ps` to see deployed containers",
+		},
+		{
+			name:        "compose yml",
+			composeFile: "compose.yml",
+			want:        "Run `topo ps -f compose.yml` to see deployed containers",
+		},
+		{
+			name:        "custom compose file",
+			composeFile: "custom-compose.yaml",
+			want:        "Run `topo ps -f custom-compose.yaml` to see deployed containers",
+		},
+		{
+			name:        "compose file with spaces",
+			composeFile: "custom compose.yaml",
+			want:        "Run `topo ps -f 'custom compose.yaml'` to see deployed containers",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := post_deploy.DefaultMessage(tt.composeFile)
+
+			assert.Equal(t, tt.want, got)
+		})
+	}
 }

--- a/internal/deploy/post_deploy/post_deploy_test.go
+++ b/internal/deploy/post_deploy/post_deploy_test.go
@@ -40,30 +40,13 @@ services:
   app:
     image: nginx
 `)
-		op := post_deploy.NewDeploySuccess(composeFile, command.LocalHost, "Run `topo ps` to see deployed containers")
+		op := post_deploy.NewDeploySuccess(composeFile, command.LocalHost, "default message")
 		var buf bytes.Buffer
 
 		err := op.Run(&buf)
 
 		require.NoError(t, err)
-		assert.Equal(t, "Run `topo ps` to see deployed containers\n", buf.String())
-	})
-
-	t.Run("Run writes compose file flag in default message for non-default compose file", func(t *testing.T) {
-		dir := t.TempDir()
-		composeFile := filepath.Join(dir, "custom-compose.yaml")
-		testutil.RequireWriteFile(t, composeFile, `
-services:
-  app:
-    image: nginx
-`)
-		op := post_deploy.NewDeploySuccess(composeFile, command.LocalHost, post_deploy.DefaultMessage(composeFile))
-		var buf bytes.Buffer
-
-		err := op.Run(&buf)
-
-		require.NoError(t, err)
-		assert.Equal(t, "Run `topo ps -f "+composeFile+"` to see deployed containers\n", buf.String())
+		assert.Equal(t, "default message\n", buf.String())
 	})
 
 	t.Run("Run returns error when compose file does not exist", func(t *testing.T) {
@@ -96,11 +79,6 @@ func TestDefaultMessage(t *testing.T) {
 			name:        "custom compose file",
 			composeFile: "custom-compose.yaml",
 			want:        "Run `topo ps -f custom-compose.yaml` to see deployed containers",
-		},
-		{
-			name:        "compose file with spaces",
-			composeFile: "custom compose.yaml",
-			want:        "Run `topo ps -f 'custom compose.yaml'` to see deployed containers",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- when the compose file has no default deployment message the `topo ps` command suggested always points to compose.yaml or compose.yml. This PR uses the full compose file when the `-f` option is used for deployment.
