### PR TITLE
chore: upgrade go to fix govuln GO-2026-5856

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/arm/topo
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/compose-spec/compose-go/v2 v2.13.0


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- Does as says on tin - see govulncheck failure: https://github.com/arm/topo/actions/runs/28958321823/job/86073420531?pr=326
