### PR TITLE
feat: experimental support for deployment to remote podman

### DIFF
--- a/cmd/topo/deploy.go
+++ b/cmd/topo/deploy.go
@@ -71,7 +71,6 @@ func deployWithPodman(cmd *cobra.Command) error {
 	if err != nil {
 		return err
 	}
-	targetHost := ssh.NewDestination(targetArg)
 
 	composeFile, err := getComposeFileName(cmd)
 	if err != nil {
@@ -82,7 +81,7 @@ func deployWithPodman(cmd *cobra.Command) error {
 	}
 
 	return executeDeployment(cmd, func(ctx context.Context) error {
-		options := podman.DeployOptions{TargetHost: targetHost}
+		options := podman.DeployOptions{TargetHost: ssh.NewDestination(targetArg)}
 		return podman.Deploy(ctx, os.Stdout, composeFile, options)
 	})
 }

--- a/cmd/topo/deploy.go
+++ b/cmd/topo/deploy.go
@@ -71,9 +71,7 @@ func deployWithPodman(cmd *cobra.Command) error {
 	if err != nil {
 		return err
 	}
-	if !ssh.NewDestination(targetArg).IsPlainLocalhost() {
-		return fmt.Errorf("podman deployments only support the localhost target")
-	}
+	targetHost := ssh.NewDestination(targetArg)
 
 	composeFile, err := getComposeFileName(cmd)
 	if err != nil {
@@ -84,7 +82,8 @@ func deployWithPodman(cmd *cobra.Command) error {
 	}
 
 	return executeDeployment(cmd, func(ctx context.Context) error {
-		return podman.Deploy(ctx, os.Stdout, composeFile)
+		options := podman.DeployOptions{TargetHost: targetHost}
+		return podman.Deploy(ctx, os.Stdout, composeFile, options)
 	})
 }
 

--- a/internal/deploy/docker/deploy_test.go
+++ b/internal/deploy/docker/deploy_test.go
@@ -3,7 +3,6 @@ package docker_test
 import (
 	"context"
 	"fmt"
-	"io"
 	"path/filepath"
 	"testing"
 
@@ -21,7 +20,7 @@ func TestDeployment(t *testing.T) {
 		requireImageDoesNotExist(t, docker.LocalHost, imageName)
 		deployOptions := docker.DeployOptions{TargetHost: ssh.PlainLocalhost}
 
-		err := docker.Deploy(t.Context(), io.Discard, composeFilePath, deployOptions)
+		err := docker.Deploy(t.Context(), t.Output(), composeFilePath, deployOptions)
 
 		require.NoError(t, err)
 		requireImageExists(t, docker.LocalHost, imageName)
@@ -35,7 +34,7 @@ func TestDeployment(t *testing.T) {
 		requireImageDoesNotExist(t, docker.NewHostFromDestination(remoteDockerHost), imageName)
 		deployOptions := docker.DeployOptions{TargetHost: remoteDockerHost}
 
-		err := docker.Deploy(t.Context(), io.Discard, composeFilePath, deployOptions)
+		err := docker.Deploy(t.Context(), t.Output(), composeFilePath, deployOptions)
 
 		require.NoError(t, err)
 		requireImageExists(t, docker.NewHostFromDestination(remoteDockerHost), imageName)
@@ -60,7 +59,7 @@ func TestDeployment(t *testing.T) {
 			},
 		}
 
-		err := docker.Deploy(t.Context(), io.Discard, composeFilePath, deployOptions)
+		err := docker.Deploy(t.Context(), t.Output(), composeFilePath, deployOptions)
 
 		require.NoError(t, err)
 		requireImageExists(t, remoteCommandHost, imageName)

--- a/internal/deploy/podman/deploy.go
+++ b/internal/deploy/podman/deploy.go
@@ -6,12 +6,10 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/arm/topo/internal/compose"
 	"github.com/arm/topo/internal/deploy/post_deploy"
 	"github.com/arm/topo/internal/output/logger"
 	"github.com/arm/topo/internal/output/term"
 	"github.com/arm/topo/internal/ssh"
-	"golang.org/x/sync/errgroup"
 )
 
 type DeployOptions struct {
@@ -45,10 +43,7 @@ func Deploy(ctx context.Context, output io.Writer, composeFile string, options D
 		}()
 
 		targetSocket = NewSocket(tunnel.SocketURL())
-		if err := term.PrintHeader(output, "Transfer images"); err != nil {
-			return err
-		}
-		if err := transferImages(ctx, output, targetSocket, composeFile); err != nil {
+		if err := transferImagesViaPipe(ctx, output, LocalSocket, targetSocket, composeFile); err != nil {
 			return err
 		}
 	}
@@ -86,47 +81,11 @@ func buildAndPullImages(ctx context.Context, output io.Writer, socket Socket, co
 	return PullImages(ctx, output, socket, composeFile)
 }
 
-func transferImages(ctx context.Context, output io.Writer, socket Socket, composeFile string) error {
-	images, err := compose.ImageNames(composeFile)
-	if err != nil {
+func transferImagesViaPipe(ctx context.Context, output io.Writer, source, destination Socket, composeFile string) error {
+	if err := term.PrintHeader(output, "Transfer images"); err != nil {
 		return err
 	}
-	for _, image := range images {
-		if err := transferImage(ctx, output, socket, image); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func transferImage(ctx context.Context, output io.Writer, socket Socket, image string) error {
-	pipeReader, pipeWriter := io.Pipe()
-	saveCommand := Command(ctx, LocalSocket, "save", image)
-	loadCommand := Command(ctx, socket, "load")
-	saveCommand.Stdout = pipeWriter
-	saveCommand.Stderr = output
-	loadCommand.Stdin = pipeReader
-	loadCommand.Stdout = output
-	loadCommand.Stderr = output
-
-	var group errgroup.Group
-	group.Go(func() error {
-		err := saveCommand.Run()
-		_ = pipeWriter.CloseWithError(err)
-		if err != nil {
-			return fmt.Errorf("failed to save Podman image %s: %w", image, err)
-		}
-		return nil
-	})
-	group.Go(func() error {
-		err := loadCommand.Run()
-		_ = pipeReader.CloseWithError(err)
-		if err != nil {
-			return fmt.Errorf("failed to load Podman image %s: %w", image, err)
-		}
-		return nil
-	})
-	return group.Wait()
+	return TransferImagesViaPipe(ctx, output, source, destination, composeFile)
 }
 
 func closeRemoteTunnel(tunnel *ssh.TCPToUnixSocketTunnel) error {

--- a/internal/deploy/podman/deploy.go
+++ b/internal/deploy/podman/deploy.go
@@ -7,7 +7,6 @@ import (
 	"io"
 
 	"github.com/arm/topo/internal/deploy/post_deploy"
-	"github.com/arm/topo/internal/output/logger"
 	"github.com/arm/topo/internal/output/term"
 	"github.com/arm/topo/internal/ssh"
 )
@@ -24,8 +23,12 @@ func Deploy(ctx context.Context, output io.Writer, composeFile string, options D
 	targetSocket := LocalSocket
 	var tunnel *ssh.TCPToUnixSocketTunnel
 	if !options.TargetHost.IsPlainLocalhost() {
+		if err := term.PrintHeader(output, "Open Podman socket SSH tunnel"); err != nil {
+			return err
+		}
+
 		var err error
-		tunnel, err = openRemotePodmanSocketTunnel(ctx, output, options.TargetHost)
+		tunnel, err = TunnelRemoteSocketPath(ctx, output, options.TargetHost)
 		if err != nil {
 			return err
 		}
@@ -72,22 +75,6 @@ func buildAndPullImages(ctx context.Context, output io.Writer, socket Socket, co
 		return err
 	}
 	return PullImages(ctx, output, socket, composeFile)
-}
-
-func openRemotePodmanSocketTunnel(ctx context.Context, output io.Writer, destination ssh.Destination) (*ssh.TCPToUnixSocketTunnel, error) {
-	if err := term.PrintHeader(output, "Open Podman socket SSH tunnel"); err != nil {
-		return nil, err
-	}
-	remoteSocketPath, err := ResolveRemoteSocketPath(ctx, destination)
-	if err != nil {
-		return nil, err
-	}
-	logger.Info(fmt.Sprintf("discovered remote Podman socket path: %s", remoteSocketPath))
-	tunnel, err := ssh.OpenTCPToUnixSocketTunnel(ctx, output, destination, remoteSocketPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to open remote Podman socket tunnel: %w", err)
-	}
-	return tunnel, nil
 }
 
 func transferImagesViaPipe(ctx context.Context, output io.Writer, source, destination Socket, composeFile string) error {

--- a/internal/deploy/podman/deploy.go
+++ b/internal/deploy/podman/deploy.go
@@ -24,17 +24,10 @@ func Deploy(ctx context.Context, output io.Writer, composeFile string, options D
 	targetSocket := LocalSocket
 	var tunnel *ssh.TCPToUnixSocketTunnel
 	if !options.TargetHost.IsPlainLocalhost() {
-		remoteSocketPath, err := ResolveRemoteSocketPath(ctx, options.TargetHost)
+		var err error
+		tunnel, err = openRemotePodmanSocketTunnel(ctx, output, options.TargetHost)
 		if err != nil {
 			return err
-		}
-		logger.Info(fmt.Sprintf("discovered remote Podman socket path: %s", remoteSocketPath))
-		if err := term.PrintHeader(output, "Open Podman socket SSH tunnel"); err != nil {
-			return err
-		}
-		tunnel, err = ssh.OpenTCPToUnixSocketTunnel(ctx, output, options.TargetHost, remoteSocketPath)
-		if err != nil {
-			return fmt.Errorf("failed to open remote Podman socket tunnel: %w", err)
 		}
 		defer func() {
 			if tunnel != nil {
@@ -79,6 +72,22 @@ func buildAndPullImages(ctx context.Context, output io.Writer, socket Socket, co
 		return err
 	}
 	return PullImages(ctx, output, socket, composeFile)
+}
+
+func openRemotePodmanSocketTunnel(ctx context.Context, output io.Writer, destination ssh.Destination) (*ssh.TCPToUnixSocketTunnel, error) {
+	if err := term.PrintHeader(output, "Open Podman socket SSH tunnel"); err != nil {
+		return nil, err
+	}
+	remoteSocketPath, err := ResolveRemoteSocketPath(ctx, destination)
+	if err != nil {
+		return nil, err
+	}
+	logger.Info(fmt.Sprintf("discovered remote Podman socket path: %s", remoteSocketPath))
+	tunnel, err := ssh.OpenTCPToUnixSocketTunnel(ctx, output, destination, remoteSocketPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open remote Podman socket tunnel: %w", err)
+	}
+	return tunnel, nil
 }
 
 func transferImagesViaPipe(ctx context.Context, output io.Writer, source, destination Socket, composeFile string) error {

--- a/internal/deploy/podman/deploy.go
+++ b/internal/deploy/podman/deploy.go
@@ -5,8 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"path/filepath"
-	"strings"
 
 	"github.com/arm/topo/internal/compose"
 	"github.com/arm/topo/internal/deploy/post_deploy"
@@ -28,7 +26,7 @@ func Deploy(ctx context.Context, output io.Writer, composeFile string, options D
 	targetSocket := LocalSocket
 	var tunnel *ssh.TCPToUnixSocketTunnel
 	if !options.TargetHost.IsPlainLocalhost() {
-		remoteSocketPath, err := remotePodmanSocketPath(ctx, options.TargetHost)
+		remoteSocketPath, err := ResolveRemoteSocketPath(ctx, options.TargetHost)
 		if err != nil {
 			return err
 		}
@@ -129,19 +127,6 @@ func transferImage(ctx context.Context, output io.Writer, socket Socket, image s
 		return nil
 	})
 	return group.Wait()
-}
-
-func remotePodmanSocketPath(ctx context.Context, target ssh.Destination) (string, error) {
-	output, _, err := ssh.RunCommand(ctx, target, "podman info --format '{{.Host.RemoteSocket.Path}}'", nil)
-	if err != nil {
-		return "", fmt.Errorf("failed to get remote Podman socket path: %w", err)
-	}
-
-	socketPath := strings.TrimPrefix(strings.TrimSpace(output), "unix://")
-	if !filepath.IsAbs(socketPath) {
-		return "", fmt.Errorf("remote Podman reported a non-local API socket path %q", socketPath)
-	}
-	return socketPath, nil
 }
 
 func closeRemoteTunnel(tunnel *ssh.TCPToUnixSocketTunnel) error {

--- a/internal/deploy/podman/deploy.go
+++ b/internal/deploy/podman/deploy.go
@@ -16,7 +16,16 @@ type DeployOptions struct {
 }
 
 func Deploy(ctx context.Context, output io.Writer, composeFile string, options DeployOptions) (deployErr error) {
-	if err := buildAndPullImages(ctx, output, LocalSocket, composeFile); err != nil {
+	if err := term.PrintHeader(output, "Build images"); err != nil {
+		return err
+	}
+	if err := BuildImages(ctx, output, LocalSocket, composeFile); err != nil {
+		return err
+	}
+	if err := term.PrintHeader(output, "Pull images"); err != nil {
+		return err
+	}
+	if err := PullImages(ctx, output, LocalSocket, composeFile); err != nil {
 		return err
 	}
 
@@ -62,19 +71,6 @@ func Deploy(ctx context.Context, output io.Writer, composeFile string, options D
 		return err
 	}
 	return post_deploy.PrintDeploySuccess(output, composeFile, post_deploy.DefaultMessage(composeFile))
-}
-
-func buildAndPullImages(ctx context.Context, output io.Writer, socket Socket, composeFile string) error {
-	if err := term.PrintHeader(output, "Build images"); err != nil {
-		return err
-	}
-	if err := BuildImages(ctx, output, socket, composeFile); err != nil {
-		return err
-	}
-	if err := term.PrintHeader(output, "Pull images"); err != nil {
-		return err
-	}
-	return PullImages(ctx, output, socket, composeFile)
 }
 
 func transferImagesViaPipe(ctx context.Context, output io.Writer, source, destination Socket, composeFile string) error {

--- a/internal/deploy/podman/deploy.go
+++ b/internal/deploy/podman/deploy.go
@@ -2,28 +2,151 @@ package podman
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"io"
+	"path/filepath"
+	"strings"
 
+	"github.com/arm/topo/internal/compose"
+	"github.com/arm/topo/internal/deploy/post_deploy"
+	"github.com/arm/topo/internal/output/logger"
 	"github.com/arm/topo/internal/output/term"
+	"github.com/arm/topo/internal/ssh"
+	"golang.org/x/sync/errgroup"
 )
 
-func Deploy(ctx context.Context, output io.Writer, composeFile string) error {
-	if err := term.PrintHeader(output, "Build images"); err != nil {
-		return err
-	}
-	if err := BuildImages(ctx, output, LocalSocket, composeFile); err != nil {
+type DeployOptions struct {
+	TargetHost ssh.Destination
+}
+
+func Deploy(ctx context.Context, output io.Writer, composeFile string, options DeployOptions) (deployErr error) {
+	if err := buildAndPullImages(ctx, output, LocalSocket, composeFile); err != nil {
 		return err
 	}
 
-	if err := term.PrintHeader(output, "Pull images"); err != nil {
-		return err
-	}
-	if err := PullImages(ctx, output, LocalSocket, composeFile); err != nil {
-		return err
+	targetSocket := LocalSocket
+	var tunnel *ssh.TCPToUnixSocketTunnel
+	if !options.TargetHost.IsPlainLocalhost() {
+		remoteSocketPath, err := remotePodmanSocketPath(ctx, options.TargetHost)
+		if err != nil {
+			return err
+		}
+		logger.Info(fmt.Sprintf("discovered remote Podman socket path: %s", remoteSocketPath))
+		if err := term.PrintHeader(output, "Open Podman socket SSH tunnel"); err != nil {
+			return err
+		}
+		tunnel, err = ssh.OpenTCPToUnixSocketTunnel(ctx, output, options.TargetHost, remoteSocketPath)
+		if err != nil {
+			return fmt.Errorf("failed to open remote Podman socket tunnel: %w", err)
+		}
+		defer func() {
+			if tunnel != nil {
+				deployErr = errors.Join(deployErr, closeRemoteTunnel(tunnel))
+			}
+		}()
+
+		targetSocket = NewSocket(tunnel.SocketURL())
+		if err := term.PrintHeader(output, "Transfer images"); err != nil {
+			return err
+		}
+		if err := transferImages(ctx, output, targetSocket, composeFile); err != nil {
+			return err
+		}
 	}
 
 	if err := term.PrintHeader(output, "Start services"); err != nil {
 		return err
 	}
-	return StartServices(ctx, output, LocalSocket, composeFile)
+	if err := StartServices(ctx, output, targetSocket, composeFile); err != nil {
+		return err
+	}
+
+	if tunnel != nil {
+		if err := closeRemoteTunnel(tunnel); err != nil {
+			return err
+		}
+		tunnel = nil
+	}
+
+	if err := term.PrintHeader(output, "Deployment Success"); err != nil {
+		return err
+	}
+	return post_deploy.PrintDeploySuccess(output, composeFile, post_deploy.DefaultMessage(composeFile))
+}
+
+func buildAndPullImages(ctx context.Context, output io.Writer, socket Socket, composeFile string) error {
+	if err := term.PrintHeader(output, "Build images"); err != nil {
+		return err
+	}
+	if err := BuildImages(ctx, output, socket, composeFile); err != nil {
+		return err
+	}
+	if err := term.PrintHeader(output, "Pull images"); err != nil {
+		return err
+	}
+	return PullImages(ctx, output, socket, composeFile)
+}
+
+func transferImages(ctx context.Context, output io.Writer, socket Socket, composeFile string) error {
+	images, err := compose.ImageNames(composeFile)
+	if err != nil {
+		return err
+	}
+	for _, image := range images {
+		if err := transferImage(ctx, output, socket, image); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func transferImage(ctx context.Context, output io.Writer, socket Socket, image string) error {
+	pipeReader, pipeWriter := io.Pipe()
+	saveCommand := Command(ctx, LocalSocket, "save", image)
+	loadCommand := Command(ctx, socket, "load")
+	saveCommand.Stdout = pipeWriter
+	saveCommand.Stderr = output
+	loadCommand.Stdin = pipeReader
+	loadCommand.Stdout = output
+	loadCommand.Stderr = output
+
+	var group errgroup.Group
+	group.Go(func() error {
+		err := saveCommand.Run()
+		_ = pipeWriter.CloseWithError(err)
+		if err != nil {
+			return fmt.Errorf("failed to save Podman image %s: %w", image, err)
+		}
+		return nil
+	})
+	group.Go(func() error {
+		err := loadCommand.Run()
+		_ = pipeReader.CloseWithError(err)
+		if err != nil {
+			return fmt.Errorf("failed to load Podman image %s: %w", image, err)
+		}
+		return nil
+	})
+	return group.Wait()
+}
+
+func remotePodmanSocketPath(ctx context.Context, target ssh.Destination) (string, error) {
+	output, _, err := ssh.RunCommand(ctx, target, "podman info --format '{{.Host.RemoteSocket.Path}}'", nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to get remote Podman socket path: %w", err)
+	}
+
+	socketPath := strings.TrimPrefix(strings.TrimSpace(output), "unix://")
+	if !filepath.IsAbs(socketPath) {
+		return "", fmt.Errorf("remote Podman reported a non-local API socket path %q", socketPath)
+	}
+	return socketPath, nil
+}
+
+func closeRemoteTunnel(tunnel *ssh.TCPToUnixSocketTunnel) error {
+	if err := tunnel.Close(); err != nil {
+		return fmt.Errorf("failed to close remote Podman socket tunnel: %w", err)
+	}
+	return nil
 }

--- a/internal/deploy/podman/deploy_test.go
+++ b/internal/deploy/podman/deploy_test.go
@@ -6,25 +6,51 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/arm/topo/internal/deploy/podman"
+	"github.com/arm/topo/internal/ssh"
+	gtestutil "github.com/arm/topo/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
 func TestDeploy(t *testing.T) {
 	requireLocalPodman(t)
-	composeFile, projectName := deploymentFixture(t)
-	t.Cleanup(func() { cleanupComposeProject(t, composeFile) })
 
-	err := podman.Deploy(t.Context(), io.Discard, composeFile)
+	t.Run("deploys to localhost", func(t *testing.T) {
+		composeFile, projectName := deploymentFixture(t)
+		t.Cleanup(func() { cleanupComposeProject(t, composeFile) })
+		options := podman.DeployOptions{TargetHost: ssh.PlainLocalhost}
 
-	require.NoError(t, err)
-	assertContainersRunning(t, projectName, podman.LocalSocket)
+		err := podman.Deploy(t.Context(), t.Output(), composeFile, options)
+
+		require.NoError(t, err)
+		assertContainersRunning(t, projectName, podman.LocalSocket)
+	})
+
+	t.Run("transfers images to a remote host via pipe", func(t *testing.T) {
+		target := gtestutil.StartContainer(t, gtestutil.PodmanContainer)
+		composeFile, projectName := deploymentFixture(t)
+		fixPodmanInDockerQuirk(t, composeFile)
+		targetHost := ssh.NewDestination(target.SSHDestination)
+		options := podman.DeployOptions{TargetHost: targetHost}
+
+		err := podman.Deploy(t.Context(), t.Output(), composeFile, options)
+
+		require.NoError(t, err)
+		tunnel, err := ssh.OpenTCPToUnixSocketTunnel(context.Background(), io.Discard, targetHost, "/run/podman/podman.sock")
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			require.NoError(t, tunnel.Close())
+		})
+		assertContainersRunning(t, projectName, podman.NewSocket(tunnel.SocketURL()))
+	})
 }
 
 func requireLocalPodman(t *testing.T) {
@@ -42,7 +68,8 @@ func requireLocalPodman(t *testing.T) {
 
 func assertContainersRunning(t *testing.T, projectName string, socket podman.Socket) {
 	t.Helper()
-	cmd := podman.Command(t.Context(), socket, "ps", "--format", "json", "--all",
+	cmd := podman.Command(t.Context(), socket,
+		"ps", "--format", "json", "--all",
 		"--filter", "label=com.docker.compose.project="+projectName,
 	)
 	var diagnostics bytes.Buffer
@@ -90,6 +117,34 @@ CMD ["tail", "-f", "/dev/null"]
 		}
 	})
 	return composeFile, "test-project-" + testName
+}
+
+// fixPodmanInDockerQuirk avoids a Docker Desktop nested-container restriction.
+// The Podman target inherits oom_score_adj: 200, but Podman otherwise starts
+// each service with oom_score_adj: 0. Docker Desktop rejects that decrease, so
+// this adds oom_score_adj: 200 to each fixture service, for example:
+//
+//	services:
+//	  app:
+//	    oom_score_adj: 200
+func fixPodmanInDockerQuirk(t *testing.T, composeFile string) {
+	t.Helper()
+	contents, err := os.ReadFile(composeFile)
+	require.NoError(t, err)
+
+	var definition map[string]any
+	require.NoError(t, yaml.Unmarshal(contents, &definition))
+	services, ok := definition["services"].(map[string]any)
+	require.True(t, ok, "Compose file services must be a mapping")
+	for name, value := range services {
+		service, ok := value.(map[string]any)
+		require.Truef(t, ok, "service %q must be a mapping", name)
+		service["oom_score_adj"] = 200
+	}
+
+	contents, err = yaml.Marshal(definition)
+	require.NoError(t, err)
+	requireWriteFile(t, composeFile, string(contents))
 }
 
 func cleanupComposeProject(t *testing.T, composeFile string) {

--- a/internal/deploy/podman/deploy_test.go
+++ b/internal/deploy/podman/deploy_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -44,7 +43,7 @@ func TestDeploy(t *testing.T) {
 		err := podman.Deploy(t.Context(), t.Output(), composeFile, options)
 
 		require.NoError(t, err)
-		tunnel, err := ssh.OpenTCPToUnixSocketTunnel(context.Background(), io.Discard, targetHost, "/run/podman/podman.sock")
+		tunnel, err := podman.TunnelRemoteSocketPath(context.Background(), t.Output(), targetHost)
 		require.NoError(t, err)
 		t.Cleanup(func() {
 			require.NoError(t, tunnel.Close())

--- a/internal/deploy/podman/deploy_test.go
+++ b/internal/deploy/podman/deploy_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"
@@ -36,7 +35,6 @@ func TestDeploy(t *testing.T) {
 	t.Run("transfers images to a remote host via pipe", func(t *testing.T) {
 		target := gtestutil.StartContainer(t, gtestutil.PodmanContainer)
 		composeFile, projectName := deploymentFixture(t)
-		fixPodmanInDockerQuirk(t, composeFile)
 		targetHost := ssh.NewDestination(target.SSHDestination)
 		options := podman.DeployOptions{TargetHost: targetHost}
 
@@ -101,6 +99,8 @@ services:
     image: docker.io/library/alpine:latest
     command: ["tail", "-f", "/dev/null"]
 `, "test-project-"+testName, imageName)
+	composeFileContent, err := fixPodmanInDockerQuirk(composeFileContent)
+	require.NoError(t, err)
 	requireWriteFile(t, composeFile, composeFileContent)
 	requireWriteFile(t, filepath.Join(tempDir, "Dockerfile"), `
 FROM docker.io/library/alpine:latest
@@ -126,24 +126,28 @@ CMD ["tail", "-f", "/dev/null"]
 //	services:
 //	  app:
 //	    oom_score_adj: 200
-func fixPodmanInDockerQuirk(t *testing.T, composeFile string) {
-	t.Helper()
-	contents, err := os.ReadFile(composeFile)
-	require.NoError(t, err)
-
+func fixPodmanInDockerQuirk(contents string) (string, error) {
 	var definition map[string]any
-	require.NoError(t, yaml.Unmarshal(contents, &definition))
+	if err := yaml.Unmarshal([]byte(contents), &definition); err != nil {
+		return "", err
+	}
 	services, ok := definition["services"].(map[string]any)
-	require.True(t, ok, "Compose file services must be a mapping")
+	if !ok {
+		return "", fmt.Errorf("Compose file services must be a mapping")
+	}
 	for name, value := range services {
 		service, ok := value.(map[string]any)
-		require.Truef(t, ok, "service %q must be a mapping", name)
+		if !ok {
+			return "", fmt.Errorf("service %q must be a mapping", name)
+		}
 		service["oom_score_adj"] = 200
 	}
 
-	contents, err = yaml.Marshal(definition)
-	require.NoError(t, err)
-	requireWriteFile(t, composeFile, string(contents))
+	updatedContents, err := yaml.Marshal(definition)
+	if err != nil {
+		return "", err
+	}
+	return string(updatedContents), nil
 }
 
 func cleanupComposeProject(t *testing.T, composeFile string) {

--- a/internal/deploy/podman/image_transfer_pipe.go
+++ b/internal/deploy/podman/image_transfer_pipe.go
@@ -1,0 +1,53 @@
+package podman
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/arm/topo/internal/compose"
+	"golang.org/x/sync/errgroup"
+)
+
+func TransferImagesViaPipe(ctx context.Context, output io.Writer, source, destination Socket, composeFile string) error {
+	images, err := compose.ImageNames(composeFile)
+	if err != nil {
+		return err
+	}
+	for _, image := range images {
+		if err := transferImageViaPipe(ctx, output, source, destination, image); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func transferImageViaPipe(ctx context.Context, output io.Writer, source, destination Socket, image string) error {
+	pipeReader, pipeWriter := io.Pipe()
+	saveCommand := Command(ctx, source, "save", image)
+	loadCommand := Command(ctx, destination, "load")
+	saveCommand.Stdout = pipeWriter
+	saveCommand.Stderr = output
+	loadCommand.Stdin = pipeReader
+	loadCommand.Stdout = output
+	loadCommand.Stderr = output
+
+	var group errgroup.Group
+	group.Go(func() error {
+		err := saveCommand.Run()
+		_ = pipeWriter.CloseWithError(err)
+		if err != nil {
+			return fmt.Errorf("failed to save Podman image %s: %w", image, err)
+		}
+		return nil
+	})
+	group.Go(func() error {
+		err := loadCommand.Run()
+		_ = pipeReader.CloseWithError(err)
+		if err != nil {
+			return fmt.Errorf("failed to load Podman image %s: %w", image, err)
+		}
+		return nil
+	})
+	return group.Wait()
+}

--- a/internal/deploy/podman/image_transfer_pipe.go
+++ b/internal/deploy/podman/image_transfer_pipe.go
@@ -14,12 +14,14 @@ func TransferImagesViaPipe(ctx context.Context, output io.Writer, source, destin
 	if err != nil {
 		return err
 	}
+
+	var group errgroup.Group
 	for _, image := range images {
-		if err := transferImageViaPipe(ctx, output, source, destination, image); err != nil {
-			return err
-		}
+		group.Go(func() error {
+			return transferImageViaPipe(ctx, output, source, destination, image)
+		})
 	}
-	return nil
+	return group.Wait()
 }
 
 func transferImageViaPipe(ctx context.Context, output io.Writer, source, destination Socket, image string) error {

--- a/internal/deploy/podman/image_transfer_pipe.go
+++ b/internal/deploy/podman/image_transfer_pipe.go
@@ -37,7 +37,7 @@ func transferImageViaPipe(ctx context.Context, output io.Writer, source, destina
 		err := saveCommand.Run()
 		_ = pipeWriter.CloseWithError(err)
 		if err != nil {
-			return fmt.Errorf("failed to save Podman image %s: %w", image, err)
+			return fmt.Errorf("failed to save image %s: %w", image, err)
 		}
 		return nil
 	})
@@ -45,7 +45,7 @@ func transferImageViaPipe(ctx context.Context, output io.Writer, source, destina
 		err := loadCommand.Run()
 		_ = pipeReader.CloseWithError(err)
 		if err != nil {
-			return fmt.Errorf("failed to load Podman image %s: %w", image, err)
+			return fmt.Errorf("failed to load image %s: %w", image, err)
 		}
 		return nil
 	})

--- a/internal/deploy/podman/image_transfer_pipe_test.go
+++ b/internal/deploy/podman/image_transfer_pipe_test.go
@@ -3,7 +3,6 @@ package podman_test
 import (
 	"context"
 	"fmt"
-	"io"
 	"path/filepath"
 	"testing"
 	"time"
@@ -20,7 +19,7 @@ func TestTransferImagesViaPipe(t *testing.T) {
 	composeFile, imageName := imageTransferFixture(t)
 	target := gtestutil.StartContainer(t, gtestutil.PodmanContainer)
 	targetHost := ssh.NewDestination(target.SSHDestination)
-	tunnel, err := ssh.OpenTCPToUnixSocketTunnel(t.Context(), io.Discard, targetHost, "/run/podman/podman.sock")
+	tunnel, err := podman.TunnelRemoteSocketPath(context.Background(), t.Output(), targetHost)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		require.NoError(t, tunnel.Close())

--- a/internal/deploy/podman/image_transfer_pipe_test.go
+++ b/internal/deploy/podman/image_transfer_pipe_test.go
@@ -1,0 +1,64 @@
+package podman_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/arm/topo/internal/deploy/podman"
+	"github.com/arm/topo/internal/ssh"
+	gtestutil "github.com/arm/topo/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTransferImagesViaPipe(t *testing.T) {
+	requireLocalPodman(t)
+	composeFile, imageName := imageTransferFixture(t)
+	target := gtestutil.StartContainer(t, gtestutil.PodmanContainer)
+	targetHost := ssh.NewDestination(target.SSHDestination)
+	tunnel, err := ssh.OpenTCPToUnixSocketTunnel(t.Context(), io.Discard, targetHost, "/run/podman/podman.sock")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, tunnel.Close())
+	})
+	remoteSocket := podman.NewSocket(tunnel.SocketURL())
+
+	err = podman.BuildImages(t.Context(), t.Output(), podman.LocalSocket, composeFile)
+	require.NoError(t, err)
+	err = podman.TransferImagesViaPipe(t.Context(), t.Output(), podman.LocalSocket, remoteSocket, composeFile)
+
+	require.NoError(t, err)
+	assertImageExists(t, remoteSocket, imageName)
+}
+
+func assertImageExists(t *testing.T, socket podman.Socket, imageName string) {
+	t.Helper()
+
+	err := podman.Command(t.Context(), socket, "image", "exists", imageName).Run()
+
+	assert.NoError(t, err)
+}
+
+func imageTransferFixture(t *testing.T) (string, string) {
+	t.Helper()
+	temporaryDirectory := t.TempDir()
+	composeFile := filepath.Join(temporaryDirectory, "compose.yaml")
+	imageName := "test-image-" + sanitiseTestName(t)
+	requireWriteFile(t, composeFile, fmt.Sprintf(`
+services:
+  test:
+    build: .
+    image: %s
+`, imageName))
+	requireWriteFile(t, filepath.Join(temporaryDirectory, "Dockerfile"), "FROM docker.io/library/alpine:latest\n")
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		_ = podman.Command(ctx, podman.LocalSocket, "image", "rm", "-f", imageName).Run()
+	})
+	return composeFile, imageName
+}

--- a/internal/deploy/podman/image_transfer_pipe_test.go
+++ b/internal/deploy/podman/image_transfer_pipe_test.go
@@ -25,9 +25,9 @@ func TestTransferImagesViaPipe(t *testing.T) {
 		require.NoError(t, tunnel.Close())
 	})
 	remoteSocket := podman.NewSocket(tunnel.SocketURL())
-
 	err = podman.BuildImages(t.Context(), t.Output(), podman.LocalSocket, composeFile)
 	require.NoError(t, err)
+
 	err = podman.TransferImagesViaPipe(t.Context(), t.Output(), podman.LocalSocket, remoteSocket, composeFile)
 
 	require.NoError(t, err)

--- a/internal/deploy/podman/image_transfer_pipe_test.go
+++ b/internal/deploy/podman/image_transfer_pipe_test.go
@@ -36,9 +36,7 @@ func TestTransferImagesViaPipe(t *testing.T) {
 
 func assertImageExists(t *testing.T, socket podman.Socket, imageName string) {
 	t.Helper()
-
 	err := podman.Command(t.Context(), socket, "image", "exists", imageName).Run()
-
 	assert.NoError(t, err)
 }
 

--- a/internal/deploy/podman/socket.go
+++ b/internal/deploy/podman/socket.go
@@ -129,7 +129,6 @@ func TunnelRemoteSocketPath(ctx context.Context, w io.Writer, target ssh.Destina
 		return nil, fmt.Errorf("failed to open remote Podman socket tunnel: %w", err)
 	}
 	return tunnel, nil
-
 }
 
 func resolveNativeComposeSocket(ctx context.Context) (string, error) {

--- a/internal/deploy/podman/socket.go
+++ b/internal/deploy/podman/socket.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -108,7 +109,7 @@ func ResolveRemoteSocketPath(ctx context.Context, target ssh.Destination) (strin
 	}
 
 	socketPath := strings.TrimPrefix(strings.TrimSpace(output), "unix://")
-	if !filepath.IsAbs(socketPath) {
+	if !path.IsAbs(socketPath) {
 		return "", fmt.Errorf("remote Podman reported a non-local API socket path %q", socketPath)
 	}
 	return socketPath, nil

--- a/internal/deploy/podman/socket.go
+++ b/internal/deploy/podman/socket.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/url"
 	"os"
 	"os/exec"
@@ -13,6 +14,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/arm/topo/internal/output/logger"
 	"github.com/arm/topo/internal/ssh"
 )
 
@@ -113,6 +115,21 @@ func ResolveRemoteSocketPath(ctx context.Context, target ssh.Destination) (strin
 		return "", fmt.Errorf("remote Podman reported a non-local API socket path %q", socketPath)
 	}
 	return socketPath, nil
+}
+
+// TunnelRemoteSocketPath resolves remote socket path on the target and tunnels it to a tcp endpoint on the host.
+func TunnelRemoteSocketPath(ctx context.Context, w io.Writer, target ssh.Destination) (*ssh.TCPToUnixSocketTunnel, error) {
+	remoteSocketPath, err := ResolveRemoteSocketPath(ctx, target)
+	if err != nil {
+		return nil, err
+	}
+	logger.Info(fmt.Sprintf("discovered remote Podman socket path: %s", remoteSocketPath))
+	tunnel, err := ssh.OpenTCPToUnixSocketTunnel(ctx, w, target, remoteSocketPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open remote Podman socket tunnel: %w", err)
+	}
+	return tunnel, nil
+
 }
 
 func resolveNativeComposeSocket(ctx context.Context) (string, error) {

--- a/internal/deploy/podman/socket.go
+++ b/internal/deploy/podman/socket.go
@@ -11,6 +11,8 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+
+	"github.com/arm/topo/internal/ssh"
 )
 
 type Socket struct {
@@ -95,6 +97,21 @@ func ResolveLocalComposeSocket(ctx context.Context) (string, error) {
 		return resolveWindowsComposeSocket(ctx)
 	}
 	return resolveNativeComposeSocket(ctx)
+}
+
+// ResolveRemoteSocketPath returns the absolute Unix socket path reported by Podman
+// on target.
+func ResolveRemoteSocketPath(ctx context.Context, target ssh.Destination) (string, error) {
+	output, _, err := ssh.RunCommand(ctx, target, "podman info --format '{{.Host.RemoteSocket.Path}}'", nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to get remote Podman socket path: %w", err)
+	}
+
+	socketPath := strings.TrimPrefix(strings.TrimSpace(output), "unix://")
+	if !filepath.IsAbs(socketPath) {
+		return "", fmt.Errorf("remote Podman reported a non-local API socket path %q", socketPath)
+	}
+	return socketPath, nil
 }
 
 func resolveNativeComposeSocket(ctx context.Context) (string, error) {

--- a/internal/ssh/tcp_to_unix_socket_tunnel.go
+++ b/internal/ssh/tcp_to_unix_socket_tunnel.go
@@ -1,0 +1,100 @@
+package ssh
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os/exec"
+	"time"
+
+	"github.com/arm/topo/internal/command"
+)
+
+const tcpTunnelOpenTimeout = 10 * time.Second
+
+// TCPToUnixSocketTunnel forwards a loopback TCP endpoint to a Unix socket on an
+// SSH destination. A TCP endpoint is used locally so the transport works on
+// Unix and Windows hosts.
+type TCPToUnixSocketTunnel struct {
+	command   *exec.Cmd
+	socketURL string
+	closed    bool
+}
+
+func OpenTCPToUnixSocketTunnel(ctx context.Context, output io.Writer, dest Destination, remoteSocketPath string) (*TCPToUnixSocketTunnel, error) {
+	address, err := availableLoopbackAddress()
+	if err != nil {
+		return nil, err
+	}
+
+	args := []string{
+		"-N",
+		"-o", "ExitOnForwardFailure=yes",
+		"-L", fmt.Sprintf("%s:%s", address, remoteSocketPath),
+		dest.String(),
+	}
+	cmd := exec.CommandContext(ctx, "ssh", args...) // #nosec G204 -- arguments are not interpreted by a shell
+	cmd.Stdout = output
+	cmd.Stderr = output
+	if err := cmd.Start(); err != nil {
+		return nil, command.FormatError(cmd.Args, err)
+	}
+
+	tunnel := &TCPToUnixSocketTunnel{
+		command:   cmd,
+		socketURL: "tcp://" + address,
+	}
+	if err := waitForTCPListener(ctx, address); err != nil {
+		closeErr := tunnel.Close()
+		return nil, errors.Join(fmt.Errorf("failed to wait for SSH tunnel: %w", err), closeErr)
+	}
+	return tunnel, nil
+}
+
+func (t *TCPToUnixSocketTunnel) SocketURL() string {
+	return t.socketURL
+}
+
+func (t *TCPToUnixSocketTunnel) Close() error {
+	if t.closed {
+		return nil
+	}
+	t.closed = true
+	return killCommand(t.command)
+}
+
+func availableLoopbackAddress() (string, error) {
+	listener, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		return "", fmt.Errorf("failed to reserve tunnel port: %w", err)
+	}
+	address := listener.Addr().String()
+	if err := listener.Close(); err != nil {
+		return "", fmt.Errorf("failed to release tunnel port %s: %w", address, err)
+	}
+	return address, nil
+}
+
+func waitForTCPListener(ctx context.Context, address string) error {
+	deadline := time.NewTimer(tcpTunnelOpenTimeout)
+	defer deadline.Stop()
+	ticker := time.NewTicker(25 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		connection, err := net.DialTimeout("tcp4", address, 100*time.Millisecond)
+		if err == nil {
+			return connection.Close()
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-deadline.C:
+			return fmt.Errorf("timed out waiting for %s", address)
+		case <-ticker.C:
+		}
+	}
+}

--- a/internal/ssh/tcp_to_unix_socket_tunnel.go
+++ b/internal/ssh/tcp_to_unix_socket_tunnel.go
@@ -68,11 +68,11 @@ func (t *TCPToUnixSocketTunnel) Close() error {
 func availableLoopbackAddress() (string, error) {
 	listener, err := net.Listen("tcp4", "127.0.0.1:0")
 	if err != nil {
-		return "", fmt.Errorf("failed to reserve tunnel port: %w", err)
+		return "", fmt.Errorf("failed to reserve a local loopback address for the SSH tunnel: %w", err)
 	}
 	address := listener.Addr().String()
 	if err := listener.Close(); err != nil {
-		return "", fmt.Errorf("failed to release tunnel port %s: %w", address, err)
+		return "", fmt.Errorf("failed to release local loopback address %s for the SSH tunnel: %w", address, err)
 	}
 	return address, nil
 }

--- a/internal/testutil/container.go
+++ b/internal/testutil/container.go
@@ -60,6 +60,21 @@ var PasswordlessSSHContainer = ContainerSpec{
 	},
 }
 
+var PodmanContainer = ContainerSpec{
+	context: relPath("podman"),
+	image:   "topo-e2e-podman:latest",
+	runArgs: []string{"--privileged"},
+	setup: func(c *Container) error {
+		if err := acceptHostKey(c); err != nil {
+			return err
+		}
+		return waitForPodmanService(c)
+	},
+	cleanup: func(c *Container) {
+		removeHostKey(c)
+	},
+}
+
 func StartContainer(t *testing.T, spec ContainerSpec) *Container {
 	t.Helper()
 	if testing.Short() {
@@ -204,6 +219,24 @@ func waitForPort(host string, port string, timeout time.Duration) error {
 	}
 
 	return fmt.Errorf("port %s not ready: %w", addr, lastErr)
+}
+
+func waitForPodmanService(c *Container) error {
+	deadline := time.Now().Add(20 * time.Second)
+	var lastErr error
+
+	for time.Now().Before(deadline) {
+		// #nosec G204 -- ignore as its a test helper
+		cmd := exec.Command("docker", "exec", c.Name, "podman", "--url", "unix:///run/podman/podman.sock", "info")
+		output, err := cmd.CombinedOutput()
+		if err == nil {
+			return nil
+		}
+		lastErr = fmt.Errorf("%w output: %s", err, strings.TrimSpace(string(output)))
+		time.Sleep(200 * time.Millisecond)
+	}
+
+	return fmt.Errorf("podman service not ready: %w", lastErr)
 }
 
 func waitForDockerDaemon(c *Container) error {

--- a/internal/testutil/podman/Dockerfile
+++ b/internal/testutil/podman/Dockerfile
@@ -4,9 +4,18 @@ RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends openssh-server podman && \
     rm -rf /var/lib/apt/lists/* && \
     ssh-keygen -A && \
-    passwd -d root && \
-    printf '[storage]\ndriver = "vfs"\nrunroot = "/run/containers/storage"\ngraphroot = "/var/lib/containers/storage"\n' > /etc/containers/storage.conf && \
-    printf '\nPermitRootLogin yes\nPermitEmptyPasswords yes\nPasswordAuthentication yes\nUsePAM no\n' >> /etc/ssh/sshd_config
+    passwd -d root
+
+# Podman runs inside Docker in these tests. The vfs driver avoids nested OverlayFS,
+# while explicit storage paths ensure its runtime and image data stay writable.
+RUN echo '[storage]' > /etc/containers/storage.conf && \
+    echo 'driver = "vfs"' >> /etc/containers/storage.conf && \
+    echo 'runroot = "/run/containers/storage"' >> /etc/containers/storage.conf && \
+    echo 'graphroot = "/var/lib/containers/storage"' >> /etc/containers/storage.conf && \
+    echo "PermitRootLogin yes" >> /etc/ssh/sshd_config && \
+    echo "PermitEmptyPasswords yes" >> /etc/ssh/sshd_config && \
+    echo "PasswordAuthentication yes" >> /etc/ssh/sshd_config && \
+    echo "UsePAM no" >> /etc/ssh/sshd_config
 
 EXPOSE 22
 

--- a/internal/testutil/podman/Dockerfile
+++ b/internal/testutil/podman/Dockerfile
@@ -1,0 +1,13 @@
+FROM ubuntu:24.04
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends openssh-server podman && \
+    rm -rf /var/lib/apt/lists/* && \
+    ssh-keygen -A && \
+    passwd -d root && \
+    printf '[storage]\ndriver = "vfs"\nrunroot = "/run/containers/storage"\ngraphroot = "/var/lib/containers/storage"\n' > /etc/containers/storage.conf && \
+    printf '\nPermitRootLogin yes\nPermitEmptyPasswords yes\nPasswordAuthentication yes\nUsePAM no\n' >> /etc/ssh/sshd_config
+
+EXPOSE 22
+
+ENTRYPOINT ["/bin/sh", "-ec", "mkdir -p /run/sshd /run/podman; /usr/sbin/sshd; exec podman system service --time=0 unix:///run/podman/podman.sock"]


### PR DESCRIPTION
## Changes

- Deploy to remote Podman targets through an SSH tunnel to the Podman socket.
    - Use a loopback TCP tunnel because it bridges the target’s Unix socket to a local endpoint compatible with Podman and Compose across Unix and Windows hosts.
- Transfer images to remote targets using `podman save`/`load` pipes (registry coming next).

## Checklist

- [x] 🤖 This change is covered by tests as required.
- [ ] 🤹 All required manual testing has been performed.
- [ ] 📖 All documentation updates are complete.