### PR TITLE
refactor: simplify SSH tunnel setup and isolate registry exposure check 

### DIFF
--- a/internal/deploy/deploy.go
+++ b/internal/deploy/deploy.go
@@ -43,15 +43,15 @@ func NewDeployment(composeFile string, opts DeployOptions) (goperation.Sequence,
 	var cleanup goperation.Operation
 	if !opts.TargetHost.IsPlainLocalhost() {
 		if opts.Registry != nil {
-			start, securityCheck, stop := ssh.NewSSHTunnel(opts.TargetHost, opts.Registry.Port, opts.Registry.UseControlSockets)
-			cleanup = stop
+			startTunnel, stopTunnel := ssh.NewSSHTunnel(opts.TargetHost, opts.Registry.Port, opts.Registry.UseControlSockets)
+			cleanup = stopTunnel
 			ops = append(ops, operation.NewRunRegistry(opts.Registry.Port)...)
-			ops = append(ops, start)
+			ops = append(ops, startTunnel)
 			if !opts.Registry.SkipRemotePortCheck {
-				ops = append(ops, securityCheck)
+				ops = append(ops, operation.NewRegistryTunnelExposureCheck(opts.TargetHost, opts.Registry.Port))
 			}
 			ops = append(ops, operation.NewRegistryTransfer(composeFile, sourceHost, targetHost, opts.Registry.Port))
-			ops = append(ops, stop)
+			ops = append(ops, stopTunnel)
 		} else {
 			ops = append(ops, operation.NewDockerComposePipeTransfer(composeFile, sourceHost, targetHost))
 		}

--- a/internal/deploy/deploy_test.go
+++ b/internal/deploy/deploy_test.go
@@ -52,10 +52,10 @@ func TestNewDeployment(t *testing.T) {
 			operation.NewDockerComposePull(composeFile, localHost),
 		}
 		want = append(want, operation.NewRunRegistry(port)...)
-		wantTunnelStart, wantSecurityCheck, wantTunnelStop := ssh.NewSSHTunnel(remoteDest, port, opts.Registry.UseControlSockets)
+		wantTunnelStart, wantTunnelStop := ssh.NewSSHTunnel(remoteDest, port, opts.Registry.UseControlSockets)
 		want = append(want,
 			wantTunnelStart,
-			wantSecurityCheck,
+			operation.NewRegistryTunnelExposureCheck(remoteDest, port),
 			operation.NewRegistryTransfer(composeFile, localHost, remoteHost, port),
 			wantTunnelStop,
 			operation.NewDockerComposeUp(composeFile, remoteHost, operation.RecreateModeDefault),
@@ -130,7 +130,7 @@ func TestNewDeployment(t *testing.T) {
 
 		got, _ := deploy.NewDeployment(composeFile, opts)
 
-		wantTunnelStart, wantSecurityCheck, wantTunnelEnd := ssh.NewSSHTunnel(remoteDest, opts.Registry.Port, opts.Registry.UseControlSockets)
+		wantTunnelStart, wantTunnelStop := ssh.NewSSHTunnel(remoteDest, opts.Registry.Port, opts.Registry.UseControlSockets)
 		localHost := command.LocalHost
 		remoteHost := command.NewHostFromDestination(remoteDest)
 		want := goperation.Sequence{
@@ -140,9 +140,9 @@ func TestNewDeployment(t *testing.T) {
 		want = append(want, operation.NewRunRegistry(port)...)
 		want = append(want,
 			wantTunnelStart,
-			wantSecurityCheck,
+			operation.NewRegistryTunnelExposureCheck(remoteDest, port),
 			operation.NewRegistryTransfer(composeFile, localHost, remoteHost, port),
-			wantTunnelEnd,
+			wantTunnelStop,
 			operation.NewDockerComposeUp(composeFile, remoteHost, operation.RecreateModeDefault),
 			post_deploy.NewDeploySuccess(composeFile, remoteHost, "Run `topo ps` to see deployed containers"),
 		)
@@ -160,7 +160,7 @@ func TestNewDeployment(t *testing.T) {
 
 		got, _ := deploy.NewDeployment(composeFile, opts)
 
-		_, remotePortCheck, _ := ssh.NewSSHTunnel(remoteDest, opts.Registry.Port, opts.Registry.UseControlSockets)
+		remotePortCheck := operation.NewRegistryTunnelExposureCheck(remoteDest, opts.Registry.Port)
 		assert.NotContains(t, got, remotePortCheck)
 	})
 }

--- a/internal/deploy/operation/registry_tunnel_exposure_check.go
+++ b/internal/deploy/operation/registry_tunnel_exposure_check.go
@@ -1,0 +1,50 @@
+package operation
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/arm/topo/internal/netprobe"
+	"github.com/arm/topo/internal/ssh"
+)
+
+type RegistryTunnelExposureCheck struct {
+	TargetDest ssh.Destination
+	Port       string
+}
+
+// NewRegistryTunnelExposureCheck checks whether the registry tunnel port exposes
+// the registry to the target's network, rather than being limited to target
+// loopback. This can happen when the SSH server permits non-loopback remote
+// forwards.
+func NewRegistryTunnelExposureCheck(targetDest ssh.Destination, port string) *RegistryTunnelExposureCheck {
+	return &RegistryTunnelExposureCheck{TargetDest: targetDest, Port: port}
+}
+
+func (c *RegistryTunnelExposureCheck) Description() string {
+	return "Check registry tunnel is not exposed on remote network"
+}
+
+func (c *RegistryTunnelExposureCheck) Run(w io.Writer) error {
+	if c.TargetDest.IsLocalhost() {
+		return nil
+	}
+
+	host, err := ssh.ResolveHostName(c.TargetDest)
+	if err != nil {
+		return remotePortCheckErrorWithSuggestion(err, c.Port)
+	}
+	listening, err := netprobe.IsRemotePortListening(host, c.Port)
+	if err != nil {
+		return remotePortCheckErrorWithSuggestion(err, c.Port)
+	}
+	if listening {
+		return fmt.Errorf("the remote SSH server is exposing forwarded registry port %s beyond remote loopback; configure the SSH server to bind remote forwards to loopback only, or use `--skip-remote-port-check` if you understand that the registry may be reachable without SSH authentication", c.Port)
+	}
+	_, _ = fmt.Fprintf(w, "Registry port %s is bound to remote loopback only\n", c.Port)
+	return nil
+}
+
+func remotePortCheckErrorWithSuggestion(err error, port string) error {
+	return fmt.Errorf("cannot conclusively rule out network access to registry port %s because the exposure check did not complete: %w; retry after resolving the connectivity issue, or use `--skip-remote-port-check` if you understand the security risk", port, err)
+}

--- a/internal/deploy/operation/registry_tunnel_exposure_check_test.go
+++ b/internal/deploy/operation/registry_tunnel_exposure_check_test.go
@@ -1,0 +1,90 @@
+package operation_test
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"strings"
+	"testing"
+
+	"github.com/arm/topo/internal/deploy/operation"
+	"github.com/arm/topo/internal/ssh"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegistryTunnelExposureCheck(t *testing.T) {
+	t.Run("returns the expected description", func(t *testing.T) {
+		check := operation.NewRegistryTunnelExposureCheck(ssh.NewDestination("user@remote"), "12345")
+
+		got := check.Description()
+
+		assert.Equal(t, "Check registry tunnel is not exposed on remote network", got)
+	})
+
+	t.Run("skips the check for localhost", func(t *testing.T) {
+		check := operation.NewRegistryTunnelExposureCheck(ssh.PlainLocalhost, "invalid")
+		var output strings.Builder
+
+		err := check.Run(&output)
+
+		assert.NoError(t, err)
+		assert.Empty(t, output.String())
+	})
+
+	t.Run("fails when the SSH hostname cannot be resolved", func(t *testing.T) {
+		check := operation.NewRegistryTunnelExposureCheck(ssh.Destination{}, "12345")
+
+		err := check.Run(io.Discard)
+
+		assert.ErrorContains(t, err, "cannot conclusively rule out network access to registry port 12345")
+		assert.ErrorContains(t, err, `could not resolve SSH configuration for "ssh://"`)
+		assert.ErrorContains(t, err, "use `--skip-remote-port-check` if you understand the security risk")
+	})
+
+	t.Run("succeeds when the remote port refuses the connection", func(t *testing.T) {
+		port := reserveFreePort(t, "0.0.0.0")
+		check := operation.NewRegistryTunnelExposureCheck(ssh.NewDestination("0.0.0.0"), port)
+		var output strings.Builder
+
+		err := check.Run(&output)
+
+		assert.NoError(t, err)
+		assert.Equal(t, fmt.Sprintf("Registry port %s is bound to remote loopback only\n", port), output.String())
+	})
+
+	t.Run("fails when the remote port accepts a connection", func(t *testing.T) {
+		listener, err := net.Listen("tcp", "127.0.0.1:0")
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = listener.Close() })
+		connectionClosed := make(chan error, 1)
+		go func() {
+			connection, acceptErr := listener.Accept()
+			if acceptErr != nil {
+				connectionClosed <- acceptErr
+				return
+			}
+			connectionClosed <- connection.Close()
+		}()
+		_, port, err := net.SplitHostPort(listener.Addr().String())
+		require.NoError(t, err)
+		check := operation.NewRegistryTunnelExposureCheck(ssh.NewDestination("localhost."), port)
+
+		err = check.Run(io.Discard)
+		listenerCloseErr := listener.Close()
+
+		assert.EqualError(t, err, fmt.Sprintf("the remote SSH server is exposing forwarded registry port %s beyond remote loopback; configure the SSH server to bind remote forwards to loopback only, or use `--skip-remote-port-check` if you understand that the registry may be reachable without SSH authentication", port))
+		assert.NoError(t, listenerCloseErr)
+		assert.NoError(t, <-connectionClosed)
+	})
+}
+
+func reserveFreePort(t *testing.T, host string) string {
+	t.Helper()
+	listener, err := net.Listen("tcp", net.JoinHostPort(host, "0"))
+	require.NoError(t, err)
+	_, port, err := net.SplitHostPort(listener.Addr().String())
+	require.NoError(t, err)
+	require.NoError(t, listener.Close())
+	return port
+}

--- a/internal/netprobe/port.go
+++ b/internal/netprobe/port.go
@@ -1,0 +1,42 @@
+package netprobe
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// IsRemotePortListening reports whether host:port accepts TCP connections.
+func IsRemotePortListening(host, port string) (bool, error) {
+	address := net.JoinHostPort(host, port)
+	var remoteIP strings.Builder
+	// Use curl so host resolution matches OpenSSH for mDNS, NSS, and split-DNS configurations.
+	// - remote_ip detects a connection even when HTTP fails
+	// - noproxy ensures the connection is direct
+	// - silent suppresses curl's progress and errors.
+	cmd := exec.Command("curl", "http://"+address, "--max-time", "5", "--noproxy", "*", "--output", os.DevNull, "--silent", "--write-out", "%{remote_ip}")
+	cmd.Stdout = &remoteIP
+	cmd.Stderr = io.Discard
+	err := cmd.Run()
+	if err == nil || remoteIP.Len() > 0 {
+		return true, nil
+	}
+
+	exitError, ok := errors.AsType[*exec.ExitError](err)
+	if ok {
+		switch exitError.ExitCode() {
+		case 7:
+			return false, nil
+		case 28:
+			return false, fmt.Errorf("timed out while checking whether remote port %s is exposed: %w", address, err)
+		case 6:
+			return false, fmt.Errorf("could not resolve remote host %q while checking tunnel exposure: %w", host, err)
+		}
+	}
+
+	return false, fmt.Errorf("could not verify whether remote port %s is exposed: %w", address, err)
+}

--- a/internal/netprobe/port_test.go
+++ b/internal/netprobe/port_test.go
@@ -1,0 +1,63 @@
+package netprobe_test
+
+import (
+	"net"
+	"testing"
+
+	"github.com/arm/topo/internal/netprobe"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsRemotePortListening(t *testing.T) {
+	t.Run("returns false when the remote port refuses the connection", func(t *testing.T) {
+		port := reserveFreePort(t, "0.0.0.0")
+
+		got, err := netprobe.IsRemotePortListening("0.0.0.0", port)
+
+		assert.NoError(t, err)
+		assert.False(t, got)
+	})
+
+	t.Run("returns true when the remote port accepts a connection", func(t *testing.T) {
+		listener, err := net.Listen("tcp", "127.0.0.1:0")
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = listener.Close() })
+		connectionClosed := make(chan error, 1)
+		go func() {
+			connection, acceptErr := listener.Accept()
+			if acceptErr != nil {
+				connectionClosed <- acceptErr
+				return
+			}
+			connectionClosed <- connection.Close()
+		}()
+		_, port, err := net.SplitHostPort(listener.Addr().String())
+		require.NoError(t, err)
+
+		got, err := netprobe.IsRemotePortListening("localhost.", port)
+		listenerCloseErr := listener.Close()
+
+		assert.NoError(t, err)
+		assert.True(t, got)
+		assert.NoError(t, listenerCloseErr)
+		assert.NoError(t, <-connectionClosed)
+	})
+
+	t.Run("returns an error when the remote host cannot be resolved", func(t *testing.T) {
+		got, err := netprobe.IsRemotePortListening("nonexistent.invalid", "12345")
+
+		assert.ErrorContains(t, err, `could not resolve remote host "nonexistent.invalid"`)
+		assert.False(t, got)
+	})
+}
+
+func reserveFreePort(t *testing.T, host string) string {
+	t.Helper()
+	listener, err := net.Listen("tcp", net.JoinHostPort(host, "0"))
+	require.NoError(t, err)
+	_, port, err := net.SplitHostPort(listener.Addr().String())
+	require.NoError(t, err)
+	require.NoError(t, listener.Close())
+	return port
+}

