### PR TITLE
feat: ssh-based registry port probe

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ topo deploy --target pi@raspberrypi
 **Host machine** (where you run `topo`):
 
 - [Docker](https://docs.docker.com/get-docker/)
-- curl
 - OpenSSH Client
 
 **Target machine** (the remote Arm system):

--- a/docs/introduction/install.mdx
+++ b/docs/introduction/install.mdx
@@ -26,7 +26,6 @@ A target must run Linux on AArch64 (`linux/arm64`). Topo uses Docker to build im
 Install the following tools on the host:
 
 - [Docker](https://docs.docker.com/get-docker/)
-- `curl`
 - OpenSSH client
 - Git to clone [Topo Projects](glossary.md#topo-project) from Git repositories
 

--- a/e2e/testdata/TestHealthCheckJson.golden
+++ b/e2e/testdata/TestHealthCheckJson.golden
@@ -12,11 +12,6 @@
         "value": "ssh"
       },
       {
-        "name": "Curl",
-        "status": "ok",
-        "value": "curl"
-      },
-      {
         "name": "Container Engine",
         "status": "ok",
         "value": "docker"

--- a/internal/deploy/docker/tunnel_exposure_check.go
+++ b/internal/deploy/docker/tunnel_exposure_check.go
@@ -14,21 +14,13 @@ import (
 // loopback. This can happen when the SSH server permits non-loopback remote
 // forwards.
 func CheckTunnelExposure(ctx context.Context, output io.Writer, targetDest ssh.Destination, port string) error {
-	host, err := ssh.ResolveHostName(ctx, targetDest)
+	listening, err := netprobe.IsRemotePortListening(ctx, targetDest, port)
 	if err != nil {
-		return remotePortCheckErrorWithSuggestion(err, port)
-	}
-	listening, err := netprobe.IsRemotePortListening(ctx, host, port)
-	if err != nil {
-		return remotePortCheckErrorWithSuggestion(err, port)
+		return fmt.Errorf("cannot conclusively rule out network access to registry port %s because the exposure check did not complete: %w; retry after resolving the connectivity issue, or use `--skip-remote-port-check` if you understand the security risk", port, err)
 	}
 	if listening {
 		return fmt.Errorf("the remote SSH server is exposing forwarded registry port %s beyond remote loopback; configure the SSH server to bind remote forwards to loopback only, or use `--skip-remote-port-check` if you understand that the registry may be reachable without SSH authentication", port)
 	}
 	_, _ = fmt.Fprintf(output, "Registry port %s is bound to remote loopback only\n", port)
 	return nil
-}
-
-func remotePortCheckErrorWithSuggestion(err error, port string) error {
-	return fmt.Errorf("cannot conclusively rule out network access to registry port %s because the exposure check did not complete: %w; retry after resolving the connectivity issue, or use `--skip-remote-port-check` if you understand the security risk", port, err)
 }

--- a/internal/deploy/docker/tunnel_exposure_check_test.go
+++ b/internal/deploy/docker/tunnel_exposure_check_test.go
@@ -61,24 +61,11 @@ func openSocket(t *testing.T, dest ssh.Destination, address string, port string)
 		_ = cmd.Process.Kill()
 	})
 
-	err = waitForOpenSocket(dest, address, port)
-	require.NoError(t, err)
-}
-
-func waitForOpenSocket(dest ssh.Destination, address string, port string) error {
-	deadline := time.Now().Add(5 * time.Second)
-	var lastErr error
-
-	for time.Now().Before(deadline) {
-		// #nosec G204 -- ignore as its a test helper
+	var output []byte
+	assert.Eventually(t, func() bool {
 		cmd := exec.Command("ssh", dest.String(), fmt.Sprintf("nc -z -w 1 %s %s", address, port))
-		output, err := cmd.CombinedOutput()
-		if err == nil {
-			return nil
-		}
-		lastErr = fmt.Errorf("%w output: %s", err, strings.TrimSpace(string(output)))
-		time.Sleep(200 * time.Millisecond)
-	}
-
-	return fmt.Errorf("port %s not ready: %w", port, lastErr)
+		var err error
+		output, err = cmd.CombinedOutput()
+		return err == nil
+	}, 5*time.Second, 200*time.Millisecond, "port %s not ready on %s: %v output: %s", port, address, err, string(output))
 }

--- a/internal/deploy/docker/tunnel_exposure_check_test.go
+++ b/internal/deploy/docker/tunnel_exposure_check_test.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/arm/topo/internal/deploy/docker"
 	"github.com/arm/topo/internal/deploy/testutil"
@@ -30,7 +31,7 @@ func TestCheckTunnelExposure(t *testing.T) {
 		target := testutil.StartContainer(t, testutil.SshServerContainer)
 		dest := ssh.NewDestination(target.SSHDestination)
 		port := "12345"
-		listenOnPort(t, dest, "127.0.0.1", port)
+		openSocket(t, dest, "127.0.0.1", port)
 		var output strings.Builder
 
 		err := docker.CheckTunnelExposure(context.Background(), &output, dest, port)
@@ -43,7 +44,7 @@ func TestCheckTunnelExposure(t *testing.T) {
 		target := testutil.StartContainer(t, testutil.SshServerContainer)
 		dest := ssh.NewDestination(target.SSHDestination)
 		port := "12345"
-		listenOnPort(t, dest, "0.0.0.0", port)
+		openSocket(t, dest, "0.0.0.0", port)
 
 		err := docker.CheckTunnelExposure(context.Background(), io.Discard, dest, port)
 
@@ -51,12 +52,33 @@ func TestCheckTunnelExposure(t *testing.T) {
 	})
 }
 
-func listenOnPort(t *testing.T, dest ssh.Destination, address string, port string) {
+func openSocket(t *testing.T, dest ssh.Destination, address string, port string) {
 	t.Helper()
-	cmd := exec.Command("ssh", dest.String(), fmt.Sprintf("nc -l -p %s -s %s", port, address))
+	cmd := exec.Command("ssh", dest.String(), fmt.Sprintf("nc -lk -p %s -s %s -e cat", port, address))
 	err := cmd.Start()
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		_ = cmd.Process.Kill()
 	})
+
+	err = waitForOpenSocket(dest, address, port)
+	require.NoError(t, err)
+}
+
+func waitForOpenSocket(dest ssh.Destination, address string, port string) error {
+	deadline := time.Now().Add(5 * time.Second)
+	var lastErr error
+
+	for time.Now().Before(deadline) {
+		// #nosec G204 -- ignore as its a test helper
+		cmd := exec.Command("ssh", dest.String(), fmt.Sprintf("nc -z -w 1 %s %s", address, port))
+		output, err := cmd.CombinedOutput()
+		if err == nil {
+			return nil
+		}
+		lastErr = fmt.Errorf("%w output: %s", err, strings.TrimSpace(string(output)))
+		time.Sleep(200 * time.Millisecond)
+	}
+
+	return fmt.Errorf("port %s not ready: %w", port, lastErr)
 }

