### PR TITLE
fix: make `topo describe` support pre-2.37 versions of `lscpu`

### DIFF
--- a/internal/probe/host_processors.go
+++ b/internal/probe/host_processors.go
@@ -89,6 +89,12 @@ func groupByModelName(fields []lscpuOutputField) []modelFields {
 			groups[len(groups)-1].fields = append(groups[len(groups)-1].fields, f)
 		}
 	}
+
+	// lscpu <v2.37 reported a single processor which doesn't appear before its corresponding fields
+	// so we need to assign all the fields to the single processor if there is only one
+	if len(groups) == 1 {
+		groups[0].fields = fields
+	}
 	return groups
 }
 

--- a/internal/probe/host_processors_test.go
+++ b/internal/probe/host_processors_test.go
@@ -97,6 +97,32 @@ func TestHostProcessors(t *testing.T) {
 		assert.Equal(t, 2, got[1].Cores)
 	})
 
+	t.Run("handles out-of-order results for a single processor", func(t *testing.T) {
+		r := &runner.Fake{
+			Binaries: []string{"lscpu"},
+			Commands: map[string]runner.FakeResult{
+				"lscpu --json": {Output: lscpuJSON(`
+					{"field": "Core(s) per socket:", "data": "4"},
+					{"field": "Socket(s):", "data": "1"},
+					{"field": "Flags:", "data": "fp asimd"},
+					{"field": "Model name:", "data": "Cortex-A55"}
+				`)},
+			},
+		}
+
+		got, err := probe.HostProcessors(context.Background(), r)
+
+		require.NoError(t, err)
+		want := []probe.HostProcessor{
+			{
+				Model:    "Cortex-A55",
+				Cores:    4,
+				Features: []string{"fp", "asimd"},
+			},
+		}
+		assert.Equal(t, want, got)
+	})
+
 	t.Run("returns empty when no model name field", func(t *testing.T) {
 		r := &runner.Fake{
 			Binaries: []string{"lscpu"},


### PR DESCRIPTION
<!-- PR title should be formatted using conventional commits -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->
<!-- Example: feat: A very fancy feature -->

## Changes

<!-- List the changes this PR introduces -->

- Adds support for `lscpu` versions in `util-linux` in 2.36 and below which assumed one CPU and didn't necessarily output "Model name(s)" prior to its corresponding fields
  - Does this by making the parser looser by not expecting a string field order when only one "Model name(s)" field is present

## Checklist

<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->

- [x] 🤖 This change is covered by tests as required.
- [x] 🤹 All required manual testing has been performed.
- [x] 📖 All documentation updates are complete.
