### PR TITLE
fix: make `upgrade` unavailable, not hidden when appropriate

### DIFF
--- a/cmd/topo/upgrade.go
+++ b/cmd/topo/upgrade.go
@@ -47,8 +47,8 @@ var upgradeCmd = &cobra.Command{
 
 func init() {
 	binPath, err := upgrade.CurrentBinaryPath()
-	if err == nil {
-		upgradeCmd.Hidden = !upgrade.IsBinaryManagedByUs(binPath)
+	if err == nil && !upgrade.IsBinaryManagedByUs(binPath) {
+		return
 	}
 	addTimeoutFlag(upgradeCmd, 0)
 	rootCmd.AddCommand(upgradeCmd)


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

For installs managed by homebrew, we hide the `upgrade` command, however it’s still possible to invoke it. This PR makes it actually unavailable instead of hidden.
