### PR TITLE
docs: breaking changes policy

### DIFF
--- a/docs/development/DEVELOPMENT.md
+++ b/docs/development/DEVELOPMENT.md
@@ -44,13 +44,13 @@ Some tests have a dependency on docker. Test container images are built automati
 
 #### Golden Files
 
-A subset of the end-to-end tests use golden files to compare CLI output with known output. These tests fail whenever the output changes. An output change is not necessarily breaking. Review the [breaking change policy](breaking-changes.md) before accepting the change.
-
-Update the golden files after confirming that the new output is compatible or that the change is set as breaking:
+A subset of our e2e tests rely on "golden files" to assert CLI output against a known good state. These tests will fail when the CLI output has changed and can be updated in place with the `UPDATE_GOLDEN` environment variable when running the tests.
 
 ```
 UPDATE_GOLDEN=1 go test ./e2e/...
 ```
+
+While an output change is not necessarily breaking, it's worth reviewing the [breaking change policy](breaking-changes.md) and ensuring the change is marked as breaking/non-breaking appropriately before approving.
 
 ## Skills
 

--- a/docs/development/DEVELOPMENT.md
+++ b/docs/development/DEVELOPMENT.md
@@ -1,4 +1,4 @@
-# Development Guide
+# Development guide
 
 This guide covers the development workflow, tools, and conventions for contributing to `topo`.
 
@@ -44,7 +44,9 @@ Some tests have a dependency on docker. Test container images are built automati
 
 #### Golden Files
 
