### PR TITLE
docs: embed light/dark styling in svg diagram

### DIFF
--- a/docs/landing-page/index.module.css
+++ b/docs/landing-page/index.module.css
@@ -163,15 +163,10 @@
 }
 
 .heroDiagram {
-  color: #000;
   display: block;
   height: auto;
   width: 100%;
   max-width: 100%;
-}
-
-:global(html[data-theme="dark"]) .heroDiagram {
-  color: #fff;
 }
 
 @media screen and (min-width: 1440px) {

--- a/docs/landing-page/index.tsx
+++ b/docs/landing-page/index.tsx
@@ -5,7 +5,6 @@ import type { ReactElement } from "react";
 import { homepageContent } from "./_homepage";
 import ExternalLinkIcon from "./external-link.svg";
 import styles from "./index.module.css";
-import TopoOverviewDiagram from "./topo-overview.svg";
 
 function joinClasses(...parts: Array<string | undefined | false>): string {
   return parts.filter(Boolean).join(" ");
@@ -47,8 +46,10 @@ export default function Home(): ReactElement {
             </div>
           </div>
           <div className={styles.heroVisual}>
-            <TopoOverviewDiagram
+            <img
               className={styles.heroDiagram}
+              src="img/topo-overview.svg"
+              alt="Topo deployment and development loop"
             />
           </div>
         </section>

--- a/docs/landing-page/topo-overview.svg
+++ b/docs/landing-page/topo-overview.svg
@@ -1,1 +1,0 @@
-../static/img/topo-overview.svg

--- a/docs/static/img/topo-overview.svg
+++ b/docs/static/img/topo-overview.svg
@@ -4,6 +4,17 @@
   <desc id="description">
     A Topo Project and Topo run on the host. Topo deploys Linux containers and optional remote processor firmware to an Arm target over SSH. You review the deployment, tweak the project, and redeploy.
   </desc>
+  <style>
+    :root {
+      color: #333e48;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      :root {
+        color: #fff;
+      }
+    }
+  </style>
   <defs>
     <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
       <path d="M 0 0 L 10 5 L 0 10 z" fill="currentColor"/>


### PR DESCRIPTION
<!-- PR title should be formatted using conventional commits -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->
<!-- Example: feat: A very fancy feature -->

## Changes

<!-- List the changes this PR introduces -->

- The troublesome diagram SVG strikes again and has bricked staging deployment! The problem is that APDS wants the index page to be a standalone React app and does not support relative imports. Here's what's been tried so far:
  - Relative `@site` imports - works for publishing, does not work for previewing locally
  - Symlinking the svg into the index page dir - works for previewing locally, does not work for publishing
  - **This; embedding the light/dark styling in the svg itself (the whole reason we want to inline the svg at all) and just using an `<img>` tag in the public directory - seems to work for both.** 
- Also softens the foreground `color` in light mode to match the new text styling

Successful staging deploy from this branch: https://github.com/arm/topo/actions/runs/30658690136

## Checklist

<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->

- [x] 🤖 This change is covered by tests as required.
- [x] 🤹 All required manual testing has been performed.
- [x] 📖 All documentation updates are complete.
