### PR TITLE
refactor: add procedural layer for port exposure check

### DIFF
--- a/internal/deploy/deploy.go
+++ b/internal/deploy/deploy.go
@@ -47,7 +47,7 @@ func NewDeployment(composeFile string, opts DeployOptions) (goperation.Sequence,
 			cleanup = stopTunnel
 			ops = append(ops, operation.NewRunRegistry(opts.Registry.Port)...)
 			ops = append(ops, startTunnel)
-			if !opts.Registry.SkipRemotePortCheck {
+			if !opts.TargetHost.IsLocalhost() && !opts.Registry.SkipRemotePortCheck {
 				ops = append(ops, operation.NewRegistryTunnelExposureCheck(opts.TargetHost, opts.Registry.Port))
 			}
 			ops = append(ops, operation.NewRegistryTransfer(composeFile, sourceHost, targetHost, opts.Registry.Port))

--- a/internal/deploy/deploy_test.go
+++ b/internal/deploy/deploy_test.go
@@ -129,6 +129,19 @@ func TestNewDeployment(t *testing.T) {
 		assert.Equal(t, want, got)
 	})
 
+	t.Run("excludes the remote port check for a localhost SSH target", func(t *testing.T) {
+		localhostSSHDest := ssh.NewDestination("ssh://root@localhost:2222")
+		opts := deploy.DeployOptions{
+			TargetHost: localhostSSHDest,
+			Registry:   &deploy.RegistryConfig{Port: operation.DefaultRegistryPort},
+		}
+
+		got, _ := deploy.NewDeployment(composeFile, opts)
+
+		remotePortCheck := operation.NewRegistryTunnelExposureCheck(localhostSSHDest, opts.Registry.Port)
+		assert.NotContains(t, got, remotePortCheck)
+	})
+
 	t.Run("excludes the remote port check when skipped", func(t *testing.T) {
 		remoteDest := ssh.NewDestination("user@remote")
 		opts := deploy.DeployOptions{

--- a/internal/deploy/docker/tunnel_exposure_check.go
+++ b/internal/deploy/docker/tunnel_exposure_check.go
@@ -1,0 +1,34 @@
+package docker
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/arm/topo/internal/netprobe"
+	"github.com/arm/topo/internal/ssh"
+)
+
+// CheckTunnelExposure checks whether the registry tunnel port exposes the
+// registry to the target's network, rather than being limited to target
+// loopback. This can happen when the SSH server permits non-loopback remote
+// forwards.
+func CheckTunnelExposure(ctx context.Context, output io.Writer, targetDest ssh.Destination, port string) error {
+	host, err := ssh.ResolveHostName(ctx, targetDest)
+	if err != nil {
+		return remotePortCheckErrorWithSuggestion(err, port)
+	}
+	listening, err := netprobe.IsRemotePortListening(ctx, host, port)
+	if err != nil {
+		return remotePortCheckErrorWithSuggestion(err, port)
+	}
+	if listening {
+		return fmt.Errorf("the remote SSH server is exposing forwarded registry port %s beyond remote loopback; configure the SSH server to bind remote forwards to loopback only, or use `--skip-remote-port-check` if you understand that the registry may be reachable without SSH authentication", port)
+	}
+	_, _ = fmt.Fprintf(output, "Registry port %s is bound to remote loopback only\n", port)
+	return nil
+}
+
+func remotePortCheckErrorWithSuggestion(err error, port string) error {
+	return fmt.Errorf("cannot conclusively rule out network access to registry port %s because the exposure check did not complete: %w; retry after resolving the connectivity issue, or use `--skip-remote-port-check` if you understand the security risk", port, err)
+}

--- a/internal/deploy/docker/tunnel_exposure_check_test.go
+++ b/internal/deploy/docker/tunnel_exposure_check_test.go
@@ -1,41 +1,22 @@
-package operation_test
+package docker_test
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net"
 	"strings"
 	"testing"
 
-	"github.com/arm/topo/internal/deploy/operation"
+	"github.com/arm/topo/internal/deploy/docker"
 	"github.com/arm/topo/internal/ssh"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestRegistryTunnelExposureCheck(t *testing.T) {
-	t.Run("returns the expected description", func(t *testing.T) {
-		check := operation.NewRegistryTunnelExposureCheck(ssh.NewDestination("user@remote"), "12345")
-
-		got := check.Description()
-
-		assert.Equal(t, "Check registry tunnel is not exposed on remote network", got)
-	})
-
-	t.Run("skips the check for localhost", func(t *testing.T) {
-		check := operation.NewRegistryTunnelExposureCheck(ssh.PlainLocalhost, "invalid")
-		var output strings.Builder
-
-		err := check.Run(&output)
-
-		assert.NoError(t, err)
-		assert.Empty(t, output.String())
-	})
-
+func TestCheckTunnelExposure(t *testing.T) {
 	t.Run("fails when the SSH hostname cannot be resolved", func(t *testing.T) {
-		check := operation.NewRegistryTunnelExposureCheck(ssh.Destination{}, "12345")
-
-		err := check.Run(io.Discard)
+		err := docker.CheckTunnelExposure(context.Background(), io.Discard, ssh.Destination{}, "12345")
 
 		assert.ErrorContains(t, err, "cannot conclusively rule out network access to registry port 12345")
 		assert.ErrorContains(t, err, `could not resolve SSH configuration for "ssh://"`)
@@ -44,10 +25,9 @@ func TestRegistryTunnelExposureCheck(t *testing.T) {
 
 	t.Run("succeeds when the remote port refuses the connection", func(t *testing.T) {
 		port := reserveFreePort(t, "0.0.0.0")
-		check := operation.NewRegistryTunnelExposureCheck(ssh.NewDestination("0.0.0.0"), port)
 		var output strings.Builder
 
-		err := check.Run(&output)
+		err := docker.CheckTunnelExposure(context.Background(), &output, ssh.NewDestination("0.0.0.0"), port)
 
 		assert.NoError(t, err)
 		assert.Equal(t, fmt.Sprintf("Registry port %s is bound to remote loopback only\n", port), output.String())
@@ -68,9 +48,8 @@ func TestRegistryTunnelExposureCheck(t *testing.T) {
 		}()
 		_, port, err := net.SplitHostPort(listener.Addr().String())
 		require.NoError(t, err)
-		check := operation.NewRegistryTunnelExposureCheck(ssh.NewDestination("localhost."), port)
 
-		err = check.Run(io.Discard)
+		err = docker.CheckTunnelExposure(context.Background(), io.Discard, ssh.NewDestination("localhost."), port)
 		listenerCloseErr := listener.Close()
 
 		assert.EqualError(t, err, fmt.Sprintf("the remote SSH server is exposing forwarded registry port %s beyond remote loopback; configure the SSH server to bind remote forwards to loopback only, or use `--skip-remote-port-check` if you understand that the registry may be reachable without SSH authentication", port))

--- a/internal/deploy/operation/registry_tunnel_exposure_check.go
+++ b/internal/deploy/operation/registry_tunnel_exposure_check.go
@@ -1,10 +1,10 @@
 package operation
 
 import (
-	"fmt"
+	"context"
 	"io"
 
-	"github.com/arm/topo/internal/netprobe"
+	"github.com/arm/topo/internal/deploy/docker"
 	"github.com/arm/topo/internal/ssh"
 )
 
@@ -25,26 +25,6 @@ func (c *RegistryTunnelExposureCheck) Description() string {
 	return "Check registry tunnel is not exposed on remote network"
 }
 
-func (c *RegistryTunnelExposureCheck) Run(w io.Writer) error {
-	if c.TargetDest.IsLocalhost() {
-		return nil
-	}
-
-	host, err := ssh.ResolveHostName(c.TargetDest)
-	if err != nil {
-		return remotePortCheckErrorWithSuggestion(err, c.Port)
-	}
-	listening, err := netprobe.IsRemotePortListening(host, c.Port)
-	if err != nil {
-		return remotePortCheckErrorWithSuggestion(err, c.Port)
-	}
-	if listening {
-		return fmt.Errorf("the remote SSH server is exposing forwarded registry port %s beyond remote loopback; configure the SSH server to bind remote forwards to loopback only, or use `--skip-remote-port-check` if you understand that the registry may be reachable without SSH authentication", c.Port)
-	}
-	_, _ = fmt.Fprintf(w, "Registry port %s is bound to remote loopback only\n", c.Port)
-	return nil
-}
-
-func remotePortCheckErrorWithSuggestion(err error, port string) error {
-	return fmt.Errorf("cannot conclusively rule out network access to registry port %s because the exposure check did not complete: %w; retry after resolving the connectivity issue, or use `--skip-remote-port-check` if you understand the security risk", port, err)
+func (c *RegistryTunnelExposureCheck) Run(output io.Writer) error {
+	return docker.CheckTunnelExposure(context.Background(), output, c.TargetDest, c.Port)
 }

--- a/internal/netprobe/port.go
+++ b/internal/netprobe/port.go
@@ -1,6 +1,7 @@
 package netprobe
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -11,14 +12,14 @@ import (
 )
 
 // IsRemotePortListening reports whether host:port accepts TCP connections.
-func IsRemotePortListening(host, port string) (bool, error) {
+func IsRemotePortListening(ctx context.Context, host, port string) (bool, error) {
 	address := net.JoinHostPort(host, port)
 	var remoteIP strings.Builder
 	// Use curl so host resolution matches OpenSSH for mDNS, NSS, and split-DNS configurations.
 	// - remote_ip detects a connection even when HTTP fails
 	// - noproxy ensures the connection is direct
 	// - silent suppresses curl's progress and errors.
-	cmd := exec.Command("curl", "http://"+address, "--max-time", "5", "--noproxy", "*", "--output", os.DevNull, "--silent", "--write-out", "%{remote_ip}")
+	cmd := exec.CommandContext(ctx, "curl", "http://"+address, "--max-time", "5", "--noproxy", "*", "--output", os.DevNull, "--silent", "--write-out", "%{remote_ip}")
 	cmd.Stdout = &remoteIP
 	cmd.Stderr = io.Discard
 	err := cmd.Run()

--- a/internal/netprobe/port_test.go
+++ b/internal/netprobe/port_test.go
@@ -1,6 +1,7 @@
 package netprobe_test
 
 import (
+	"context"
 	"net"
 	"testing"
 
@@ -13,7 +14,7 @@ func TestIsRemotePortListening(t *testing.T) {
 	t.Run("returns false when the remote port refuses the connection", func(t *testing.T) {
 		port := reserveFreePort(t, "0.0.0.0")
 
-		got, err := netprobe.IsRemotePortListening("0.0.0.0", port)
+		got, err := netprobe.IsRemotePortListening(context.Background(), "0.0.0.0", port)
 
 		assert.NoError(t, err)
 		assert.False(t, got)
@@ -35,7 +36,7 @@ func TestIsRemotePortListening(t *testing.T) {
 		_, port, err := net.SplitHostPort(listener.Addr().String())
 		require.NoError(t, err)
 
-		got, err := netprobe.IsRemotePortListening("localhost.", port)
+		got, err := netprobe.IsRemotePortListening(context.Background(), "localhost.", port)
 		listenerCloseErr := listener.Close()
 
 		assert.NoError(t, err)
@@ -45,7 +46,7 @@ func TestIsRemotePortListening(t *testing.T) {
 	})
 
 	t.Run("returns an error when the remote host cannot be resolved", func(t *testing.T) {
-		got, err := netprobe.IsRemotePortListening("nonexistent.invalid", "12345")
+		got, err := netprobe.IsRemotePortListening(context.Background(), "nonexistent.invalid", "12345")
 
 		assert.ErrorContains(t, err, `could not resolve remote host "nonexistent.invalid"`)
 		assert.False(t, got)

--- a/internal/ssh/config.go
+++ b/internal/ssh/config.go
@@ -3,6 +3,7 @@ package ssh
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"fmt"
 	"os/exec"
 	"strings"
@@ -22,8 +23,8 @@ func NewConfig(dest Destination) Config {
 	return NewConfigFromBytes(output)
 }
 
-func ResolveHostName(dest Destination) (string, error) {
-	output, err := readConfig(dest)
+func ResolveHostName(ctx context.Context, dest Destination) (string, error) {
+	output, err := readConfigContext(ctx, dest)
 	if err != nil {
 		return "", fmt.Errorf("could not resolve SSH configuration for %q: %w", dest.String(), err)
 	}
@@ -125,5 +126,9 @@ func IsExplicitHostConfig(host string, config []byte) bool {
 }
 
 func readConfig(dest Destination) ([]byte, error) {
-	return exec.Command("ssh", "-v", "-G", dest.String()).CombinedOutput()
+	return readConfigContext(context.Background(), dest)
+}
+
+func readConfigContext(ctx context.Context, dest Destination) ([]byte, error) {
+	return exec.CommandContext(ctx, "ssh", "-v", "-G", dest.String()).CombinedOutput()
 }


### PR DESCRIPTION
## Changes

- Extract registry tunnel exposure checking from the operation layer into the Docker procedural layer.
- Move exposure-check coverage alongside the new procedural function.
- Add context propagation to SSH hostname resolution and remote port probing.
- Keep the existing operation as a delegating compatibility layer.

## Checklist

- [x] 🤖 This change is covered by tests as required.
- [ ] 🤹 All required manual testing has been performed.
- [ ] 📖 All documentation updates are complete.