-A subset of our e2e tests rely on "golden files" to assert CLI output against a known good state. These tests will fail when breaking changes are made and can be updated in place with the `UPDATE_GOLDEN` environment variable when running the tests.
+A subset of the end-to-end tests use golden files to compare CLI output with known output. These tests fail whenever the output changes. An output change is not necessarily breaking. Review the [breaking change policy](breaking-changes.md) before accepting the change.
+
+Update the golden files after confirming that the new output is compatible or that the change is set as breaking:
 
 ```
 UPDATE_GOLDEN=1 go test ./e2e/...

--- a/docs/development/_category_.json
+++ b/docs/development/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "Contributing",
+  "position": 2,
+  "link": null
+}

--- a/docs/development/breaking-changes.md
+++ b/docs/development/breaking-changes.md
@@ -1,0 +1,121 @@
+# Breaking change policy
+
+This policy defines which changes to the Topo are breaking changes for end users. It helps reviewers classify changes consistently before a release.
+
+This policy explicitly does not extend to:
+
+- Hidden commands and flags
+- Experimental features
+- Human-readable output, help text, warnings, and logs
+- Source code APIs and packages
+- Build tools and developer scripts
+- Undocumented or malformed input that the binary happened to accept
+
+A hidden or experimental interface becomes part of the compatibility contract when it is promoted to a documented, supported interface.
+
+## CLI compatibility
+
+The following CLI changes are breaking:
+
+- Removing or renaming of a supported command, flag, positional argument, or environment variable consitutes a breaking change.
+- Making an optional flag or environment variable required
+
+The following CLI changes are not breaking:
+
+- Adding a command, flag, positional argument, or environment variable without changing existing behavior
+- Renaming an interface while retaining the old form as a functional alias
+- Changing help text or completion descriptions
+
+## JSON compatibility
+
+JSON structure is contractual. JSON values are not contractual unless their allowed values are explicitly documented as a closed set.
+
+The following JSON changes are breaking:
+
+- Removing or renaming a field
+- Changing a field type, nullability/optionality or nesting
+- Changing documented array ordering semantics
+- Adding a value to an explicitly documented closed set of allowed values
+
+The following JSON changes are not breaking:
+
+- Adding an optional field
+- Reordering object fields
+- Changing field values, descriptive labels, or messages
+- Changing array contents
+- Adding a value when the allowed values are not documented as a closed set
+
+Consumers must ignore unknown optional fields and must not depend on specific values unless the documentation defines those values as stable.
+
+A JSON value change can still accompany a breaking behavior change. Evaluate the underlying behavior separately under this policy.
+
+## Host and target requirements
+
+A new or stricter requirement is breaking when a previously supported host or target no longer works.
+This rule includes:
+
+- Requiring a new executable, daemon, runtime, kernel capability, hardware feature, or network service
+- Increasing a minimum dependency version
+- Supporting fewer implementations, operating systems, or architectures
+- Requiring new permissions, configuration, credentials, or network access
+
+Removing a host or target requirement is not breaking if existing user capabilities remain available.
+
+## Project and configuration formats
+
+The following input format changes are breaking:
+
+- Rejecting input that was valid according to the released documentation
+- Removing or renaming a supported field
+- Making an optional field required
+- Narrowing an accepted type, range, or set of values
+- Giving existing input incompatible semantics
+
+The following input format changes are not breaking:
+
+- Adding an optional field or accepted value
+- Accepting additional input forms
+- Warning that a supported input form is deprecated while continuing to accept it
+- Rejecting malformed or undocumented input that happened to be tolerated
+
+## Compatibility across upgrades
+
+A newer binary must continue to read and operate on files created or modified by the previous released version. A change is breaking if it requires manual migration, silently discards data, or cannot read those files.
+
+Automatic, lossless migration is not breaking. Topo does not guarantee that an older binary can read files after a newer binary migrates them unless rollback support is explicitly documented.
+
+A newer binary must also continue to manage existing deployments. A change is breaking if users can no longer inspect, update, redeploy, or stop a deployment without recreating or manually repairing it.
+
+## Exit status compatibility
+
+The following changes are breaking:
+
+- Changing an existing successful scenario from exit status `0` to a nonzero status
+- Changing an existing failure scenario from a nonzero status to `0`
+- Changing a specific nonzero status when that status is documented
+
+Changing an undocumented nonzero status is not breaking. Error wording, log levels, timestamps, and diagnostic detail are not contractual.
+
+JSON-formatted logs follow the JSON compatibility rules in this policy.
+
+## Human-readable output
+
+Human-readable output is not contractual. The following output can change without creating a breaking change:
+
+- Wording and labels
+- Formatting and ordering
+- Progress indicators
+- Warnings and logs
+- Help text
+
+User scripts are encouraged to consume JSON output when Topo provides it. Text is contractual only if the documentation explicitly defines it as machine-readable or suitable for shell evaluation.
+
+## Deprecation and removal
+
+Deprecation does not make a later removal non-breaking. It only communicates a future breaking change and gives users time to migrate.
+
+## Bug fixes
+
+Correcting behavior that clearly contradicts the documentation is not breaking, even if users may rely on the incorrect behavior. Changing documented behavior is breaking, even when the change is described as a fix.
+
+For undocumented behavior, try to apply the general rules outlined in this policy.

--- a/docs/development/breaking-changes.md
+++ b/docs/development/breaking-changes.md
@@ -1,6 +1,6 @@
 # Breaking change policy
 
-This policy defines which changes to the Topo are breaking changes for end users. It helps reviewers classify changes consistently before a release.
+This policy defines which changes to the Topo are breaking changes. It helps reviewers classify changes consistently before a release.
 
 This policy explicitly does not extend to:
 

--- a/docs/development/breaking-changes.md
+++ b/docs/development/breaking-changes.md
@@ -33,13 +33,15 @@ JSON structure is contractual. JSON values are not contractual unless their allo
 The following JSON changes are breaking:
 
 - Removing or renaming a field
-- Changing a field type, nullability/optionality or nesting
+- Making a previously required/non-nullable field optional/nullable
+- Changing a field type or nesting
 - Changing documented array ordering semantics
 - Adding a value to an explicitly documented closed set of allowed values
 
 The following JSON changes are not breaking:
 
 - Adding an optional field
+- Making a previously optional/nullable field required/non-nullable
 - Reordering object fields
 - Changing field values, descriptive labels, or messages
 - Changing array contents


### PR DESCRIPTION
<!-- PR title should be formatted using conventional commits -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->
<!-- Example: feat: A very fancy feature -->

## Changes

<!-- List the changes this PR introduces -->

- Adds a breaking changes policy document, links to it from the general development guide.
  - The content of this policy is relatively opinionated and is informed by my ideas of where to draw the line on breaking changes. Please throw many stones at it so we can get something we're all happy with!
- Fixes the casing of 'Development guide' to use sentence case as encouraged by the Arm technical writing style guide as I was editing that file.
- Puts both these files under a 'Contributing' section

<img width="237" height="100" alt="Screenshot 2026-07-17 at 13 31 44" src="https://github.com/user-attachments/assets/9284011f-842a-4300-a1e3-94c8ae953d23" />


## Checklist

<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->

- [x] 🤖 This change is covered by tests as required.
- [x] 🤹 All required manual testing has been performed.
- [x] 📖 All documentation updates are complete.
