### PR TITLE
feat: install remoteproc runtime from artifactory

### DIFF
--- a/cmd/topo/install_remoteproc_runtime.go
+++ b/cmd/topo/install_remoteproc_runtime.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"os"
 
 	"github.com/arm/topo/internal/install"
@@ -10,15 +11,17 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const remoteprocRuntimeRepoURL = "arm/remoteproc-runtime"
+const (
+	remoteprocRuntimeURL         = "https://artifacts.tools.arm.com/remoteproc-runtime/"
+	remoteprocRuntimeArchiveName = "remoteproc-runtime_%s_linux_arm64.tar.gz"
+)
 
 var installRemoteprocRuntimeCmd = &cobra.Command{
 	Use:   "remoteproc-runtime",
 	Short: "Install remoteproc-runtime and shim to a location on the target's PATH",
 	Long: `Install remoteproc-runtime and shim to a location on the target's PATH.
 
-Fetches binaries from https://github.com/` + remoteprocRuntimeRepoURL + `
-Set GITHUB_TOKEN to authenticate with the GitHub API and avoid rate limits.
+Fetches binaries from https://artifacts.tools.arm.com/remoteproc-runtime/
 
 Attempts to replace existing installations if found.
 Falls back to ~/bin if no suitable locations are automatically found.`,
@@ -31,7 +34,7 @@ Falls back to ~/bin if no suitable locations are automatically found.`,
 		}
 
 		outputFormat := resolveOutput(cmd)
-		p, err := installRemoteprocRuntime(ssh.NewDestination(targetArg))
+		p, err := installRemoteprocRuntime(cmd.Context(), ssh.NewDestination(targetArg))
 		if err != nil {
 			return err
 		}
@@ -39,9 +42,9 @@ Falls back to ~/bin if no suitable locations are automatically found.`,
 	},
 }
 
