### PR TITLE
feat!: add docker compose health check

### DIFF
--- a/e2e/testdata/TestHealthCheckJson.golden
+++ b/e2e/testdata/TestHealthCheckJson.golden
@@ -20,6 +20,11 @@
         "name": "Container Engine",
         "status": "ok",
         "value": "docker"
+      },
+      {
+        "name": "Docker Compose",
+        "status": "ok",
+        "value": "docker-compose"
       }
     ]
   },

--- a/internal/health/check.go
+++ b/internal/health/check.go
@@ -109,8 +109,8 @@ func (c DockerComposeCompatible) Run(ctx context.Context, r runner.Runner, _ Dep
 
 	if !version.IsAtLeastVersion(stdout, c.MinVersion) {
 		return &Fix{
-			Description: fmt.Sprintf("Upgrade Docker Compose to at least version %s", c.MinVersion),
-		}, fmt.Errorf("installed docker compose version %q is less than required version %q", stdout, c.MinVersion)
+			Description: fmt.Sprintf("Upgrade Docker Compose to version %s or later", c.MinVersion),
+		}, fmt.Errorf("installed docker compose version %q is older than required version %q", stdout, c.MinVersion)
 	}
 
 	return nil, nil

--- a/internal/health/check.go
+++ b/internal/health/check.go
@@ -2,6 +2,7 @@ package health
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"slices"
@@ -95,22 +96,28 @@ func (o OpenSSHAvailable) Run(ctx context.Context, r runner.Runner, dep Dependen
 	return nil, nil
 }
 
