### PR TITLE
chore: add checks + conventional commit comment to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,17 @@
+<!-- PR title should be formatted using conventional commits -->
+<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->
+<!-- Example: feat: A very fancy feature -->
+
 ## Changes
 
 <!-- List the changes this PR introduces -->
 
 -
+
+## Checklist
+
+<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
+
+- [ ] 🤖 This change is covered by tests as required.
+- [ ] 🤹 All required manual testing has been performed.
+- [ ] 📖 All documentation updates are complete.


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- Adds a check list of items to the PR template to remind us to test and update docs (mostly focused on the latter w/ the introduction of #336)
- Adds a comment to remind contributors to use conventional commits as the PR title

This makes our PR template identical with the other OSS product we maintain; `remoteproc-runtime`.

## Checklist

<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->

- [x] 🤖 This change is covered by tests as required.
- [x] 🤹 All required manual testing has been performed.
- [x] 📖 All documentation updates are complete.
