### PR TITLE
feat: support legacy `x-topo.args` with a warning

### DIFF
--- a/internal/project/definition.go
+++ b/internal/project/definition.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/arm/topo/internal/output/logger"
 	"gopkg.in/yaml.v3"
 )
 
@@ -81,6 +82,7 @@ type rawMetadata struct {
 	DeploymentSuccessMessage string                  `yaml:"deployment_success_message"`
 	Features                 []string                `yaml:"features,omitempty"`
 	Parameters               map[string]rawParameter `yaml:"parameters,omitempty"`
+	Args                     map[string]rawParameter `yaml:"args,omitempty"`
 }
 
 type rawParameter struct {
@@ -100,32 +102,55 @@ func (t *Metadata) UnmarshalYAML(node *yaml.Node) error {
 	t.Description = raw.Description
 	t.DeploymentSuccessMessage = raw.DeploymentSuccessMessage
 	t.Features = raw.Features
-	t.Parameters = parseParametersInOrder(node, raw.Parameters)
+	parametersNode := findMetadataNode(node, "parameters")
+	parameters := raw.Parameters
+	if len(parameters) == 0 && len(raw.Args) > 0 {
+		logger.Warn("x-topo.args is deprecated; use x-topo.parameters instead")
+		parametersNode = findMetadataNode(node, "args")
+		parameters = raw.Args
+	}
+	t.Parameters = parseParametersInOrder(parametersNode, parameters)
 
 	return nil
 }
 
-func parseParametersInOrder(node *yaml.Node, parametersMap map[string]rawParameter) []Parameter {
-	var result []Parameter
-
+func findMetadataNode(node *yaml.Node, key string) *yaml.Node {
 	for i := 0; i < len(node.Content); i += 2 {
-		if node.Content[i].Value == "parameters" {
-			parametersNode := node.Content[i+1]
-			for j := 0; j < len(parametersNode.Content); j += 2 {
-				name := parametersNode.Content[j].Value
-				if metadata, ok := parametersMap[name]; ok {
-					result = append(result, Parameter{
-						Name:        name,
-						Description: metadata.Description,
-						Required:    metadata.Required,
-						Example:     metadata.Example,
-						Default:     metadata.Default,
-					})
-				}
-			}
-			break
+		if node.Content[i].Value == key {
+			return node.Content[i+1]
+		}
+	}
+
+	return nil
+}
+
+func parseParametersInOrder(parametersNode *yaml.Node, parametersMap map[string]rawParameter) []Parameter {
+	var result []Parameter
+	parametersNode = resolveAlias(parametersNode)
+	if parametersNode == nil {
+		return result
+	}
+
+	for i := 0; i < len(parametersNode.Content); i += 2 {
+		name := parametersNode.Content[i].Value
+		if metadata, ok := parametersMap[name]; ok {
+			result = append(result, Parameter{
+				Name:        name,
+				Description: metadata.Description,
+				Required:    metadata.Required,
+				Example:     metadata.Example,
+				Default:     metadata.Default,
+			})
 		}
 	}
 
 	return result
+}
+
+func resolveAlias(node *yaml.Node) *yaml.Node {
+	if node != nil && node.Kind == yaml.AliasNode {
+		return node.Alias
+	}
+
+	return node
 }

--- a/internal/project/definition_test.go
+++ b/internal/project/definition_test.go
@@ -1,10 +1,13 @@
 package project_test
 
 import (
+	"bytes"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/arm/topo/internal/output/logger"
+	"github.com/arm/topo/internal/output/term"
 	"github.com/arm/topo/internal/project"
 	"github.com/arm/topo/internal/testutil"
 	"github.com/stretchr/testify/assert"
@@ -78,6 +81,85 @@ services:
 		got := p.Metadata.Parameters
 
 		require.NoError(t, err)
+		want := []project.Parameter{
+			{
+				Name:        "GREETING",
+				Description: "The greeting message to display",
+				Required:    true,
+				Example:     "Hello, World",
+			},
+			{
+				Name:        "PORT",
+				Description: "Port number",
+				Required:    false,
+			},
+		}
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("parses legacy args from x-topo metadata when parameters are absent", func(t *testing.T) {
+		composeFileContents := `
+  x-topo:
+    args:
+      GREETING:
+        description: "The greeting message to display"
+        required: true
+        example: "Hello, World"
+      PORT:
+        description: "Port number"
+        required: false
+  `
+		var logOutput bytes.Buffer
+		logger.SetOptions(logger.Options{Output: &logOutput, Format: term.Plain})
+		t.Cleanup(func() {
+			logger.SetOptions(logger.Options{})
+		})
+
+		p, err := project.FromContent(strings.NewReader(composeFileContents))
+		got := p.Metadata.Parameters
+
+		require.NoError(t, err)
+		assert.Contains(t, logOutput.String(), "x-topo.args is deprecated; use x-topo.parameters instead")
+		want := []project.Parameter{
+			{
+				Name:        "GREETING",
+				Description: "The greeting message to display",
+				Required:    true,
+				Example:     "Hello, World",
+			},
+			{
+				Name:        "PORT",
+				Description: "Port number",
+				Required:    false,
+			},
+		}
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("parses parameters aliased to legacy args", func(t *testing.T) {
+		composeFileContents := `
+  x-topo:
+    args: &args
+      GREETING:
+        description: "The greeting message to display"
+        required: true
+        example: "Hello, World"
+      PORT:
+        description: "Port number"
+        required: false
+    parameters: *args
+  `
+		var logOutput bytes.Buffer
+		logger.SetOptions(logger.Options{Output: &logOutput, Format: term.Plain})
+		t.Cleanup(func() {
+			logger.SetOptions(logger.Options{})
+		})
+
+		p, err := project.FromContent(strings.NewReader(composeFileContents))
+		got := p.Metadata.Parameters
+
+		require.NoError(t, err)
+		assert.Empty(t, logOutput.String())
 		want := []project.Parameter{
 			{
 				Name:        "GREETING",

--- a/scripts/update_projects/project.go
+++ b/scripts/update_projects/project.go
@@ -20,7 +20,7 @@ type XTopo struct {
 	Name        string               `json:"name"`
 	Description string               `json:"description"`
 	Features    []string             `json:"features"`
-	Parameters  map[string]Parameter `json:"parameters,omitempty" yaml:"parameters,omitempty"`
+	Parameters  map[string]Parameter `json:"parameters,omitempty"`
 }
 
 type Parameter struct {
@@ -29,6 +29,31 @@ type Parameter struct {
 	Default     string         `json:"default,omitempty"`
 	Example     string         `json:"example,omitempty"`
 	Hints       map[string]any `json:"hints,omitempty"`
+}
+
+func (t *XTopo) UnmarshalYAML(node *yaml.Node) error {
+	type rawXTopo struct {
+		Name        string               `yaml:"name"`
+		Description string               `yaml:"description"`
+		Features    []string             `yaml:"features"`
+		Parameters  map[string]Parameter `yaml:"parameters,omitempty"`
+		Args        map[string]Parameter `yaml:"args,omitempty"`
+	}
+
+	var raw rawXTopo
+	if err := node.Decode(&raw); err != nil {
+		return err
+	}
+
+	t.Name = raw.Name
+	t.Description = raw.Description
+	t.Features = raw.Features
+	t.Parameters = raw.Parameters
+	if len(t.Parameters) == 0 && len(raw.Args) > 0 {
+		t.Parameters = raw.Args
+	}
+
+	return nil
 }
 
 func NewProject(source GitHubSource, composeFile io.Reader) (Project, error) {

--- a/scripts/update_projects/project_test.go
+++ b/scripts/update_projects/project_test.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewProject(t *testing.T) {
+	t.Run("reads parameters from x-topo parameters", func(t *testing.T) {
+		source := GitHubSource{Repo: "Arm-Examples/topo-example", SHA: "main"}
+		composeFile := strings.NewReader(`
+x-topo:
+  name: Hello World
+  description: A friendly project
+  features:
+    - web
+  parameters:
+    username:
+      description: User name
+      required: true
+      example: alice
+`)
+
+		got, err := NewProject(source, composeFile)
+
+		require.NoError(t, err)
+		want := map[string]Parameter{
+			"username": {
+				Description: "User name",
+				Required:    true,
+				Example:     "alice",
+			},
+		}
+		assert.Equal(t, want, got.Parameters)
+	})
+
+	t.Run("reads deprecated args as parameters", func(t *testing.T) {
+		source := GitHubSource{Repo: "Arm-Examples/topo-example", SHA: "main"}
+		composeFile := strings.NewReader(`
+x-topo:
+  name: Hello World
+  description: A friendly project
+  args:
+    username:
+      description: User name
+      required: true
+      default: alice
+`)
+
+		got, err := NewProject(source, composeFile)
+
+		require.NoError(t, err)
+		want := map[string]Parameter{
+			"username": {
+				Description: "User name",
+				Required:    true,
+				Default:     "alice",
+			},
+		}
+		assert.Equal(t, want, got.Parameters)
+	})
+
+	t.Run("prefers parameters over args", func(t *testing.T) {
+		source := GitHubSource{Repo: "Arm-Examples/topo-example", SHA: "main"}
+		composeFile := strings.NewReader(`
+x-topo:
+  name: Hello World
+  description: A friendly project
+  parameters:
+    username:
+      description: New name
+  args:
+    username:
+      description: Old name
+    token:
+      description: Secret token
+`)
+
+		got, err := NewProject(source, composeFile)
+
+		require.NoError(t, err)
+		want := map[string]Parameter{
+			"username": {
+				Description: "New name",
+			},
+		}
+		assert.Equal(t, want, got.Parameters)
+	})
+
+	t.Run("reads parameters aliased to args", func(t *testing.T) {
+		source := GitHubSource{Repo: "Arm-Examples/topo-example", SHA: "main"}
+		composeFile := strings.NewReader(`
+x-topo:
+  name: Hello World
+  description: A friendly project
+  args: &args
+    username:
+      description: User name
+      required: true
+      example: alice
+  parameters: *args
+`)
+
+		got, err := NewProject(source, composeFile)
+
+		require.NoError(t, err)
+		want := map[string]Parameter{
+			"username": {
+				Description: "User name",
+				Required:    true,
+				Example:     "alice",
+			},
+		}
+		assert.Equal(t, want, got.Parameters)
+	})
+}


### PR DESCRIPTION
## Changes

- Add backwards-compatible parsing for deprecated `x-topo.args` metadata
- Prefer `x-topo.parameters` when present, including when it aliases legacy `args`
- Emit a deprecation warning only when falling back to `x-topo.args`