-type DockerComposeCompatible struct {
+type DockerComposeMinVersion struct {
 	MinVersion string
 }
 
-func (c DockerComposeCompatible) Run(ctx context.Context, r runner.Runner, _ Dependency) (*Fix, error) {
-	stdout, _, err := r.Run(ctx, "docker compose version")
+func (c DockerComposeMinVersion) Run(ctx context.Context, r runner.Runner, _ Dependency) (*Fix, error) {
+	stdout, _, err := r.Run(ctx, "docker compose version --format json")
 	if err != nil {
-		return &Fix{
-			Description: "Ensure Docker Compose is installed as a plugin for Docker",
-		}, errors.New(strings.ReplaceAll(err.Error(), "\n", " "))
+		return nil, err
 	}
 
-	if !version.IsAtLeastVersion(stdout, c.MinVersion) {
+	var output struct {
+		Version string `json:"version"`
+	}
+	err = json.Unmarshal([]byte(stdout), &output)
+	if err != nil {
+		return nil, err
+	}
+
+	if !version.IsAtLeastVersion(output.Version, c.MinVersion) {
 		return &Fix{
 			Description: fmt.Sprintf("Upgrade Docker Compose to version %s or later", c.MinVersion),
-		}, fmt.Errorf("installed docker compose version %q is older than required version %q", stdout, c.MinVersion)
+		}, fmt.Errorf("installed docker compose version %s is older than required version %s", output.Version, c.MinVersion)
 	}
 
 	return nil, nil

--- a/internal/health/check.go
+++ b/internal/health/check.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/arm/topo/internal/output/logger"
 	"github.com/arm/topo/internal/runner"
+	"github.com/arm/topo/internal/version"
 )
 
 type Check interface {
@@ -91,6 +92,27 @@ func (o OpenSSHAvailable) Run(ctx context.Context, r runner.Runner, dep Dependen
 			Description: "Install OpenSSH and ensure its ssh executable is first on PATH",
 		}, fmt.Errorf("%q does not resolve to OpenSSH: %s", dep.Binary, stderr)
 	}
+	return nil, nil
+}
+
+type DockerComposeCompatible struct {
+	MinVersion string
+}
+
+func (c DockerComposeCompatible) Run(ctx context.Context, r runner.Runner, _ Dependency) (*Fix, error) {
+	stdout, _, err := r.Run(ctx, "docker compose version")
+	if err != nil {
+		return &Fix{
+			Description: "Ensure Docker Compose is installed as a plugin for Docker",
+		}, errors.New(strings.ReplaceAll(err.Error(), "\n", " "))
+	}
+
+	if !version.IsAtLeastVersion(stdout, c.MinVersion) {
+		return &Fix{
+			Description: fmt.Sprintf("Upgrade Docker Compose to at least version %s", c.MinVersion),
+		}, fmt.Errorf("installed docker compose version %q is less than required version %q", stdout, c.MinVersion)
+	}
+
 	return nil, nil
 }
 

--- a/internal/health/check_test.go
+++ b/internal/health/check_test.go
@@ -212,7 +212,7 @@ Run 'docker --help' for more information`
 		fix, err := check.Run(ctx, runner, dep)
 
 		assert.Contains(t, err.Error(), "1.9.0")
-		assert.Contains(t, err.Error(), "less than required version")
+		assert.Contains(t, err.Error(), "older than required version")
 		assert.Contains(t, fix.Description, "Upgrade Docker Compose")
 	})
 }

--- a/internal/health/check_test.go
+++ b/internal/health/check_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/arm/topo/internal/health"
@@ -141,10 +140,10 @@ func TestDockerComposeCompatible(t *testing.T) {
 	dep := health.Dependency{}
 
 	t.Run("accepts Docker Compose at the minimum version", func(t *testing.T) {
-		check := health.DockerComposeCompatible{MinVersion: "2.0.0"}
+		check := health.DockerComposeMinVersion{MinVersion: "2.0.0"}
 		runner := &runner.Fake{
 			Commands: map[string]runner.FakeResult{
-				"docker compose version": {Output: "Docker Compose version 2.0.0"},
+				"docker compose version --format json": {Output: `{"version": "2.0.0"}`},
 			},
 		}
 
@@ -155,10 +154,10 @@ func TestDockerComposeCompatible(t *testing.T) {
 	})
 
 	t.Run("accepts Docker Compose newer than the minimum version", func(t *testing.T) {
-		check := health.DockerComposeCompatible{MinVersion: "2.0.0"}
+		check := health.DockerComposeMinVersion{MinVersion: "2.0.0"}
 		runner := &runner.Fake{
 			Commands: map[string]runner.FakeResult{
-				"docker compose version": {Output: "Docker Compose version 5.2.0"},
+				"docker compose version --format json": {Output: `{"version": "5.2.0"}`},
 			},
 		}
 
@@ -168,51 +167,17 @@ func TestDockerComposeCompatible(t *testing.T) {
 		assert.Nil(t, fix)
 	})
 
-	t.Run("returns a plugin installation fix when the version command fails", func(t *testing.T) {
-		check := health.DockerComposeCompatible{MinVersion: "2.0.0"}
-		runner := &runner.Fake{
-			Commands: map[string]runner.FakeResult{
-				"docker compose version": {
-					Err: fmt.Errorf("it blew up"),
-				},
-			},
-		}
-
-		fix, err := check.Run(ctx, runner, dep)
-
-		assert.EqualError(t, err, "it blew up")
-		assert.Equal(t, fix.Description, "Ensure Docker Compose is installed as a plugin for Docker")
-	})
-
-	t.Run("joins multi-line executions error into a one line", func(t *testing.T) {
-		stderr := `docker: unknown command: docker compose
-
-Run 'docker --help' for more information`
-		check := health.DockerComposeCompatible{MinVersion: "2.0.0"}
-		runner := &runner.Fake{
-			Commands: map[string]runner.FakeResult{
-				"docker compose version": {
-					Err: errors.New(stderr),
-				},
-			},
-		}
-
-		_, err := check.Run(ctx, runner, dep)
-
-		assert.EqualError(t, err, strings.ReplaceAll(stderr, "\n", " "))
-	})
-
 	t.Run("returns an upgrade fix when Docker Compose is too old", func(t *testing.T) {
-		check := health.DockerComposeCompatible{MinVersion: "2.0.0"}
+		check := health.DockerComposeMinVersion{MinVersion: "2.0.0"}
 		runner := &runner.Fake{
 			Commands: map[string]runner.FakeResult{
-				"docker compose version": {Output: "Docker Compose version 1.9.0"},
+				"docker compose version --format json": {Output: `{"version": "v1.9.0"}`},
 			},
 		}
 
 		fix, err := check.Run(ctx, runner, dep)
 
-		assert.EqualError(t, err, "installed docker compose version \"Docker Compose version 1.9.0\" is older than required version \"2.0.0\"")
+		assert.EqualError(t, err, "installed docker compose version v1.9.0 is older than required version 2.0.0")
 		assert.Contains(t, fix.Description, "Upgrade Docker Compose")
 	})
 }

--- a/internal/health/check_test.go
+++ b/internal/health/check_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/arm/topo/internal/health"
@@ -171,10 +172,7 @@ func TestDockerComposeCompatible(t *testing.T) {
 		runner := &runner.Fake{
 			Commands: map[string]runner.FakeResult{
 				"docker compose version": {
-					Stderr: `docker: unknown command: docker compose
-
-Run 'docker --help' for more information`,
-					Err: errors.New("it blew up"),
+					Err: fmt.Errorf("it blew up"),
 				},
 			},
 		}
@@ -183,6 +181,24 @@ Run 'docker --help' for more information`,
 
 		assert.Contains(t, err.Error(), "it blew up")
 		assert.Contains(t, fix.Description, "as a plugin")
+	})
+
+	t.Run("joins multi-line executions error into a one line", func(t *testing.T) {
+		stderr := `docker: unknown command: docker compose
+
+Run 'docker --help' for more information`
+		check := health.DockerComposeCompatible{MinVersion: "2.0.0"}
+		runner := &runner.Fake{
+			Commands: map[string]runner.FakeResult{
+				"docker compose version": {
+					Err: errors.New(stderr),
+				},
+			},
+		}
+
+		_, err := check.Run(ctx, runner, dep)
+
+		assert.Contains(t, err.Error(), strings.ReplaceAll(stderr, "\n", " "))
 	})
 
 	t.Run("returns an upgrade fix when Docker Compose is too old", func(t *testing.T) {

--- a/internal/health/check_test.go
+++ b/internal/health/check_test.go
@@ -134,3 +134,69 @@ func TestOpenSSHAvailable(t *testing.T) {
 		assert.Nil(t, fix)
 	})
 }
