### PR TITLE
feat: control ability to self-upgrade with `TOPO_DISABLE_SELF_UPGRADE`

### DIFF
--- a/cmd/topo/upgrade.go
+++ b/cmd/topo/upgrade.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/arm/topo/internal/env"
 	"github.com/arm/topo/internal/output/term"
 	"github.com/arm/topo/internal/upgrade"
 	"github.com/arm/topo/internal/version"
@@ -46,10 +47,19 @@ var upgradeCmd = &cobra.Command{
 }
 
 func init() {
-	binPath, err := upgrade.CurrentBinaryPath()
-	if err == nil && !upgrade.IsBinaryManagedByUs(binPath) {
+	if isSelfUpgradeDisabled() {
 		return
 	}
 	addTimeoutFlag(upgradeCmd, 0)
 	rootCmd.AddCommand(upgradeCmd)
+}
+
+func isSelfUpgradeDisabled() bool {
+	const disableSelfUpgradeEnvVar = "TOPO_DISABLE_SELF_UPGRADE"
+	if env.IsVarTruthy(disableSelfUpgradeEnvVar) {
+		return true
+	}
+
+	binPath, err := upgrade.CurrentBinaryPath()
+	return err == nil && !upgrade.IsBinaryManagedByUs(binPath)
 }


### PR DESCRIPTION
## Background

First party integrations that ship with their own `topo` installation want to disable self-upgrade facility. One example of that is `vscode-topo`, where user can inadvertently upgrade topo version from vscode’s terminal. One way to prevent that would be to use similar mechanism to the one we have already - detect install path and disable self upgrade if it’s not managed by topo cli itself. For vscode however, this would mean leaking vscode-specific knowledge into topo, which is not ideal. This PR disables `upgrade` sub-command based on the environment variable.

## Changes

<!-- List the changes this PR introduces -->

- Disable `topo upgrade` when `TOPO_DISABLE_SELF_UPGRADE` is set to truthy value