--- a/internal/deploy/docker/tunnel_exposure_check_test.go
+++ b/internal/deploy/docker/tunnel_exposure_check_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"net"
+	"os/exec"
 	"strings"
 	"testing"
 
@@ -17,44 +17,46 @@ import (
 
 func TestCheckTunnelExposure(t *testing.T) {
 	t.Run("fails when the SSH hostname cannot be resolved", func(t *testing.T) {
-		err := docker.CheckTunnelExposure(context.Background(), io.Discard, ssh.Destination{}, "12345")
+		err := docker.CheckTunnelExposure(context.Background(), io.Discard, ssh.Destination{
+			Host: "not-a-host",
+		}, "12345")
 
 		assert.ErrorContains(t, err, "cannot conclusively rule out network access to registry port 12345")
-		assert.ErrorContains(t, err, `could not resolve SSH configuration for "ssh://"`)
+		assert.ErrorContains(t, err, `Could not resolve hostname not-a-host`)
 		assert.ErrorContains(t, err, "use `--skip-remote-port-check` if you understand the security risk")
 	})
 
 	t.Run("succeeds when the remote port refuses the connection", func(t *testing.T) {
-		port := testutil.RequireAvailableTCPPort(t, "0.0.0.0")
+		target := testutil.StartContainer(t, testutil.SshServerContainer)
+		dest := ssh.NewDestination(target.SSHDestination)
+		port := "12345"
+		listenOnPort(t, dest, "127.0.0.1", port)
 		var output strings.Builder
 
-		err := docker.CheckTunnelExposure(context.Background(), &output, ssh.NewDestination("0.0.0.0"), port)
+		err := docker.CheckTunnelExposure(context.Background(), &output, dest, port)
 
 		assert.NoError(t, err)
 		assert.Equal(t, fmt.Sprintf("Registry port %s is bound to remote loopback only\n", port), output.String())
 	})
 
 	t.Run("fails when the remote port accepts a connection", func(t *testing.T) {
-		listener, err := net.Listen("tcp", "127.0.0.1:0")
-		require.NoError(t, err)
-		t.Cleanup(func() { _ = listener.Close() })
-		connectionClosed := make(chan error, 1)
-		go func() {
-			connection, acceptErr := listener.Accept()
-			if acceptErr != nil {
-				connectionClosed <- acceptErr
-				return
-			}
-			connectionClosed <- connection.Close()
-		}()
-		_, port, err := net.SplitHostPort(listener.Addr().String())
-		require.NoError(t, err)
+		target := testutil.StartContainer(t, testutil.SshServerContainer)
+		dest := ssh.NewDestination(target.SSHDestination)
+		port := "12345"
+		listenOnPort(t, dest, "0.0.0.0", port)
 
-		err = docker.CheckTunnelExposure(context.Background(), io.Discard, ssh.NewDestination("localhost."), port)
-		listenerCloseErr := listener.Close()
+		err := docker.CheckTunnelExposure(context.Background(), io.Discard, dest, port)
 
 		assert.EqualError(t, err, fmt.Sprintf("the remote SSH server is exposing forwarded registry port %s beyond remote loopback; configure the SSH server to bind remote forwards to loopback only, or use `--skip-remote-port-check` if you understand that the registry may be reachable without SSH authentication", port))
-		assert.NoError(t, listenerCloseErr)
-		assert.NoError(t, <-connectionClosed)
+	})
+}
+
+func listenOnPort(t *testing.T, dest ssh.Destination, address string, port string) {
+	t.Helper()
+	cmd := exec.Command("ssh", dest.String(), fmt.Sprintf("nc -l -p %s -s %s", port, address))
+	err := cmd.Start()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
 	})
 }