+func TestDockerComposeCompatible(t *testing.T) {
+	ctx := context.Background()
+	dep := health.Dependency{}
+
+	t.Run("accepts Docker Compose at the minimum version", func(t *testing.T) {
+		check := health.DockerComposeCompatible{MinVersion: "2.0.0"}
+		runner := &runner.Fake{
+			Commands: map[string]runner.FakeResult{
+				"docker compose version": {Output: "Docker Compose version 2.0.0"},
+			},
+		}
+
+		fix, err := check.Run(ctx, runner, dep)
+
+		assert.NoError(t, err)
+		assert.Nil(t, fix)
+	})
+
+	t.Run("accepts Docker Compose newer than the minimum version", func(t *testing.T) {
+		check := health.DockerComposeCompatible{MinVersion: "2.0.0"}
+		runner := &runner.Fake{
+			Commands: map[string]runner.FakeResult{
+				"docker compose version": {Output: "Docker Compose version 5.2.0"},
+			},
+		}
+
+		fix, err := check.Run(ctx, runner, dep)
+
+		assert.NoError(t, err)
+		assert.Nil(t, fix)
+	})
+
+	t.Run("returns a plugin installation fix when the version command fails", func(t *testing.T) {
+		check := health.DockerComposeCompatible{MinVersion: "2.0.0"}
+		runner := &runner.Fake{
+			Commands: map[string]runner.FakeResult{
+				"docker compose version": {
+					Stderr: `docker: unknown command: docker compose
+
+Run 'docker --help' for more information`,
+					Err: errors.New("it blew up"),
+				},
+			},
+		}
+
+		fix, err := check.Run(ctx, runner, dep)
+
+		assert.Contains(t, err.Error(), "it blew up")
+		assert.Contains(t, fix.Description, "as a plugin")
+	})
+
+	t.Run("returns an upgrade fix when Docker Compose is too old", func(t *testing.T) {
+		check := health.DockerComposeCompatible{MinVersion: "2.0.0"}
+		runner := &runner.Fake{
+			Commands: map[string]runner.FakeResult{
+				"docker compose version": {Output: "Docker Compose version 1.9.0"},
+			},
+		}
+
+		fix, err := check.Run(ctx, runner, dep)
+
+		assert.Contains(t, err.Error(), "1.9.0")
+		assert.Contains(t, err.Error(), "less than required version")
+		assert.Contains(t, fix.Description, "Upgrade Docker Compose")
+	})
+}

--- a/internal/health/check_test.go
+++ b/internal/health/check_test.go
@@ -135,6 +135,7 @@ func TestOpenSSHAvailable(t *testing.T) {
 		assert.Nil(t, fix)
 	})
 }