-func installRemoteprocRuntime(targetDest ssh.Destination) (views.View, error) {
+func installRemoteprocRuntime(ctx context.Context, targetDest ssh.Destination) (views.View, error) {
 	r := runner.For(targetDest)
-	results, err := install.InstallBinariesFromGithubRelease(r, remoteprocRuntimeRepoURL, []string{"remoteproc-runtime", "containerd-shim-remoteproc-v1"})
+	results, err := install.InstallBinariesFromArtifactory(ctx, r, remoteprocRuntimeURL, remoteprocRuntimeArchiveName, []string{"remoteproc-runtime", "containerd-shim-remoteproc-v1"})
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/topo/install_remoteproc_runtime.go
+++ b/cmd/topo/install_remoteproc_runtime.go
@@ -21,8 +21,6 @@ var installRemoteprocRuntimeCmd = &cobra.Command{
 	Short: "Install remoteproc-runtime and shim to a location on the target's PATH",
 	Long: `Install remoteproc-runtime and shim to a location on the target's PATH.
 
-Fetches binaries from https://artifacts.tools.arm.com/remoteproc-runtime/
-
 Attempts to replace existing installations if found.
 Falls back to ~/bin if no suitable locations are automatically found.`,
 	Args: cobra.ExactArgs(0),

--- a/internal/archive/extract.go
+++ b/internal/archive/extract.go
@@ -1,0 +1,60 @@
+package archive
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"path/filepath"
+
+	"github.com/mholt/archives"
+)
+
+func ExtractFiles(ctx context.Context, archiveData []byte, fileNames []string) (map[string][]byte, error) {
+	requested := make(map[string]struct{}, len(fileNames))
+	for _, fileName := range fileNames {
+		requested[fileName] = struct{}{}
+	}
+
+	format, stream, err := archives.Identify(ctx, "", bytes.NewReader(archiveData))
+	if err != nil {
+		return nil, fmt.Errorf("identifying archive format: %w", err)
+	}
+
+	extractor, ok := format.(archives.Extractor)
+	if !ok {
+		return nil, fmt.Errorf("archive format does not support extraction")
+	}
+
+	extracted := make(map[string][]byte, len(requested))
+	err = extractor.Extract(ctx, stream, func(_ context.Context, fileInfo archives.FileInfo) error {
+		fileName := filepath.Base(fileInfo.Name())
+		if _, ok := requested[fileName]; !ok {
+			return nil
+		}
+
+		file, err := fileInfo.Open()
+		if err != nil {
+			return fmt.Errorf("opening %s: %w", fileInfo.Name(), err)
+		}
+
+		content, readErr := io.ReadAll(file)
+		closeErr := file.Close()
+		if err := errors.Join(readErr, closeErr); err != nil {
+			return fmt.Errorf("reading archive entry %s: %w", fileInfo.Name(), err)
+		}
+		extracted[fileName] = content
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("extracting archive: %w", err)
+	}
+
+	for fileName := range requested {
+		if _, ok := extracted[fileName]; !ok {
+			return nil, fmt.Errorf("%q not found in archive", fileName)
+		}
+	}
+	return extracted, nil
+}

--- a/internal/archive/extract_test.go
+++ b/internal/archive/extract_test.go
@@ -1,0 +1,56 @@
+package archive_test
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"testing"
+
+	archiveutil "github.com/arm/topo/internal/archive"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractFiles(t *testing.T) {
+	t.Run("returns requested files by base name", func(t *testing.T) {
+		archiveData := createTarGz(t, map[string]string{
+			"bin/first":  "first contents",
+			"bin/second": "second contents",
+			"ignored":    "ignored contents",
+		})
+
+		got, err := archiveutil.ExtractFiles(context.Background(), archiveData, []string{"first", "second"})
+
+		require.NoError(t, err)
+		assert.Equal(t, map[string][]byte{
+			"first":  []byte("first contents"),
+			"second": []byte("second contents"),
+		}, got)
+	})
+
+	t.Run("returns an error when a requested file is absent", func(t *testing.T) {
+		archiveData := createTarGz(t, map[string]string{"first": "contents"})
+
+		_, err := archiveutil.ExtractFiles(context.Background(), archiveData, []string{"missing"})
+
+		assert.ErrorContains(t, err, `"missing" not found in archive`)
+	})
+}
+
+func createTarGz(t *testing.T, files map[string]string) []byte {
+	t.Helper()
+
+	var output bytes.Buffer
+	gzipWriter := gzip.NewWriter(&output)
+	tarWriter := tar.NewWriter(gzipWriter)
+	for name, contents := range files {
+		err := tarWriter.WriteHeader(&tar.Header{Name: name, Mode: 0o755, Size: int64(len(contents))})
+		require.NoError(t, err)
+		_, err = tarWriter.Write([]byte(contents))
+		require.NoError(t, err)
+	}
+	require.NoError(t, tarWriter.Close())
+	require.NoError(t, gzipWriter.Close())
+	return output.Bytes()
+}

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -113,14 +113,14 @@ func downloadFile(ctx context.Context, url *url.URL) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unexpected fetch status code: %d", resp.StatusCode)
+		statusErr := fmt.Errorf("unexpected fetch status code: %d", resp.StatusCode)
+		return nil, errors.Join(statusErr, resp.Body.Close())
 	}
 
-	b, err := io.ReadAll(resp.Body)
-	if err != nil {
+	b, readErr := io.ReadAll(resp.Body)
+	if err := errors.Join(readErr, resp.Body.Close()); err != nil {
 		return nil, err
 	}
 	return b, nil

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -1,28 +1,24 @@
 package install
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
-	"os"
-	"path"
 	"slices"
 	"strings"
 	"time"
 
+	archiveutil "github.com/arm/topo/internal/archive"
 	"github.com/arm/topo/internal/command"
 	"github.com/arm/topo/internal/runner"
 	"github.com/arm/topo/internal/ssh"
-	"github.com/mholt/archives"
+	"github.com/arm/topo/internal/version"
 )
 
 const (
-	apiTimeout      = 15 * time.Second
 	downloadTimeout = 2 * time.Minute
 )
 
@@ -103,140 +99,14 @@ func FindPathDirs(r runner.Runner) ([]PathCandidate, error) {
 	return validPaths, nil
 }
 
-type githubAsset struct {
-	Name               string `json:"name"`
-	BrowserDownloadURL string `json:"browser_download_url"`
-}
-
-type githubRelease struct {
-	Assets []githubAsset `json:"assets"`
-}
-
-func addGitHubAuthHeader(req *http.Request) {
-	token := strings.TrimSpace(os.Getenv("GITHUB_TOKEN"))
-	if token == "" {
-		return
-	}
-
-	host := req.URL.Hostname()
-	if host == "github.com" || host == "api.github.com" || strings.HasSuffix(host, ".github.com") {
-		req.Header.Set("Authorization", "Bearer "+token)
-	}
-}
-
-func getLatestReleaseTarAddress(repoURL string) (*url.URL, error) {
-	base, err := url.Parse("https://api.github.com")
-	if err != nil {
-		return nil, err
-	}
-
-	base.Path = path.Join(
-		"repos",
-		repoURL,
-		"releases",
-		"latest",
-	)
-
-	ctx, cancel := context.WithTimeout(context.Background(), apiTimeout)
-	defer cancel()
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, base.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	addGitHubAuthHeader(req)
-
-	// #nosec G704 -- request is validated, false positive warning
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		msg := strings.TrimSpace(string(body))
-		if msg != "" {
-			return nil, fmt.Errorf("GitHub API rejected request (status %d): %s", resp.StatusCode, msg)
-		}
-		return nil, fmt.Errorf("GitHub API rejected request (status %d)", resp.StatusCode)
-	}
-
-	var release githubRelease
-	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
-		return nil, err
-	}
-
-	for _, asset := range release.Assets {
-		if strings.HasSuffix(asset.Name, "_linux_arm64.tar.gz") {
-			u, err := url.Parse(asset.BrowserDownloadURL)
-			if err != nil {
-				return nil, err
-			}
-			return u, nil
-		}
-	}
-
-	return nil, fmt.Errorf("no _linux_arm64.tar.gz release asset found")
-}
-
-func extractFilesFromTarGz(tarGzData []byte, targetFiles []string) (map[string][]byte, error) {
-	reader := bytes.NewReader(tarGzData)
-
-	format, stream, err := archives.Identify(context.Background(), "", reader)
-	if err != nil {
-		return nil, err
-	}
-
-	extractor, ok := format.(archives.Extractor)
-	if !ok {
-		return nil, fmt.Errorf("format does not support extraction")
-	}
-
-	extractedFiles := make(map[string][]byte)
-
-	err = extractor.Extract(context.Background(), stream, func(ctx context.Context, fileInfo archives.FileInfo) error {
-		baseName := path.Base(fileInfo.Name())
-		for _, target := range targetFiles {
-			if baseName == target {
-				file, err := fileInfo.Open()
-				if err != nil {
-					return fmt.Errorf("failed to open %s: %w", fileInfo.Name(), err)
-				}
-				defer func() { _ = file.Close() }()
-
-				content, err := io.ReadAll(file)
-				if err != nil {
-					return fmt.Errorf("failed to read %s: %w", fileInfo.Name(), err)
-				}
-
-				extractedFiles[baseName] = content
-				break
-			}
-		}
-		return nil
-	})
-	if err != nil {
-		return nil, err
-	}
-	if len(extractedFiles) == 0 {
-		return nil, fmt.Errorf("files not found in archive")
-	}
-
-	return extractedFiles, nil
-}
-
-func fetchFile(url *url.URL) ([]byte, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), downloadTimeout)
+func downloadFile(ctx context.Context, url *url.URL) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(ctx, downloadTimeout)
 	defer cancel()
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url.String(), nil)
 	if err != nil {
 		return nil, err
 	}
