### PR TITLE
refactor: move docker ps to its own namespace

### DIFF
--- a/cmd/topo/ps.go
+++ b/cmd/topo/ps.go
@@ -3,8 +3,8 @@ package main
 import (
 	"os"
 
-	"github.com/arm/topo/internal/deploy"
 	"github.com/arm/topo/internal/deploy/command"
+	"github.com/arm/topo/internal/deploy/docker"
 	"github.com/arm/topo/internal/output/views"
 	"github.com/arm/topo/internal/ssh"
 	"github.com/spf13/cobra"
@@ -40,13 +40,29 @@ By default, Topo uses compose.yaml in the current working directory, then compos
 		}
 
 		host := command.NewHostFromDestination(dest)
-		containers, err := deploy.ListContainers(composeFile, host, hostName, allContainers)
+		containers, err := docker.ListContainers(composeFile, host, hostName, allContainers)
 		if err != nil {
 			return err
 		}
 
-		return views.Print(views.ContainerList{Containers: containers}, os.Stdout, outputFormat)
+		return views.Print(newContainerList(containers), os.Stdout, outputFormat)
 	},
+}
+
+func newContainerList(containers []docker.Container) views.ContainerList {
+	items := make([]views.Container, len(containers))
+	for i, container := range containers {
+		items[i] = views.Container{
+			ID:               container.Id,
+			Names:            container.Names,
+			Image:            container.Image,
+			State:            container.State,
+			Status:           container.Status,
+			ProcessingDomain: container.ProcessingDomain,
+			Address:          container.Address,
+		}
+	}
+	return views.ContainerList{Containers: items}
 }
 
 func init() {

--- a/internal/deploy/docker/ps.go
+++ b/internal/deploy/docker/ps.go
@@ -1,4 +1,4 @@
-package deploy
+package docker
 
 import (
 	"bytes"

--- a/internal/deploy/docker/ps_test.go
+++ b/internal/deploy/docker/ps_test.go
@@ -3,7 +3,7 @@ package docker_test
 import (
 	"testing"
 
-	docker "github.com/arm/topo/internal/deploy/docker"
+	"github.com/arm/topo/internal/deploy/docker"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/deploy/docker/ps_test.go
+++ b/internal/deploy/docker/ps_test.go
@@ -1,9 +1,9 @@
-package deploy_test
+package docker_test
 
 import (
 	"testing"
 
-	"github.com/arm/topo/internal/deploy"
+	docker "github.com/arm/topo/internal/deploy/docker"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -13,10 +13,10 @@ func TestParseContainers(t *testing.T) {
 		input := `{"ID":"abc123","Names":"project-web-1","Image":"web","State":"running","Status":"Up 5 minutes","Ports":"0.0.0.0:8080->80/tcp"}
 {"ID":"def456","Names":"project-db-1","Image":"db","State":"running","Status":"Up 5 minutes","Ports":""}`
 
-		got, err := deploy.ParseContainers(input)
+		got, err := docker.ParseContainers(input)
 
 		require.NoError(t, err)
-		want := []deploy.PSContainer{
+		want := []docker.PSContainer{
 			{ID: "abc123", Names: "project-web-1", Image: "web", State: "running", Status: "Up 5 minutes", Ports: "0.0.0.0:8080->80/tcp"},
 			{ID: "def456", Names: "project-db-1", Image: "db", State: "running", Status: "Up 5 minutes", Ports: ""},
 		}
@@ -24,14 +24,14 @@ func TestParseContainers(t *testing.T) {
 	})
 
 	t.Run("returns an empty slice for empty input", func(t *testing.T) {
-		got, err := deploy.ParseContainers("")
+		got, err := docker.ParseContainers("")
 
 		require.NoError(t, err)
-		assert.Equal(t, []deploy.PSContainer{}, got)
+		assert.Equal(t, []docker.PSContainer{}, got)
 	})
 
 	t.Run("returns an error on malformed JSON", func(t *testing.T) {
-		_, err := deploy.ParseContainers("{not json")
+		_, err := docker.ParseContainers("{not json")
 
 		assert.Error(t, err)
 	})
@@ -52,14 +52,14 @@ func TestParseInspectedContainers(t *testing.T) {
 			}
 		]`
 
-		got, err := deploy.ParseInspectedContainers(input)
+		got, err := docker.ParseInspectedContainers(input)
 
 		require.NoError(t, err)
-		want := []deploy.InspectedContainer{
+		want := []docker.InspectedContainer{
 			{
 				ID:   "abc123",
 				Name: "/project-web-1",
-				HostConfig: deploy.InspectedHostConfig{
+				HostConfig: docker.InspectedHostConfig{
 					Runtime: "io.containerd.remoteproc.v1",
 					Annotations: map[string]string{
 						"remoteproc.name": "m0",
@@ -71,14 +71,14 @@ func TestParseInspectedContainers(t *testing.T) {
 	})
 
 	t.Run("returns empty slice for empty input", func(t *testing.T) {
-		got, err := deploy.ParseInspectedContainers("")
+		got, err := docker.ParseInspectedContainers("")
 
 		require.NoError(t, err)
-		assert.Equal(t, []deploy.InspectedContainer{}, got)
+		assert.Equal(t, []docker.InspectedContainer{}, got)
 	})
 
 	t.Run("returns error on malformed JSON", func(t *testing.T) {
-		_, err := deploy.ParseInspectedContainers("{not json")
+		_, err := docker.ParseInspectedContainers("{not json")
 
 		assert.Error(t, err)
 	})
@@ -86,10 +86,10 @@ func TestParseInspectedContainers(t *testing.T) {
 
 func TestBuildProcessingDomainLookup(t *testing.T) {
 	t.Run("indexes remoteproc containers by id", func(t *testing.T) {
-		input := []deploy.InspectedContainer{
+		input := []docker.InspectedContainer{
 			{
 				ID: "abc123",
-				HostConfig: deploy.InspectedHostConfig{
+				HostConfig: docker.InspectedHostConfig{
 					Runtime: "io.containerd.remoteproc.v1",
 					Annotations: map[string]string{
 						"remoteproc.name": "m0",
@@ -98,17 +98,17 @@ func TestBuildProcessingDomainLookup(t *testing.T) {
 			},
 		}
 
-		got := deploy.BuildProcessingDomainLookup(input)
+		got := docker.BuildProcessingDomainLookup(input)
 
 		want := map[string]string{"abc123": "m0"}
 		assert.Equal(t, want, got)
 	})
 
 	t.Run("indexes remoteproc containers by short docker id", func(t *testing.T) {
-		input := []deploy.InspectedContainer{
+		input := []docker.InspectedContainer{
 			{
 				ID: "0ccbbb5c98961db4e650d8db70b0154c3cf5bbfcd4a44450b019fea11a6afb9a",
-				HostConfig: deploy.InspectedHostConfig{
+				HostConfig: docker.InspectedHostConfig{
 					Runtime: "io.containerd.remoteproc.v1",
 					Annotations: map[string]string{
 						"remoteproc.name": "m33",
@@ -117,7 +117,7 @@ func TestBuildProcessingDomainLookup(t *testing.T) {
 			},
 		}
 
-		got := deploy.BuildProcessingDomainLookup(input)
+		got := docker.BuildProcessingDomainLookup(input)
 
 		want := map[string]string{
 			"0ccbbb5c9896": "m33",
@@ -126,10 +126,10 @@ func TestBuildProcessingDomainLookup(t *testing.T) {
 	})
 
 	t.Run("skips non remoteproc containers", func(t *testing.T) {
-		input := []deploy.InspectedContainer{
+		input := []docker.InspectedContainer{
 			{
 				ID: "abc123",
-				HostConfig: deploy.InspectedHostConfig{
+				HostConfig: docker.InspectedHostConfig{
 					Runtime: "runc",
 					Annotations: map[string]string{
 						"remoteproc.name": "m0",
@@ -138,23 +138,23 @@ func TestBuildProcessingDomainLookup(t *testing.T) {
 			},
 		}
 
-		got := deploy.BuildProcessingDomainLookup(input)
+		got := docker.BuildProcessingDomainLookup(input)
 
 		assert.Empty(t, got)
 	})
 
 	t.Run("skips remoteproc containers without a processing domain annotation", func(t *testing.T) {
-		input := []deploy.InspectedContainer{
+		input := []docker.InspectedContainer{
 			{
 				ID: "abc123",
-				HostConfig: deploy.InspectedHostConfig{
+				HostConfig: docker.InspectedHostConfig{
 					Runtime:     "io.containerd.remoteproc.v1",
 					Annotations: map[string]string{},
 				},
 			},
 		}
 
-		got := deploy.BuildProcessingDomainLookup(input)
+		got := docker.BuildProcessingDomainLookup(input)
 
 		assert.Empty(t, got)
 	})
@@ -162,52 +162,52 @@ func TestBuildProcessingDomainLookup(t *testing.T) {
 
 func TestRemapAddresses(t *testing.T) {
 	t.Run("strips the container-side port mapping and substitutes the hostname", func(t *testing.T) {
-		input := []deploy.PSContainer{{Ports: "0.0.0.0:8080->80/tcp"}}
+		input := []docker.PSContainer{{Ports: "0.0.0.0:8080->80/tcp"}}
 
-		got := deploy.RemapAddresses(input, "myhost")
+		got := docker.RemapAddresses(input, "myhost")
 
-		want := []deploy.Container{{Address: "myhost:8080"}}
+		want := []docker.Container{{Address: "myhost:8080"}}
 		assert.Equal(t, want, got)
 	})
 
 	t.Run("retains unmapped fields", func(t *testing.T) {
-		input := []deploy.PSContainer{{Image: "web", State: "running", Status: "Up", ID: "such-a-cool-id", Names: "project-web-1"}}
+		input := []docker.PSContainer{{Image: "web", State: "running", Status: "Up", ID: "such-a-cool-id", Names: "project-web-1"}}
 
-		got := deploy.RemapAddresses(input, "myhost")
+		got := docker.RemapAddresses(input, "myhost")
 
-		want := []deploy.Container{{Image: "web", State: "running", Status: "Up", Id: "such-a-cool-id", Names: "project-web-1"}}
+		want := []docker.Container{{Image: "web", State: "running", Status: "Up", Id: "such-a-cool-id", Names: "project-web-1"}}
 		assert.Equal(t, want, got)
 	})
 
 	t.Run("leaves ports untouched when hostname is empty", func(t *testing.T) {
-		input := []deploy.PSContainer{{Ports: "0.0.0.0:8080->80/tcp"}}
+		input := []docker.PSContainer{{Ports: "0.0.0.0:8080->80/tcp"}}
 
-		got := deploy.RemapAddresses(input, "")
+		got := docker.RemapAddresses(input, "")
 
-		want := []deploy.Container{{Address: "0.0.0.0:8080->80/tcp"}}
+		want := []docker.Container{{Address: "0.0.0.0:8080->80/tcp"}}
 		assert.Equal(t, want, got)
 	})
 
 	t.Run("leaves addresses without 0.0.0.0 untouched", func(t *testing.T) {
-		input := []deploy.PSContainer{{Ports: "127.0.0.1:8080"}}
+		input := []docker.PSContainer{{Ports: "127.0.0.1:8080"}}
 
-		got := deploy.RemapAddresses(input, "myhost")
+		got := docker.RemapAddresses(input, "myhost")
 
-		want := []deploy.Container{{Address: "127.0.0.1:8080"}}
+		want := []docker.Container{{Address: "127.0.0.1:8080"}}
 		assert.Equal(t, want, got)
 	})
 
 	t.Run("remaps all published ports", func(t *testing.T) {
-		input := []deploy.PSContainer{{Ports: "0.0.0.0:8080->80/tcp, 0.0.0.0:8443->443/tcp"}}
+		input := []docker.PSContainer{{Ports: "0.0.0.0:8080->80/tcp, 0.0.0.0:8443->443/tcp"}}
 
-		got := deploy.RemapAddresses(input, "myhost")
+		got := docker.RemapAddresses(input, "myhost")
 
-		want := []deploy.Container{{Address: "myhost:8080, myhost:8443"}}
+		want := []docker.Container{{Address: "myhost:8080, myhost:8443"}}
 		assert.Equal(t, want, got)
 	})
 
 	t.Run("returns an empty slice when given no containers", func(t *testing.T) {
-		got := deploy.RemapAddresses(nil, "myhost")
+		got := docker.RemapAddresses(nil, "myhost")
 
 		assert.Empty(t, got)
 	})

--- a/internal/output/views/container_list.go
+++ b/internal/output/views/container_list.go
@@ -6,17 +6,25 @@ import (
 	"fmt"
 	"text/tabwriter"
 	"text/template"
-
-	"github.com/arm/topo/internal/deploy"
 )
 
+type Container struct {
+	ID               string `json:"id"`
+	Names            string `json:"names"`
+	Image            string `json:"image"`
+	State            string `json:"state"`
+	Status           string `json:"status"`
+	ProcessingDomain string `json:"processingDomain"`
+	Address          string `json:"address"`
+}
+
 type ContainerList struct {
-	Containers []deploy.Container `json:"containers"`
+	Containers []Container `json:"containers"`
 }
 
 const containerListTemplate = `Container ID	Names	Image	Status	Processing Domain	Address
 {{- range .}}
-{{.Id}}	{{.Names}}	{{.Image}}	{{.Status}}	{{.ProcessingDomain}}	{{.Address}}
+{{.ID}}	{{.Names}}	{{.Image}}	{{.Status}}	{{.ProcessingDomain}}	{{.Address}}
 {{- end }}`
 
 func (r ContainerList) AsPlain(isTTY bool) (string, error) {

--- a/internal/output/views/container_list_test.go
+++ b/internal/output/views/container_list_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/arm/topo/internal/deploy"
 	"github.com/arm/topo/internal/output/term"
 	"github.com/arm/topo/internal/output/views"
 	"github.com/stretchr/testify/assert"
@@ -16,9 +15,9 @@ func TestContainerList(t *testing.T) {
 	t.Run("PlainFormat", func(t *testing.T) {
 		t.Run("renders container id, names, image, status, processing domain, and address", func(t *testing.T) {
 			toPrint := views.ContainerList{
-				Containers: []deploy.Container{
+				Containers: []views.Container{
 					{
-						Id:               "abcdef123456",
+						ID:               "abcdef123456",
 						Names:            "project-web-1",
 						Image:            "my-app",
 						State:            "running",
@@ -48,7 +47,7 @@ func TestContainerList(t *testing.T) {
 
 		t.Run("renders multiple containers", func(t *testing.T) {
 			toPrint := views.ContainerList{
-				Containers: []deploy.Container{
+				Containers: []views.Container{
 					{Image: "web", ProcessingDomain: "Linux Host"},
 					{Image: "db", ProcessingDomain: "Linux Host"},
 				},
@@ -77,9 +76,9 @@ func TestContainerList(t *testing.T) {
 	t.Run("JSONFormat", func(t *testing.T) {
 		t.Run("renders report as valid JSON with expected fields", func(t *testing.T) {
 			toPrint := views.ContainerList{
-				Containers: []deploy.Container{
+				Containers: []views.Container{
 					{
-						Id:               "abcdef123456",
+						ID:               "abcdef123456",
 						Names:            "project-web-1",
 						Image:            "my-app",
 						State:            "running",
@@ -102,7 +101,7 @@ func TestContainerList(t *testing.T) {
 
 		t.Run("renders empty containers as empty array", func(t *testing.T) {
 			toPrint := views.ContainerList{
-				Containers: []deploy.Container{},
+				Containers: []views.Container{},
 			}
 			var out bytes.Buffer
 


### PR DESCRIPTION
## Changes

- Move Docker-specific container listing and tests into the `deploy/docker` package.
- Decouple output rendering from Docker in preparation for supporting other runtimes.

## Checklist

- [x] 🤖 This change is covered by tests as required.
- [ ] 🤹 All required manual testing has been performed.
- [ ] 📖 All documentation updates are complete.