### PR TITLE
chore: move openssh health check

### DIFF
--- a/internal/health/check.go
+++ b/internal/health/check.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"strings"
 
 	"github.com/arm/topo/internal/output/logger"
 	"github.com/arm/topo/internal/runner"
@@ -76,6 +77,21 @@ func (v VersionMatches) Run(ctx context.Context, _ runner.Runner, _ Dependency) 
 	}
 
 	return &fix, InfoError{Err: fmt.Errorf("out of date - current: %s, latest version: %s", v.CurrentVersion, latest)}
+}
+
+type OpenSSHAvailable struct{}
+
+func (o OpenSSHAvailable) Run(ctx context.Context, r runner.Runner, dep Dependency) (*Fix, error) {
+	_, stderr, err := r.Run(ctx, "ssh -V")
+	if err != nil {
+		return nil, err
+	}
+	if !strings.Contains(stderr, "OpenSSH_") {
+		return &Fix{
+			Description: "Install OpenSSH and ensure its ssh executable is first on PATH",
+		}, fmt.Errorf("%q does not resolve to OpenSSH: %s", dep.Binary, stderr)
+	}
+	return nil, nil
 }
 
 func RemoveVersionChecks(deps []Dependency) []Dependency {

--- a/internal/health/check_test.go
+++ b/internal/health/check_test.go
@@ -2,6 +2,7 @@ package health_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -87,5 +88,49 @@ func TestVersionMatches(t *testing.T) {
 
 		assert.NoError(t, err)
 		assert.Empty(t, fix)
+	})
+}
+
+func TestOpenSSHAvailable(t *testing.T) {
+	ctx := context.Background()
+	dependency := health.Dependency{Binary: "ssh", Label: "OpenSSH"}
+
+	t.Run("accepts OpenSSH", func(t *testing.T) {
+		check := health.OpenSSHAvailable{}
+		r := &runner.Fake{Commands: map[string]runner.FakeResult{
+			"ssh -V": {Stderr: "OpenSSH_9.9p1, OpenSSL 3.4.0"},
+		}}
+
+		fix, err := check.Run(ctx, r, dependency)
+
+		assert.NoError(t, err)
+		assert.Nil(t, fix)
+	})
+
+	t.Run("rejects another SSH implementation", func(t *testing.T) {
+		check := health.OpenSSHAvailable{}
+		r := &runner.Fake{Commands: map[string]runner.FakeResult{
+			"ssh -V": {Stderr: "Dropbear v2025.88"},
+		}}
+
+		fix, err := check.Run(ctx, r, dependency)
+
+		assert.EqualError(t, err, `"ssh" does not resolve to OpenSSH: Dropbear v2025.88`)
+		assert.Equal(t, &health.Fix{
+			Description: "Install OpenSSH and ensure its ssh executable is first on PATH",
+		}, fix)
+	})
+
+	t.Run("returns an error when the version cannot be checked", func(t *testing.T) {
+		check := health.OpenSSHAvailable{}
+		versionErr := errors.New("version check failed")
+		r := &runner.Fake{Commands: map[string]runner.FakeResult{
+			"ssh -V": {Err: versionErr},
+		}}
+
+		fix, err := check.Run(ctx, r, dependency)
+
+		assert.ErrorIs(t, err, versionErr)
+		assert.Nil(t, fix)
 	})
 }

--- a/internal/health/dependencies.go
+++ b/internal/health/dependencies.go
@@ -3,7 +3,6 @@ package health
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/arm/topo/internal/runner"
 	"github.com/arm/topo/internal/ssh"
@@ -40,21 +39,6 @@ type Dependency struct {
 	SoftwareEnumID        SoftwareDependency
 	SoftwarePrerequisites []SoftwareDependency
 	HardwarePrerequisite  []HardwareCapability
-}
-
-type OpenSSHAvailable struct{}
-
-func (o OpenSSHAvailable) Run(ctx context.Context, r runner.Runner, dep Dependency) (*Fix, error) {
-	_, stderr, err := r.Run(ctx, "ssh -V")
-	if err != nil {
-		return nil, err
-	}
-	if !strings.Contains(stderr, "OpenSSH_") {
-		return &Fix{
-			Description: "Install OpenSSH and ensure its ssh executable is first on PATH",
-		}, fmt.Errorf("%q does not resolve to OpenSSH: %s", dep.Binary, stderr)
-	}
-	return nil, nil
 }
 
 var HostRequiredDependencies = []Dependency{

--- a/internal/health/dependencies_test.go
+++ b/internal/health/dependencies_test.go
@@ -68,50 +68,6 @@ func TestTargetRequiredDependencies(t *testing.T) {
 	})
 }
 
-func TestOpenSSHAvailable(t *testing.T) {
-	ctx := context.Background()
-	dependency := health.Dependency{Binary: "ssh", Label: "OpenSSH"}
-
-	t.Run("accepts OpenSSH", func(t *testing.T) {
-		check := health.OpenSSHAvailable{}
-		r := &runner.Fake{Commands: map[string]runner.FakeResult{
-			"ssh -V": {Stderr: "OpenSSH_9.9p1, OpenSSL 3.4.0"},
-		}}
-
-		fix, err := check.Run(ctx, r, dependency)
-
-		assert.NoError(t, err)
-		assert.Nil(t, fix)
-	})
-
-	t.Run("rejects another SSH implementation", func(t *testing.T) {
-		check := health.OpenSSHAvailable{}
-		r := &runner.Fake{Commands: map[string]runner.FakeResult{
-			"ssh -V": {Stderr: "Dropbear v2025.88"},
-		}}
-
-		fix, err := check.Run(ctx, r, dependency)
-
-		assert.EqualError(t, err, `"ssh" does not resolve to OpenSSH: Dropbear v2025.88`)
-		assert.Equal(t, &health.Fix{
-			Description: "Install OpenSSH and ensure its ssh executable is first on PATH",
-		}, fix)
-	})
-
-	t.Run("returns an error when the version cannot be checked", func(t *testing.T) {
-		check := health.OpenSSHAvailable{}
-		versionErr := errors.New("version check failed")
-		r := &runner.Fake{Commands: map[string]runner.FakeResult{
-			"ssh -V": {Err: versionErr},
-		}}
-
-		fix, err := check.Run(ctx, r, dependency)
-
-		assert.ErrorIs(t, err, versionErr)
-		assert.Nil(t, fix)
-	})
-}
-
 func TestPerformChecks(t *testing.T) {
 	t.Run("when no dependencies are found, statuses show not installed", func(t *testing.T) {
 		fooDependency := health.Dependency{Binary: "foo", Label: "bar", Checks: []health.Check{health.BinaryExists{}}}


### PR DESCRIPTION
<!-- PR title should be formatted using conventional commits -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->
<!-- Example: feat: A very fancy feature -->

## Changes

<!-- List the changes this PR introduces -->

- Purely mechanical change to move `OpenSSHAvailable` which implements `Check` into `check.go` with the other health check implementations

## Checklist

<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->

- [x] 🤖 This change is covered by tests as required.
- [x] 🤹 All required manual testing has been performed.
- [x] 📖 All documentation updates are complete.
