### PR TITLE
feat: experimental support for Podman localhost deployment

### DIFF
--- a/cmd/topo/deploy.go
+++ b/cmd/topo/deploy.go
@@ -22,7 +22,7 @@ import (
 )
 
 var (
-	deploymentEngine    string
+	engine              string
 	noRegistry          bool
 	registryPort        string
 	skipRemotePortCheck bool
@@ -34,8 +34,8 @@ var (
 type containerEngine string
 
 const (
-	deploymentEngineDocker containerEngine = "docker"
-	deploymentEnginePodman containerEngine = "podman"
+	containerEngineDocker containerEngine = "docker"
+	containerEnginePodman containerEngine = "podman"
 )
 
 var deployOpts deploy.DeployOptions
@@ -56,11 +56,11 @@ By default, Topo uses compose.yaml in the current working directory, then compos
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 
-		engine, err := parseDeploymentEngine(deploymentEngine)
+		parsedEngine, err := parseContainerEngine(engine)
 		if err != nil {
 			return err
 		}
-		if engine == deploymentEnginePodman {
+		if parsedEngine == containerEnginePodman {
 			return deployWithPodman(cmd)
 		}
 		return deployWithDocker(cmd)
@@ -158,15 +158,15 @@ func executeDeployment(cmd *cobra.Command, deployment func(context.Context) erro
 	return nil
 }
 
-func parseDeploymentEngine(value string) (containerEngine, error) {
-	engine := containerEngine(value)
-	if engine == "" {
-		return deploymentEngineDocker, nil
+func parseContainerEngine(value string) (containerEngine, error) {
+	parsedEngine := containerEngine(value)
+	if parsedEngine == "" {
+		return containerEngineDocker, nil
 	}
-	if engine != deploymentEngineDocker && engine != deploymentEnginePodman {
+	if parsedEngine != containerEngineDocker && parsedEngine != containerEnginePodman {
 		return "", fmt.Errorf("invalid engine %q: must be docker or podman", value)
 	}
-	return engine, nil
+	return parsedEngine, nil
 }
 
 func validatePort(port string) error {
@@ -208,7 +208,7 @@ func init() {
 	addTargetFlag(deployCmd)
 	addComposeFileFlag(deployCmd)
 	if experimentalFeaturesEnabled() {
-		deployCmd.Flags().StringVar(&deploymentEngine, "engine", string(deploymentEngineDocker), "container engine to use (docker or podman)")
+		deployCmd.Flags().StringVar(&engine, "engine", string(containerEngineDocker), "container engine to use (docker or podman)")
 	}
 	deployCmd.Flags().StringVarP(&registryPort, "registry-port", "p", deploy.DefaultRegistryPort, fmt.Sprintf("registry and SSH tunnel port (can also be set via %s env var)", portEnvVar))
 	deployCmd.Flags().BoolVar(&noRegistry, "no-registry", false, "disable private registry flow; use direct save/load transfer")

--- a/cmd/topo/deploy.go
+++ b/cmd/topo/deploy.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/signal"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/arm/topo/internal/deploy"
 	"github.com/arm/topo/internal/deploy/docker"
+	"github.com/arm/topo/internal/deploy/podman"
 	checks "github.com/arm/topo/internal/deploy/project_checks"
 	"github.com/arm/topo/internal/env"
 	"github.com/arm/topo/internal/output/logger"
@@ -20,12 +22,20 @@ import (
 )
 
 var (
+	deploymentEngine    string
 	noRegistry          bool
 	registryPort        string
 	skipRemotePortCheck bool
 	skipProjectChecks   bool
 	forceRecreate       bool
 	noRecreate          bool
+)
+
+type containerEngine string
+
+const (
+	deploymentEngineDocker containerEngine = "docker"
+	deploymentEnginePodman containerEngine = "podman"
 )
 
 var deployOpts deploy.DeployOptions
@@ -46,68 +56,117 @@ By default, Topo uses compose.yaml in the current working directory, then compos
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 
-		portChanged := cmd.Flags().Changed("registry-port")
-		if portChanged && noRegistry {
-			logger.Warn("--registry-port has no effect when --no-registry is set. Define a port in your ssh config instead.")
-		}
-
-		targetArg, err := requireTarget(cmd)
+		engine, err := parseDeploymentEngine(deploymentEngine)
 		if err != nil {
 			return err
 		}
-
-		composeFile, err := getComposeFileName(cmd)
-		if err != nil {
-			return err
+		if engine == deploymentEnginePodman {
+			return deployWithPodman(cmd)
 		}
-
-		resolvedPort, err := resolvePort(cmd, registryPort)
-		if err != nil {
-			return err
-		}
-
-		if err := validatePort(resolvedPort); err != nil {
-			return err
-		}
-
-		deployOpts.TargetHost = ssh.NewDestination(targetArg)
-
-		if !skipProjectChecks {
-			if err := checks.EnsureProjectIsLinuxArm64Ready(composeFile); err != nil {
-				return err
-			}
-		}
-
-		goos := runtime.GOOS
-		if deploy.SupportsRegistry(noRegistry, deployOpts.TargetHost) {
-			deployOpts.Registry = &deploy.RegistryConfig{
-				Port:                resolvedPort,
-				SkipRemotePortCheck: resolveSkipRemotePortCheck(cmd),
-				UseControlSockets:   deploy.SupportsSSHControlSockets(goos),
-			}
-		}
-		switch {
-		case forceRecreate:
-			deployOpts.RecreateMode = docker.RecreateModeForce
-		case noRecreate:
-			deployOpts.RecreateMode = docker.RecreateModeNone
-		}
-
-		if deployOpts.Registry == nil {
-			logger.Warn("registry transfer is not yet supported with this configuration. Falling back to direct transfer.")
-		}
-
-		ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
-		defer stop()
-
-		if err := deploy.Deploy(ctx, os.Stdout, composeFile, deployOpts); err != nil {
-			if ctx.Err() != nil {
-				return ctx.Err()
-			}
-			return fmt.Errorf("deployment failed; ensure topo health is passing: %w", err)
-		}
-		return nil
+		return deployWithDocker(cmd)
 	},
+}
+
+func deployWithPodman(cmd *cobra.Command) error {
+	targetArg, err := requireTarget(cmd)
+	if err != nil {
+		return err
+	}
+	if !ssh.NewDestination(targetArg).IsPlainLocalhost() {
+		return fmt.Errorf("podman deployments only support the localhost target")
+	}
+
+	composeFile, err := getComposeFileName(cmd)
+	if err != nil {
+		return err
+	}
+	if err := ensureProjectIsReady(composeFile); err != nil {
+		return err
+	}
+
+	return executeDeployment(cmd, func(ctx context.Context) error {
+		return podman.Deploy(ctx, os.Stdout, composeFile)
+	})
+}
+
+func deployWithDocker(cmd *cobra.Command) error {
+	if cmd.Flags().Changed("registry-port") && noRegistry {
+		logger.Warn("--registry-port has no effect when --no-registry is set. Define a port in your ssh config instead.")
+	}
+
+	targetArg, err := requireTarget(cmd)
+	if err != nil {
+		return err
+	}
+	composeFile, err := getComposeFileName(cmd)
+	if err != nil {
+		return err
+	}
+	if err := ensureProjectIsReady(composeFile); err != nil {
+		return err
+	}
+
+	resolvedPort, err := resolvePort(cmd, registryPort)
+	if err != nil {
+		return err
+	}
+	if err := validatePort(resolvedPort); err != nil {
+		return err
+	}
+
+	deployOpts.TargetHost = ssh.NewDestination(targetArg)
+	if deploy.SupportsRegistry(noRegistry, deployOpts.TargetHost) {
+		deployOpts.Registry = &deploy.RegistryConfig{
+			Port:                resolvedPort,
+			SkipRemotePortCheck: resolveSkipRemotePortCheck(cmd),
+			UseControlSockets:   deploy.SupportsSSHControlSockets(runtime.GOOS),
+		}
+	}
+	switch {
+	case forceRecreate:
+		deployOpts.RecreateMode = docker.RecreateModeForce
+	case noRecreate:
+		deployOpts.RecreateMode = docker.RecreateModeNone
+	}
+
+	if deployOpts.Registry == nil {
+		logger.Warn("registry transfer is not yet supported with this configuration. Falling back to direct transfer.")
+	}
+
+	return executeDeployment(cmd, func(ctx context.Context) error {
+		return deploy.Deploy(ctx, os.Stdout, composeFile, deployOpts)
+	})
+}
+
+func ensureProjectIsReady(composeFile string) error {
+	if skipProjectChecks {
+		return nil
+	}
+	return checks.EnsureProjectIsLinuxArm64Ready(composeFile)
+}
+
+func executeDeployment(cmd *cobra.Command, deployment func(context.Context) error) error {
+	ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	if err := deployment(ctx); err != nil {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		return fmt.Errorf("deployment failed; ensure topo health is passing: %w", err)
+	}
+	return nil
+}
+
+func parseDeploymentEngine(value string) (containerEngine, error) {
+	engine := containerEngine(value)
+	if engine == "" {
+		return deploymentEngineDocker, nil
+	}
+	if engine != deploymentEngineDocker && engine != deploymentEnginePodman {
+		return "", fmt.Errorf("invalid engine %q: must be docker or podman", value)
+	}
+	return engine, nil
 }
 
 func validatePort(port string) error {
@@ -148,6 +207,9 @@ func resolveSkipRemotePortCheck(cmd *cobra.Command) bool {
 func init() {
 	addTargetFlag(deployCmd)
 	addComposeFileFlag(deployCmd)
+	if experimentalFeaturesEnabled() {
+		deployCmd.Flags().StringVar(&deploymentEngine, "engine", string(deploymentEngineDocker), "container engine to use (docker or podman)")
+	}
 	deployCmd.Flags().StringVarP(&registryPort, "registry-port", "p", deploy.DefaultRegistryPort, fmt.Sprintf("registry and SSH tunnel port (can also be set via %s env var)", portEnvVar))
 	deployCmd.Flags().BoolVar(&noRegistry, "no-registry", false, "disable private registry flow; use direct save/load transfer")
 	deployCmd.Flags().BoolVar(&skipRemotePortCheck, "skip-remote-port-check", false, fmt.Sprintf("skip checking whether the SSH tunnel port is exposed on the remote network (can also be set via %s env var)", skipRemotePortCheckEnvVar))

--- a/internal/deploy/podman/command.go
+++ b/internal/deploy/podman/command.go
@@ -1,0 +1,36 @@
+package podman
+
+import (
+	"context"
+	"io"
+	"os"
+	"os/exec"
+
+	"github.com/arm/topo/internal/command"
+)
+
+const composeProvider = "docker-compose"
+
+func Command(ctx context.Context, args ...string) *exec.Cmd {
+	return exec.CommandContext(ctx, "podman", args...)
+}
+
+func ComposeCommand(ctx context.Context, composeFile string, args ...string) *exec.Cmd {
+	composeArgs := append([]string{"compose", "-f", composeFile}, args...)
+	cmd := exec.CommandContext(ctx, "podman", composeArgs...)
+	cmd.Env = append(os.Environ(),
+		"PODMAN_COMPOSE_PROVIDER="+composeProvider,
+		"PODMAN_COMPOSE_WARNING_LOGS=false",
+	)
+	return cmd
+}
+
+func RunComposeCommand(ctx context.Context, output io.Writer, composeFile string, args ...string) error {
+	cmd := ComposeCommand(ctx, composeFile, args...)
+	cmd.Stdout = output
+	cmd.Stderr = output
+	if err := cmd.Run(); err != nil {
+		return command.FormatError(cmd.Args, err)
+	}
+	return nil
+}

--- a/internal/deploy/podman/compose.go
+++ b/internal/deploy/podman/compose.go
@@ -1,0 +1,29 @@
+package podman
+
+import (
+	"context"
+	"io"
+
+	"github.com/arm/topo/internal/compose"
+)
+
+func BuildImages(ctx context.Context, output io.Writer, composeFile string) error {
+	return RunComposeCommand(ctx, output, composeFile, "build")
+}
+
+func PullImages(ctx context.Context, output io.Writer, composeFile string) error {
+	services, err := compose.PullableServices(composeFile)
+	if err != nil {
+		return err
+	}
+	if len(services) == 0 {
+		return nil
+	}
+
+	args := append([]string{"pull"}, services...)
+	return RunComposeCommand(ctx, output, composeFile, args...)
+}
+
+func StartServices(ctx context.Context, output io.Writer, composeFile string) error {
+	return RunComposeCommand(ctx, output, composeFile, "up", "-d", "--no-build", "--pull", "never")
+}

--- a/internal/deploy/podman/deploy.go
+++ b/internal/deploy/podman/deploy.go
@@ -1,0 +1,29 @@
+package podman
+
+import (
+	"context"
+	"io"
+
+	"github.com/arm/topo/internal/output/term"
+)
+
+func Deploy(ctx context.Context, output io.Writer, composeFile string) error {
+	if err := term.PrintHeader(output, "Build images"); err != nil {
+		return err
+	}
+	if err := BuildImages(ctx, output, composeFile); err != nil {
+		return err
+	}
+
+	if err := term.PrintHeader(output, "Pull images"); err != nil {
+		return err
+	}
+	if err := PullImages(ctx, output, composeFile); err != nil {
+		return err
+	}
+
+	if err := term.PrintHeader(output, "Start services"); err != nil {
+		return err
+	}
+	return StartServices(ctx, output, composeFile)
+}

--- a/internal/deploy/podman/deploy_test.go
+++ b/internal/deploy/podman/deploy_test.go
@@ -1,0 +1,122 @@
+package podman_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/arm/topo/internal/deploy/podman"
+	gtestutil "github.com/arm/topo/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeploy(t *testing.T) {
+	requireLocalPodman(t)
+	composeFile := deploymentFixture(t)
+	t.Cleanup(func() { cleanupComposeProject(t, composeFile) })
+
+	err := podman.Deploy(t.Context(), io.Discard, composeFile)
+
+	require.NoError(t, err)
+	assertContainersRunning(t, composeFile)
+}
+
+func requireLocalPodman(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("podman"); err != nil {
+		t.Skip("podman is not installed")
+	}
+	if _, err := exec.LookPath("docker-compose"); err != nil {
+		t.Skip("docker-compose is not installed")
+	}
+	if output, err := exec.Command("podman", "info").CombinedOutput(); err != nil {
+		t.Skipf("local Podman engine is unavailable: %v: %s", err, output)
+	}
+}
+
+func assertContainersRunning(t *testing.T, composeFile string) {
+	t.Helper()
+	cmd := podman.ComposeCommand(t.Context(), composeFile, "ps", "--format", "json", "--all")
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(output))
+	require.NotEmpty(t, bytes.TrimSpace(output), "no containers reported")
+
+	containers, err := unmarshalNDJSON(output)
+	require.NoError(t, err)
+
+	for _, container := range containers {
+		assert.Equal(t, "running", container["State"], "container %s is not running: %s", container["Name"], container["State"])
+	}
+}
+
+type jsonObject map[string]any
+
+func unmarshalNDJSON(ndJSON []byte) ([]jsonObject, error) {
+	objects := []jsonObject{}
+	lines := bytes.SplitSeq(bytes.TrimSpace(ndJSON), []byte("\n"))
+
+	for line := range lines {
+		line = bytes.TrimSpace(line)
+		if len(line) == 0 {
+			continue
+		}
+
+		var object jsonObject
+		if err := json.Unmarshal(line, &object); err != nil {
+			return objects, err
+		}
+		objects = append(objects, object)
+	}
+	return objects, nil
+}
+
+func deploymentFixture(t *testing.T) string {
+	t.Helper()
+	tempDir := t.TempDir()
+	testName := gtestutil.SanitiseTestName(t)
+	imageName := "test-image-" + testName
+	composeFile := filepath.Join(tempDir, "compose.yaml")
+	composeFileContent := fmt.Sprintf(`
+name: %s
+services:
+  built:
+    build: .
+    image: %s
+  pulled:
+    image: docker.io/library/alpine:latest
+    command: ["tail", "-f", "/dev/null"]
+`, "test-project-"+testName, imageName)
+	gtestutil.RequireWriteFile(t, composeFile, composeFileContent)
+	gtestutil.RequireWriteFile(t, filepath.Join(tempDir, "Dockerfile"), `
+FROM docker.io/library/alpine:latest
+CMD ["tail", "-f", "/dev/null"]
+`)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		removeOutput, err := podman.Command(ctx, "image", "rm", "-f", imageName).CombinedOutput()
+		if err != nil {
+			t.Logf("failed to remove image %s: %v: %s", imageName, err, string(removeOutput))
+		}
+	})
+	return composeFile
+}
+
+func cleanupComposeProject(t *testing.T, composeFile string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	cmd := podman.ComposeCommand(ctx, composeFile, "down", "-v", "--remove-orphans", "--rmi", "local")
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Logf("Podman Compose cleanup failed: %v: %s", err, output)
+	}
+}

--- a/internal/deploy/podman/deploy_test.go
+++ b/internal/deploy/podman/deploy_test.go
@@ -3,7 +3,6 @@ package podman_test
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"os/exec"
@@ -12,6 +11,7 @@ import (
 	"time"
 
 	"github.com/arm/topo/internal/deploy/podman"
+	"github.com/arm/topo/internal/deploy/testutil"
 	gtestutil "github.com/arm/topo/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -48,33 +48,12 @@ func assertContainersRunning(t *testing.T, composeFile string) {
 	require.NoError(t, err, string(output))
 	require.NotEmpty(t, bytes.TrimSpace(output), "no containers reported")
 
-	containers, err := unmarshalNDJSON(output)
+	containers, err := testutil.UnmarshalNDJSON(output)
 	require.NoError(t, err)
 
 	for _, container := range containers {
 		assert.Equal(t, "running", container["State"], "container %s is not running: %s", container["Name"], container["State"])
 	}
-}
-
-type jsonObject map[string]any
-
-func unmarshalNDJSON(ndJSON []byte) ([]jsonObject, error) {
-	objects := []jsonObject{}
-	lines := bytes.SplitSeq(bytes.TrimSpace(ndJSON), []byte("\n"))
-
-	for line := range lines {
-		line = bytes.TrimSpace(line)
-		if len(line) == 0 {
-			continue
-		}
-
-		var object jsonObject
-		if err := json.Unmarshal(line, &object); err != nil {
-			return objects, err
-		}
-		objects = append(objects, object)
-	}
-	return objects, nil
 }
 
 func deploymentFixture(t *testing.T) string {

--- a/internal/deploy/testutil/testutil.go
+++ b/internal/deploy/testutil/testutil.go
@@ -88,7 +88,7 @@ func AssertContainersRunning(t *testing.T, dest ssh.Destination, composeFilePath
 
 	require.NotEmpty(t, bytes.TrimSpace(output), "no containers running")
 
-	containers, err := unmarshalNDJSON(output)
+	containers, err := UnmarshalNDJSON(output)
 	require.NoError(t, err)
 
 	for _, container := range containers {
@@ -104,7 +104,7 @@ func AssertContainersStopped(t *testing.T, dest ssh.Destination, composeFilePath
 
 	require.NotEmpty(t, bytes.TrimSpace(output), "no containers reported")
 
-	containers, err := unmarshalNDJSON(output)
+	containers, err := UnmarshalNDJSON(output)
 	require.NoError(t, err)
 
 	for _, container := range containers {
@@ -112,10 +112,10 @@ func AssertContainersStopped(t *testing.T, dest ssh.Destination, composeFilePath
 	}
 }
 
-type jsonObject map[string]any
+type JsonObject map[string]any
 
-func unmarshalNDJSON(ndJSON []byte) ([]jsonObject, error) {
-	objects := []jsonObject{}
+func UnmarshalNDJSON(ndJSON []byte) ([]JsonObject, error) {
+	objects := []JsonObject{}
 	lines := bytes.SplitSeq(bytes.TrimSpace(ndJSON), []byte("\n"))
 
 	for line := range lines {
@@ -124,7 +124,7 @@ func unmarshalNDJSON(ndJSON []byte) ([]jsonObject, error) {
 			continue
 		}
 
-		var obj jsonObject
+		var obj JsonObject
 		err := json.Unmarshal(line, &obj)
 		if err != nil {
 			return objects, err


### PR DESCRIPTION
## Changes

- Add an experimental `--engine podman` deployment path for localhost targets.
- Build, pull, and start Compose services using Podman with `docker-compose` as the Compose provider.
- Reject remote targets when Podman is selected.

## Try it locally

Prerequisites:

- Podman installed and running
- `docker-compose` installed

Create `compose-podman.yaml`:

```yaml
name: topo-podman-test

services:
  app:
    platform: linux/arm64
    image: docker.io/library/alpine:latest
    command: ["sh", "-c", "while true; do echo 'Topo Podman test is running'; sleep 30; done"]
```

Run the deployment:

```shell
TOPO_EXPERIMENTAL_FEATURES=1 go run ./cmd/topo deploy \
  --engine podman \
  --target localhost \
  --file compose-podman.yaml
```

Verify the service:

```bash
podman compose -f compose-podman.yaml ps
podman logs topo-podman-test-app-1
```

Clean up:

```bash
podman compose -f compose-podman.yaml down
```

## Checklist

- [x] 🤖 This change is covered by tests as required.
- [ ] 🤹 All required manual testing has been performed.
- [ ] 📖 All documentation updates are complete.