--- a/internal/ssh/config.go
+++ b/internal/ssh/config.go
@@ -22,7 +22,8 @@ func NewConfig(dest Destination) Config {
 	return NewConfigFromBytes(output)
 }
 
-func resolveHostName(dest Destination) (string, error) {
+// ResolveHostName resolves the SSH hostname for dest.
+func ResolveHostName(dest Destination) (string, error) {
 	output, err := readConfig(dest)
 	if err != nil {
 		return "", fmt.Errorf("could not resolve SSH configuration for %q: %w", dest.String(), err)

--- a/internal/ssh/config.go
+++ b/internal/ssh/config.go
@@ -22,7 +22,6 @@ func NewConfig(dest Destination) Config {
 	return NewConfigFromBytes(output)
 }
 
-// ResolveHostName resolves the SSH hostname for dest.
 func ResolveHostName(dest Destination) (string, error) {
 	output, err := readConfig(dest)
 	if err != nil {

--- a/internal/ssh/ssh_tunnel.go
+++ b/internal/ssh/ssh_tunnel.go
@@ -2,15 +2,12 @@ package ssh
 
 import (
 	"crypto/sha256"
-	"errors"
 	"fmt"
 	"io"
-	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
-	"strings"
 
 	"github.com/arm/topo/internal/command"
 	"github.com/arm/topo/internal/operation"
@@ -24,19 +21,17 @@ func ControlSocketPath(targetHost string) string {
 	return filepath.Join(os.TempDir(), fmt.Sprintf("topo-tunnel-%s", hostHash))
 }
 
-func NewSSHTunnel(targetDest Destination, port string, useControlSockets bool) (operation.Operation, operation.Operation, operation.Operation) {
-	start := NewSSHTunnelStart(targetDest, port, useControlSockets)
+func NewSSHTunnel(targetDest Destination, port string, useControlSockets bool) (operation.Operation, operation.Operation) {
+	startTunnel := NewSSHTunnelStart(targetDest, port, useControlSockets)
 
-	securityCheck := NewCheckRemoteForwardNotExposed(targetDest, port)
-
-	var stop operation.Operation
+	var stopTunnel operation.Operation
 	if useControlSockets {
-		stop = NewSSHTunnelStop(targetDest)
+		stopTunnel = NewSSHTunnelStop(targetDest)
 	} else {
-		stop = NewSSHTunnelProcessStop(start)
+		stopTunnel = NewSSHTunnelProcessStop(startTunnel)
 	}
 
-	return start, securityCheck, stop
+	return startTunnel, stopTunnel
 }
 
 type SSHTunnelStart struct {
@@ -86,76 +81,6 @@ func (s *SSHTunnelStart) Run(w io.Writer) error {
 	}
 	_, _ = fmt.Fprintln(w, "Tunnel created")
 	return nil
-}
-
-type CheckRemoteForwardNotExposed struct {
-	TargetDest Destination
-	Port       string
-}
-
-// Checks whether the RemoteForward port exposes the registry to the target's
-// network, rather than being limited to target loopback. This can happen when
-// the SSH server permits non-loopback remote forwards.
-func NewCheckRemoteForwardNotExposed(targetDest Destination, port string) *CheckRemoteForwardNotExposed {
-	return &CheckRemoteForwardNotExposed{TargetDest: targetDest, Port: port}
-}
-
-func (ct *CheckRemoteForwardNotExposed) Description() string {
-	return "Check tunnel port is not exposed on remote network"
-}
-
-func (ct *CheckRemoteForwardNotExposed) Run(w io.Writer) error {
-	if ct.TargetDest.IsLocalhost() {
-		return nil
-	}
-
-	host, err := resolveHostName(ct.TargetDest)
-	if err != nil {
-		return remotePortCheckErrorWithSuggestion(err, ct.Port)
-	}
-	listening, err := isRemotePortListening(host, ct.Port)
-	if err != nil {
-		return remotePortCheckErrorWithSuggestion(err, ct.Port)
-	}
-	if listening {
-		return fmt.Errorf("the remote SSH server is exposing forwarded registry port %s beyond remote loopback; configure the SSH server to bind remote forwards to loopback only, or use `--skip-remote-port-check` if you understand that the registry may be reachable without SSH authentication", ct.Port)
-	}
-	_, _ = fmt.Fprintf(w, "Port %s is bound to remote loopback only\n", ct.Port)
-	return nil
-}
-
-func isRemotePortListening(host, port string) (bool, error) {
-	address := net.JoinHostPort(host, port)
-	var remoteIP strings.Builder
-	// Release binaries use Go's resolver because CGO is disabled. Use curl so
-	// host resolution matches OpenSSH for mDNS, NSS, and split-DNS configurations.
-	// remote_ip detects a connection even when HTTP fails, noproxy ensures the
-	// connection is direct, and silent suppresses curl's progress and errors.
-	cmd := exec.Command("curl", "http://"+address, "--max-time", "5", "--noproxy", "*", "--output", os.DevNull, "--silent", "--write-out", "%{remote_ip}")
-	cmd.Stdout = &remoteIP
-	cmd.Stderr = io.Discard
-	err := cmd.Run()
-	if err == nil || remoteIP.Len() > 0 {
-		return true, nil
-	}
-
-	exitError, ok := errors.AsType[*exec.ExitError](err)
-	if ok {
-		switch exitError.ExitCode() {
-		case 7:
-			return false, nil
-		case 28:
-			return false, fmt.Errorf("timed out while checking whether remote port %s is exposed: %w", address, err)
-		case 6:
-			return false, fmt.Errorf("could not resolve remote host %q while checking tunnel exposure: %w", host, err)
-		}
-	}
-
-	return false, fmt.Errorf("could not verify whether remote port %s is exposed: %w", address, err)
-}
-
-func remotePortCheckErrorWithSuggestion(err error, port string) error {
-	return fmt.Errorf("cannot conclusively rule out network access to registry port %s because the exposure check did not complete: %w; retry after resolving the connectivity issue, or use `--skip-remote-port-check` if you understand the security risk", port, err)
 }
 
 type SSHTunnelStop struct {

--- a/internal/ssh/ssh_tunnel_test.go
+++ b/internal/ssh/ssh_tunnel_test.go
@@ -2,8 +2,6 @@ package ssh_test
 
 import (
 	"fmt"
-	"io"
-	"net"
 	"os"
 	"strings"
 	"testing"
@@ -11,55 +9,7 @@ import (
 	"github.com/arm/topo/internal/ssh"
 	"github.com/arm/topo/internal/testutil"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
-
-func TestSSHTunnel(t *testing.T) {
-	t.Run("NewSSHTunnel", func(t *testing.T) {
-		t.Run("it returns start and stop operations with control sockets", func(t *testing.T) {
-			dest := ssh.NewDestination("user@remote")
-
-			start, _, stop := ssh.NewSSHTunnel(dest, "91232", true)
-
-			_, ok := start.(*ssh.SSHTunnelStart)
-			assert.True(t, ok, "start operation is not of type SSHTunnelStart")
-			_, ok = stop.(*ssh.SSHTunnelStop)
-			assert.True(t, ok, "stop operation is not of type SSHTunnelStop")
-		})
-
-		t.Run("it returns start and stop operations without control sockets", func(t *testing.T) {
-			dest := ssh.NewDestination("user@remote")
-
-			start, _, stop := ssh.NewSSHTunnel(dest, "12201", false)
-
-			_, ok := start.(*ssh.SSHTunnelStart)
-			assert.True(t, ok, "start operation is not of type SSHTunnelStart")
-			_, ok = stop.(*ssh.SSHTunnelProcessStop)
-			assert.True(t, ok, "stop operation is not of type SSHTunnelProcessStop")
-		})
-
-		t.Run("stop operation has access to start operation process", func(t *testing.T) {
-			dest := ssh.NewDestination("user@remote")
-
-			start, _, stop := ssh.NewSSHTunnel(dest, "07070", false)
-			startOp, ok := start.(*ssh.SSHTunnelStart)
-			require.True(t, ok, "start operation is not of type SSHTunnelStart")
-
-			stopOp, ok := stop.(*ssh.SSHTunnelProcessStop)
-			require.True(t, ok, "stop operation is not of type SSHTunnelProcessStop")
-			assert.Equal(t, startOp, stopOp.Start, "stop operation process does not match start operation process")
-		})
-
-		t.Run("it returns security check operation", func(t *testing.T) {
-			dest := ssh.NewDestination("user@remote")
-
-			_, securityCheck, _ := ssh.NewSSHTunnel(dest, "44553", true)
-
-			_, ok := securityCheck.(*ssh.CheckRemoteForwardNotExposed)
-			assert.True(t, ok, "security check operation is not of type CheckRemoteForwardNotExposed")
-		})
-	})
-}
 
 func TestSSHTunnelStart(t *testing.T) {
 	t.Run("Command", func(t *testing.T) {
@@ -95,86 +45,6 @@ func TestSSHTunnelStart(t *testing.T) {
 			assert.Equal(t, "Open registry SSH tunnel", got)
 		})
 	})
-}
-
-func TestCheckRemoteForwardNotExposed(t *testing.T) {
-	t.Run("Description", func(t *testing.T) {
-		t.Run("it returns the expected string", func(t *testing.T) {
-			cs := ssh.NewCheckRemoteForwardNotExposed(ssh.NewDestination("user@remote"), "12345")
-
-			got := cs.Description()
-
-			assert.Equal(t, "Check tunnel port is not exposed on remote network", got)
-		})
-	})
-
-	t.Run("Run", func(t *testing.T) {
-		t.Run("it skips the check for localhost", func(t *testing.T) {
-			check := ssh.NewCheckRemoteForwardNotExposed(ssh.PlainLocalhost, "invalid")
-			var output strings.Builder
-
-			err := check.Run(&output)
-
-			assert.NoError(t, err)
-			assert.Empty(t, output.String())
-		})
-
-		t.Run("it fails when the SSH hostname cannot be resolved", func(t *testing.T) {
-			check := ssh.NewCheckRemoteForwardNotExposed(ssh.Destination{}, "12345")
-
-			err := check.Run(io.Discard)
-
-			assert.ErrorContains(t, err, "cannot conclusively rule out network access to registry port 12345")
-			assert.ErrorContains(t, err, `could not resolve SSH configuration for "ssh://"`)
-			assert.ErrorContains(t, err, "use `--skip-remote-port-check` if you understand the security risk")
-		})
-
-		t.Run("it succeeds when the remote port refuses the connection", func(t *testing.T) {
-			port := reserveFreePort(t, "0.0.0.0")
-			check := ssh.NewCheckRemoteForwardNotExposed(ssh.NewDestination("0.0.0.0"), port)
-			var output strings.Builder
-
-			err := check.Run(&output)
-
-			assert.NoError(t, err)
-			assert.Equal(t, fmt.Sprintf("Port %s is bound to remote loopback only\n", port), output.String())
-		})
-
-		t.Run("it fails when the remote port accepts a connection", func(t *testing.T) {
-			listener, err := net.Listen("tcp", "127.0.0.1:0")
-			require.NoError(t, err)
-			t.Cleanup(func() { _ = listener.Close() })
-			connectionClosed := make(chan error, 1)
-			go func() {
-				connection, acceptErr := listener.Accept()
-				if acceptErr != nil {
-					connectionClosed <- acceptErr
-					return
-				}
-				connectionClosed <- connection.Close()
-			}()
-			_, port, err := net.SplitHostPort(listener.Addr().String())
-			require.NoError(t, err)
-			check := ssh.NewCheckRemoteForwardNotExposed(ssh.NewDestination("localhost."), port)
-
-			err = check.Run(io.Discard)
-			listenerCloseErr := listener.Close()
-
-			assert.EqualError(t, err, fmt.Sprintf("the remote SSH server is exposing forwarded registry port %s beyond remote loopback; configure the SSH server to bind remote forwards to loopback only, or use `--skip-remote-port-check` if you understand that the registry may be reachable without SSH authentication", port))
-			assert.NoError(t, listenerCloseErr)
-			assert.NoError(t, <-connectionClosed)
-		})
-	})
-}
-
-func reserveFreePort(t *testing.T, host string) string {
-	t.Helper()
-	listener, err := net.Listen("tcp", net.JoinHostPort(host, "0"))
-	require.NoError(t, err)
-	_, port, err := net.SplitHostPort(listener.Addr().String())
-	require.NoError(t, err)
-	require.NoError(t, listener.Close())
-	return port
 }
 
 func TestSSHTunnelStop(t *testing.T) {


### PR DESCRIPTION
<!-- PR title should be formatted using conventional commits -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->
<!-- Example: feat: A very fancy feature -->

## Changes

<!-- List the changes this PR introduces -->

- Move registry tunnel exposure validation out of `internal/ssh` and into a deploy operation.
- Simplify `ssh.NewSSHTunnel` to only return tunnel start and stop operations.
- Add `internal/netprobe.PortRefusesConnection` for reusable port probing.
- Update deployment sequencing/tests to insert the registry tunnel exposure check explicitly.

## Checklist

<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->

- [x] 🤖 This change is covered by tests as required.
- [x] 🤹 All required manual testing has been performed.
- [x] 📖 All documentation updates are complete.
