### PR TITLE
docs: pull topo project spec + skills into`arm/topo`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,10 @@
 # Contribution Guidelines
 
-The Arm Topo CLI project is open for external contributors, and welcomes contributions.
+The Arm Topo project is open for external contributors, and welcomes contributions.
 
-Topo CLI is licensed under the [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) license and all accepted contributions must have the same license.
+Topo is licensed under the [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) license and all accepted contributions must have the same license.
 
-## Contributing code to Topo CLI
+## Contributing code to Topo
 
 - Before this project accepts your contribution, you need to certify its origin and give us your permission. To manage this process, we use [Developer Certificate of Origin (DCO) V1.1](https://developercertificate.org/).
   To indicate that contributors agree to the terms of the DCO, it's necessary to "sign off" the contribution by adding a line with your name and email address to every git commit message:
@@ -26,4 +26,4 @@ Topo CLI is licensed under the [Apache-2.0](https://spdx.org/licenses/Apache-2.0
 
   ## Continuous integration
 
-  Contributions to Topo CLI must go through testing and formatting before being merged to main. All unit and integration tests must pass, as well as formatting checks, before a contribution is merged. These tests are run through GitHub Actions, which require the permission of a maintainer to run.
+  Contributions to Topo must go through testing and formatting before being merged to main. All unit and integration tests must pass, as well as formatting checks, before a contribution is merged. These tests are run through GitHub Actions, which require the permission of a maintainer to run.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Already have a Compose project? Topo gives you a fast, incremental build-deploy 
 
 ## Who is this for?
 
-**You just got a board and want to see what it can do.** Topo scans your target and finds [Topo Projects](https://github.com/arm/topo-project-specification) that showcase its capabilities, from running an LLM to comparing SIMD performance. Each one deploys in minutes and is a real Compose project you can learn from or build on.
+**You just got a board and want to see what it can do.** Topo scans your target and finds [Topo Projects](https://github.com/arm/topo/docs/project-specification) that showcase its capabilities, from running an LLM to comparing SIMD performance. Each one deploys in minutes and is a real Compose project you can learn from or build on.
 
 **You want a faster edit-build-deploy loop.** Build on your laptop and deploy to a Pi or Jetson over SSH. Rebuilds are incremental, so after the first deploy you're often iterating in seconds.
 

--- a/README.md
+++ b/README.md
@@ -128,3 +128,24 @@ topo stop --target [user@]host
 ## Other Commands
 
 Run `topo <command> --help` for full usage details.
+
+## Project Authoring Skills
+
+This repository includes public agent skills that help authors create and validate Topo Projects.
+
+- `topo-project-context`: provides Topo and Topo Project reference context for questions about `x-topo` metadata, schema, docs, and CLI Project behavior.
+- `topo-project-bootstrap`: converts a repository into a Topo Project by adding or improving `compose.yaml` and `x-topo` metadata.
+- `topo-project-lint`: reviews an existing Topo Project for correctness, consistency, and authoring best practices.
+- `topo-project-optimize-deployment`: optimizes `topo deploy` or Docker build performance for initial deployment and iteration workflows.
+
+### Installing Skills
+
+You can install the skills with [`npx skills`](https://github.com/vercel-labs/skills):
+
+```sh
+npx skills add arm/topo
+```
+
+Or install the skills manually by copying or symlinking the directories under `skills/` into your agent's skills directory.
+
+Restart your agent after installing or updating skills.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -2,17 +2,19 @@
 
 This guide covers the development workflow, tools, and conventions for contributing to `topo`.
 
-## Prerequisites 
+## Topo CLI
+
+### Prerequisites
 
 - Go 1.26+
 
-## Building 
+### Building
 
 ```sh
 go build ./cmd/topo
 ```
 
-## Linting
+### Linting
 
 The project uses [golangci-lint](https://golangci-lint.run/) for Go code quality checks.
 
@@ -27,7 +29,7 @@ golangci-lint run
 golangci-lint run --fix
 ```
 
-## Testing
+### Testing
 
 The project uses [Go's built-in support for unit testing](https://pkg.go.dev/cmd/go/internal/test) to provide test coverage.
 
@@ -40,10 +42,34 @@ Some tests have a dependency on docker. Test container images are built automati
 
 > Note that if docker is missing, the dependent tests will just be skipped as opposed to failing.
 
-### Golden Files
+#### Golden Files
 
 A subset of our e2e tests rely on "golden files" to assert CLI output against a known good state. These tests will fail when breaking changes are made and can be updated in place with the `UPDATE_GOLDEN` environment variable when running the tests.
 
 ```
 UPDATE_GOLDEN=1 go test ./e2e/...
 ```
+
+## Skills
+
+Public agent skills live under `skills/`.
+
+To test skills from this checkout while developing them, install the local repository with `npx skills`. Choose symlinks when prompted if you want edits in this checkout to be reflected immediately.
+
+```sh
+npx skills add . --global
+```
+
+Each installable skill folder should be self-contained, but shared Topo Project context is maintained in `skills/_shared/topo-project-context.md` to avoid hand-edited drift across skills. After editing that shared context, update each skill's `references/topo-project-context.md` copy:
+
+```bash
+node scripts/sync-skill-context.js
+```
+
+Check that skill context references are current:
+
+```bash
+node scripts/sync-skill-context.js --check
+```
+
+Skill-specific instructions should stay workflow-focused. Put stable common vocabulary in the shared context, reference the current schema/docs for evolving spec details, and avoid copying the full specification into individual skills.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,0 @@
-# Topo CLI
-
-Documentation for developing and maintaining the Topo command-line interface.
-
-## Start here
-
-- [Development guide](./DEVELOPMENT.md)
-- [Glossary](./glossary.md)

--- a/docs/project-specification/00-overview.md
+++ b/docs/project-specification/00-overview.md
@@ -1,0 +1,128 @@
+# Overview
+
+A Topo Project is a repository that defines one or more container services using the [Compose Spec](https://compose-spec.io) with Topo-specific metadata.
+
+## Requirements
+
+- _Must_ Contain a Compose Spec file named `compose.yaml`, which:
+  - _Should_ contain a `x-topo` attribute defining the required fields
+    - see [x-topo schema](#x-topo-schema)
+  - _Must_ define one or more valid [services](https://github.com/compose-spec/compose-spec/blob/main/05-services.md)
+  - _Must_ set `platform: linux/arm64` on every service unless that service uses Remoteproc Runtime
+- _Could_ Be a git repo
+
+## Examples
+
+### Single Service Project
+
+A Project that builds a single container image:
+
+**compose.yaml**
+
+```yaml
+# standard https://github.com/compose-spec/compose-spec/blob/main/05-services.md
+services:
+  app:
+    platform: linux/arm64
+    build:
+      context: .
+
+# Topo-specific metadata
+x-topo:
+  name: "kleidi-llm" # Required
+  description: |
+    Run an LLM locally using KleidiAI optimised inference on Arm CPU
+  features:
+    - "SME"
+    - "NEON"
+```
+
+### Multi-Service Project
+
+A Project that composes multiple services, which can extend other Projects or use public images:
+
+**compose.yaml**
+
+```yaml
+# standard https://github.com/compose-spec/compose-spec/
+services:
+  # A service that extends another Project
+  cool-service:
+    extends:
+      file: ./cool-service-project/compose.yaml
+      service: cool-service
+    build:
+      args:
+        MODEL: "llama-3.1-8b"
+        QUANTIZATION: "q4_0"
+  # A service using a public container image
+  open-webui:
+    platform: linux/arm64
+    image: ghcr.io/open-webui/open-webui:main
+
+# Topo-specific metadata
+x-topo:
+  name: "kleidi-llm-webui"
+  description: |
+    Run an LLM chat web app with Kleidi inference
+  features:
+    - "SME"
+    - "NEON"
+```
+
+This allows Projects to be runnable with plain `docker compose` while Implementations can add customization and local development workflows.
+
+## Spec Examples
+
+- [Hello World](https://github.com/Arm-Examples/topo-welcome)
+- [Lightbulb Moment](https://github.com/Arm-Examples/topo-lightbulb-moment)
+- [Topo llama.cpp WebUI Chat](https://github.com/Arm-Examples/topo-llama-web-ui)
+- [SIMD Visual Benchmark](https://github.com/Arm-Examples/topo-simd-visual-benchmark)
+
+## Use Cases
+
+- A Zephyr starter program compatible with [Remoteproc Runtime](https://github.com/arm/remoteproc-runtime)
+- An LLM model running on an Arm-SIMD optimised (e.g. KleidiAI) inference back-end
+- A Project with one service running on the primary OS and another running on a remote processor, with both services co-ordinating over RPMsg
+
+## x-topo Schema
+
+The `x-topo` extension provides metadata for Projects. If included, it must be specified at the root level of a [Compose file](https://compose-spec.io).
+
+### Example
+
+```yaml
+x-topo:
+  name: string # Required
+  description: string # Optional
+  features: [string] # Optional
+  deployment_success_message: string # Optional
+  parameters: # Optional
+    <PARAMETER_NAME>:
+      description: string # Optional
+      required: boolean # Optional
+      default: string # Optional
+      example: string # Optional
+```
+
+### Fields
+
+**`name`** (string, required)
+Unique identifier for the Project.
+
+**`description`** (string, optional)
+Multiline human-readable explanation of what the Project does.
+
+**`features`** (array of strings, optional)
+Target features required or utilised by the Project (e.g., `SVE`, `NEON`, `SME`).
+
+**`deploy_success_message`** (string, optional)
+Message displayed to the user after a successful deployment. If omitted, a default message is shown.
+
+**`parameters`** (object, optional)
+Dictionary of project parameter definitions. Each key is a parameter name (e.g., `GREETING`) with the following properties:
+
+- **`description`** (string, optional) — Context displayed in user prompts
+- **`required`** (boolean, optional) — If `true`, Implementations must enforce input or error
+- **`default`** (string, optional) — Value used if user skips input (only valid when not required)
+- **`example`** (string, optional) — Hint text displayed in help and prompts

--- a/docs/project-specification/01-authoring-projects.md
+++ b/docs/project-specification/01-authoring-projects.md
@@ -1,0 +1,95 @@
+# Topo Project Authoring Guide
+
+This guide details how to create Topo Projects for the Topo ecosystem.
+
+## File Structure
+
+```
+my-project/
+├── compose.yaml   # REQUIRED: The definition file
+├── Dockerfile     # Optional, but typical for Projects defining custom images
+└── ...            # Any other files supporting the service, e.g. source code
+```
+
+## The compose.yaml
+
+You must extend the standard [Compose Spec](https://compose-spec.io) with `x-topo` metadata. In addition, all Project services must explicitly set `platform: linux/arm64` so Implementations target Arm64. The only exception is for services deployed via remoteproc.
+
+```yaml
+services:
+  hello:
+    platform: linux/arm64
+    build:
+      context: .
+      # (Optional) defaults for plain docker compose; Implementations may override these from x-topo parameters
+      args:
+        GREETING: "Hello, World"
+
+x-topo:
+  name: "hello-world"
+  description: |
+    A simple Hello World service with a customizable greeting.
+  # PROJECT PARAMETER DEFINITIONS
+  # These enable interactive prompting behavior.
+  parameters:
+    GREETING:
+      description: "The greeting message to display"
+      required: true
+      example: "Hello from Arm!"
+```
+
+## The Dockerfile
+
+Implementations pass arguments via standard Docker `ARG` directives.
+
+```Dockerfile
+FROM nginx:alpine
+
+# 1. Consume the arg
+ARG GREETING
+
+# 2. Enforce requirement (Best Practice)
+RUN test -n "$GREETING" || (echo "ERROR: GREETING project parameter is required" && exit 1)
+
+# 3. Use the arg to create a simple HTML page
+RUN echo "<h1>$GREETING</h1>" > /usr/share/nginx/html/index.html
+```
+
+---
+
+## 3. The x-topo Schema Reference
+
+The `x-topo` block must be placed at the root of your YAML file.
+
+```yaml
+x-topo:
+  name: string # Required
+  description: string # Optional
+  features: [string] # Optional
+  deployment_success_message: string # Optional
+  parameters: # Optional
+    <PARAMETER_NAME>:
+      description: string # Optional
+      required: boolean # Optional
+      default: string # Optional
+      example: string # Optional
+```
+
+---
+
+## 4. Testing Your Project
+
+Use the Topo CLI to verify your Projects locally.
+
+```sh
+# Create a compose.yaml
+topo init
+
+# Use your Project using the local directory option `dir:`
+topo extend compose.yaml dir:./path/to/my-project
+
+# The CLI will prompt for project parameters specified in your service
+
+# Verify build success
+topo deploy --target root@some-ssh-target
+```

--- a/docs/project-specification/02-project-configuration.md
+++ b/docs/project-specification/02-project-configuration.md
@@ -1,0 +1,221 @@
+# Project Configuration
+
+## Overview
+
+Topo Projects support configuration through project parameters:
+
+- `x-topo.parameters` defines parameter metadata (description, whether required, examples, and advisory hints)
+- When a project parameter is used during an image build, its value is passed through standard Compose `build.args` and consumed by the Dockerfile as an `ARG`
+
+## How Project Parameters Work
+
+Projects extend [compose-spec](https://compose-spec.io/) with `x-topo.parameters` to define and document user-configurable project parameters.
+Unless a service is intended for a remote processor, every service definition in these examples (and in compliant Projects) must include `platform: linux/arm64`. Remote processor services omit `platform` but must set `remoteproc` as their `runtime` so Implementations can recognize the exception.
+
+**compose.yaml**
+
+```yaml
+services:
+  welcome:
+    platform: linux/arm64
+    build:
+      context: .
+      # Optional default: allows running with plain docker compose
+      # Not used by Implementations that read x-topo.parameters
+      args:
+        GREETING: "Hello, World"
+
+x-topo:
+  name: "Topo Welcome"
+
+  # Project parameter metadata for interactive prompting
+  parameters:
+    # Implementations prompt users to provide these values
+    GREETING:
+      description: |
+        The greeting message to display in the container
+      required: true
+      example: "Hello from Arm SME"
+```
+
+These project parameters are then passed to the service's Dockerfile as standard Docker `ARG` values when the service uses Compose `build.args`.
+
+### Example Dockerfile
+
+**Dockerfile**
+
+```Dockerfile
+FROM nginx:alpine
+
+ARG GREETING
+
+# Docker files cannot require an arg - it is necessary to force failure if the value is not specified
+RUN test -n "$GREETING" || (echo "ERROR: GREETING project parameter is required" && exit 1)
+...
+```
+
+## Worked example
+
+### Creating a Project
+
+Users can initialize a new Project, resulting in an empty `compose.yaml` file.
+
+### Extending Projects with Project Services
+
+When users extend a Project with services defined in another Project, Implementations must handle project parameter collection and validation. The examples below illustrate how a CLI interface might handle this:
+
+**Interactive Mode**
+Implementations may choose to prompt users when required parameters are missing:
+
+```
+$ topo extend ...
+
+Missing Project Parameter
+The greeting message to display in the container
+GREETING (required)> Sup
+```
+
+**Direct Parameter Specification**
+Implementations may support providing parameters directly:
+
+```
+$ topo extend ... GREETING=Sup`
+```
+
+**Non-Interactive Mode)**
+Implementations may support a non-interactive mode that errors on missing required parameters:
+
+```
+$ topo extend ... --no-prompt
+
+error: "Missing project parameters"
+missing_parameters:
+    GREETING:
+      description: |
+          The greeting message to display in the container
+      required: true
+      example: "Hello from Arm SME"
+```
+
+## Parameter Hints
+
+Parameter definitions may include `hints`, which Implementations can use to discover, filter, or suggest suitable parameter values. Hints do not define validation constraints, and Implementations may ignore hints they do not understand.
+
+Hint keys must use lowercase dotted namespaces to avoid collisions, such as `huggingface.task` or `file.format`. Hint values may be strings, numbers, booleans, or arrays of those scalar values.
+
+```yaml
+x-topo:
+  parameters:
+    MODEL:
+      description: "Model artifact reference"
+      default: "bartowski/Qwen_Qwen3.5-0.8B-GGUF:SmolLM2-135M-Instruct-Q4_K_M.gguf"
+      hints:
+        huggingface.task: text-generation
+        file.format: gguf
+```
+
+Recommended hint key conventions include:
+
+- `huggingface.task` — suggests a Hugging Face task or pipeline filter, such as `text-generation`
+- `file.format` — suggests a desired artifact or file format, such as `gguf`
+
+### Processing Steps
+
+When users extend a Project with another Project, Implementations should perform the following steps:
+
+1.  Retrieve the Project repository (e.g., clone to a local subdirectory)
+1.  Parse the Project's `compose.yaml` and read parameter metadata from `x-topo.parameters`
+1.  Collect values for any required parameters from `x-topo.parameters` (e.g., by prompting the user)
+1.  Update the Project's `compose.yaml` with a service definition that extends the retrieved Project
+1.  Set the `services.<service-name>.build.args` with the collected values when those parameters are consumed as Docker build arguments
+
+### Resulting Configuration
+
+After adding the service with project parameters, the compose file is updated:
+
+**compose.yaml**
+
+```yaml
+services:
+  cool-service:
+    extends:
+      file: ./cool-service/compose.yaml
+      service: welcome
+    build:
+      args:
+        GREETING: "Sup"
+```
+
+## Project Configuration Layering
+
+### Projects Satisfying Requirements
+
+Projects can provide default `build.args` values that satisfy requirements from Projects they extend. When a Project provides a value for a parameter that another Project marks as `required: true`, that parameter effectively becomes **optional** for end users.
+
+**Extended Project's compose.yaml**
+
+```yaml
+x-topo:
+  parameters:
+    GREETING:
+      description: The greeting message to display
+      required: true
+      example: "Hello, World"
+```
+
+**Parent Project's compose.yaml**
+
+```yaml
+services:
+  welcome-service:
+    extends:
+      file: ./welcome-service/compose.yaml
+      service: welcome
+    build:
+      args:
+        GREETING: "Hello from Arm SME Project" # Satisfies the extended Project's requirement
+```
+
+This layering means:
+
+- The extended Project declares `GREETING` as required
+- The parent Project provides a default value
+- End users can accept the default or override it
+- The Project runs with plain `docker compose up` without prompting
+
+### Projects Adding Configuration
+
+Projects can also define their own `x-topo.parameters` to expose configuration:
+
+```yaml
+services:
+  welcome-service:
+    extends:
+      file: ./welcome-service/compose.yaml
+      service: welcome
+    build:
+      args:
+        GREETING: "Hello, World"
+
+  ollama-service:
+    platform: linux/arm64
+    build:
+      context: .
+      args:
+        MODEL: qwen3:0.6B
+
+x-topo:
+  name: "My Project"
+  parameters:
+    MODEL:
+      description: "hugging face model ID to use"
+      required: true
+      default: qwen3:7B
+```
+
+The effective required parameters for the Project are:
+
+- Project-level parameters marked as `required: true`
+- Extended Project parameters marked as `required: true` that the parent Project hasn't provided defaults for
+
+When users create a new Project from an existing Project, Implementations should collect required parameters in the same manner as when extending an existing Project with another Project.

--- a/docs/project-specification/03-schema.md
+++ b/docs/project-specification/03-schema.md
@@ -1,0 +1,30 @@
+# Schema Compliance
+
+The [machine-readable schema](schema/topo-project-specification.json) to check any project against is provided as a [JSON schema](https://json-schema.org/) and is therefore compatible with any supported tooling.
+
+## Validating Schema Compliance in Your Editor
+
+The schema can be associated with a Project Compose file using a [yaml-language-server](https://github.com/redhat-developer/yaml-language-server) modeline comment. Add the following line to the top of your `compose.yaml`:
+
+```yaml
+# yaml-language-server: $schema=https://raw.githubusercontent.com/arm/topo/refs/heads/main/docs/project-specification/schema/topo-project-specification.json
+services:
+  # ...
+
+x-topo:
+  # ...
+```
+
+This works in any editor that uses yaml-language-server, including:
+
+- **VS Code** — install the [YAML extension](https://github.com/redhat-developer/vscode-yaml) and check the Problems panel for schema errors.
+- **Vim / Neovim** — configure [yaml-language-server](https://github.com/redhat-developer/yaml-language-server) as an LSP source using your preferred LSP client.
+
+## Validating Schema Compliance using CLI
+
+You can validate any Project `compose.yaml` from the command line with `check-jsonschema` in your own virtual environment:
+
+```sh
+pip install check-jsonschema
+check-jsonschema --schemafile schema/topo-project-specification.json path/to/compose.yaml
+```

--- a/docs/project-specification/04-build-optimization.md
+++ b/docs/project-specification/04-build-optimization.md
@@ -1,0 +1,233 @@
+# Speeding up image builds
+
+Any image build with a slow, heavy step such as cloning large repos, installing hundreds of packages, compiling big dependency trees, downloading SDKs, fetching ML models etc., benefits from the same general set of caching strategies.
+
+The goal is simple: avoid re-running expensive work that has not meaningfully changed.
+
+## Layering
+
+Container engines build in layers. Each layer is a diff in the image's filesystem on top of the previous layer.
+
+As a rule of thumb, Dockerfile instructions such as `RUN`, `COPY`, and `ADD` create filesystem layers. Metadata-ish instructions such as `ENV`, `ARG`, `WORKDIR`, `CMD`, and `ENTRYPOINT` affect image config, but do not usually add filesystem contents themselves.
+
+Layers are immutable, so if a layer changes, that layer and all subsequent layers are invalidated and must be rebuilt.
+
+For example:
+
+```text
+layer[0] system packages
+layer[1] dependencies
+layer[2] source code build
+layer[3] final packaging
+```
+
+If the source code changes, the source code build will be rerun, as will `layer[3]`. But `layer[0]` and `layer[1]` can still be reused.
+
+As such, layers should be ordered from least often changed near the top of the file, to most often changed near the bottom:
+
+```text
+base image
+system packages
+SDK/toolchain setup
+dependency manifests
+dependency install
+source code
+build/test/package
+```
+
+System packages at the top, code near the bottom.
+
+```dockerfile
+COPY requirements.txt .
+RUN pip install -r requirements.txt
+
+COPY . .
+RUN python -m build
+```
+
+Now `pip install` only reruns when `requirements.txt` changes, not every time some source file changes.
+
+Avoid putting unrelated work in one layer. For example, a `RUN` layer that installs packages via `apt` and then runs a CMake build will lead to `apt` rerunning every time the source code changes invalidate that layer.
+
+Prefer a small final image, but do not blindly assume the smallest base image gives the fastest build. Alpine base images are usually smaller, but may require more work in the image build stage to prepare the image for use or building.
+
+Reputable sources often distribute performance and space-optimised build base images for different use cases, which are similar in size, or sometimes smaller than a DIY Alpine setup, and save a lot of setup compute.
+
+Or, create and distribute your own base image. This allows CI to do the expensive work once, then lets users quickly use that layer for time-saving.
+
+## Reduce the amount of work
+
+The first thing to check for is expensive steps. Container engines report the time taken for build steps, so find the step eating the time.
+Expensive steps increase build time and often layer size, which then increases time to transfer, pull, push, and start the image.
+
+Aim to make expensive steps do less.
+
+For example:
+
+- Use `--no-install-recommends` with `apt`.
+- Keep minimal pinned dependency lists.
+- Use `--depth=1` for Git fetches.
+- Use `-o=--depth=1` for `west` fetches.
+- Use `--narrow` with `west` to avoid full refs/tags.
+- Skip dependency groups you do not need.
+
+For `apt`:
+
+```dockerfile
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+       build-essential \
+       cmake \
+       ninja-build
+```
+
+For Git:
+
+```sh
+git clone --depth=1 <repo>
+```
+
+For west/Zephyr:
+
+```sh
+west update --narrow -o=--depth=1
+```
+
+For west configs, you can ignore unneeded module groups:
+
+```sh
+west config manifest.group-filter -- "-hal,-Nordic,-ci" # replace with a filter for your use-case.
+```
+
+## BuildKit cache mounts
+
+Builds are isolated from the host filesystem, and environments are temporary. This is generally beneficial for reproducibility; however, by default, it loses the benefits of tool-level caching.
+
+Using `--mount=type=cache` allows the container engine to use a persistent build cache for tools in layers such as `apt`, `pip`, Go, Cargo, or even your build system's cache.
+
+Unlike normal layer caching, this still helps when the `RUN` instruction has to execute again. The layer might be invalidated, but the cache directory is still there, so the tool can reuse previously downloaded or compiled data.
+
+Common examples:
+
+```dockerfile
+# apt
+RUN --mount=type=cache,target=/var/cache/apt \
+    --mount=type=cache,target=/var/lib/apt/lists \
+    apt-get update \
+    && apt-get install -y --no-install-recommends build-essential cmake ninja-build
+
+# pip
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install -r requirements.txt
+
+# Go modules
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
+
+# Go build cache
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    go build ./...
+
+# Cargo
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    cargo build
+```
+
+CMake + Ninja example:
+
+```dockerfile
+RUN --mount=type=cache,target=/src/build \
+    cmake -S . -B /src/build -G Ninja \
+    && cmake --build /src/build
+```
+
+Zephyr example:
+
+```dockerfile
+RUN --mount=type=cache,target=/git-cache \
+    west update --path-cache /git-cache --narrow -o=--depth=1
+```
+
+Even if `west update` reruns, for example because the Zephyr version changed, `west update --path-cache` can reuse cloned repos from the cache mount rather than cloning everything from scratch.
+
+This enables much faster incremental rebuilds, much closer to speed-of-light for local development.
+
+Engine support:
+
+- Docker/nerdctl with BuildKit: supported.
+- Podman/Buildah: supported in some configurations, but behaviour can differ.
+
+## Registry-backed build cache
+
+Build cache metadata and layers can be pushed to a container registry so they can be shared across machines and CI runs.
+
+This is useful for any expensive layer, especially when building a layer takes longer than downloading it.
+
+Docker/nerdctl Compose example:
+
+```yaml
+services:
+  myapp:
+    build:
+      context: .
+      cache_from:
+        - type=registry,ref=registry.example.com/myapp:buildcache
+      cache_to:
+        - type=registry,ref=registry.example.com/myapp:buildcache,mode=max
+```
+
+This usually requires a CI job, or a manual build, to populate the cache when expensive inputs change.
+
+Compared with a pre-baked base image:
+
+- A pre-baked base image is explicit and simple: `FROM registry.example.com/base:v1`.
+- A registry-backed cache is more automatic and can cache intermediate build steps.
+- A base image is easier to reason about.
+- A registry cache can be more flexible for complex builds and branch-based CI.
+
+How Docker/BuildKit and Buildah caching differ:
+
+|                     | Docker/BuildKit                              | Buildah                      |
+| ------------------- | -------------------------------------------- | ---------------------------- |
+| What's cached       | Operation graph + layer blobs                | Full intermediate images     |
+| Cache precision     | Per-operation input checksums                | Per-intermediate-image match |
+| Cache size          | Compact, deduplicated                        | Heavier                      |
+| Cross-build sharing | Better, same operation can share cache       | More limited                 |
+| Format              | BuildKit-specific cache metadata + OCI blobs | Standard OCI images          |
+
+Podman/Buildah caveats:
+
+- Buildah distributed caching uses intermediate images rather than BuildKit's operation graph model.
+- Cache references and tag support have historically differed from Docker/BuildKit.
+- The first build with an empty cache has to rebuild everything to populate the cache.
+- Test this in your actual CI rather than assuming Docker behaviour maps 1:1.
+
+Example Podman command:
+
+```sh
+podman build \
+  --cache-from registry.example.com/myapp/cache \
+  --cache-to registry.example.com/myapp/cache \
+  -t myapp .
+```
+
+Podman Compose can also support `cache_from` and `cache_to` in the build section, depending on version.
+
+## Practical checklist
+
+When a build is slow, ask:
+
+1. Which step is slow?
+2. Can that step do less work?
+3. Is that step before or after frequently changing source code?
+4. Are dependency manifests copied separately from source code?
+5. Is unrelated work accidentally bundled into one layer?
+6. Would a cache mount help the tool reuse downloads or compiled objects?
+7. Is the build running on a persistent machine or ephemeral CI?
+8. Would a pre-baked base image be simpler than relying on cache behaviour?
+9. Would a registry-backed cache help CI reuse expensive layers?
+
+For local development, good layer ordering and cache mounts usually give the best return.
+
+For CI, use good layer ordering first, then consider either a pre-baked base image or a registry-backed build cache.

--- a/docs/project-specification/README.md
+++ b/docs/project-specification/README.md
@@ -51,27 +51,6 @@ A curated project catalog can be found either via:
 
 We welcome any contributors who wish to add their own Project to the project catalog to submit a Pull Request as indicated below.
 
-## Authoring Skills
-
-This repository includes public agent skills that help authors create and validate Topo Projects.
-
-- `topo-project-context`: provides Topo and Topo Project reference context for questions about `x-topo` metadata, schema, docs, and CLI Project behavior.
-- `topo-project-bootstrap`: converts a repository into a Topo Project by adding or improving `compose.yaml` and `x-topo` metadata.
-- `topo-project-lint`: reviews an existing Topo Project for correctness, consistency, and authoring best practices.
-- `topo-project-optimize-deployment`: optimizes `topo deploy` or Docker build performance for initial deployment and iteration workflows.
-
-### Installing Skills
-
-You can install the skills with [`npx skills`](https://github.com/vercel-labs/skills):
-
-```sh
-npx skills add arm/topo
-```
-
-Or install the skills manually by copying or symlinking the directories under `skills/` into your agent's skills directory.
-
-Restart your agent after installing or updating skills.
-
 ## Propose Your Project to Topo
 
 If you want your Project to be added to the project catalog:

--- a/docs/project-specification/README.md
+++ b/docs/project-specification/README.md
@@ -1,0 +1,101 @@
+# Topo Project Specification
+
+A Topo Project is a containerized sample project for Arm-based Linux systems. At minimum, it is a directory containing a `compose.yaml`, Dockerfiles, and source code, with an `x-topo` metadata block that describes what the Project does, what hardware features it requires, and what parameters a user can configure.
+
+This specification defines the `x-topo` extension. It was developed for use with [Topo CLI](https://github.com/arm/topo/), but this is an open spec and any tool can read and act on `x-topo` metadata to discover, validate, and deploy Projects.
+
+Not sure what these terms mean? [Topo's glossary](../glossary.md) defines many of its core concepts.
+
+## How It Works
+
+A Project's `compose.yaml` is a standard [Compose](https://compose-spec.io/) file with an `x-topo` block at the root:
+
+```yaml
+services:
+  app:
+    platform: linux/arm64
+    build:
+      context: .
+      args:
+        GREETING: "Hello, World"
+
+x-topo:
+  name: "hello-world"
+  description: "A simple greeting app for Arm"
+  features: ["NEON"]
+  parameters:
+    GREETING:
+      description: "Message shown by the app"
+      required: true
+      example: "Hello from Arm"
+```
+
+Because this is valid Compose, any Project can be run with plain `docker compose`. The `x-topo` block is what allows tools like Topo to add interactive configuration, parameter validation, and target feature matching on top.
+
+## Specification
+
+- Human-readable spec:
+  - [Overview](docs/00-overview.md)
+  - [Authoring Topo Projects](docs/01-authoring-projects.md)
+  - [Project Configuration](docs/02-project-configuration.md)
+  - [Schema Compliance](docs/03-schema.md)
+- Machine-readable schema:
+  - [`schema/topo-project-specification.json`](schema/topo-project-specification.json)
+
+## Discover Topo Projects
+
+A curated project catalog can be found either via:
+
+- the [topo projects](https://github.com/arm/topo#2-find-a-topo-project) command or
+- the [Topo Project Catalog](https://github.com/arm/topo-project-catalog/blob/main/data/catalog.json).
+
+We welcome any contributors who wish to add their own Project to the project catalog to submit a Pull Request as indicated below.
+
+## Authoring Skills
+
+This repository includes public agent skills that help authors create and validate Topo Projects.
+
+- `topo-project-context`: provides Topo and Topo Project reference context for questions about `x-topo` metadata, schema, docs, and CLI Project behavior.
+- `topo-project-bootstrap`: converts a repository into a Topo Project by adding or improving `compose.yaml` and `x-topo` metadata.
+- `topo-project-lint`: reviews an existing Topo Project for correctness, consistency, and authoring best practices.
+- `topo-project-optimize-deployment`: optimizes `topo deploy` or Docker build performance for initial deployment and iteration workflows.
+
+### Installing Skills
+
+You can install the skills with [`npx skills`](https://github.com/vercel-labs/skills):
+
+```sh
+npx skills add arm/topo
+```
+
+Or install the skills manually by copying or symlinking the directories under `skills/` into your agent's skills directory.
+
+Restart your agent after installing or updating skills.
+
+## Propose Your Project to Topo
+
+If you want your Project to be added to the project catalog:
+
+1. Review the [Authoring Topo Projects section of the Specification](docs/01-authoring-projects.md).
+2. [Validate Schema Compliance](./README.md#validate-schema-compliance) of your proposed Project.
+3. Open a Pull Request in the `Topo Project Catalog` repository to update the [catalog sources](https://github.com/arm/topo-project-catalog/blob/main/data/github_sources.json).
+
+### Validate Schema Compliance
+
+The [machine-readable schema](schema/topo-project-specification.json) to check any Project against is provided as a [JSON schema](https://json-schema.org/) and is therefore compatible with any supported tooling.
+
+For validation workflows, see:
+
+- [Validating Schema Compliance in Your Editor](docs/03-schema.md#validating-schema-compliance-in-your-editor)
+- [Validating Schema Compliance using CLI](docs/03-schema.md#validating-schema-compliance-using-cli)
+
+## Versioning
+
+This format follows Compose-style evolution and does not require strict schema-version pinning by implementations.
+
+Implementations should follow [Compose guidance for optional attributes](https://github.com/compose-spec/compose-spec/blob/main/01-status.md#requirements-and-optional-attributes).
+
+| Metadata |                  |
+| -------- | ---------------: |
+| Status   | Work in progress |
+| Created  |       2025-11-10 |

--- a/docs/project-specification/schema/topo-project-specification.json
+++ b/docs/project-specification/schema/topo-project-specification.json
@@ -1,0 +1,132 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema",
+  "$id": "topo-project-specification",
+  "type": "object",
+  "title": "Topo Project Specification",
+  "description": "Schema for Topo Project files, extending the Compose specification.",
+  "allOf": [
+    {
+      "type": "object",
+      "properties": {
+        "x-topo": {
+          "type": "object",
+          "description": "Topo Project extension properties.",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "Unique identifier for the Project."
+            },
+            "description": {
+              "type": "string",
+              "description": "Multiline human-readable explanation of what the Project does."
+            },
+            "features": {
+              "type": "array",
+              "description": "Target features required or utilised by the Project (e.g., `SVE`, `NEON`, `SME`).",
+              "items": {
+                "type": "string"
+              }
+            },
+            "deployment_success_message": {
+              "type": "string",
+              "description": "Message displayed to the user after a successful deployment. If omitted, a default message is shown."
+            },
+            "parameters": {
+              "type": "object",
+              "description": "Dictionary of project parameter definitions.",
+              "additionalProperties": {
+                "type": "object",
+                "description": "Project parameter definition.",
+                "properties": {
+                  "description": {
+                    "type": "string",
+                    "description": "Context displayed in user prompts."
+                  },
+                  "required": {
+                    "type": "boolean",
+                    "description": "If `true`, Implementations must enforce input or error"
+                  },
+                  "default": {
+                    "type": "string",
+                    "description": "Value used if user skips input (only valid when not required)"
+                  },
+                  "example": {
+                    "type": "string",
+                    "description": "Hint text displayed in help and prompts"
+                  },
+                  "hints": {
+                    "type": "object",
+                    "description": "Advisory metadata that Implementations may use to discover, filter, or suggest suitable parameter values. Unknown hint keys should be ignored.",
+                    "patternProperties": {
+                      "^[a-z][a-z0-9-]*(\\.[a-z][a-z0-9-]*)+$": {
+                        "oneOf": [
+                          {
+                            "type": ["string", "number", "boolean"]
+                          },
+                          {
+                            "type": "array",
+                            "items": {
+                              "type": ["string", "number", "boolean"]
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          },
+          "required": ["name"]
+        }
+      }
+    },
+    {
+      "type": "object",
+      "properties": {
+        "services": {
+          "type": "object",
+          "description": "The services that will be used by your application.\nEach one must specify `platform: linux/arm64` unless using `runtime: *remoteproc*` or `extends`.",
+          "additionalProperties": {
+            "allOf": [
+              {
+                "if": {
+                  "not": {
+                    "anyOf": [
+                      {
+                        "required": ["runtime"],
+                        "properties": {
+                          "runtime": {
+                            "type": "string",
+                            "pattern": "remoteproc"
+                          }
+                        }
+                      },
+                      {
+                        "required": ["extends"]
+                      }
+                    ]
+                  }
+                },
+                "then": {
+                  "required": ["platform"],
+                  "properties": {
+                    "platform": {
+                      "const": "linux/arm64",
+                      "description": "Project services must default to linux/arm64 to ensure compatibility with the target."
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "$ref": "https://raw.githubusercontent.com/compose-spec/compose-spec/refs/heads/main/schema/compose-spec.json"
+    }
+  ]
+}

--- a/scripts/sync-skill-context.js
+++ b/scripts/sync-skill-context.js
@@ -1,0 +1,69 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const root = path.resolve(__dirname, "..");
+const skills_dir = path.join(root, "skills");
+
+const check = process.argv.includes("--check");
+
+const shared_context_syncs = {
+  source: path.join(skills_dir, "_shared", "topo-project-context.md"),
+  destinations: fs
+    .readdirSync(skills_dir, { withFileTypes: true })
+    .filter(
+      (entry) => entry.isDirectory() && entry.name.startsWith("topo-project-"),
+    )
+    .map((entry) => path.join(skills_dir, entry.name))
+    .filter((skill_dir) => fs.existsSync(path.join(skill_dir, "SKILL.md")))
+    .map((skill_dir) =>
+      path.join(skill_dir, "references", "topo-project-context.md"),
+    ),
+};
+
+const specific_syncs = [
+  {
+    source: path.join(root, "docs", "04-build-optimization.md"),
+    destinations: [
+      path.join(
+        skills_dir,
+        "topo-project-optimize-deployment",
+        "references",
+        "docker-build-performance.md",
+      ),
+    ],
+  },
+];
+
+const all_syncs = [shared_context_syncs, ...specific_syncs];
+
+let stale = false;
+
+for (const { source, destinations } of all_syncs) {
+  const canonical = fs.readFileSync(source, "utf8");
+
+  for (const dest of destinations) {
+    const relative_path = path.relative(root, dest);
+    const current = fs.existsSync(dest) ? fs.readFileSync(dest, "utf8") : null;
+
+    if (current !== canonical) {
+      stale = true;
+
+      if (check) {
+        const state = current === null ? "missing" : "stale";
+        console.error(`${relative_path} is ${state}`);
+        continue;
+      }
+
+      fs.mkdirSync(path.dirname(dest), { recursive: true });
+      fs.writeFileSync(dest, canonical);
+      console.log(`Updated ${relative_path}`);
+    }
+  }
+}
+
+if (check && stale) {
+  console.error(
+    "Run `npm run sync:skills` to update skill context references.",
+  );
+  process.exit(1);
+}

--- a/skills/_shared/topo-project-context.md
+++ b/skills/_shared/topo-project-context.md
@@ -1,0 +1,24 @@
+# Shared Topo Project Context
+
+Topo (https://github.com/arm/topo) is a CLI app which discovers, configures, builds, and deploys containerized examples to Arm-based Linux targets over SSH. A Topo Project (https://github.com/arm/topo/docs/project-specification) is a Compose project that remains runnable with plain `docker compose`, plus root-level `x-topo` metadata that lets Topo validate the Project, match it to target hardware features, and prompt for build-time configuration.
+
+Use Topo vocabulary precisely:
+
+- Host: the machine running Topo and building images.
+- Target: the Arm64 Linux system where the deployment runs.
+- Project: a containerized sample project containing `compose.yaml`, supporting files such as Dockerfiles and source, and `x-topo` metadata.
+- X-Topo: the Compose extension key, written `x-topo`, that describes Project identity, type, hardware features, deploy message, and configurable project parameters.
+- Feature: a Target hardware capability required or used by the Project, such as `NEON`, `SVE`, `SME`, a GPU, or an NPU.
+- Remote processor: a peer execution environment managed from Linux, usually through Remoteproc Runtime and `runtime: remoteproc` services.
+- Project parameters: Project configuration values, with prompts and validation described in `x-topo.parameters` and actual Docker build values carried through Compose `build.args` when needed.
+
+Refresh spec-sensitive context at runtime before making or validating Project changes. Authoritative references, in order:
+
+- Published Topo Project Specification schema: `https://raw.githubusercontent.com/arm/topo/refs/heads/main/docs/project-specification/schema/topo-project-specification.json`.
+- Published Topo Project Specification docs: `https://github.com/arm/topo/docs/project-specification`, especially `README.md`, `00-overview.md`, `01-authoring-projects.md`, `02-project-configuration.md`, and `03-schema.md`.
+- Published Topo glossary for domain terms: `https://github.com/arm/topo/blob/main/docs/glossary.md`.
+- Compose Spec for standard Compose semantics. Do not invent non-standard Compose keys except the root-level `x-topo` extension.
+
+When references conflict, prefer the schema for validation behavior, then the specification docs for authoring intent, then the target repository's actual Compose behavior for the smallest safe change.
+
+When validating changes, check if `topo` is installed, and prompt the user for an SSH target to test against. `topo clone dir:./path/to/project` can be used to test project parameters, `topo deploy` can be used to test build and deploy.

--- a/skills/topo-project-bootstrap/SKILL.md
+++ b/skills/topo-project-bootstrap/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: topo-project-bootstrap
+description: Convert a repository into a Topo Project by adding or improving compose.yaml and x-topo metadata.
+---
+
+# Topo Project Bootstrap
+
+Use this skill when the user asks to create, convert, initialize, or bootstrap a repository as a Topo Project.
+
+Before acting, read `references/topo-project-context.md` for shared Topo Project vocabulary, authoritative references, and validation expectations.
+
+## Workflow
+
+1. Identify the Project root. Prefer the repository directory that contains or should contain the root-level `compose.yaml`.
+2. Inspect the existing repository before editing. Read `compose.yaml`, Dockerfiles, README files, and source files needed to understand service purpose and build arguments.
+3. Refresh the current schema and authoring docs when the requested change depends on field names, allowed values, service platform rules, or project parameter behavior.
+4. Make the smallest safe change that turns the repository into a valid, useful Project while preserving plain `docker compose` behavior.
+5. Validate the result with the topo-project-lint workflow or equivalent schema validation.
+
+## Bootstrap Guidance
+
+- Add a root-level `compose.yaml` only when one is missing. If one exists, preserve existing services, build contexts, images, volumes, networks, and runtime settings unless they conflict with the Project requirements.
+- Add or improve a root-level `x-topo` block. Do not place `x-topo` under `services`.
+- Choose `x-topo.name` from the repository or application purpose. Prefer short, stable, lowercase, hyphenated names.
+- Set `x-topo.description` from the actual application behavior, not generic marketing language.
+- Set `x-topo.type` only when useful. Use `application` for runnable examples that compose services and `library` for reusable Projects intended to be extended by other projects.
+- Add `x-topo.features` only when the repository clearly requires or showcases target capabilities. Do not guess hardware requirements from weak evidence.
+- Set `platform: linux/arm64` on services unless the service uses Remoteproc Runtime.
+- Expose configuration through `x-topo.parameters` only for project parameters that users should set. When parameters are passed as Docker build arguments, ensure parameter names match the keys used in `services.<service>.build.args` and Dockerfile `ARG` instructions.
+- Keep default `build.args` values when they help the project run with plain `docker compose`. Use `x-topo.parameters` for prompt metadata and validation intent.
+
+## Reporting
+
+Report what changed and why. Include the Project root, files edited, validation command used, validation result, and any spec-sensitive assumptions that came from current docs or schema.

--- a/skills/topo-project-bootstrap/references/topo-project-context.md
+++ b/skills/topo-project-bootstrap/references/topo-project-context.md
@@ -1,0 +1,24 @@
+# Shared Topo Project Context
+
+Topo (https://github.com/arm/topo) is a CLI app which discovers, configures, builds, and deploys containerized examples to Arm-based Linux targets over SSH. A Topo Project (https://github.com/arm/topo/docs/project-specification) is a Compose project that remains runnable with plain `docker compose`, plus root-level `x-topo` metadata that lets Topo validate the Project, match it to target hardware features, and prompt for build-time configuration.
+
+Use Topo vocabulary precisely:
+
+- Host: the machine running Topo and building images.
+- Target: the Arm64 Linux system where the deployment runs.
+- Project: a containerized sample project containing `compose.yaml`, supporting files such as Dockerfiles and source, and `x-topo` metadata.
+- X-Topo: the Compose extension key, written `x-topo`, that describes Project identity, type, hardware features, deploy message, and configurable project parameters.
+- Feature: a Target hardware capability required or used by the Project, such as `NEON`, `SVE`, `SME`, a GPU, or an NPU.
+- Remote processor: a peer execution environment managed from Linux, usually through Remoteproc Runtime and `runtime: remoteproc` services.
+- Project parameters: Project configuration values, with prompts and validation described in `x-topo.parameters` and actual Docker build values carried through Compose `build.args` when needed.
+
+Refresh spec-sensitive context at runtime before making or validating Project changes. Authoritative references, in order:
+
+- Published Topo Project Specification schema: `https://raw.githubusercontent.com/arm/topo/refs/heads/main/docs/project-specification/schema/topo-project-specification.json`.
+- Published Topo Project Specification docs: `https://github.com/arm/topo/docs/project-specification`, especially `README.md`, `00-overview.md`, `01-authoring-projects.md`, `02-project-configuration.md`, and `03-schema.md`.
+- Published Topo glossary for domain terms: `https://github.com/arm/topo/blob/main/docs/glossary.md`.
+- Compose Spec for standard Compose semantics. Do not invent non-standard Compose keys except the root-level `x-topo` extension.
+
+When references conflict, prefer the schema for validation behavior, then the specification docs for authoring intent, then the target repository's actual Compose behavior for the smallest safe change.
+
+When validating changes, check if `topo` is installed, and prompt the user for an SSH target to test against. `topo clone dir:./path/to/project` can be used to test project parameters, `topo deploy` can be used to test build and deploy.

--- a/skills/topo-project-context/SKILL.md
+++ b/skills/topo-project-context/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: topo-project-context
+description: Topo and Topo Project reference context. Use when answering general Topo Project questions, reviewing or editing x-topo metadata, or when another Topo Project skill needs shared domain context.
+---
+
+# Topo Project Context
+
+Use this skill when the user asks about Topo, Topo Projects, `compose.yaml` files with `x-topo` metadata, Topo Project schema/docs, or Topo CLI project behavior.
+
+Read `references/topo-project-context.md` before answering.

--- a/skills/topo-project-context/references/topo-project-context.md
+++ b/skills/topo-project-context/references/topo-project-context.md
@@ -1,0 +1,24 @@
+# Shared Topo Project Context
+
+Topo (https://github.com/arm/topo) is a CLI app which discovers, configures, builds, and deploys containerized examples to Arm-based Linux targets over SSH. A Topo Project (https://github.com/arm/topo/docs/project-specification) is a Compose project that remains runnable with plain `docker compose`, plus root-level `x-topo` metadata that lets Topo validate the Project, match it to target hardware features, and prompt for build-time configuration.
+
+Use Topo vocabulary precisely:
+
+- Host: the machine running Topo and building images.
+- Target: the Arm64 Linux system where the deployment runs.
+- Project: a containerized sample project containing `compose.yaml`, supporting files such as Dockerfiles and source, and `x-topo` metadata.
+- X-Topo: the Compose extension key, written `x-topo`, that describes Project identity, type, hardware features, deploy message, and configurable project parameters.
+- Feature: a Target hardware capability required or used by the Project, such as `NEON`, `SVE`, `SME`, a GPU, or an NPU.
+- Remote processor: a peer execution environment managed from Linux, usually through Remoteproc Runtime and `runtime: remoteproc` services.
+- Project parameters: Project configuration values, with prompts and validation described in `x-topo.parameters` and actual Docker build values carried through Compose `build.args` when needed.
+
+Refresh spec-sensitive context at runtime before making or validating Project changes. Authoritative references, in order:
+
+- Published Topo Project Specification schema: `https://raw.githubusercontent.com/arm/topo/refs/heads/main/docs/project-specification/schema/topo-project-specification.json`.
+- Published Topo Project Specification docs: `https://github.com/arm/topo/docs/project-specification`, especially `README.md`, `00-overview.md`, `01-authoring-projects.md`, `02-project-configuration.md`, and `03-schema.md`.
+- Published Topo glossary for domain terms: `https://github.com/arm/topo/blob/main/docs/glossary.md`.
+- Compose Spec for standard Compose semantics. Do not invent non-standard Compose keys except the root-level `x-topo` extension.
+
+When references conflict, prefer the schema for validation behavior, then the specification docs for authoring intent, then the target repository's actual Compose behavior for the smallest safe change.
+
+When validating changes, check if `topo` is installed, and prompt the user for an SSH target to test against. `topo clone dir:./path/to/project` can be used to test project parameters, `topo deploy` can be used to test build and deploy.

--- a/skills/topo-project-lint/SKILL.md
+++ b/skills/topo-project-lint/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: topo-project-lint
+description: Check Topo Project metadata correctness. Use when validating compose.yaml x-topo metadata, README alignment, deployment success messages, or project parameter wiring.
+---
+
+# Topo Project Lint
+
+Use this skill when the user asks to lint, validate, check, review, or fix Topo Project metadata correctness.
+
+Before acting, read `references/topo-project-context.md` for shared Topo Project vocabulary, authoritative references, and validation expectations.
+
+## Workflow
+
+Run these checks in order. If the user asked you to fix issues, make the smallest safe changes and re-run the relevant checks after editing.
+
+1. Confirm the current directory is a Project root.
+2. Validate `compose.yaml` against the Topo Project Specification schema.
+3. Check that `x-topo.name` and `x-topo.description` match `README.md`.
+4. Check that `x-topo.deployment_success_message` exists and is useful.
+5. Check that every `x-topo.parameters` entry is consumed by the corresponding Docker build.
+
+## Checks
+
+### 1. Project Root
+
+- Require a root-level `compose.yaml`.
+- Require a root-level `x-topo` block in `compose.yaml`.
+- Require `x-topo.name` to be present. This is the schema-minimum signal that the directory is a Topo Project.
+- If the check fails, report that the current directory is not a Project and stop before schema validation unless the user asked you to repair it.
+
+### 2. Schema
+
+- Fetch the current published schema before validating.
+- Check whether a supported validator is already installed, in this order: `check-jsonschema`, `ajv`, `jsonschema`.
+- Prefer `check-jsonschema` because it validates YAML directly and is available from Homebrew as `brew install check-jsonschema`; on supported Ubuntu releases it may be available as `apt install python3-check-jsonschema`.
+- Do not install validators on the user's behalf. If no supported validator is installed, stop and tell the user to install one before continuing.
+- Treat schema errors as blocking issues. Fix schema errors before judging higher-level metadata intent.
+- `check-jsonschema` caches schemas by default. If fetching a schema with a floating tag (e.g. `main`), ensure you specify `--no-cache` to get the current version.
+
+### 3. README Alignment
+
+- Read `README.md` from the Project root.
+- Compare `x-topo.name` with the README title or clearly named project heading. The values do not need to be byte-identical, but they must identify the same Project without ambiguity.
+- Compare `x-topo.description` with the README's first useful project summary. The metadata should accurately describe the same behavior, hardware focus, and user-facing purpose as the README.
+- Flag generic, stale, marketing-only, or contradictory metadata.
+- Prefer updating `x-topo` from the README when the README is specific and current. Prefer updating the README only when the Compose services show the README is stale.
+
+### 4. Deployment Success Message
+
+- Require `x-topo.deployment_success_message` to be present.
+- The message should tell the user what succeeded and how to observe or use the deployed Project next.
+- Flag placeholder messages, empty strings, and messages that mention URLs, ports, commands, or files not supported by the Compose services or README.
+
+### 5. Project Parameter Consumption
+
+- For every key in `x-topo.parameters`, find the service or services whose `build.args` provide that parameter as a Docker build argument.
+- For each matching service, resolve its Docker build context and Dockerfile path. Use `Dockerfile` in the build context when `build.dockerfile` is omitted.
+- Require the Dockerfile to declare the argument with `ARG <NAME>` or `ARG <NAME>=<default>` in a stage where it is needed.
+- Check that the parameter is actually used after declaration, for example in `RUN`, `ENV`, `LABEL`, `COPY --from`, or another instruction. A declared but unused `ARG` does not count as consumed.
+- Flag `x-topo.parameters` keys that are not present in any `services.<service>.build.args` unless the service extends another Project where the parameter is intentionally supplied by the parent Project.
+- Flag `services.<service>.build.args` entries that look user-configurable but are missing from `x-topo.parameters` when the user asked for a comprehensive lint.
+- Do not require runtime-only environment variables to appear in `x-topo.parameters`; this check is only for Docker build arguments.
+
+## Reporting
+
+Report findings in the same order as the checks. Include file paths, line numbers when available, the validation command used, and whether each check passed or failed. If changes were made, summarize the files edited and the re-validation result.

--- a/skills/topo-project-lint/references/topo-project-context.md
+++ b/skills/topo-project-lint/references/topo-project-context.md
@@ -1,0 +1,24 @@
+# Shared Topo Project Context
+
+Topo (https://github.com/arm/topo) is a CLI app which discovers, configures, builds, and deploys containerized examples to Arm-based Linux targets over SSH. A Topo Project (https://github.com/arm/topo/docs/project-specification) is a Compose project that remains runnable with plain `docker compose`, plus root-level `x-topo` metadata that lets Topo validate the Project, match it to target hardware features, and prompt for build-time configuration.
+
+Use Topo vocabulary precisely:
+
+- Host: the machine running Topo and building images.
+- Target: the Arm64 Linux system where the deployment runs.
+- Project: a containerized sample project containing `compose.yaml`, supporting files such as Dockerfiles and source, and `x-topo` metadata.
+- X-Topo: the Compose extension key, written `x-topo`, that describes Project identity, type, hardware features, deploy message, and configurable project parameters.
+- Feature: a Target hardware capability required or used by the Project, such as `NEON`, `SVE`, `SME`, a GPU, or an NPU.
+- Remote processor: a peer execution environment managed from Linux, usually through Remoteproc Runtime and `runtime: remoteproc` services.
+- Project parameters: Project configuration values, with prompts and validation described in `x-topo.parameters` and actual Docker build values carried through Compose `build.args` when needed.
+
+Refresh spec-sensitive context at runtime before making or validating Project changes. Authoritative references, in order:
+
+- Published Topo Project Specification schema: `https://raw.githubusercontent.com/arm/topo/refs/heads/main/docs/project-specification/schema/topo-project-specification.json`.
+- Published Topo Project Specification docs: `https://github.com/arm/topo/docs/project-specification`, especially `README.md`, `00-overview.md`, `01-authoring-projects.md`, `02-project-configuration.md`, and `03-schema.md`.
+- Published Topo glossary for domain terms: `https://github.com/arm/topo/blob/main/docs/glossary.md`.
+- Compose Spec for standard Compose semantics. Do not invent non-standard Compose keys except the root-level `x-topo` extension.
+
+When references conflict, prefer the schema for validation behavior, then the specification docs for authoring intent, then the target repository's actual Compose behavior for the smallest safe change.
+
+When validating changes, check if `topo` is installed, and prompt the user for an SSH target to test against. `topo clone dir:./path/to/project` can be used to test project parameters, `topo deploy` can be used to test build and deploy.

--- a/skills/topo-project-optimize-deployment/SKILL.md
+++ b/skills/topo-project-optimize-deployment/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: topo-project-optimize-deployment
+description: Optimize Topo Project deployment or development iteration performance by measuring the current bottleneck and applying the highest-leverage Docker build improvement.
+---
+
+# Topo Project - Optimize Deployment
+
+Use this skill when the user asks to make `topo deploy`, Docker builds, initial deployment, or development iteration faster for a Topo Project.
+
+Before acting, read `references/topo-project-context.md` for shared Topo Project vocabulary and validation expectations. Read `references/docker-build-performance.md` before proposing or editing Dockerfile or Compose build changes.
+
+## Workflow
+
+1. Identify the Project root. Prefer the repository directory containing the root-level `compose.yaml`.
+1. Read `./project-benchmarking.md` in the Project root if it exists. Create it when recording the first benchmark entry.
+1. Ask whether the user wants to prioritize initial deployment time or iteration time.
+1. If the user prioritizes iteration time, inspect the project and identify the most likely frequent edit path, such as Python source, C/C++ source, model files, dependency manifests, or configuration. Ask the user to confirm the change type to optimize for before editing.
+1. Check whether `topo` is installed. If it is, ask the user for an SSH Target and benchmark with `topo deploy --target <ssh-target>`. If `topo` is unavailable or the user cannot provide a Target, benchmark with `docker compose build`.
+1. Inspect `compose.yaml`, Dockerfiles, `.dockerignore`, dependency manifests, and source layout to find cache invalidation boundaries and expensive build steps.
+1. Before editing, identify and write down the current bottleneck hypothesis from benchmark output. If using `topo deploy`, treat it as the authoritative end-to-end benchmark. If the build phase is suspected but the Topo output does not clearly show the cause, run `docker compose build --progress=plain` as a diagnostic and extract three facts: the slowest non-cached build step, the first unexpected cache miss, and the build context transfer size. Choose the optimization that directly addresses one of those facts. Do not make generic Dockerfile cleanup changes unless they are tied to the recorded bottleneck.
+1. Treat `x-topo.parameters` defaults and Compose `build.args` defaults as product behavior, not ordinary benchmark tuning knobs. Do not change a default value, such as a model, dataset, precision mode, feature flag, or runtime option, as the first optimization attempt just because it makes the benchmark faster.
+1. Choose one high-leverage optimization. Prefer the smallest change likely to improve the selected scenario.
+1. Take a baseline. To do this, ensure the docker build cache for the build images is clear first. Record the baseline in `./project-benchmarking.md`.
+1. Apply the change, then re-run the same benchmark path used for the baseline. Update the same `./project-benchmarking.md` entry with the after-change result.
+1. Report the baseline, change, result, and remaining likely bottlenecks. Encourage the user to start a new chat session for the next incremental optimization.
+
+## Benchmarking
+
+- Use the same command, Project root, build arguments, and Target for baseline and after-change measurements.
+- Prefer `topo deploy --target <ssh-target>` because it includes Project build, transfer through the peer-to-peer registry, and deployment to the Target.
+- Use `docker compose build` as the fallback when there is no Topo Target or `topo` is unavailable.
+- Capture enough output to identify slow steps and cache misses, not just total wall-clock time.
+- If optimizing iteration time, run or request a representative edit before the after-change benchmark when practical.
+- Clear Docker caches as necessary to establish representative timings. Ask for user permission to do this _once_, remembering their decision if they consent.
+
+## Benchmark Log
+
+Record benchmark results in `./project-benchmarking.md` in the Project root so future runs can compare against prior work. Append a new entry for each optimization attempt and use this format:
+
+```markdown
+## YYYY-MM-DD - <initial deployment|iteration> - <short optimization name>
+
+- Benchmark command: `<exact command>`
+- Project root: `<path>`
+- Target: `<ssh-target or none>`
+- Representative edit: `<change type or n/a>`
+- Bottleneck hypothesis: <one sentence>
+- Diagnostic facts: <slowest non-cached step, first unexpected cache miss, context transfer size, or other relevant facts>
+- Optimization: <exact change made>
+- Baseline: <duration and key output facts>
+- After change: <duration and key output facts>
+- Result: <delta or inconclusive>
+- Caveats: <missing Target testing, unsupported build engine behavior, noisy timing, or none>
+```
+
+If an attempt stops before an after-change benchmark, still record the baseline, hypothesis, and blocker so the next run has context.
+
+## Optimization Guidance
+
+- For initial deployment time, prioritize reducing the amount of work, using smaller dependency sets, avoiding unnecessary downloads, and pre-baking stable expensive setup into base images when appropriate.
+- For iteration time, prioritize isolating expensive layers from frequently edited files, copying dependency manifests before source, and moving app code late in the Dockerfile.
+- Use BuildKit cache mounts for package managers, compiler caches, model downloads, Git object stores, or similar local rebuild accelerators when the build engine supports them.
+- Use registry-backed build cache only when a shared registry and cache population workflow exist or the user explicitly wants CI or multi-host cache reuse.
+- Avoid adding non-standard Compose keys. Build settings must remain valid Compose build configuration.
+- Avoid changing user-facing Project defaults to improve benchmark results. A default argument change is acceptable only when the user explicitly asks for a product trade-off, or when the current default is demonstrably wrong and the replacement preserves intended behavior. If proposing such a change, call it out as a behavior/product change rather than a Docker build optimization.
+- Do not introduce a large pre-baked base image without explaining the registry storage, rebuild, and publishing trade-offs.
+
+## Reporting
+
+Report the priority selected, benchmark command, bottleneck hypothesis, diagnostic fact that supported it, edited files, exact optimization made, measured before and after results, and why the chosen change was the smallest change likely to improve the selected benchmark. Include any caveats such as missing Target testing or unsupported build engine behavior.

--- a/skills/topo-project-optimize-deployment/references/docker-build-performance.md
+++ b/skills/topo-project-optimize-deployment/references/docker-build-performance.md
@@ -1,0 +1,233 @@
+# Speeding up image builds
+
+Any image build with a slow, heavy step such as cloning large repos, installing hundreds of packages, compiling big dependency trees, downloading SDKs, fetching ML models etc., benefits from the same general set of caching strategies.
+
+The goal is simple: avoid re-running expensive work that has not meaningfully changed.
+
+## Layering
+
+Container engines build in layers. Each layer is a diff in the image's filesystem on top of the previous layer.
+
+As a rule of thumb, Dockerfile instructions such as `RUN`, `COPY`, and `ADD` create filesystem layers. Metadata-ish instructions such as `ENV`, `ARG`, `WORKDIR`, `CMD`, and `ENTRYPOINT` affect image config, but do not usually add filesystem contents themselves.
+
+Layers are immutable, so if a layer changes, that layer and all subsequent layers are invalidated and must be rebuilt.
+
+For example:
+
+```text
+layer[0] system packages
+layer[1] dependencies
+layer[2] source code build
+layer[3] final packaging
+```
+
+If the source code changes, the source code build will be rerun, as will `layer[3]`. But `layer[0]` and `layer[1]` can still be reused.
+
+As such, layers should be ordered from least often changed near the top of the file, to most often changed near the bottom:
+
+```text
+base image
+system packages
+SDK/toolchain setup
+dependency manifests
+dependency install
+source code
+build/test/package
+```
+
+System packages at the top, code near the bottom.
+
+```dockerfile
+COPY requirements.txt .
+RUN pip install -r requirements.txt
+
+COPY . .
+RUN python -m build
+```
+
+Now `pip install` only reruns when `requirements.txt` changes, not every time some source file changes.
+
+Avoid putting unrelated work in one layer. For example, a `RUN` layer that installs packages via `apt` and then runs a CMake build will lead to `apt` rerunning every time the source code changes invalidate that layer.
+
+Prefer a small final image, but do not blindly assume the smallest base image gives the fastest build. Alpine base images are usually smaller, but may require more work in the image build stage to prepare the image for use or building.
+
+Reputable sources often distribute performance and space-optimised build base images for different use cases, which are similar in size, or sometimes smaller than a DIY Alpine setup, and save a lot of setup compute.
+
+Or, create and distribute your own base image. This allows CI to do the expensive work once, then lets users quickly use that layer for time-saving.
+
+## Reduce the amount of work
+
+The first thing to check for is expensive steps. Container engines report the time taken for build steps, so find the step eating the time.
+Expensive steps increase build time and often layer size, which then increases time to transfer, pull, push, and start the image.
+
+Aim to make expensive steps do less.
+
+For example:
+
+- Use `--no-install-recommends` with `apt`.
+- Keep minimal pinned dependency lists.
+- Use `--depth=1` for Git fetches.
+- Use `-o=--depth=1` for `west` fetches.
+- Use `--narrow` with `west` to avoid full refs/tags.
+- Skip dependency groups you do not need.
+
+For `apt`:
+
+```dockerfile
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+       build-essential \
+       cmake \
+       ninja-build
+```
+
+For Git:
+
+```sh
+git clone --depth=1 <repo>
+```
+
+For west/Zephyr:
+
+```sh
+west update --narrow -o=--depth=1
+```
+
+For west configs, you can ignore unneeded module groups:
+
+```sh
+west config manifest.group-filter -- "-hal,-Nordic,-ci" # replace with a filter for your use-case.
+```
+
+## BuildKit cache mounts
+
+Builds are isolated from the host filesystem, and environments are temporary. This is generally beneficial for reproducibility; however, by default, it loses the benefits of tool-level caching.
+
+Using `--mount=type=cache` allows the container engine to use a persistent build cache for tools in layers such as `apt`, `pip`, Go, Cargo, or even your build system's cache.
+
+Unlike normal layer caching, this still helps when the `RUN` instruction has to execute again. The layer might be invalidated, but the cache directory is still there, so the tool can reuse previously downloaded or compiled data.
+
+Common examples:
+
+```dockerfile
+# apt
+RUN --mount=type=cache,target=/var/cache/apt \
+    --mount=type=cache,target=/var/lib/apt/lists \
+    apt-get update \
+    && apt-get install -y --no-install-recommends build-essential cmake ninja-build
+
+# pip
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install -r requirements.txt
+
+# Go modules
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
+
+# Go build cache
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    go build ./...
+
+# Cargo
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    cargo build
+```
+
+CMake + Ninja example:
+
+```dockerfile
+RUN --mount=type=cache,target=/src/build \
+    cmake -S . -B /src/build -G Ninja \
+    && cmake --build /src/build
+```
+
+Zephyr example:
+
+```dockerfile
+RUN --mount=type=cache,target=/git-cache \
+    west update --path-cache /git-cache --narrow -o=--depth=1
+```
+
+Even if `west update` reruns, for example because the Zephyr version changed, `west update --path-cache` can reuse cloned repos from the cache mount rather than cloning everything from scratch.
+
+This enables much faster incremental rebuilds, much closer to speed-of-light for local development.
+
+Engine support:
+
+- Docker/nerdctl with BuildKit: supported.
+- Podman/Buildah: supported in some configurations, but behaviour can differ.
+
+## Registry-backed build cache
+
+Build cache metadata and layers can be pushed to a container registry so they can be shared across machines and CI runs.
+
+This is useful for any expensive layer, especially when building a layer takes longer than downloading it.
+
+Docker/nerdctl Compose example:
+
+```yaml
+services:
+  myapp:
+    build:
+      context: .
+      cache_from:
+        - type=registry,ref=registry.example.com/myapp:buildcache
+      cache_to:
+        - type=registry,ref=registry.example.com/myapp:buildcache,mode=max
+```
+
+This usually requires a CI job, or a manual build, to populate the cache when expensive inputs change.
+
+Compared with a pre-baked base image:
+
+- A pre-baked base image is explicit and simple: `FROM registry.example.com/base:v1`.
+- A registry-backed cache is more automatic and can cache intermediate build steps.
+- A base image is easier to reason about.
+- A registry cache can be more flexible for complex builds and branch-based CI.
+
+How Docker/BuildKit and Buildah caching differ:
+
+|                     | Docker/BuildKit                              | Buildah                      |
+| ------------------- | -------------------------------------------- | ---------------------------- |
+| What's cached       | Operation graph + layer blobs                | Full intermediate images     |
+| Cache precision     | Per-operation input checksums                | Per-intermediate-image match |
+| Cache size          | Compact, deduplicated                        | Heavier                      |
+| Cross-build sharing | Better, same operation can share cache       | More limited                 |
+| Format              | BuildKit-specific cache metadata + OCI blobs | Standard OCI images          |
+
+Podman/Buildah caveats:
+
+- Buildah distributed caching uses intermediate images rather than BuildKit's operation graph model.
+- Cache references and tag support have historically differed from Docker/BuildKit.
+- The first build with an empty cache has to rebuild everything to populate the cache.
+- Test this in your actual CI rather than assuming Docker behaviour maps 1:1.
+
+Example Podman command:
+
+```sh
+podman build \
+  --cache-from registry.example.com/myapp/cache \
+  --cache-to registry.example.com/myapp/cache \
+  -t myapp .
+```
+
+Podman Compose can also support `cache_from` and `cache_to` in the build section, depending on version.
+
+## Practical checklist
+
+When a build is slow, ask:
+
+1. Which step is slow?
+2. Can that step do less work?
+3. Is that step before or after frequently changing source code?
+4. Are dependency manifests copied separately from source code?
+5. Is unrelated work accidentally bundled into one layer?
+6. Would a cache mount help the tool reuse downloads or compiled objects?
+7. Is the build running on a persistent machine or ephemeral CI?
+8. Would a pre-baked base image be simpler than relying on cache behaviour?
+9. Would a registry-backed cache help CI reuse expensive layers?
+
+For local development, good layer ordering and cache mounts usually give the best return.
+
+For CI, use good layer ordering first, then consider either a pre-baked base image or a registry-backed build cache.

--- a/skills/topo-project-optimize-deployment/references/topo-project-context.md
+++ b/skills/topo-project-optimize-deployment/references/topo-project-context.md
@@ -1,0 +1,24 @@
+# Shared Topo Project Context
+
+Topo (https://github.com/arm/topo) is a CLI app which discovers, configures, builds, and deploys containerized examples to Arm-based Linux targets over SSH. A Topo Project (https://github.com/arm/topo/docs/project-specification) is a Compose project that remains runnable with plain `docker compose`, plus root-level `x-topo` metadata that lets Topo validate the Project, match it to target hardware features, and prompt for build-time configuration.
+
+Use Topo vocabulary precisely:
+
+- Host: the machine running Topo and building images.
+- Target: the Arm64 Linux system where the deployment runs.
+- Project: a containerized sample project containing `compose.yaml`, supporting files such as Dockerfiles and source, and `x-topo` metadata.
+- X-Topo: the Compose extension key, written `x-topo`, that describes Project identity, type, hardware features, deploy message, and configurable project parameters.
+- Feature: a Target hardware capability required or used by the Project, such as `NEON`, `SVE`, `SME`, a GPU, or an NPU.
+- Remote processor: a peer execution environment managed from Linux, usually through Remoteproc Runtime and `runtime: remoteproc` services.
+- Project parameters: Project configuration values, with prompts and validation described in `x-topo.parameters` and actual Docker build values carried through Compose `build.args` when needed.
+
+Refresh spec-sensitive context at runtime before making or validating Project changes. Authoritative references, in order:
+
+- Published Topo Project Specification schema: `https://raw.githubusercontent.com/arm/topo/refs/heads/main/docs/project-specification/schema/topo-project-specification.json`.
+- Published Topo Project Specification docs: `https://github.com/arm/topo/docs/project-specification`, especially `README.md`, `00-overview.md`, `01-authoring-projects.md`, `02-project-configuration.md`, and `03-schema.md`.
+- Published Topo glossary for domain terms: `https://github.com/arm/topo/blob/main/docs/glossary.md`.
+- Compose Spec for standard Compose semantics. Do not invent non-standard Compose keys except the root-level `x-topo` extension.
+
+When references conflict, prefer the schema for validation behavior, then the specification docs for authoring intent, then the target repository's actual Compose behavior for the smallest safe change.
+
+When validating changes, check if `topo` is installed, and prompt the user for an SSH target to test against. `topo clone dir:./path/to/project` can be used to test project parameters, `topo deploy` can be used to test build and deploy.


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- Pulls in the content from [arm/topo-project-specification](https://github.com/arm/topo-project-specification) into this repo (format = `location-in-old-repo` -> `location-in-this-repo`):
  - `docs/` -> `docs/project-specification`
  - `README.md` -> `docs/project-specification/README.md` (so it still serves as homepage of some sort even on GH)
  - `docs/DEVELOPMENT.md` -> `docs/DEVELOPMENT.md` (merged, since skills are now a first-class part of this repo)
  - `scripts/` -> `scripts/` (merged, we had one script in the project spec to sync skill context)
  - `skills/` -> `skills/` - skills are now a first-class part of this repo. This makes them more discoverable, gives a snappier `npx skills` installation command. Also gives a clearer path to supporting installation of them via the CLI!
- Fixes now broken links and prefers local-file links over GH-bound links
- Adjusts the language in a few small places to call the repo as a whole 'Topo' but the CLI 'Topo CLI'.
- Removed `package.json` - our only dep was prettier which we don't use for our markdown in this repo. Could introduce later repo-wide but don't want to deal with that here.
  - Note this also meant updating the DEVELOPMENT guide to invoke `node scripts/xyz.js` directly instead of an `npm` alias
- Deletes the old `docs/index.md` used by the placeholder internal docs site. I've turned the cron job off that syncs this site so it won't break with this change. Plan is to move the deployment of that site into this repo. 

All project spec content is unchanged besides:
- README
  - One mention of 'Topo' changed to 'Topo CLI' - link unchanged
  - Moved skills installation/break-down to the top-level `README` and renamed heading to 'Project Authoring Skills'

## Next steps
- [ ] Nuke `arm/topo-project-specification`. Leave it up as a redirect prompt only for a while as stop-gap if we miss a link.
- [ ] Update all existing example projects (previously templates) links to point to new home for the spec under `arm/topo`
- [ ] Scaffold a docs site that can be previewed locally. This may require some shuffling of the `docs/` directory. Do not wire up any deployment quite yet. 
- [ ] Wire up internal deployment of the docs. Deployed at the same time of CLI release **after signing**
- [ ] Write some proper docs!
