### PR TITLE
feat: skip version checks when self-upgrade is disabled

### DIFF
--- a/cmd/topo/health.go
+++ b/cmd/topo/health.go
@@ -17,7 +17,10 @@ const (
 	skipVersionChecksFlag = "skip-version-checks"
 )
 
-const skipVersionChecksEnvVar = "TOPO_SKIP_VERSION_CHECKS"
+const (
+	skipVersionChecksEnvVar  = "TOPO_SKIP_VERSION_CHECKS"
+	disableSelfUpgradeEnvVar = "TOPO_DISABLE_SELF_UPGRADE"
+)
 
 var healthCmd = &cobra.Command{
 	Use:   "health",
@@ -76,6 +79,10 @@ func init() {
 }
 
 func resolveSkipVersionChecks(cmd *cobra.Command) bool {
+	if env.IsVarTruthy(disableSelfUpgradeEnvVar) {
+		return true
+	}
+
 	if !cmd.Flags().Changed(skipVersionChecksFlag) {
 		return env.IsVarTruthy(skipVersionChecksEnvVar)
 	}

--- a/cmd/topo/health.go
+++ b/cmd/topo/health.go
@@ -17,10 +17,7 @@ const (
 	skipVersionChecksFlag = "skip-version-checks"
 )
 
-const (
-	skipVersionChecksEnvVar  = "TOPO_SKIP_VERSION_CHECKS"
-	disableSelfUpgradeEnvVar = "TOPO_DISABLE_SELF_UPGRADE"
-)
+const skipVersionChecksEnvVar = "TOPO_SKIP_VERSION_CHECKS"
 
 var healthCmd = &cobra.Command{
 	Use:   "health",

--- a/cmd/topo/upgrade.go
+++ b/cmd/topo/upgrade.go
@@ -55,7 +55,6 @@ func init() {
 }
 
 func isSelfUpgradeDisabled() bool {
-	const disableSelfUpgradeEnvVar = "TOPO_DISABLE_SELF_UPGRADE"
 	if env.IsVarTruthy(disableSelfUpgradeEnvVar) {
 		return true
 	}

--- a/cmd/topo/upgrade.go
+++ b/cmd/topo/upgrade.go
@@ -11,6 +11,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const disableSelfUpgradeEnvVar = "TOPO_DISABLE_SELF_UPGRADE"
+
 var upgradeCmd = &cobra.Command{
 	Use:   "upgrade",
 	Short: "Upgrade topo to the latest version",


### PR DESCRIPTION
## Changes

<!-- List the changes this PR introduces -->

- if self-upgrade is disabled, it's not ideal to keep alert our users to upgrade the topo version. Especially when this topo is installed from vscode. Disabling version check when self-upgrade is disabled.
- Manual testing results shown below
<img width="768" height="455" alt="Screenshot 2026-07-16 at 14 20 24" src="https://github.com/user-attachments/assets/3fff6a87-27f7-4b01-a4d1-2c0afbdab8d3" />

