### PR TITLE
fix: Podman compose incorrectly targets docker engine w/ compose

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -142,11 +142,14 @@ jobs:
         if: runner.os == 'Linux'
         shell: bash
         run: |
-          runtime_dir="$RUNNER_TEMP/podman-runtime"
+          runtime_dir="${XDG_RUNTIME_DIR:-$RUNNER_TEMP/podman-runtime}"
           mkdir -p "$runtime_dir/podman"
-          chmod 700 "$runtime_dir"
-          echo "XDG_RUNTIME_DIR=$runtime_dir" >> "$GITHUB_ENV"
-          export XDG_RUNTIME_DIR="$runtime_dir"
+
+          if [ -z "${XDG_RUNTIME_DIR:-}" ]; then
+            chmod 700 "$runtime_dir"
+            echo "XDG_RUNTIME_DIR=$runtime_dir" >> "$GITHUB_ENV"
+            export XDG_RUNTIME_DIR="$runtime_dir"
+          fi
 
           socket_path="$XDG_RUNTIME_DIR/podman/podman.sock"
           if [ ! -S "$socket_path" ]; then

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -138,6 +138,29 @@ jobs:
         run: |
           podman machine init --cpus 2 --memory 2048 --now
 
+      - name: Start Podman API service (Linux)
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          runtime_dir="$RUNNER_TEMP/podman-runtime"
+          mkdir -p "$runtime_dir/podman"
+          chmod 700 "$runtime_dir"
+          echo "XDG_RUNTIME_DIR=$runtime_dir" >> "$GITHUB_ENV"
+          export XDG_RUNTIME_DIR="$runtime_dir"
+
+          socket_path="$XDG_RUNTIME_DIR/podman/podman.sock"
+          if [ ! -S "$socket_path" ]; then
+            podman system service --time=0 "unix://$socket_path" >"$RUNNER_TEMP/podman-system-service.log" 2>&1 &
+          fi
+
+          for _ in {1..20}; do
+            [ -S "$socket_path" ] && exit 0
+            sleep 1
+          done
+
+          cat "$RUNNER_TEMP/podman-system-service.log" >&2 || true
+          exit 1
+
       - name: Verify Podman test prerequisites (Linux)
         if: runner.os == 'Linux'
         shell: bash

--- a/internal/deploy/podman/command.go
+++ b/internal/deploy/podman/command.go
@@ -25,7 +25,7 @@ func ComposeCommand(ctx context.Context, socket Socket, composeFile string, args
 		"PODMAN_COMPOSE_WARNING_LOGS=false",
 	)
 	var err error
-	cmd.Env, err = socket.ConfigureComposeEnv(cmd.Env)
+	cmd.Env, err = socket.ConfigureComposeEnv(ctx, cmd.Env)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/deploy/podman/command.go
+++ b/internal/deploy/podman/command.go
@@ -11,22 +11,29 @@ import (
 
 const composeProvider = "docker-compose"
 
-func Command(ctx context.Context, args ...string) *exec.Cmd {
-	return exec.CommandContext(ctx, "podman", args...)
+func Command(ctx context.Context, socket Socket, args ...string) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, "podman", args...)
+	if socket.url != "" {
+		cmd.Env = append(os.Environ(), "CONTAINER_HOST="+socket.url)
+	}
+	return cmd
 }
 