+
 func TestDockerComposeCompatible(t *testing.T) {
 	ctx := context.Background()
 	dep := health.Dependency{}

--- a/internal/health/check_test.go
+++ b/internal/health/check_test.go
@@ -198,7 +198,7 @@ Run 'docker --help' for more information`
 
 		_, err := check.Run(ctx, runner, dep)
 
-		assert.Contains(t, err.Error(), strings.ReplaceAll(stderr, "\n", " "))
+		assert.EqualError(t, err, strings.ReplaceAll(stderr, "\n", " "))
 	})
 
 	t.Run("returns an upgrade fix when Docker Compose is too old", func(t *testing.T) {

--- a/internal/health/check_test.go
+++ b/internal/health/check_test.go
@@ -179,8 +179,8 @@ func TestDockerComposeCompatible(t *testing.T) {
 
 		fix, err := check.Run(ctx, runner, dep)
 
-		assert.Contains(t, err.Error(), "it blew up")
-		assert.Contains(t, fix.Description, "as a plugin")
+		assert.EqualError(t, err, "it blew up")
+		assert.Equal(t, fix.Description, "Ensure Docker Compose is installed as a plugin for Docker")
 	})
 
 	t.Run("joins multi-line executions error into a one line", func(t *testing.T) {
@@ -211,8 +211,7 @@ Run 'docker --help' for more information`
 
 		fix, err := check.Run(ctx, runner, dep)
 
-		assert.Contains(t, err.Error(), "1.9.0")
-		assert.Contains(t, err.Error(), "older than required version")
+		assert.EqualError(t, err, "installed docker compose version \"Docker Compose version 1.9.0\" is older than required version \"2.0.0\"")
 		assert.Contains(t, fix.Description, "Upgrade Docker Compose")
 	})
 }

--- a/internal/health/dependencies.go
+++ b/internal/health/dependencies.go
@@ -103,7 +103,13 @@ var HostRequiredDependencies = []Dependency{
 		Label:                 "Docker Compose",
 		SoftwarePrerequisites: []SoftwareDependency{Docker},
 		Checks: []Check{
-			DockerComposeCompatible{
+			CommandSuccessful{
+				Cmd: "docker compose",
+				Fix: &Fix{
+					Description: "Ensure Docker Compose is installed as a plugin for Docker",
+				},
+			},
+			DockerComposeMinVersion{
 				MinVersion: "2.21.0",
 			},
 		},

--- a/internal/health/dependencies.go
+++ b/internal/health/dependencies.go
@@ -98,6 +98,16 @@ var HostRequiredDependencies = []Dependency{
 			},
 		},
 	},
