### PR TITLE
docs: make target need for deploy command more explicit in successful clone message

### DIFF
--- a/internal/project/operations.go
+++ b/internal/project/operations.go
@@ -311,7 +311,7 @@ func (o printSummary) Run(w io.Writer) error {
 
 Now run:
   cd %s
-  topo deploy`, o.path, o.path)
+  topo deploy --target [user@]host`, o.path, o.path)
 
 	_, err := fmt.Fprintln(w, toPrint)
 	return err

--- a/internal/project/operations.go
+++ b/internal/project/operations.go
@@ -311,7 +311,9 @@ func (o printSummary) Run(w io.Writer) error {
 
 Now run:
   cd %s
-  topo deploy --target [user@]host`, o.path, o.path)
+  topo deploy
+
+A deployment target is required. Provide --target or set TOPO_TARGET.`, o.path, o.path)
 
 	_, err := fmt.Fprintln(w, toPrint)
 	return err

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -74,7 +74,7 @@ services:
 		assert.Contains(t, out, "Project ready")
 		assert.Contains(t, out, fmt.Sprintf("Created in '%s'", destDir))
 		assert.Contains(t, out, "cd "+destDir)
-		assert.Contains(t, out, "topo deploy")
+		assert.Contains(t, out, "topo deploy --target [user@]host")
 	})
 
 	t.Run("clones source into destination directory", func(t *testing.T) {

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -73,8 +73,11 @@ services:
 		out := output.String()
 		assert.Contains(t, out, "Project ready")
 		assert.Contains(t, out, fmt.Sprintf("Created in '%s'", destDir))
-		assert.Contains(t, out, "cd "+destDir)
-		assert.Contains(t, out, "topo deploy --target [user@]host")
+		assert.Contains(t, out, fmt.Sprintf(`Now run:
+  cd %s
+  topo deploy
+
+A deployment target is required. Provide --target or set TOPO_TARGET.`, destDir))
 	})
 
 	t.Run("clones source into destination directory", func(t *testing.T) {

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -73,11 +73,8 @@ services:
 		out := output.String()
 		assert.Contains(t, out, "Project ready")
 		assert.Contains(t, out, fmt.Sprintf("Created in '%s'", destDir))
-		assert.Contains(t, out, fmt.Sprintf(`Now run:
-  cd %s
-  topo deploy
-
-A deployment target is required. Provide --target or set TOPO_TARGET.`, destDir))
+		assert.Contains(t, out, "cd "+destDir)
+		assert.Contains(t, out, "topo deploy")
 	})
 
 	t.Run("clones source into destination directory", func(t *testing.T) {


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- Suggested by @ZachMaso. I agree the deploy suggestion can be more useful here and strengthen the user mental mode of how things are generally supposed to work.
