### PR TITLE
ci: tag deleted on fail

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -164,45 +164,16 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.publisher-token.outputs.token }}
           PUBLISHER_RUN_ID: ${{ steps.trigger_sign_and_release.outputs.publisher_run_id }}
-          ARTIFACT_NAME: release-links
         run: |
-          echo "Waiting for $ARTIFACT_NAME artifact from topo-publisher run $PUBLISHER_RUN_ID"
+          gh run watch "$PUBLISHER_RUN_ID" \
+            --repo Arm-Debug/topo-publisher \
+            --compact \
+            --exit-status
 
-          for attempt in {1..30}; do
-            artifact_id="$(gh api \
-              "repos/Arm-Debug/topo-publisher/actions/runs/$PUBLISHER_RUN_ID/artifacts" \
-              --jq ".artifacts | map(select(.name == \"$ARTIFACT_NAME\")) | .[0].id // empty")"
-
-            if [ -n "$artifact_id" ]; then
-              echo "Found $ARTIFACT_NAME artifact: $artifact_id"
-              gh run download "$PUBLISHER_RUN_ID" \
-                --repo Arm-Debug/topo-publisher \
-                --name "$ARTIFACT_NAME" \
-                --dir publisher-artifacts
-              exit $?
-            fi
-
-            status="$(gh run view "$PUBLISHER_RUN_ID" \
-              --repo Arm-Debug/topo-publisher \
-              --json status \
-              --jq .status)"
-
-            conclusion="$(gh run view "$PUBLISHER_RUN_ID" \
-              --repo Arm-Debug/topo-publisher \
-              --json conclusion \
-              --jq '.conclusion // ""')"
-
-            if [ "$status" = "completed" ]; then
-              echo "::error::topo-publisher run completed with conclusion '$conclusion' before producing $ARTIFACT_NAME"
-              exit 1
-            fi
-
-            echo "$ARTIFACT_NAME is not available yet; publisher run status is $status; retrying in 60 seconds ($attempt/30)"
-            sleep 60
-          done
-
-          echo "::error::Timed out waiting for $ARTIFACT_NAME artifact from topo-publisher run $PUBLISHER_RUN_ID"
-          exit 1
+          gh run download "$PUBLISHER_RUN_ID" \
+            --repo Arm-Debug/topo-publisher \
+            --name release-links \
+            --dir publisher-artifacts
 
       - name: Update and publish release
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,6 +49,7 @@ jobs:
           git config --global user.name "topo-release"
 
       - name: Create tag
+        id: create_tag
         run: |
           git tag -a "${{ steps.calculate_next_version.outputs.next_version }}" -m "Release ${{ steps.calculate_next_version.outputs.next_version }}"
           git push origin "${{ steps.calculate_next_version.outputs.next_version }}"
@@ -197,3 +198,9 @@ jobs:
           else
             gh release create "$RELEASE_TAG" --title "$RELEASE_TAG" --notes-file combined_notes.md
           fi
+
+      - name: Delete tag after failure
+        if: ${{ (failure() || cancelled()) && steps.create_tag.outcome == 'success' }}
+        env:
+          RELEASE_TAG: ${{ steps.calculate_next_version.outputs.next_version }}
+        run: git push origin --delete "$RELEASE_TAG"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,6 +16,9 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-24.04-arm
+    outputs:
+      release_tag: ${{ steps.calculate_next_version.outputs.next_version }}
+      tag_created: ${{ steps.create_tag.outcome == 'success' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -200,8 +203,13 @@ jobs:
             gh release create "$RELEASE_TAG" --title "$RELEASE_TAG" --notes-file combined_notes.md
           fi
 
-      - name: Delete tag after failure
-        if: ${{ (failure() || cancelled()) && steps.create_tag.outcome == 'success' }}
+  cleanup:
+    needs: release
+    if: ${{ always() && needs.release.result != 'success' && needs.release.outputs.tag_created == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete tag after release failure
         env:
-          RELEASE_TAG: ${{ steps.calculate_next_version.outputs.next_version }}
-        run: git push origin --delete "$RELEASE_TAG"
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ needs.release.outputs.release_tag }}
+        run: gh api --method DELETE "repos/${{ github.repository }}/git/refs/tags/$RELEASE_TAG"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -169,6 +169,7 @@ jobs:
           gh run watch "$PUBLISHER_RUN_ID" \
             --repo Arm-Debug/topo-publisher \
             --compact \
+            --interval 60 \
             --exit-status
 
           gh run download "$PUBLISHER_RUN_ID" \


### PR DESCRIPTION
<!-- PR title should be formatted using conventional commits -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->
<!-- Example: feat: A very fancy feature -->

## Changes

<!-- List the changes this PR introduces -->

- remove the release tag from repo if the release failed
- use `gh run watch` instead of polling to keep an eye of publisher's failure

## Checklist

<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->

- [ ] 🤖 This change is covered by tests as required.
- [ ] 🤹 All required manual testing has been performed.
- [ ] 📖 All documentation updates are complete.