+	{
+		Binary:                "docker-compose",
+		Label:                 "Docker Compose",
+		SoftwarePrerequisites: []SoftwareDependency{Docker},
+		Checks: []Check{
+			DockerComposeCompatible{
+				MinVersion: "2.21.0",
+			},
+		},
+	},
 }
 
 func TargetRequiredDependencies(target ssh.Destination) []Dependency {

--- a/internal/version/latest_artifactory.go
+++ b/internal/version/latest_artifactory.go
@@ -6,18 +6,13 @@ import (
 	"io"
 	"maps"
 	"net/http"
-	"regexp"
 	"slices"
 	"sort"
-	"strconv"
-	"strings"
 
 	"github.com/arm/topo/internal/output/logger"
 )
 
 const ArtifactoryBaseURL = "https://artifacts.tools.arm.com/topo"
-
-var semverRe = regexp.MustCompile(`v(\d+)\.(\d+)\.(\d+)`)
 
 func FetchLatestArtifactory(ctx context.Context, url string) (string, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
@@ -65,17 +60,4 @@ func FetchLatestArtifactory(ctx context.Context, url string) (string, error) {
 	latest := versionsList[len(versionsList)-1]
 
 	return latest[1:], nil
-}
-
-func compareSemver(a, b string) int {
-	pa := semverRe.FindStringSubmatch(a)
-	pb := semverRe.FindStringSubmatch(b)
-	for i := 1; i <= 3; i++ {
-		na, _ := strconv.Atoi(pa[i])
-		nb, _ := strconv.Atoi(pb[i])
-		if na != nb {
-			return na - nb
-		}
-	}
-	return strings.Compare(a, b)
 }

--- a/internal/version/semver.go
+++ b/internal/version/semver.go
@@ -1,0 +1,37 @@
+package version
+
+import (
+	"regexp"
+	"strconv"
+)
+
+var semverRe = regexp.MustCompile(`v?(\d+)\.(\d+)\.(\d+)`)
+
+func parseSemver(version string) (major, minor, patch int) {
+	matches := semverRe.FindStringSubmatch(version)
+	if matches == nil {
+		return 0, 0, 0
+	}
+
+	major, _ = strconv.Atoi(matches[1])
+	minor, _ = strconv.Atoi(matches[2])
+	patch, _ = strconv.Atoi(matches[3])
+	return major, minor, patch
+}
+
+func compareSemver(a, b string) int {
+	majorA, minorA, patchA := parseSemver(a)
+	majorB, minorB, patchB := parseSemver(b)
+
+	if majorA != majorB {
+		return majorA - majorB
+	}
+	if minorA != minorB {
+		return minorA - minorB
+	}
+	return patchA - patchB
+}
+
+func IsAtLeastVersion(current, minimum string) bool {
+	return compareSemver(current, minimum) >= 0
+}

--- a/internal/version/semver_test.go
+++ b/internal/version/semver_test.go
@@ -1,9 +1,10 @@
-package version
+package version_test
 
 import (
 	"fmt"
 	"testing"
 
+	"github.com/arm/topo/internal/version"
 	"github.com/stretchr/testify/require"
 )
 
@@ -23,7 +24,7 @@ func TestIsAtLeastVersion(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("current = %s, minimum = %s", test.current, test.minimum), func(t *testing.T) {
-			result := IsAtLeastVersion(test.current, test.minimum)
+			result := version.IsAtLeastVersion(test.current, test.minimum)
 
 			require.Equal(t, test.expected, result)
 		})

--- a/internal/version/semver_test.go
+++ b/internal/version/semver_test.go
@@ -1,0 +1,31 @@
+package version
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsAtLeastVersion(t *testing.T) {
+	tests := []struct {
+		current, minimum string
+		expected         bool
+	}{
+		{"v1.0.0", "v1.0.0", true},
+		{"v1.2.3", "v1.0.0", true},
+		{"v1.9.9", "v1.10.0", false},
+		{"v2.0.0-alpha", "v2.0.0", true},
+		{"v2.1.0", "2.0.0", true},
+		{"v1.0.0", "invalid", true},
+		{"invalid", "v1.0.0", false},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("current = %s, minimum = %s", test.current, test.minimum), func(t *testing.T) {
+			result := IsAtLeastVersion(test.current, test.minimum)
+
+			require.Equal(t, test.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
<!-- PR title should be formatted using conventional commits -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->
<!-- Example: feat: A very fancy feature -->

## Changes

<!-- List the changes this PR introduces -->

- Adds a `docker compose version` probe to the health check that asserts:
  - Docker compose is usable as a docker CLI plugin with `docker compose` syntax
  - Docker compose is of the minimum required version. I found this to be [2.21.0](https://github.com/docker/compose/releases?page=8#release-v2.21.0) which changes the `docker compose ps` output format to the one we expect

## Implementation

- Avoids use of `docker compose --version` since docker CLI ignores invalid subcommands and parses the `--version` flag first i.e.:
```
❯ docker foobar --version          
Docker version 29.6.1, build 8900f1d330
```
- Pulls semver parsing out of the `upgrade` internals, exposes a public func for the check to use. Also makes semver parsing tolerate the lackof a `v` as it was dropped from the `docker-compose version` output at some point
```
adahod01@lima-default:~$ docker compose version
Docker Compose version v2.21.0
```
```
❯ docker compose version
Docker Compose version 5.2.0
```
- Robust to a dead daemon since `docker compose version` does not rely on it. We also predicate the check on the container engine health check.

## Future podman concerns

Podman allows us to force a certain compose provider with an env var, thus never needing to assert anything about the 'Docker Compose version ...' bit of the stdout e.g.:
```
❯ PODMAN_COMPOSE_PROVIDER=docker-compose podman compose version 2>/dev/null
Docker Compose version 5.2.0
```
This usually means `docker-compose` will be on the path. This doesn't really matter to us - we will only care if `podman compose version` gives the expected output. 

## Checklist

<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->

- [x] 🤖 This change is covered by tests as required.
- [x] 🤹 All required manual testing has been performed.
- [x] 📖 All documentation updates are complete.
