### PR TITLE
fix: avoid relative import from landing page to fix docs site build

### DIFF
--- a/docs/landing-page/index.tsx
+++ b/docs/landing-page/index.tsx
@@ -5,7 +5,7 @@ import type { ReactElement } from "react";
 import { homepageContent } from "./_homepage";
 import ExternalLinkIcon from "./external-link.svg";
 import styles from "./index.module.css";
-import TopoOverviewDiagram from "../static/img/topo-overview.svg";
+import TopoOverviewDiagram from "@site/project-static/img/topo-overview.svg";
 
 function joinClasses(...parts: Array<string | undefined | false>): string {
   return parts.filter(Boolean).join(" ");

--- a/docs/landing-page/index.tsx
+++ b/docs/landing-page/index.tsx
@@ -5,7 +5,7 @@ import type { ReactElement } from "react";
 import { homepageContent } from "./_homepage";
 import ExternalLinkIcon from "./external-link.svg";
 import styles from "./index.module.css";
-import TopoOverviewDiagram from "@site/project-static/img/topo-overview.svg";
+import TopoOverviewDiagram from "./topo-overview.svg";
 
 function joinClasses(...parts: Array<string | undefined | false>): string {
   return parts.filter(Boolean).join(" ");

--- a/docs/landing-page/topo-overview.svg
+++ b/docs/landing-page/topo-overview.svg
@@ -1,0 +1,1 @@
+../static/img/topo-overview.svg


### PR DESCRIPTION
<!-- PR title should be formatted using conventional commits -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->
<!-- Example: feat: A very fancy feature -->

## Changes

<!-- List the changes this PR introduces -->

- As title says, docs site would not build with a relative import on the landing page for no good reason.
- Unfortunately, ADPS provides no mechanism for sharing importable static assets between the landing page and elsewhere in the docs. For that reason a symlink from `/static` -> landing page seemed like the least evil solution.

## Checklist

<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->

- [x] 🤖 This change is covered by tests as required.
- [x] 🤹 All required manual testing has been performed.
- [x] 📖 All documentation updates are complete.