--- a/internal/deploy/docker/tunnel_exposure_check_test.go
+++ b/internal/deploy/docker/tunnel_exposure_check_test.go
@@ -28,7 +28,7 @@ func TestCheckTunnelExposure(t *testing.T) {
 	})
 
 	t.Run("succeeds when the remote port refuses the connection", func(t *testing.T) {
-		target := testutil.StartContainer(t, testutil.SshServerContainer)
+		target := testutil.StartContainer(t, testutil.PasswordlessSSHContainer)
 		dest := ssh.NewDestination(target.SSHDestination)
 		port := "12345"
 		openSocket(t, dest, "127.0.0.1", port)
@@ -41,7 +41,7 @@ func TestCheckTunnelExposure(t *testing.T) {
 	})
 
 	t.Run("fails when the remote port accepts a connection", func(t *testing.T) {
-		target := testutil.StartContainer(t, testutil.SshServerContainer)
+		target := testutil.StartContainer(t, testutil.PasswordlessSSHContainer)
 		dest := ssh.NewDestination(target.SSHDestination)
 		port := "12345"
 		openSocket(t, dest, "0.0.0.0", port)

--- a/internal/deploy/testutil/testutil.go
+++ b/internal/deploy/testutil/testutil.go
@@ -22,6 +22,7 @@ var (
 	SanitiseTestName         = gtestutil.SanitiseTestName
 	StartContainer           = gtestutil.StartContainer
 	DinDContainer            = gtestutil.DinDContainer
+	SshServerContainer       = gtestutil.SshServerContainer
 )
 
 func TestImageName(t *testing.T) string {

--- a/internal/deploy/testutil/testutil.go
+++ b/internal/deploy/testutil/testutil.go
@@ -22,7 +22,7 @@ var (
 	SanitiseTestName         = gtestutil.SanitiseTestName
 	StartContainer           = gtestutil.StartContainer
 	DinDContainer            = gtestutil.DinDContainer
-	SshServerContainer       = gtestutil.SshServerContainer
+	PasswordlessSSHContainer = gtestutil.PasswordlessSSHContainer
 )
 
 func TestImageName(t *testing.T) string {

--- a/internal/health/dependencies.go
+++ b/internal/health/dependencies.go
@@ -80,13 +80,6 @@ var HostRequiredDependencies = []Dependency{
 		Checks: []Check{BinaryExists{}, OpenSSHAvailable{}},
 	},
 	{
-		Binary: "curl",
-		Label:  "Curl",
-		Checks: []Check{
-			BinaryExists{},
-		},
-	},
-	{
 		Binary:         "docker",
 		Label:          "Container Engine",
 		SoftwareEnumID: Docker,

--- a/internal/netprobe/port.go
+++ b/internal/netprobe/port.go
@@ -2,42 +2,114 @@ package netprobe
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"io"
-	"net"
-	"os"
-	"os/exec"
+	"strconv"
 	"strings"
+
+	"github.com/arm/topo/internal/runner"
+	"github.com/arm/topo/internal/ssh"
 )
 
-// IsRemotePortListening reports whether host:port accepts TCP connections.
-func IsRemotePortListening(ctx context.Context, host, port string) (bool, error) {
-	address := net.JoinHostPort(host, port)
-	var remoteIP strings.Builder
-	// Use curl so host resolution matches OpenSSH for mDNS, NSS, and split-DNS configurations.
-	// - remote_ip detects a connection even when HTTP fails
-	// - noproxy ensures the connection is direct
-	// - silent suppresses curl's progress and errors.
-	cmd := exec.CommandContext(ctx, "curl", "http://"+address, "--max-time", "5", "--noproxy", "*", "--output", os.DevNull, "--silent", "--write-out", "%{remote_ip}")
-	cmd.Stdout = &remoteIP
-	cmd.Stderr = io.Discard
-	err := cmd.Run()
-	if err == nil || remoteIP.Len() > 0 {
-		return true, nil
-	}
+var procNetTcpFiles = []string{"/proc/net/tcp", "/proc/net/tcp6"}
 
-	exitError, ok := errors.AsType[*exec.ExitError](err)
-	if ok {
-		switch exitError.ExitCode() {
-		case 7:
-			return false, nil
-		case 28:
-			return false, fmt.Errorf("timed out while checking whether remote port %s is exposed: %w", address, err)
-		case 6:
-			return false, fmt.Errorf("could not resolve remote host %q while checking tunnel exposure: %w", host, err)
+const (
+	loopbackV4Hex     = "0100007F"
+	loopbackV6Hex     = "00000000000000000000000001000000"
+	tcpListeningState = "0A"
+)
+
+type parsedTable struct {
+	columnIndexes map[string]int
+	rows          [][]string
+}
+
+// IsRemotePortListening reports whether the target is listening beyond the local loopback on the given TCP port
+func IsRemotePortListening(ctx context.Context, targetDest ssh.Destination, port string) (bool, error) {
+	sshRunner := runner.NewSSH(targetDest)
+	for _, path := range procNetTcpFiles {
+		stdout, _, err := sshRunner.Run(ctx, fmt.Sprintf("cat %s", path))
+		if err != nil {
+			return false, err
+		}
+
+		listening, err := IsRemotePortListeningInProcNetTCP(stdout, port)
+		if err != nil {
+			return false, err
+		}
+		if listening {
+			return true, nil
 		}
 	}
+	return false, nil
+}
 
-	return false, fmt.Errorf("could not verify whether remote port %s is exposed: %w", address, err)
+func IsRemotePortListeningInProcNetTCP(procNetTCP, port string) (bool, error) {
+	portNumber, err := strconv.ParseUint(port, 10, 16)
+	if err != nil {
+		return false, fmt.Errorf("invalid TCP port %q: %w", port, err)
+	}
+	portHex := fmt.Sprintf("%04X", portNumber)
+
+	table, err := parseTable(procNetTCP)
+	if err != nil {
+		return false, fmt.Errorf("parse proc net TCP table: %w", err)
+	}
+	localAddressColumn, ok := table.columnIndexes["local_address"]
+	if !ok {
+		return false, fmt.Errorf(`parse proc net TCP table: missing "local_address" column`)
+	}
+	stateColumn, ok := table.columnIndexes["st"]
+	if !ok {
+		return false, fmt.Errorf(`parse proc net TCP table: missing "st" column`)
+	}
+
+	for _, row := range table.rows {
+		localAddress := row[localAddressColumn]
+		state := row[stateColumn]
+		if hasPort(localAddress, portHex) && state == tcpListeningState && !isLoopback(localAddress) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func parseTable(rawTable string) (parsedTable, error) {
+	lines := strings.Split(rawTable, "\n")
+	headers := strings.Fields(lines[0])
+	if len(headers) == 0 {
+		return parsedTable{}, fmt.Errorf("table header is empty")
+	}
+
+	table := parsedTable{
+		columnIndexes: make(map[string]int, len(headers)),
+		rows:          make([][]string, 0, len(lines)-1),
+	}
+	for index, header := range headers {
+		table.columnIndexes[header] = index
+	}
+
+	for index, line := range lines[1:] {
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+		if len(fields) < len(headers) {
+			return parsedTable{}, fmt.Errorf(
+				"row %d has %d fields, expected at least %d",
+				index+2,
+				len(fields),
+				len(headers),
+			)
+		}
+		table.rows = append(table.rows, fields)
+	}
+	return table, nil
+}
+
+func hasPort(localAddress, portHex string) bool {
+	return strings.HasSuffix(localAddress, ":"+portHex)
+}
+
+func isLoopback(localAddress string) bool {
+	return strings.HasPrefix(localAddress, loopbackV4Hex+":") || strings.HasPrefix(localAddress, loopbackV6Hex+":")
 }

--- a/internal/netprobe/port_test.go
+++ b/internal/netprobe/port_test.go
@@ -1,55 +1,114 @@
 package netprobe_test
 
 import (
-	"context"
-	"net"
 	"testing"
 
 	"github.com/arm/topo/internal/netprobe"
-	"github.com/arm/topo/internal/testutil"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
-func TestIsRemotePortListening(t *testing.T) {
-	t.Run("returns false when the remote port refuses the connection", func(t *testing.T) {
-		port := testutil.RequireAvailableTCPPort(t, "0.0.0.0")
+const (
+	procNetTCPV4 = `  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode
+   0: 0100007F:2AF8 00000000:0000 0A 00000000:00000000 00:00000000 00000000   117        0 18993 2 0000000000000000 100 0 0 10 0
+   1: 00000000:2CAA 00000000:0000 0A 00000000:00000000 00:00000000 00000000     0        0 150348294 1 0000000000000000 100 0 0 10 0`
 
-		got, err := netprobe.IsRemotePortListening(context.Background(), "0.0.0.0", port)
+	procNetTCPV6 = `  sl  local_address                         remote_address                        st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode
+   0: 00000000000000000000000000000000:2CAA 00000000000000000000000000000000:0000 0A 00000000:00000000 00:00000000 00000000     0        0 150348295 1 0000000000000000 100 0 0 10 0
+  10: 00000000000000000000000001000000:0277 00000000000000000000000000000000:0000 0A 00000000:00000000 00:00000000 00000000     0        0 160432833 1 0000000000000000 100 0 0 10 0`
+)
+
+func TestIsPortListeningInProcNetTCP(t *testing.T) {
+	tests := []struct {
+		name       string
+		procNetTCP string
+		port       string
+		expected   bool
+	}{
+		{
+			name:       "returns false for an IPv4 loopback listener",
+			procNetTCP: procNetTCPV4,
+			port:       "11000",
+			expected:   false,
+		},
+		{
+			name:       "returns true for an IPv4 all-interfaces listener",
+			procNetTCP: procNetTCPV4,
+			port:       "11434",
+			expected:   true,
+		},
+		{
+			name:       "returns false for an IPv6 loopback listener",
+			procNetTCP: procNetTCPV6,
+			port:       "631",
+			expected:   false,
+		},
+		{
+			name:       "returns true for an IPv6 all-interfaces listener",
+			procNetTCP: procNetTCPV6,
+			port:       "11434",
+			expected:   true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := netprobe.IsRemotePortListeningInProcNetTCP(test.procNetTCP, test.port)
+
+			assert.NoError(t, err)
+			assert.Equal(t, test.expected, got)
+		})
+	}
+
+	t.Run("returns false when the port is not present", func(t *testing.T) {
+		got, err := netprobe.IsRemotePortListeningInProcNetTCP(procNetTCPV4, "631")
 
 		assert.NoError(t, err)
 		assert.False(t, got)
 	})
 
-	t.Run("returns true when the remote port accepts a connection", func(t *testing.T) {
-		listener, err := net.Listen("tcp", "127.0.0.1:0")
-		require.NoError(t, err)
-		t.Cleanup(func() { _ = listener.Close() })
-		connectionClosed := make(chan error, 1)
-		go func() {
-			connection, acceptErr := listener.Accept()
-			if acceptErr != nil {
-				connectionClosed <- acceptErr
-				return
-			}
-			connectionClosed <- connection.Close()
-		}()
-		_, port, err := net.SplitHostPort(listener.Addr().String())
-		require.NoError(t, err)
+	t.Run("returns false when the matching socket is not listening", func(t *testing.T) {
+		procNetTCP := `sl local_address rem_address st
+0: 0100007F:2AF8 00000000:0000 01`
 
-		got, err := netprobe.IsRemotePortListening(context.Background(), "localhost.", port)
-		listenerCloseErr := listener.Close()
+		got, err := netprobe.IsRemotePortListeningInProcNetTCP(procNetTCP, "11000")
+
+		assert.NoError(t, err)
+		assert.False(t, got)
+	})
+
+	t.Run("returns true when a non-loopback interface is listening", func(t *testing.T) {
+		procNetTCP := `sl local_address rem_address st
+0: 0100000A:2AF8 00000000:0000 0A`
+
+		got, err := netprobe.IsRemotePortListeningInProcNetTCP(procNetTCP, "11000")
 
 		assert.NoError(t, err)
 		assert.True(t, got)
-		assert.NoError(t, listenerCloseErr)
-		assert.NoError(t, <-connectionClosed)
 	})
 
-	t.Run("returns an error when the remote host cannot be resolved", func(t *testing.T) {
-		got, err := netprobe.IsRemotePortListening(context.Background(), "nonexistent.invalid", "12345")
+	t.Run("returns an error for an invalid port", func(t *testing.T) {
+		got, err := netprobe.IsRemotePortListeningInProcNetTCP(procNetTCPV4, "not-a-port")
 
-		assert.ErrorContains(t, err, `could not resolve remote host "nonexistent.invalid"`)
+		assert.ErrorContains(t, err, `invalid TCP port "not-a-port"`)
+		assert.False(t, got)
+	})
+
+	t.Run("returns an error when the table is missing required columns", func(t *testing.T) {
+		procNetTCP := `sl rem_address
+0: 00000000:0000`
+
+		got, err := netprobe.IsRemotePortListeningInProcNetTCP(procNetTCP, "11000")
+
+		assert.ErrorContains(t, err, `missing "local_address" column`)
+		assert.False(t, got)
+	})
+
+	t.Run("returns an error when a table row is incomplete", func(t *testing.T) {
+		procNetTCP := `sl local_address rem_address st
+0: 0100007F:2AF8`
+
+		got, err := netprobe.IsRemotePortListeningInProcNetTCP(procNetTCP, "11000")
+
+		assert.ErrorContains(t, err, "row 2 has 2 fields, expected at least 4")
 		assert.False(t, got)
 	})
 }

--- a/internal/netprobe/port_test.go
+++ b/internal/netprobe/port_test.go
@@ -1,6 +1,7 @@
 package netprobe_test
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/arm/topo/internal/netprobe"
@@ -27,25 +28,25 @@ func TestIsPortListeningInProcNetTCP(t *testing.T) {
 		{
 			name:       "returns false for an IPv4 loopback listener",
 			procNetTCP: procNetTCPV4,
-			port:       "11000",
+			port:       strconv.Itoa(0x2AF8),
 			expected:   false,
 		},
 		{
 			name:       "returns true for an IPv4 all-interfaces listener",
 			procNetTCP: procNetTCPV4,
-			port:       "11434",
+			port:       strconv.Itoa(0x2CAA),
 			expected:   true,
 		},
 		{
 			name:       "returns false for an IPv6 loopback listener",
 			procNetTCP: procNetTCPV6,
-			port:       "631",
+			port:       strconv.Itoa(0x0277),
 			expected:   false,
 		},
 		{
 			name:       "returns true for an IPv6 all-interfaces listener",
 			procNetTCP: procNetTCPV6,
-			port:       "11434",
+			port:       strconv.Itoa(0x2CAA),
 			expected:   true,
 		},
 	}
@@ -59,7 +60,7 @@ func TestIsPortListeningInProcNetTCP(t *testing.T) {
 	}
 
 	t.Run("returns false when the port is not present", func(t *testing.T) {
-		got, err := netprobe.IsRemotePortListeningInProcNetTCP(procNetTCPV4, "631")
+		got, err := netprobe.IsRemotePortListeningInProcNetTCP(procNetTCPV4, "9999")
 
 		assert.NoError(t, err)
 		assert.False(t, got)
@@ -68,8 +69,9 @@ func TestIsPortListeningInProcNetTCP(t *testing.T) {
 	t.Run("returns false when the matching socket is not listening", func(t *testing.T) {
 		procNetTCP := `sl local_address rem_address st
 0: 0100007F:2AF8 00000000:0000 01`
+		port := strconv.Itoa(0x2AF8)
 
-		got, err := netprobe.IsRemotePortListeningInProcNetTCP(procNetTCP, "11000")
+		got, err := netprobe.IsRemotePortListeningInProcNetTCP(procNetTCP, port)
 
 		assert.NoError(t, err)
 		assert.False(t, got)
@@ -77,16 +79,18 @@ func TestIsPortListeningInProcNetTCP(t *testing.T) {
 
 	t.Run("returns true when a non-loopback interface is listening", func(t *testing.T) {
 		procNetTCP := `sl local_address rem_address st
-0: 0100000A:2AF8 00000000:0000 0A`
+0: 0100000A:2B28 00000000:0000 0A`
+		port := strconv.Itoa(0x2B28)
 
-		got, err := netprobe.IsRemotePortListeningInProcNetTCP(procNetTCP, "11000")
+		got, err := netprobe.IsRemotePortListeningInProcNetTCP(procNetTCP, port)
 
 		assert.NoError(t, err)
 		assert.True(t, got)
 	})
 
 	t.Run("returns an error for an invalid port", func(t *testing.T) {
-		got, err := netprobe.IsRemotePortListeningInProcNetTCP(procNetTCPV4, "not-a-port")
+		procNetTCP := `sl local_address rem_address st`
+		got, err := netprobe.IsRemotePortListeningInProcNetTCP(procNetTCP, "not-a-port")
 
 		assert.ErrorContains(t, err, `invalid TCP port "not-a-port"`)
 		assert.False(t, got)
@@ -96,7 +100,7 @@ func TestIsPortListeningInProcNetTCP(t *testing.T) {
 		procNetTCP := `sl rem_address
 0: 00000000:0000`
 
-		got, err := netprobe.IsRemotePortListeningInProcNetTCP(procNetTCP, "11000")
+		got, err := netprobe.IsRemotePortListeningInProcNetTCP(procNetTCP, "12345")
 
 		assert.ErrorContains(t, err, `missing "local_address" column`)
 		assert.False(t, got)
@@ -104,9 +108,10 @@ func TestIsPortListeningInProcNetTCP(t *testing.T) {
 
 	t.Run("returns an error when a table row is incomplete", func(t *testing.T) {
 		procNetTCP := `sl local_address rem_address st
-0: 0100007F:2AF8`
+0: 0100007F:1A18`
+		port := strconv.Itoa(0x1A18)
 
-		got, err := netprobe.IsRemotePortListeningInProcNetTCP(procNetTCP, "11000")
+		got, err := netprobe.IsRemotePortListeningInProcNetTCP(procNetTCP, port)
 
 		assert.ErrorContains(t, err, "row 2 has 2 fields, expected at least 4")
 		assert.False(t, got)

--- a/internal/testutil/container.go
+++ b/internal/testutil/container.go
@@ -46,7 +46,7 @@ var DinDContainer = ContainerSpec{
 	},
 }
 
-var SshServerContainer = ContainerSpec{
+var PasswordlessSSHContainer = ContainerSpec{
 	context: relPath("passwordless-ssh"),
 	image:   "topo-e2e-passwordless-ssh:latest",
 	setup: func(c *Container) error {

--- a/internal/testutil/container.go
+++ b/internal/testutil/container.go
@@ -55,6 +55,9 @@ var SshServerContainer = ContainerSpec{
 		}
 		return nil
 	},
+	cleanup: func(c *Container) {
+		removeHostKey(c)
+	},
 }
 
 func StartContainer(t *testing.T, spec ContainerSpec) *Container {

--- a/internal/testutil/container.go
+++ b/internal/testutil/container.go
@@ -46,6 +46,17 @@ var DinDContainer = ContainerSpec{
 	},
 }
 
+var SshServerContainer = ContainerSpec{
+	context: relPath("passwordless-ssh"),
+	image:   "topo-e2e-passwordless-ssh:latest",
+	setup: func(c *Container) error {
+		if err := acceptHostKey(c); err != nil {
+			return err
+		}
+		return nil
+	},
+}
+
 func StartContainer(t *testing.T, spec ContainerSpec) *Container {
 	t.Helper()
 	if testing.Short() {

--- a/internal/testutil/passwordless-ssh/Dockerfile
+++ b/internal/testutil/passwordless-ssh/Dockerfile
@@ -1,0 +1,22 @@
+FROM alpine:3.21
+
+RUN apk add --no-cache openssh-server
+
+RUN echo "PasswordAuthentication yes" >> /etc/ssh/sshd_config && \
+    echo "PermitEmptyPasswords yes" >> /etc/ssh/sshd_config && \
+    echo "PermitRootLogin yes" >> /etc/ssh/sshd_config && \
+    echo "KexAlgorithms curve25519-sha256,curve25519-sha256@libssh.org" >> /etc/ssh/sshd_config && \
+    echo "DisableForwarding no" >> /etc/ssh/sshd_config && \
+    echo "PermitOpen any" >> /etc/ssh/sshd_config && \
+    echo "PermitListen any" >> /etc/ssh/sshd_config && \
+    echo "" >> /etc/ssh/sshd_config && \
+    echo "Match all" >> /etc/ssh/sshd_config && \
+    echo "    AllowTcpForwarding yes" >> /etc/ssh/sshd_config && \
+    echo "    DisableForwarding no" >> /etc/ssh/sshd_config
+
+RUN passwd -d root
+RUN ssh-keygen -A
+
+EXPOSE 22
+
+CMD ["/usr/sbin/sshd", "-D", "-e"]


### PR DESCRIPTION
<!-- PR title should be formatted using conventional commits -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->
<!-- Example: feat: A very fancy feature -->

## Changes

<!-- List the changes this PR introduces -->

- Implements a new ssh-based port probe for our registry port listening check that works by parsing `/proc/net/tcp{6}`
  - Why do we need an ssh-based probe? `curl`, along with being an extra dependency for something quite minor, does not work with non-trivial SSH setups like `ProxyJump`/`ProxyCommand`.
  - Why parse procfs? It came with the least dependencies. Ofc it can still fail on particularly esoteric kernel builds or setups where the ssh user cannot access procfs for any reason but that's also the case with `topo describe` and rarer than curl-based failures.
    - Other alternative explored: Forwarding a TCP port from the target to the host and pushing an HTTP request down its stdin. This came with two downsides: required the ssh server to support tcp forwarding (particularly annoying on dropbear where it's a compile flag), required parsing ssh stderr to differentiate between positive/negative states which is unreliable as the output is server-specific.
  - How stable is`/proc/net/tcp`? Some basic reading suggests yes - all the columns we care about are stable and haven't changed in decades as many tools rely on them too.
- Rejigs the necessary tests to spin up target containers and start loopback-only or all interface listening processes to give some confidence the check actually functions in both the positive and negative cases
- Drops dependency on curl!

## Checklist

<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->

- [x] 🤖 This change is covered by tests as required.
- [x] 🤹 All required manual testing has been performed.
- [x] 📖 All documentation updates are complete.