-func ComposeCommand(ctx context.Context, composeFile string, args ...string) *exec.Cmd {
+func ComposeCommand(ctx context.Context, socket Socket, composeFile string, args ...string) *exec.Cmd {
 	composeArgs := append([]string{"compose", "-f", composeFile}, args...)
 	cmd := exec.CommandContext(ctx, "podman", composeArgs...)
 	cmd.Env = append(os.Environ(),
 		"PODMAN_COMPOSE_PROVIDER="+composeProvider,
 		"PODMAN_COMPOSE_WARNING_LOGS=false",
 	)
+	if socket.url != "" {
+		cmd.Env = append(cmd.Env, "DOCKER_HOST="+socket.url)
+	}
 	return cmd
 }
 
-func RunComposeCommand(ctx context.Context, output io.Writer, composeFile string, args ...string) error {
-	cmd := ComposeCommand(ctx, composeFile, args...)
+func RunComposeCommand(ctx context.Context, output io.Writer, socket Socket, composeFile string, args ...string) error {
+	cmd := ComposeCommand(ctx, socket, composeFile, args...)
 	cmd.Stdout = output
 	cmd.Stderr = output
 	if err := cmd.Run(); err != nil {

--- a/internal/deploy/podman/command.go
+++ b/internal/deploy/podman/command.go
@@ -13,27 +13,30 @@ const composeProvider = "docker-compose"
 
 func Command(ctx context.Context, socket Socket, args ...string) *exec.Cmd {
 	cmd := exec.CommandContext(ctx, "podman", args...)
-	if socket.url != "" {
-		cmd.Env = append(os.Environ(), "CONTAINER_HOST="+socket.url)
-	}
+	cmd.Env = socket.ConfigurePodmanEnv(os.Environ())
 	return cmd
 }
 
-func ComposeCommand(ctx context.Context, socket Socket, composeFile string, args ...string) *exec.Cmd {
+func ComposeCommand(ctx context.Context, socket Socket, composeFile string, args ...string) (*exec.Cmd, error) {
 	composeArgs := append([]string{"compose", "-f", composeFile}, args...)
 	cmd := exec.CommandContext(ctx, "podman", composeArgs...)
 	cmd.Env = append(os.Environ(),
 		"PODMAN_COMPOSE_PROVIDER="+composeProvider,
 		"PODMAN_COMPOSE_WARNING_LOGS=false",
 	)
-	if socket.url != "" {
-		cmd.Env = append(cmd.Env, "DOCKER_HOST="+socket.url)
+	var err error
+	cmd.Env, err = socket.ConfigureComposeEnv(cmd.Env)
+	if err != nil {
+		return nil, err
 	}
-	return cmd
+	return cmd, nil
 }
 
 func RunComposeCommand(ctx context.Context, output io.Writer, socket Socket, composeFile string, args ...string) error {
-	cmd := ComposeCommand(ctx, socket, composeFile, args...)
+	cmd, err := ComposeCommand(ctx, socket, composeFile, args...)
+	if err != nil {
+		return err
+	}
 	cmd.Stdout = output
 	cmd.Stderr = output
 	if err := cmd.Run(); err != nil {

--- a/internal/deploy/podman/command_test.go
+++ b/internal/deploy/podman/command_test.go
@@ -23,13 +23,7 @@ func TestCommand(t *testing.T) {
 		command := podman.Command(context.Background(), socket, "info")
 
 		assert.Equal(t, []string{"podman", "info"}, command.Args)
-		assert.Equal(t, "tcp://127.0.0.1:12345", environmentValue(command.Env, "CONTAINER_HOST"))
-	})
-
-	t.Run("does not configure a socket for localhost", func(t *testing.T) {
-		command := podman.Command(context.Background(), podman.LocalSocket, "info")
-
-		assert.Empty(t, environmentValue(command.Env, "CONTAINER_HOST"))
+		assert.Contains(t, command.Env, "CONTAINER_HOST=tcp://127.0.0.1:12345")
 	})
 }
 
@@ -45,7 +39,7 @@ func TestComposeCommand(t *testing.T) {
 		command, err := podman.ComposeCommand(context.Background(), podman.NewSocket("tcp://127.0.0.1:12345"), "compose.yaml", "ps")
 
 		require.NoError(t, err)
-		assert.Equal(t, "docker-compose", environmentValue(command.Env, "PODMAN_COMPOSE_PROVIDER"))
+		assert.Contains(t, command.Env, "PODMAN_COMPOSE_PROVIDER=docker-compose")
 	})
 
 	t.Run("configures remote socket", func(t *testing.T) {
@@ -55,16 +49,6 @@ func TestComposeCommand(t *testing.T) {
 		command, err := podman.ComposeCommand(context.Background(), socket, "compose.yaml", "ps")
 
 		require.NoError(t, err)
-		assert.Equal(t, "tcp://127.0.0.1:12345", environmentValue(command.Env, "DOCKER_HOST"))
+		assert.Contains(t, command.Env, "DOCKER_HOST=tcp://127.0.0.1:12345")
 	})
-}
-
-func environmentValue(environment []string, key string) string {
-	for index := len(environment) - 1; index >= 0; index-- {
-		entry := environment[index]
-		if len(entry) > len(key) && entry[:len(key)+1] == key+"=" {
-			return entry[len(key)+1:]
-		}
-	}
-	return ""
 }

--- a/internal/deploy/podman/command_test.go
+++ b/internal/deploy/podman/command_test.go
@@ -1,0 +1,66 @@
+package podman_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/arm/topo/internal/deploy/podman"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCommand(t *testing.T) {
+	t.Run("sets args", func(t *testing.T) {
+		command := podman.Command(context.Background(), podman.LocalSocket, "info")
+
+		assert.Equal(t, []string{"podman", "info"}, command.Args)
+	})
+
+	t.Run("configures remote socket", func(t *testing.T) {
+		t.Setenv("CONTAINER_HOST", "unix:///stale-podman.sock")
+		socket := podman.NewSocket("tcp://127.0.0.1:12345")
+
+		command := podman.Command(context.Background(), socket, "info")
+
+		assert.Equal(t, []string{"podman", "info"}, command.Args)
+		assert.Equal(t, "tcp://127.0.0.1:12345", environmentValue(command.Env, "CONTAINER_HOST"))
+	})
+
+	t.Run("does not configure a socket for localhost", func(t *testing.T) {
+		command := podman.ComposeCommand(context.Background(), podman.LocalSocket, "info")
+
+		assert.Empty(t, environmentValue(command.Env, "CONTAINER_HOST"))
+	})
+}
+
+func TestComposeCommand(t *testing.T) {
+	t.Run("sets args", func(t *testing.T) {
+		command := podman.ComposeCommand(context.Background(), podman.LocalSocket, "compose.yaml", "up", "-d")
+
+		assert.Equal(t, []string{"podman", "compose", "-f", "compose.yaml", "up", "-d"}, command.Args)
+	})
+
+	t.Run("configures compose provider", func(t *testing.T) {
+		command := podman.ComposeCommand(context.Background(), podman.LocalSocket, "compose.yaml", "ps")
+
+		assert.Equal(t, "docker-compose", environmentValue(command.Env, "PODMAN_COMPOSE_PROVIDER"))
+	})
+
+	t.Run("configures remote socket", func(t *testing.T) {
+		t.Setenv("DOCKER_HOST", "unix:///stale-docker.sock")
+		socket := podman.NewSocket("tcp://127.0.0.1:12345")
+
+		command := podman.ComposeCommand(context.Background(), socket, "compose.yaml", "ps")
+
+		assert.Equal(t, "tcp://127.0.0.1:12345", environmentValue(command.Env, "DOCKER_HOST"))
+	})
+}
+
+func environmentValue(environment []string, key string) string {
+	for index := len(environment) - 1; index >= 0; index-- {
+		entry := environment[index]
+		if len(entry) > len(key) && entry[:len(key)+1] == key+"=" {
+			return entry[len(key)+1:]
+		}
+	}
+	return ""
+}

--- a/internal/deploy/podman/command_test.go
+++ b/internal/deploy/podman/command_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/arm/topo/internal/deploy/podman"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCommand(t *testing.T) {
@@ -26,7 +27,7 @@ func TestCommand(t *testing.T) {
 	})
 
 	t.Run("does not configure a socket for localhost", func(t *testing.T) {
-		command := podman.ComposeCommand(context.Background(), podman.LocalSocket, "info")
+		command := podman.Command(context.Background(), podman.LocalSocket, "info")
 
 		assert.Empty(t, environmentValue(command.Env, "CONTAINER_HOST"))
 	})
@@ -34,14 +35,16 @@ func TestCommand(t *testing.T) {
 
 func TestComposeCommand(t *testing.T) {
 	t.Run("sets args", func(t *testing.T) {
-		command := podman.ComposeCommand(context.Background(), podman.LocalSocket, "compose.yaml", "up", "-d")
+		command, err := podman.ComposeCommand(context.Background(), podman.NewSocket("tcp://127.0.0.1:12345"), "compose.yaml", "up", "-d")
 
+		require.NoError(t, err)
 		assert.Equal(t, []string{"podman", "compose", "-f", "compose.yaml", "up", "-d"}, command.Args)
 	})
 
 	t.Run("configures compose provider", func(t *testing.T) {
-		command := podman.ComposeCommand(context.Background(), podman.LocalSocket, "compose.yaml", "ps")
+		command, err := podman.ComposeCommand(context.Background(), podman.NewSocket("tcp://127.0.0.1:12345"), "compose.yaml", "ps")
 
+		require.NoError(t, err)
 		assert.Equal(t, "docker-compose", environmentValue(command.Env, "PODMAN_COMPOSE_PROVIDER"))
 	})
 
@@ -49,8 +52,9 @@ func TestComposeCommand(t *testing.T) {
 		t.Setenv("DOCKER_HOST", "unix:///stale-docker.sock")
 		socket := podman.NewSocket("tcp://127.0.0.1:12345")
 
-		command := podman.ComposeCommand(context.Background(), socket, "compose.yaml", "ps")
+		command, err := podman.ComposeCommand(context.Background(), socket, "compose.yaml", "ps")
 
+		require.NoError(t, err)
 		assert.Equal(t, "tcp://127.0.0.1:12345", environmentValue(command.Env, "DOCKER_HOST"))
 	})
 }

--- a/internal/deploy/podman/compose.go
+++ b/internal/deploy/podman/compose.go
@@ -7,11 +7,11 @@ import (
 	"github.com/arm/topo/internal/compose"
 )
 
-func BuildImages(ctx context.Context, output io.Writer, composeFile string) error {
-	return RunComposeCommand(ctx, output, composeFile, "build")
+func BuildImages(ctx context.Context, output io.Writer, socket Socket, composeFile string) error {
+	return RunComposeCommand(ctx, output, socket, composeFile, "build")
 }
 
-func PullImages(ctx context.Context, output io.Writer, composeFile string) error {
+func PullImages(ctx context.Context, output io.Writer, socket Socket, composeFile string) error {
 	services, err := compose.PullableServices(composeFile)
 	if err != nil {
 		return err
@@ -21,9 +21,9 @@ func PullImages(ctx context.Context, output io.Writer, composeFile string) error
 	}
 
 	args := append([]string{"pull"}, services...)
-	return RunComposeCommand(ctx, output, composeFile, args...)
+	return RunComposeCommand(ctx, output, socket, composeFile, args...)
 }
 
-func StartServices(ctx context.Context, output io.Writer, composeFile string) error {
-	return RunComposeCommand(ctx, output, composeFile, "up", "-d", "--no-build", "--pull", "never")
+func StartServices(ctx context.Context, output io.Writer, socket Socket, composeFile string) error {
+	return RunComposeCommand(ctx, output, socket, composeFile, "up", "-d", "--no-build", "--pull", "never")
 }

--- a/internal/deploy/podman/deploy.go
+++ b/internal/deploy/podman/deploy.go
@@ -8,26 +8,22 @@ import (
 )
 
 func Deploy(ctx context.Context, output io.Writer, composeFile string) error {
-	socket, err := ResolveLocalComposeSocket(ctx)
-	if err != nil {
-		return err
-	}
 	if err := term.PrintHeader(output, "Build images"); err != nil {
 		return err
 	}
-	if err := BuildImages(ctx, output, socket, composeFile); err != nil {
+	if err := BuildImages(ctx, output, LocalSocket, composeFile); err != nil {
 		return err
 	}
 
 	if err := term.PrintHeader(output, "Pull images"); err != nil {
 		return err
 	}
-	if err := PullImages(ctx, output, socket, composeFile); err != nil {
+	if err := PullImages(ctx, output, LocalSocket, composeFile); err != nil {
 		return err
 	}
 
 	if err := term.PrintHeader(output, "Start services"); err != nil {
 		return err
 	}
-	return StartServices(ctx, output, socket, composeFile)
+	return StartServices(ctx, output, LocalSocket, composeFile)
 }

--- a/internal/deploy/podman/deploy.go
+++ b/internal/deploy/podman/deploy.go
@@ -8,22 +8,26 @@ import (
 )
 
 func Deploy(ctx context.Context, output io.Writer, composeFile string) error {
+	socket, err := ResolveLocalComposeSocket(ctx)
+	if err != nil {
+		return err
+	}
 	if err := term.PrintHeader(output, "Build images"); err != nil {
 		return err
 	}
-	if err := BuildImages(ctx, output, composeFile); err != nil {
+	if err := BuildImages(ctx, output, socket, composeFile); err != nil {
 		return err
 	}
 
 	if err := term.PrintHeader(output, "Pull images"); err != nil {
 		return err
 	}
-	if err := PullImages(ctx, output, composeFile); err != nil {
+	if err := PullImages(ctx, output, socket, composeFile); err != nil {
 		return err
 	}
 
 	if err := term.PrintHeader(output, "Start services"); err != nil {
 		return err
 	}
-	return StartServices(ctx, output, composeFile)
+	return StartServices(ctx, output, socket, composeFile)
 }

--- a/internal/deploy/podman/deploy_test.go
+++ b/internal/deploy/podman/deploy_test.go
@@ -24,7 +24,9 @@ func TestDeploy(t *testing.T) {
 	err := podman.Deploy(t.Context(), io.Discard, composeFile)
 
 	require.NoError(t, err)
-	assertContainersRunning(t, projectName)
+	socket, err := podman.ResolveLocalComposeSocket(t.Context())
+	require.NoError(t, err)
+	assertContainersRunning(t, projectName, socket)
 }
 
 func requireLocalPodman(t *testing.T) {
@@ -40,9 +42,9 @@ func requireLocalPodman(t *testing.T) {
 	}
 }
 
-func assertContainersRunning(t *testing.T, projectName string) {
+func assertContainersRunning(t *testing.T, projectName string, socket podman.Socket) {
 	t.Helper()
-	cmd := podman.Command(t.Context(), "ps", "--format", "json", "--all",
+	cmd := podman.Command(t.Context(), socket, "ps", "--format", "json", "--all",
 		"--filter", "label=com.docker.compose.project="+projectName,
 	)
 	var diagnostics bytes.Buffer
@@ -84,7 +86,7 @@ CMD ["tail", "-f", "/dev/null"]
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 
-		removeOutput, err := podman.Command(ctx, "image", "rm", "-f", imageName).CombinedOutput()
+		removeOutput, err := podman.Command(ctx, podman.LocalSocket, "image", "rm", "-f", imageName).CombinedOutput()
 		if err != nil {
 			t.Logf("failed to remove image %s: %v: %s", imageName, err, string(removeOutput))
 		}
@@ -97,7 +99,12 @@ func cleanupComposeProject(t *testing.T, composeFile string) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	cmd := podman.ComposeCommand(ctx, composeFile, "down", "-v", "--remove-orphans", "--rmi", "local")
+	socket, err := podman.ResolveLocalComposeSocket(ctx)
+	if err != nil {
+		t.Logf("failed to resolve local Podman Compose socket: %v", err)
+		return
+	}
+	cmd := podman.ComposeCommand(ctx, socket, composeFile, "down", "-v", "--remove-orphans", "--rmi", "local")
 	if output, err := cmd.CombinedOutput(); err != nil {
 		t.Logf("Podman Compose cleanup failed: %v: %s", err, output)
 	}

--- a/internal/deploy/podman/deploy_test.go
+++ b/internal/deploy/podman/deploy_test.go
@@ -24,9 +24,7 @@ func TestDeploy(t *testing.T) {
 	err := podman.Deploy(t.Context(), io.Discard, composeFile)
 
 	require.NoError(t, err)
-	socket, err := podman.ResolveLocalComposeSocket(t.Context())
-	require.NoError(t, err)
-	assertContainersRunning(t, projectName, socket)
+	assertContainersRunning(t, projectName, podman.LocalSocket)
 }
 
 func requireLocalPodman(t *testing.T) {
@@ -99,12 +97,11 @@ func cleanupComposeProject(t *testing.T, composeFile string) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	socket, err := podman.ResolveLocalComposeSocket(ctx)
+	cmd, err := podman.ComposeCommand(ctx, podman.LocalSocket, composeFile, "down", "-v", "--remove-orphans", "--rmi", "local")
 	if err != nil {
-		t.Logf("failed to resolve local Podman Compose socket: %v", err)
+		t.Logf("failed to configure Podman Compose: %v", err)
 		return
 	}
-	cmd := podman.ComposeCommand(ctx, socket, composeFile, "down", "-v", "--remove-orphans", "--rmi", "local")
 	if output, err := cmd.CombinedOutput(); err != nil {
 		t.Logf("Podman Compose cleanup failed: %v: %s", err, output)
 	}

--- a/internal/deploy/podman/deploy_test.go
+++ b/internal/deploy/podman/deploy_test.go
@@ -3,6 +3,7 @@ package podman_test
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os/exec"
@@ -17,13 +18,13 @@ import (
 
 func TestDeploy(t *testing.T) {
 	requireLocalPodman(t)
-	composeFile := deploymentFixture(t)
+	composeFile, projectName := deploymentFixture(t)
 	t.Cleanup(func() { cleanupComposeProject(t, composeFile) })
 
 	err := podman.Deploy(t.Context(), io.Discard, composeFile)
 
 	require.NoError(t, err)
-	assertContainersRunning(t, composeFile)
+	assertContainersRunning(t, projectName)
 }
 
 func requireLocalPodman(t *testing.T) {
@@ -39,24 +40,26 @@ func requireLocalPodman(t *testing.T) {
 	}
 }
 
-func assertContainersRunning(t *testing.T, composeFile string) {
+func assertContainersRunning(t *testing.T, projectName string) {
 	t.Helper()
-	cmd := podman.ComposeCommand(t.Context(), composeFile, "ps", "--format", "json", "--all")
+	cmd := podman.Command(t.Context(), "ps", "--format", "json", "--all",
+		"--filter", "label=com.docker.compose.project="+projectName,
+	)
 	var diagnostics bytes.Buffer
 	cmd.Stderr = &diagnostics
 	output, err := cmd.Output()
 	require.NoError(t, err, "stdout: %s\nstderr: %s", output, diagnostics.String())
-	require.NotEmpty(t, bytes.TrimSpace(output), "no containers reported; stderr: %s", diagnostics.String())
 
-	containers, err := unmarshalNDJSON(output)
-	require.NoError(t, err)
+	var containers []map[string]any
+	require.NoError(t, json.Unmarshal(output, &containers))
+	require.NotEmpty(t, containers, "no containers reported; stderr: %s", diagnostics.String())
 
 	for _, container := range containers {
-		assert.Equal(t, "running", container["State"], "container %s is not running: %s", container["Name"], container["State"])
+		assert.Equal(t, "running", container["State"], "container %s is not running: %s", container["Names"], container["State"])
 	}
 }
 
-func deploymentFixture(t *testing.T) string {
+func deploymentFixture(t *testing.T) (string, string) {
 	t.Helper()
 	tempDir := t.TempDir()
 	testName := sanitiseTestName(t)
@@ -86,7 +89,7 @@ CMD ["tail", "-f", "/dev/null"]
 			t.Logf("failed to remove image %s: %v: %s", imageName, err, string(removeOutput))
 		}
 	})
-	return composeFile
+	return composeFile, "test-project-" + testName
 }
 
 func cleanupComposeProject(t *testing.T, composeFile string) {

--- a/internal/deploy/podman/socket.go
+++ b/internal/deploy/podman/socket.go
@@ -1,0 +1,197 @@
+package podman
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+type Socket struct {
+	url string
+}
+
+var LocalSocket Socket
+
+func NewSocket(url string) Socket {
+	return Socket{url: url}
+}
+
+type podmanConnection struct {
+	Name      string
+	URI       string
+	Default   bool
+	IsMachine bool
+}
+
+type machineConnectionInfo struct {
+	PodmanSocket *machineSocket
+	PodmanPipe   *machinePipe
+}
+
+type machineSocket struct {
+	Path string
+}
+
+type machinePipe struct {
+	Path string
+}
+
+// ResolveLocalComposeSocket returns the host-accessible Podman API endpoint
+// that the external Compose provider must use for a local deployment.
+func ResolveLocalComposeSocket(ctx context.Context) (Socket, error) {
+	if runtime.GOOS == "darwin" {
+		return resolveDarwinComposeSocket(ctx)
+	}
+	if runtime.GOOS == "windows" {
+		return resolveWindowsComposeSocket(ctx)
+	}
+	return resolveNativeComposeSocket(ctx)
+}
+
+func resolveNativeComposeSocket(ctx context.Context) (Socket, error) {
+	output, err := exec.CommandContext(ctx, "podman", "info", "--format", "{{.Host.RemoteSocket.Path}}").Output()
+	if err != nil {
+		return Socket{}, fmt.Errorf("failed to get Podman API socket: %w", err)
+	}
+
+	socketURL, err := unixSocketURL(strings.TrimSpace(string(output)))
+	if err != nil {
+		return Socket{}, err
+	}
+	if err := requireSocket(socketURL); err != nil {
+		return Socket{}, err
+	}
+	return NewSocket(socketURL), nil
+}
+
+func resolveDarwinComposeSocket(ctx context.Context) (Socket, error) {
+	connection, err := defaultPodmanConnection(ctx)
+	if err != nil {
+		return Socket{}, err
+	}
+	if !connection.IsMachine {
+		if isDarwinComposeEndpoint(connection.URI) {
+			return NewSocket(connection.URI), nil
+		}
+		return Socket{}, fmt.Errorf("default Podman connection %q has no Compose-compatible endpoint", connection.Name)
+	}
+
+	info, err := inspectPodmanMachine(ctx, connection)
+	if err != nil {
+		return Socket{}, err
+	}
+	if info.PodmanSocket == nil {
+		return Socket{}, fmt.Errorf("podman machine %q has no host-accessible API socket", connection.Name)
+	}
+	socketURL, err := unixSocketURL(info.PodmanSocket.Path)
+	if err != nil {
+		return Socket{}, err
+	}
+	return NewSocket(socketURL), nil
+}
+
+func resolveWindowsComposeSocket(ctx context.Context) (Socket, error) {
+	connection, err := defaultPodmanConnection(ctx)
+	if err != nil {
+		return Socket{}, err
+	}
+	if !connection.IsMachine {
+		if isWindowsComposeEndpoint(connection.URI) {
+			return NewSocket(connection.URI), nil
+		}
+		return Socket{}, fmt.Errorf("default Podman connection %q has no Compose-compatible endpoint", connection.Name)
+	}
+
+	info, err := inspectPodmanMachine(ctx, connection)
+	if err != nil {
+		return Socket{}, err
+	}
+	if info.PodmanPipe == nil {
+		return Socket{}, fmt.Errorf("podman machine %q has no host-accessible API pipe", connection.Name)
+	}
+	pipeURL, err := namedPipeURL(info.PodmanPipe.Path)
+	if err != nil {
+		return Socket{}, err
+	}
+	return NewSocket(pipeURL), nil
+}
+
+func inspectPodmanMachine(ctx context.Context, connection podmanConnection) (machineConnectionInfo, error) {
+	output, err := exec.CommandContext(ctx, "podman", "machine", "inspect", connection.Name, "--format", "{{json .ConnectionInfo}}").Output()
+	if err != nil {
+		return machineConnectionInfo{}, fmt.Errorf("failed to inspect Podman machine %q: %w", connection.Name, err)
+	}
+
+	var info machineConnectionInfo
+	if err := json.Unmarshal(output, &info); err != nil {
+		return machineConnectionInfo{}, fmt.Errorf("failed to parse Podman machine connection information: %w", err)
+	}
+	return info, nil
+}
+
+func defaultPodmanConnection(ctx context.Context) (podmanConnection, error) {
+	output, err := exec.CommandContext(ctx, "podman", "system", "connection", "list", "--format", "json").Output()
+	if err != nil {
+		return podmanConnection{}, fmt.Errorf("failed to list Podman connections: %w", err)
+	}
+
+	var connections []podmanConnection
+	if err := json.Unmarshal(output, &connections); err != nil {
+		return podmanConnection{}, fmt.Errorf("failed to parse Podman connections: %w", err)
+	}
+	for _, connection := range connections {
+		if connection.Default {
+			return connection, nil
+		}
+	}
+	return podmanConnection{}, fmt.Errorf("no default Podman connection is configured")
+}
+
+func isDarwinComposeEndpoint(endpoint string) bool {
+	return strings.HasPrefix(endpoint, "unix://") || strings.HasPrefix(endpoint, "tcp://")
+}
+
+func isWindowsComposeEndpoint(endpoint string) bool {
+	return strings.HasPrefix(endpoint, "npipe://") || strings.HasPrefix(endpoint, "tcp://")
+}
+
+func unixSocketURL(path string) (string, error) {
+	if path == "" {
+		return "", fmt.Errorf("podman did not report an API socket")
+	}
+	if strings.HasPrefix(path, "unix://") {
+		return path, nil
+	}
+	if !filepath.IsAbs(path) {
+		return "", fmt.Errorf("podman reported a non-local API socket path %q", path)
+	}
+	return "unix://" + path, nil
+}
+
+func namedPipeURL(path string) (string, error) {
+	path = strings.ReplaceAll(path, `\`, "/")
+	if !strings.HasPrefix(path, "//./pipe/") {
+		return "", fmt.Errorf("podman reported an invalid named pipe path %q", path)
+	}
+	return "npipe:////./pipe/" + strings.TrimPrefix(path, "//./pipe/"), nil
+}
+
+func requireSocket(socketURL string) error {
+	parsedURL, err := url.Parse(socketURL)
+	if err != nil {
+		return fmt.Errorf("failed to parse Podman API socket URL: %w", err)
+	}
+	if parsedURL.Scheme != "unix" {
+		return fmt.Errorf("podman reported an unsupported API socket URL %q", socketURL)
+	}
+	if _, err := os.Stat(parsedURL.Path); err != nil { // #nosec G703 -- socket URL comes from Podman.
+		return fmt.Errorf("podman API socket %s is unavailable; start podman.socket: %w", socketURL, err)
+	}
+	return nil
+}

--- a/internal/deploy/podman/socket.go
+++ b/internal/deploy/podman/socket.go
@@ -10,32 +10,49 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 )
 
 type Socket struct {
-	url string
+	url                string
+	localComposeSocket *localComposeSocket
 }
 
-var LocalSocket Socket
+type localComposeSocket struct {
+	mutex sync.Mutex
+	url   string
+}
+
+var LocalSocket = Socket{localComposeSocket: &localComposeSocket{}}
 
 func NewSocket(url string) Socket {
 	return Socket{url: url}
 }
 
 func (socket Socket) ConfigurePodmanEnv(environment []string) []string {
-	if socket == LocalSocket {
+	if socket.url == "" {
 		return environment
 	}
 	return append(environment, "CONTAINER_HOST="+socket.url)
 }
 
 func (socket Socket) ConfigureComposeEnv(environment []string) ([]string, error) {
-	if socket == LocalSocket {
+	if socket.localComposeSocket == nil {
+		return append(environment, "DOCKER_HOST="+socket.url), nil
+	}
+	return socket.localComposeSocket.ConfigureEnv(environment)
+}
+
+func (socket *localComposeSocket) ConfigureEnv(environment []string) ([]string, error) {
+	socket.mutex.Lock()
+	defer socket.mutex.Unlock()
+
+	if socket.url == "" {
 		url, err := ResolveLocalComposeSocket(context.Background())
 		if err != nil {
 			return nil, err
 		}
-		return append(environment, "DOCKER_HOST="+url), nil
+		socket.url = url
 	}
 	return append(environment, "DOCKER_HOST="+socket.url), nil
 }

--- a/internal/deploy/podman/socket.go
+++ b/internal/deploy/podman/socket.go
@@ -37,24 +37,32 @@ func (socket Socket) ConfigurePodmanEnv(environment []string) []string {
 }
 
 func (socket Socket) ConfigureComposeEnv(ctx context.Context, environment []string) ([]string, error) {
-	if socket.localComposeSocket == nil {
-		return append(environment, "DOCKER_HOST="+socket.url), nil
+	socketURL, err := socket.getComposeSocketURL(ctx)
+	if err != nil {
+		return nil, err
 	}
-	return socket.localComposeSocket.configureEnv(ctx, environment)
+	return append(environment, "DOCKER_HOST="+socketURL), nil
 }
 
-func (socket *localComposeSocket) configureEnv(ctx context.Context, environment []string) ([]string, error) {
+func (socket Socket) getComposeSocketURL(ctx context.Context) (string, error) {
+	if socket.localComposeSocket == nil {
+		return socket.url, nil
+	}
+	return socket.localComposeSocket.getURL(ctx)
+}
+
+func (socket *localComposeSocket) getURL(ctx context.Context) (string, error) {
 	socket.mutex.Lock()
 	defer socket.mutex.Unlock()
 
 	if socket.url == "" {
 		url, err := ResolveLocalComposeSocket(ctx)
 		if err != nil {
-			return nil, err
+			return "", err
 		}
 		socket.url = url
 	}
-	return append(environment, "DOCKER_HOST="+socket.url), nil
+	return socket.url, nil
 }
 
 type podmanConnection struct {

--- a/internal/deploy/podman/socket.go
+++ b/internal/deploy/podman/socket.go
@@ -40,10 +40,10 @@ func (socket Socket) ConfigureComposeEnv(ctx context.Context, environment []stri
 	if socket.localComposeSocket == nil {
 		return append(environment, "DOCKER_HOST="+socket.url), nil
 	}
-	return socket.localComposeSocket.ConfigureEnv(ctx, environment)
+	return socket.localComposeSocket.configureEnv(ctx, environment)
 }
 
-func (socket *localComposeSocket) ConfigureEnv(ctx context.Context, environment []string) ([]string, error) {
+func (socket *localComposeSocket) configureEnv(ctx context.Context, environment []string) ([]string, error) {
 	socket.mutex.Lock()
 	defer socket.mutex.Unlock()
 

--- a/internal/deploy/podman/socket.go
+++ b/internal/deploy/podman/socket.go
@@ -36,19 +36,19 @@ func (socket Socket) ConfigurePodmanEnv(environment []string) []string {
 	return append(environment, "CONTAINER_HOST="+socket.url)
 }
 
-func (socket Socket) ConfigureComposeEnv(environment []string) ([]string, error) {
+func (socket Socket) ConfigureComposeEnv(ctx context.Context, environment []string) ([]string, error) {
 	if socket.localComposeSocket == nil {
 		return append(environment, "DOCKER_HOST="+socket.url), nil
 	}
-	return socket.localComposeSocket.ConfigureEnv(environment)
+	return socket.localComposeSocket.ConfigureEnv(ctx, environment)
 }
 
-func (socket *localComposeSocket) ConfigureEnv(environment []string) ([]string, error) {
+func (socket *localComposeSocket) ConfigureEnv(ctx context.Context, environment []string) ([]string, error) {
 	socket.mutex.Lock()
 	defer socket.mutex.Unlock()
 
 	if socket.url == "" {
-		url, err := ResolveLocalComposeSocket(context.Background())
+		url, err := ResolveLocalComposeSocket(ctx)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/deploy/podman/socket.go
+++ b/internal/deploy/podman/socket.go
@@ -22,6 +22,24 @@ func NewSocket(url string) Socket {
 	return Socket{url: url}
 }
 
+func (socket Socket) ConfigurePodmanEnv(environment []string) []string {
+	if socket == LocalSocket {
+		return environment
+	}
+	return append(environment, "CONTAINER_HOST="+socket.url)
+}
+
+func (socket Socket) ConfigureComposeEnv(environment []string) ([]string, error) {
+	if socket == LocalSocket {
+		url, err := ResolveLocalComposeSocket(context.Background())
+		if err != nil {
+			return nil, err
+		}
+		return append(environment, "DOCKER_HOST="+url), nil
+	}
+	return append(environment, "DOCKER_HOST="+socket.url), nil
+}
+
 type podmanConnection struct {
 	Name      string
 	URI       string
@@ -44,7 +62,7 @@ type machinePipe struct {
 
 // ResolveLocalComposeSocket returns the host-accessible Podman API endpoint
 // that the external Compose provider must use for a local deployment.
-func ResolveLocalComposeSocket(ctx context.Context) (Socket, error) {
+func ResolveLocalComposeSocket(ctx context.Context) (string, error) {
 	if runtime.GOOS == "darwin" {
 		return resolveDarwinComposeSocket(ctx)
 	}
@@ -54,72 +72,72 @@ func ResolveLocalComposeSocket(ctx context.Context) (Socket, error) {
 	return resolveNativeComposeSocket(ctx)
 }
 
-func resolveNativeComposeSocket(ctx context.Context) (Socket, error) {
+func resolveNativeComposeSocket(ctx context.Context) (string, error) {
 	output, err := exec.CommandContext(ctx, "podman", "info", "--format", "{{.Host.RemoteSocket.Path}}").Output()
 	if err != nil {
-		return Socket{}, fmt.Errorf("failed to get Podman API socket: %w", err)
+		return "", fmt.Errorf("failed to get Podman API socket: %w", err)
 	}
 
 	socketURL, err := unixSocketURL(strings.TrimSpace(string(output)))
 	if err != nil {
-		return Socket{}, err
+		return "", err
 	}
 	if err := requireSocket(socketURL); err != nil {
-		return Socket{}, err
+		return "", err
 	}
-	return NewSocket(socketURL), nil
+	return socketURL, nil
 }
 
-func resolveDarwinComposeSocket(ctx context.Context) (Socket, error) {
+func resolveDarwinComposeSocket(ctx context.Context) (string, error) {
 	connection, err := defaultPodmanConnection(ctx)
 	if err != nil {
-		return Socket{}, err
+		return "", err
 	}
 	if !connection.IsMachine {
 		if isDarwinComposeEndpoint(connection.URI) {
-			return NewSocket(connection.URI), nil
+			return connection.URI, nil
 		}
-		return Socket{}, fmt.Errorf("default Podman connection %q has no Compose-compatible endpoint", connection.Name)
+		return "", fmt.Errorf("default Podman connection %q has no Compose-compatible endpoint", connection.Name)
 	}
 
 	info, err := inspectPodmanMachine(ctx, connection)
 	if err != nil {
-		return Socket{}, err
+		return "", err
 	}
 	if info.PodmanSocket == nil {
-		return Socket{}, fmt.Errorf("podman machine %q has no host-accessible API socket", connection.Name)
+		return "", fmt.Errorf("podman machine %q has no host-accessible API socket", connection.Name)
 	}
 	socketURL, err := unixSocketURL(info.PodmanSocket.Path)
 	if err != nil {
-		return Socket{}, err
+		return "", err
 	}
-	return NewSocket(socketURL), nil
+	return socketURL, nil
 }
 
-func resolveWindowsComposeSocket(ctx context.Context) (Socket, error) {
+func resolveWindowsComposeSocket(ctx context.Context) (string, error) {
 	connection, err := defaultPodmanConnection(ctx)
 	if err != nil {
-		return Socket{}, err
+		return "", err
 	}
 	if !connection.IsMachine {
 		if isWindowsComposeEndpoint(connection.URI) {
-			return NewSocket(connection.URI), nil
+			return connection.URI, nil
 		}
-		return Socket{}, fmt.Errorf("default Podman connection %q has no Compose-compatible endpoint", connection.Name)
+		return "", fmt.Errorf("default Podman connection %q has no Compose-compatible endpoint", connection.Name)
 	}
 
 	info, err := inspectPodmanMachine(ctx, connection)
 	if err != nil {
-		return Socket{}, err
+		return "", err
 	}
 	if info.PodmanPipe == nil {
-		return Socket{}, fmt.Errorf("podman machine %q has no host-accessible API pipe", connection.Name)
+		return "", fmt.Errorf("podman machine %q has no host-accessible API pipe", connection.Name)
 	}
 	pipeURL, err := namedPipeURL(info.PodmanPipe.Path)
 	if err != nil {
-		return Socket{}, err
+		return "", err
 	}
-	return NewSocket(pipeURL), nil
+	return pipeURL, nil
 }
 
 func inspectPodmanMachine(ctx context.Context, connection podmanConnection) (machineConnectionInfo, error) {

--- a/internal/deploy/podman/testutil_test.go
+++ b/internal/deploy/podman/testutil_test.go
@@ -3,13 +3,8 @@ package podman_test
 import (
 	"testing"
 
-	deploytestutil "github.com/arm/topo/internal/deploy/testutil"
 	gtestutil "github.com/arm/topo/internal/testutil"
 )
-
-func unmarshalNDJSON(ndJSON []byte) ([]deploytestutil.JsonObject, error) {
-	return deploytestutil.UnmarshalNDJSON(ndJSON)
-}
 
 func sanitiseTestName(t *testing.T) string {
 	t.Helper()


### PR DESCRIPTION
## Changes

ℹ️  This seems to affect podman 4.9.x, which is the version ubuntu 24.04 LTS ship with, my local tests with brewed podman 6.0.0 did work as expected w/o explicit `DOCKER_HOST` being set

- Configure the `docker-compose` provider with Podman’s resolved local API endpoint via `DOCKER_HOST`.
- Keep raw Podman commands on their normal local configuration; use `CONTAINER_HOST` only for explicit sockets.
- Correct deployment assertions to query containers with raw Podman rather than Compose, preventing tests from checking Docker while Podman Compose was misconfigured.
   - See the CI failure from the first commit of this PR 
- Cache the resolved local Compose endpoint

## Checklist

- [x] 🤖 This change is covered by tests as required.
- [ ] 🤹 All required manual testing has been performed.
- [ ] 📖 All documentation updates are complete.