### PR TITLE
refactor: fix naming redundancy in ssh tunnel

### DIFF
--- a/internal/deploy/docker/deploy.go
+++ b/internal/deploy/docker/deploy.go
@@ -104,7 +104,7 @@ func transferImagesViaRegistry(ctx context.Context, output io.Writer, composeFil
 	if err := term.PrintHeader(output, "Open registry SSH tunnel"); err != nil {
 		return err
 	}
-	tunnel, err := ssh.OpenSSHTunnel(ctx, output, targetHost, opts.Port, opts.UseControlSockets)
+	tunnel, err := ssh.OpenTunnel(ctx, output, targetHost, opts.Port, opts.UseControlSockets)
 	if err != nil {
 		return fmt.Errorf("failed to open SSH tunnel: %w; ensure port %s is free or specify a different one with `--registry-port`", err, opts.Port)
 	}
@@ -131,7 +131,7 @@ func transferImagesViaRegistry(ctx context.Context, output io.Writer, composeFil
 	return nil
 }
 
-func closeTunnel(output io.Writer, tunnel *ssh.SSHTunnel) error {
+func closeTunnel(output io.Writer, tunnel *ssh.Tunnel) error {
 	ctx, cancel := context.WithTimeout(context.Background(), tunnelCleanupTimeout)
 	defer cancel()
 

--- a/internal/deploy/docker/image_transfer_registry_test.go
+++ b/internal/deploy/docker/image_transfer_registry_test.go
@@ -39,7 +39,7 @@ func TestTransferImagesViaRegistry(t *testing.T) {
 	destinationHost := docker.NewHostFromDestination(destination)
 	requireImageDoesNotExist(t, destinationHost, imageName)
 
-	tunnel, err := ssh.OpenSSHTunnel(context.Background(), os.Stdout, destination, registryPort, false)
+	tunnel, err := ssh.OpenTunnel(context.Background(), os.Stdout, destination, registryPort, false)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		assert.NoError(t, tunnel.Close(context.Background(), os.Stdout))

--- a/internal/ssh/tunnel.go
+++ b/internal/ssh/tunnel.go
@@ -19,7 +19,7 @@ func ControlSocketPath(targetHost string) string {
 	return filepath.Join(os.TempDir(), fmt.Sprintf("topo-tunnel-%s", hostHash))
 }
 
-type SSHTunnel struct {
+type Tunnel struct {
 	useControlSockets bool
 	dest              string
 
@@ -27,8 +27,8 @@ type SSHTunnel struct {
 	closed  bool
 }
 
-func OpenSSHTunnel(ctx context.Context, w io.Writer, dest Destination, port string, useControlSockets bool) (*SSHTunnel, error) {
-	t := &SSHTunnel{
+func OpenTunnel(ctx context.Context, w io.Writer, dest Destination, port string, useControlSockets bool) (*Tunnel, error) {
+	t := &Tunnel{
 		useControlSockets: useControlSockets,
 		dest:              dest.String(),
 	}
@@ -63,7 +63,7 @@ func OpenSSHTunnel(ctx context.Context, w io.Writer, dest Destination, port stri
 	return t, nil
 }
 
-func (t *SSHTunnel) Close(ctx context.Context, w io.Writer) error {
+func (t *Tunnel) Close(ctx context.Context, w io.Writer) error {
 	if t.closed {
 		return nil
 	}

--- a/internal/ssh/tunnel_unix_test.go
+++ b/internal/ssh/tunnel_unix_test.go
@@ -20,12 +20,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSSHTunnel(t *testing.T) {
+func TestTunnel(t *testing.T) {
 	t.Run("opens and closes through a control socket", func(t *testing.T) {
 		logPath := installFakeSSH(t)
 		destination := ssh.NewDestination("user@remote")
 
-		tunnel, openErr := ssh.OpenSSHTunnel(context.Background(), io.Discard, destination, "1337", true)
+		tunnel, openErr := ssh.OpenTunnel(context.Background(), io.Discard, destination, "1337", true)
 		require.NoError(t, openErr)
 		closeErr := tunnel.Close(context.Background(), io.Discard)
 
@@ -43,7 +43,7 @@ func TestSSHTunnel(t *testing.T) {
 		destination := ssh.NewDestination("user@remote")
 		var output bytes.Buffer
 
-		tunnel, err := ssh.OpenSSHTunnel(context.Background(), &output, destination, "1337", true)
+		tunnel, err := ssh.OpenTunnel(context.Background(), &output, destination, "1337", true)
 
 		require.NoError(t, err)
 		t.Cleanup(func() {
@@ -57,7 +57,7 @@ func TestSSHTunnel(t *testing.T) {
 		logPath := installFakeSSH(t)
 		destination := ssh.NewDestination("user@remote")
 
-		tunnel, openErr := ssh.OpenSSHTunnel(context.Background(), io.Discard, destination, "1338", false)
+		tunnel, openErr := ssh.OpenTunnel(context.Background(), io.Discard, destination, "1338", false)
 		require.NoError(t, openErr)
 		pid := readSSHPID(t, logPath+".pid")
 		closeErr := tunnel.Close(context.Background(), io.Discard)
@@ -72,7 +72,7 @@ func TestSSHTunnel(t *testing.T) {
 		logPath := installFakeSSH(t)
 		destination := ssh.NewDestination("user@remote")
 
-		tunnel, openErr := ssh.OpenSSHTunnel(context.Background(), nil, destination, "1339", true)
+		tunnel, openErr := ssh.OpenTunnel(context.Background(), nil, destination, "1339", true)
 		require.NoError(t, openErr)
 		firstCloseErr := tunnel.Close(context.Background(), nil)
 		secondCloseErr := tunnel.Close(context.Background(), nil)


### PR DESCRIPTION
<!-- PR title should be formatted using conventional commits -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->
<!-- Example: feat: A very fancy feature -->

## Changes

<!-- List the changes this PR introduces -->

- Remove `ssh_` prefix from the file names, it’s already in `ssh` folder
- Rename `ssh.SSHTunnel` -> `ssh.Tunnel`

## Checklist

<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->

- [x] 🤖 This change is covered by tests as required.
- [ ] 🤹 All required manual testing has been performed.
- [ ] 📖 All documentation updates are complete.