-
-	addGitHubAuthHeader(req)
 
 	// #nosec G704 -- Request is previously validated
 	resp, err := http.DefaultClient.Do(req)
@@ -254,24 +124,6 @@ func fetchFile(url *url.URL) ([]byte, error) {
 		return nil, err
 	}
 	return b, nil
-}
-
-func FetchLatestReleaseBinaries(githubRepoSlug string, binaries []string) (map[string][]byte, error) {
-	url, err := getLatestReleaseTarAddress(githubRepoSlug)
-	if err != nil {
-		return nil, fmt.Errorf("failed to resolve latest release download URL: %w", err)
-	}
-
-	tarball, err := fetchFile(url)
-	if err != nil {
-		return nil, fmt.Errorf("failed to download latest release: %w", err)
-	}
-
-	files, err := extractFilesFromTarGz(tarball, binaries)
-	if err != nil {
-		return nil, fmt.Errorf("failed to extract files from tar.gz: %w", err)
-	}
-	return files, err
 }
 
 func install(installPath string, r runner.Runner, binaries map[string][]byte) error {
@@ -327,14 +179,43 @@ type InstallResult struct {
 	Binary   string
 }
 
-func InstallBinariesFromGithubRelease(r runner.Runner, repoURL string, binaryNames []string) ([]InstallResult, error) {
+func downloadLatestArtifactoryBinaries(ctx context.Context, artifactoryURL string, archiveNameFormat string, binaryNames []string) (map[string][]byte, error) {
+	latest, err := version.FetchLatestArtifactory(ctx, artifactoryURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve latest Artifactory version: %w", err)
+	}
+
+	archiveName := fmt.Sprintf(archiveNameFormat, latest)
+	archiveURL, err := url.JoinPath(artifactoryURL, latest, archiveName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to construct Artifactory download URL: %w", err)
+	}
+
+	parsedArchiveURL, err := url.Parse(archiveURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse Artifactory download URL: %w", err)
+	}
+
+	tarball, err := downloadFile(ctx, parsedArchiveURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to download latest release: %w", err)
+	}
+
+	binaries, err := archiveutil.ExtractFiles(ctx, tarball, binaryNames)
+	if err != nil {
+		return nil, fmt.Errorf("failed to extract files from tar.gz: %w", err)
+	}
+	return binaries, nil
+}
+
+func InstallBinariesFromArtifactory(ctx context.Context, r runner.Runner, artifactoryURL string, archiveNameFormat string, binaryNames []string) ([]InstallResult, error) {
 	for _, binaryName := range binaryNames {
 		if err := command.ValidateBinaryName(binaryName); err != nil {
 			return nil, err
 		}
 	}
 
-	binaries, err := FetchLatestReleaseBinaries(repoURL, binaryNames)
+	binaries, err := downloadLatestArtifactoryBinaries(ctx, artifactoryURL, archiveNameFormat, binaryNames)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch latest release binaries: %w", err)
 	}

--- a/internal/upgrade/upgrade.go
+++ b/internal/upgrade/upgrade.go
@@ -1,7 +1,6 @@
 package upgrade
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -10,10 +9,10 @@ import (
 	"path/filepath"
 	"runtime"
 
+	archiveutil "github.com/arm/topo/internal/archive"
 	"github.com/arm/topo/internal/output/logger"
 	"github.com/arm/topo/internal/output/term"
 	"github.com/arm/topo/internal/version"
-	"github.com/mholt/archives"
 )
 
 func Upgrade(ctx context.Context, reporter term.ProgressReporter) (string, error) {
@@ -37,7 +36,7 @@ func Upgrade(ctx context.Context, reporter term.ProgressReporter) (string, error
 		return version.Version, nil
 	}
 
-	downloadURL := ArtifactoryDownloadURL(runtime.GOOS, runtime.GOARCH, latest)
+	downloadURL := TopoDownloadURL(runtime.GOOS, runtime.GOARCH, latest)
 
 	if reporter != nil {
 		reporter.Step(fmt.Sprintf("Installing topo version %s...", latest))
@@ -77,7 +76,7 @@ func CurrentBinaryPath() (string, error) {
 	return binPath, nil
 }
 
-func ArtifactoryDownloadURL(os string, arch string, targetVersion string) string {
+func TopoDownloadURL(os string, arch string, targetVersion string) string {
 	ext := "tar.gz"
 	if os == "windows" {
 		ext = "zip"
@@ -124,48 +123,26 @@ func downloadArchive(ctx context.Context, url string) ([]byte, error) {
 }
 
 func extractBinary(ctx context.Context, archiveData []byte, destDir string) (string, error) {
-	format, stream, err := archives.Identify(ctx, "", bytes.NewReader(archiveData))
+	binaryName := BinaryName("topo")
+	files, err := archiveutil.ExtractFiles(ctx, archiveData, []string{binaryName})
 	if err != nil {
-		return "", fmt.Errorf("failed to identify archive format: %w", err)
+		return "", err
 	}
 
-	extractor, ok := format.(archives.Extractor)
-	if !ok {
-		return "", fmt.Errorf("archive format does not support extraction")
-	}
-
-	var tmpPath string
-
-	err = extractor.Extract(ctx, stream, func(ctx context.Context, fileInfo archives.FileInfo) error {
-		if filepath.Base(fileInfo.Name()) != BinaryName("topo") {
-			return nil
-		}
-
-		rc, err := fileInfo.Open()
-		if err != nil {
-			return fmt.Errorf("failed to open %s in archive: %w", fileInfo.Name(), err)
-		}
-		defer rc.Close() //nolint:errcheck
-
-		// important to create the temp file in the same directory to ensure atomic rename works across filesystems
-		tmp, err := os.CreateTemp(destDir, BinaryName(".topo-new-*"))
-		if err != nil {
-			return fmt.Errorf("failed to create temp file: %w", err)
-		}
-		tmpPath = tmp.Name()
-
-		// #nosec G110 -- archive from a hardcoded, trusted Artifactory URL
-		if _, err := io.Copy(tmp, rc); err != nil {
-			tmp.Close() //nolint:errcheck
-			return fmt.Errorf("failed to extract binary: %w", err)
-		}
-		return tmp.Close()
-	})
+	tmp, err := os.CreateTemp(destDir, BinaryName(".topo-new-*"))
 	if err != nil {
+		return "", fmt.Errorf("failed to create temp file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	if _, err := tmp.Write(files[binaryName]); err != nil {
+		_ = tmp.Close()
 		ensureFileRemoved(tmpPath)
-		return "", fmt.Errorf("failed to read archive: %w", err)
+		return "", fmt.Errorf("failed to extract binary: %w", err)
 	}
-
+	if err := tmp.Close(); err != nil {
+		ensureFileRemoved(tmpPath)
+		return "", fmt.Errorf("failed to close extracted binary: %w", err)
+	}
 	return tmpPath, nil
 }
 

--- a/internal/upgrade/upgrade.go
+++ b/internal/upgrade/upgrade.go
@@ -176,6 +176,7 @@ func moveBinary(src, dst string) error {
 }
 
 func ensureFileRemoved(path string) {
+	// #nosec G703 -- path is returned by os.CreateTemp and only used for temporary-file cleanup
 	err := os.Remove(path)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/internal/upgrade/upgrade.go
+++ b/internal/upgrade/upgrade.go
@@ -2,6 +2,7 @@ package upgrade
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -135,7 +136,7 @@ func extractBinary(ctx context.Context, archiveData []byte, destDir string) (str
 	}
 	tmpPath := tmp.Name()
 	if _, err := tmp.Write(files[binaryName]); err != nil {
-		_ = tmp.Close()
+		err = errors.Join(err, tmp.Close())
 		ensureFileRemoved(tmpPath)
 		return "", fmt.Errorf("failed to extract binary: %w", err)
 	}

--- a/internal/upgrade/upgrade_test.go
+++ b/internal/upgrade/upgrade_test.go
@@ -153,7 +153,7 @@ func TestInstall(t *testing.T) {
 	})
 }
 
-func TestArtifactoryDownloadURL(t *testing.T) {
+func TestTopoDownloadURL(t *testing.T) {
 	version := "3.13.37"
 	tests := []struct {
 		os       string

--- a/internal/upgrade/upgrade_test.go
+++ b/internal/upgrade/upgrade_test.go
@@ -171,7 +171,7 @@ func TestArtifactoryDownloadURL(t *testing.T) {
 	for _, tt := range tests {
 		name := tt.os + "/" + tt.arch
 		t.Run(name, func(t *testing.T) {
-			url := upgrade.ArtifactoryDownloadURL(tt.os, tt.arch, version)
+			url := upgrade.TopoDownloadURL(tt.os, tt.arch, version)
 
 			assert.Equal(t, url, tt.expected)
 		})

--- a/internal/version/latest_artifactory.go
+++ b/internal/version/latest_artifactory.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"maps"
 	"net/http"
+	"regexp"
 	"slices"
 	"sort"
 
@@ -13,6 +14,8 @@ import (
 )
 
 const ArtifactoryBaseURL = "https://artifacts.tools.arm.com/topo"
+
+var artifactoryVersionRe = regexp.MustCompile(`href="v?(\d+)\.(\d+)\.(\d+)/"`)
 
 func FetchLatestArtifactory(ctx context.Context, url string) (string, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
@@ -40,14 +43,14 @@ func FetchLatestArtifactory(ctx context.Context, url string) (string, error) {
 		return "", fmt.Errorf("reading version index: %w", err)
 	}
 
-	matches := semverRe.FindAllStringSubmatch(string(body), -1)
+	matches := artifactoryVersionRe.FindAllStringSubmatch(string(body), -1)
 	if len(matches) == 0 {
 		return "", fmt.Errorf("no versions found in %q", url)
 	}
 
 	versions := make(map[string]struct{})
 	for _, m := range matches {
-		v := m[0]
+		v := fmt.Sprintf("%s.%s.%s", m[1], m[2], m[3])
 		if _, ok := versions[v]; !ok {
 			versions[v] = struct{}{}
 		}
@@ -59,5 +62,5 @@ func FetchLatestArtifactory(ctx context.Context, url string) (string, error) {
 	})
 	latest := versionsList[len(versionsList)-1]
 
-	return latest[1:], nil
+	return latest, nil
 }

--- a/internal/version/latest_artifactory_test.go
+++ b/internal/version/latest_artifactory_test.go
@@ -53,6 +53,28 @@ func TestFetchLatestArtifactory(t *testing.T) {
 		assert.Equal(t, "4.1.0", got)
 	})
 
+	t.Run("returns highest version without a v prefix", func(t *testing.T) {
+		body := `<a href="1.1.0/">1.1.0/</a>
+<a href="1.1.1/">1.1.1/</a>`
+		srv := createTestServerWithBody(t, body)
+
+		got, err := version.FetchLatestArtifactory(context.Background(), srv.URL)
+
+		require.NoError(t, err)
+		assert.Equal(t, "1.1.1", got)
+	})
+
+	t.Run("ignores versions outside Artifactory directory links", func(t *testing.T) {
+		body := `Latest version: 99.0.0
+<a href="v1.2.3/">v1.2.3/</a>`
+		srv := createTestServerWithBody(t, body)
+
+		got, err := version.FetchLatestArtifactory(context.Background(), srv.URL)
+
+		require.NoError(t, err)
+		assert.Equal(t, "1.2.3", got)
+	})
+
 	t.Run("picks correct version when order is scrambled", func(t *testing.T) {
 		body := `<a href="v2.0.0/">v2.0.0/</a>
 <a href="v10.0.0/">v10.0.0/</a>

--- a/internal/version/latest_artifactory_test.go
+++ b/internal/version/latest_artifactory_test.go
@@ -58,7 +58,7 @@ func TestFetchLatestArtifactory(t *testing.T) {
 		assert.Equal(t, "1.1.1", got)
 	})
 
-	t.Run("ignores versions outside Artifactory directory links", func(t *testing.T) {
+	t.Run("ignores entries that are not Artifactory directory links", func(t *testing.T) {
 		body := `Latest version: 99.0.0
 <a href="v1.2.3/">v1.2.3/</a>`
 		srv := createTestServerWithBody(t, body)

--- a/internal/version/latest_artifactory_test.go
+++ b/internal/version/latest_artifactory_test.go
@@ -38,12 +38,6 @@ const artifactoryHTML = `<!DOCTYPE html>
 <hr/><address style="font-size:small;">Artifactory Online Server</address></body></html>`
 
 func TestFetchLatestArtifactory(t *testing.T) {
-	t.Run("can reach real artifactory index page", func(t *testing.T) {
-		_, err := version.FetchLatestArtifactory(context.Background(), version.ArtifactoryBaseURL)
-
-		require.NoError(t, err)
-	})
-
 	t.Run("returns highest version from artifactory index", func(t *testing.T) {
 		srv := createTestServerWithBody(t, artifactoryHTML)
 


### PR DESCRIPTION
<!-- PR title should be formatted using conventional commits -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->
<!-- Example: feat: A very fancy feature -->

## Changes

<!-- List the changes this PR introduces -->

- Installs remoteproc-runtime from Arm Artifactory instead of GitHub.
- Supports version directories with or without v.
- Adds shared archive extraction
- 3 less lines of code :D

## Checklist

<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->

- [ ] 🤖 This change is covered by tests as required.
- [ ] 🤹 All required manual testing has been performed.
- [ ] 📖 All documentation updates are complete.
