### PR TITLE
test: avoid SSH tunnel cleanup race

### DIFF
--- a/internal/deploy/docker/image_transfer_registry_test.go
+++ b/internal/deploy/docker/image_transfer_registry_test.go
@@ -41,7 +41,7 @@ func TestTransferImagesViaRegistry(t *testing.T) {
 	destinationHost := command.NewHostFromDestination(destination)
 	testutil.RequireImageDoesNotExist(t, destinationHost, imageName)
 
-	tunnel, err := ssh.OpenSSHTunnel(t.Context(), os.Stdout, destination, registryPort, false)
+	tunnel, err := ssh.OpenSSHTunnel(context.Background(), os.Stdout, destination, registryPort, false)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		assert.NoError(t, tunnel.Close(context.Background(), os.Stdout))


### PR DESCRIPTION
## Changes

- Prevent `t.Context()` cancellation from racing with SSH tunnel cleanup in `TestTransferImagesViaRegistry`.
    - Let the registered cleanup exclusively manage the tunnel lifecycle.

## Checklist

- [x] 🤖 This change is covered by tests as required.
- [ ] 🤹 All required manual testing has been performed.
- [ ] 📖 All documentation updates are complete.