### PR TITLE
fix: broken project spec links in skills

### DIFF
--- a/skills/_shared/topo-project-context.md
+++ b/skills/_shared/topo-project-context.md
@@ -1,6 +1,6 @@
 # Shared Topo Project Context
 
-Topo (https://github.com/arm/topo) is a CLI app which discovers, configures, builds, and deploys containerized examples to Arm-based Linux targets over SSH. A Topo Project (https://github.com/arm/topo/docs/project-specification) is a Compose project that remains runnable with plain `docker compose`, plus root-level `x-topo` metadata that lets Topo validate the Project, match it to target hardware features, and prompt for build-time configuration.
+Topo (https://github.com/arm/topo) is a CLI app which discovers, configures, builds, and deploys containerized examples to Arm-based Linux targets over SSH. A Topo Project (https://github.com/arm/topo/tree/main/docs/project-specification) is a Compose project that remains runnable with plain `docker compose`, plus root-level `x-topo` metadata that lets Topo validate the Project, match it to target hardware features, and prompt for build-time configuration.
 
 Use Topo vocabulary precisely:
 
@@ -15,7 +15,7 @@ Use Topo vocabulary precisely:
 Refresh spec-sensitive context at runtime before making or validating Project changes. Authoritative references, in order:
 
 - Published Topo Project Specification schema: `https://raw.githubusercontent.com/arm/topo/refs/heads/main/docs/project-specification/schema/topo-project-specification.json`.
-- Published Topo Project Specification docs: `https://github.com/arm/topo/docs/project-specification`, especially `README.md`, `01-authoring-projects.md`, `02-project-configuration.md`, and `03-schema.md`.
+- Published Topo Project Specification docs: `https://github.com/arm/topo/tree/main/docs/project-specification`, especially `README.md`, `01-authoring-projects.md`, `02-project-configuration.md`, and `03-schema.md`.
 - Published Topo glossary for domain terms: `https://github.com/arm/topo/blob/main/docs/introduction/glossary.md`.
 - Compose Spec for standard Compose semantics. Do not invent non-standard Compose keys except the root-level `x-topo` extension.
 

--- a/skills/topo-project-bootstrap/references/topo-project-context.md
+++ b/skills/topo-project-bootstrap/references/topo-project-context.md
@@ -1,6 +1,6 @@
 # Shared Topo Project Context
 
-Topo (https://github.com/arm/topo) is a CLI app which discovers, configures, builds, and deploys containerized examples to Arm-based Linux targets over SSH. A Topo Project (https://github.com/arm/topo/docs/project-specification) is a Compose project that remains runnable with plain `docker compose`, plus root-level `x-topo` metadata that lets Topo validate the Project, match it to target hardware features, and prompt for build-time configuration.
+Topo (https://github.com/arm/topo) is a CLI app which discovers, configures, builds, and deploys containerized examples to Arm-based Linux targets over SSH. A Topo Project (https://github.com/arm/topo/tree/main/docs/project-specification) is a Compose project that remains runnable with plain `docker compose`, plus root-level `x-topo` metadata that lets Topo validate the Project, match it to target hardware features, and prompt for build-time configuration.
 
 Use Topo vocabulary precisely:
 
@@ -15,7 +15,7 @@ Use Topo vocabulary precisely:
 Refresh spec-sensitive context at runtime before making or validating Project changes. Authoritative references, in order:
 
 - Published Topo Project Specification schema: `https://raw.githubusercontent.com/arm/topo/refs/heads/main/docs/project-specification/schema/topo-project-specification.json`.
-- Published Topo Project Specification docs: `https://github.com/arm/topo/docs/project-specification`, especially `README.md`, `01-authoring-projects.md`, `02-project-configuration.md`, and `03-schema.md`.
+- Published Topo Project Specification docs: `https://github.com/arm/topo/tree/main/docs/project-specification`, especially `README.md`, `01-authoring-projects.md`, `02-project-configuration.md`, and `03-schema.md`.
 - Published Topo glossary for domain terms: `https://github.com/arm/topo/blob/main/docs/introduction/glossary.md`.
 - Compose Spec for standard Compose semantics. Do not invent non-standard Compose keys except the root-level `x-topo` extension.
 

--- a/skills/topo-project-context/references/topo-project-context.md
+++ b/skills/topo-project-context/references/topo-project-context.md
@@ -1,6 +1,6 @@
 # Shared Topo Project Context
 
-Topo (https://github.com/arm/topo) is a CLI app which discovers, configures, builds, and deploys containerized examples to Arm-based Linux targets over SSH. A Topo Project (https://github.com/arm/topo/docs/project-specification) is a Compose project that remains runnable with plain `docker compose`, plus root-level `x-topo` metadata that lets Topo validate the Project, match it to target hardware features, and prompt for build-time configuration.
+Topo (https://github.com/arm/topo) is a CLI app which discovers, configures, builds, and deploys containerized examples to Arm-based Linux targets over SSH. A Topo Project (https://github.com/arm/topo/tree/main/docs/project-specification) is a Compose project that remains runnable with plain `docker compose`, plus root-level `x-topo` metadata that lets Topo validate the Project, match it to target hardware features, and prompt for build-time configuration.
 
 Use Topo vocabulary precisely:
 
@@ -15,7 +15,7 @@ Use Topo vocabulary precisely:
 Refresh spec-sensitive context at runtime before making or validating Project changes. Authoritative references, in order:
 
 - Published Topo Project Specification schema: `https://raw.githubusercontent.com/arm/topo/refs/heads/main/docs/project-specification/schema/topo-project-specification.json`.
-- Published Topo Project Specification docs: `https://github.com/arm/topo/docs/project-specification`, especially `README.md`, `01-authoring-projects.md`, `02-project-configuration.md`, and `03-schema.md`.
+- Published Topo Project Specification docs: `https://github.com/arm/topo/tree/main/docs/project-specification`, especially `README.md`, `01-authoring-projects.md`, `02-project-configuration.md`, and `03-schema.md`.
 - Published Topo glossary for domain terms: `https://github.com/arm/topo/blob/main/docs/introduction/glossary.md`.
 - Compose Spec for standard Compose semantics. Do not invent non-standard Compose keys except the root-level `x-topo` extension.
 

--- a/skills/topo-project-lint/references/topo-project-context.md
+++ b/skills/topo-project-lint/references/topo-project-context.md
@@ -1,6 +1,6 @@
 # Shared Topo Project Context
 
-Topo (https://github.com/arm/topo) is a CLI app which discovers, configures, builds, and deploys containerized examples to Arm-based Linux targets over SSH. A Topo Project (https://github.com/arm/topo/docs/project-specification) is a Compose project that remains runnable with plain `docker compose`, plus root-level `x-topo` metadata that lets Topo validate the Project, match it to target hardware features, and prompt for build-time configuration.
+Topo (https://github.com/arm/topo) is a CLI app which discovers, configures, builds, and deploys containerized examples to Arm-based Linux targets over SSH. A Topo Project (https://github.com/arm/topo/tree/main/docs/project-specification) is a Compose project that remains runnable with plain `docker compose`, plus root-level `x-topo` metadata that lets Topo validate the Project, match it to target hardware features, and prompt for build-time configuration.
 
 Use Topo vocabulary precisely:
 
@@ -15,7 +15,7 @@ Use Topo vocabulary precisely:
 Refresh spec-sensitive context at runtime before making or validating Project changes. Authoritative references, in order:
 
 - Published Topo Project Specification schema: `https://raw.githubusercontent.com/arm/topo/refs/heads/main/docs/project-specification/schema/topo-project-specification.json`.
-- Published Topo Project Specification docs: `https://github.com/arm/topo/docs/project-specification`, especially `README.md`, `01-authoring-projects.md`, `02-project-configuration.md`, and `03-schema.md`.
+- Published Topo Project Specification docs: `https://github.com/arm/topo/tree/main/docs/project-specification`, especially `README.md`, `01-authoring-projects.md`, `02-project-configuration.md`, and `03-schema.md`.
 - Published Topo glossary for domain terms: `https://github.com/arm/topo/blob/main/docs/introduction/glossary.md`.
 - Compose Spec for standard Compose semantics. Do not invent non-standard Compose keys except the root-level `x-topo` extension.
 

--- a/skills/topo-project-optimize-deployment/references/topo-project-context.md
+++ b/skills/topo-project-optimize-deployment/references/topo-project-context.md
@@ -1,6 +1,6 @@
 # Shared Topo Project Context
 
-Topo (https://github.com/arm/topo) is a CLI app which discovers, configures, builds, and deploys containerized examples to Arm-based Linux targets over SSH. A Topo Project (https://github.com/arm/topo/docs/project-specification) is a Compose project that remains runnable with plain `docker compose`, plus root-level `x-topo` metadata that lets Topo validate the Project, match it to target hardware features, and prompt for build-time configuration.
+Topo (https://github.com/arm/topo) is a CLI app which discovers, configures, builds, and deploys containerized examples to Arm-based Linux targets over SSH. A Topo Project (https://github.com/arm/topo/tree/main/docs/project-specification) is a Compose project that remains runnable with plain `docker compose`, plus root-level `x-topo` metadata that lets Topo validate the Project, match it to target hardware features, and prompt for build-time configuration.
 
 Use Topo vocabulary precisely:
 
@@ -15,7 +15,7 @@ Use Topo vocabulary precisely:
 Refresh spec-sensitive context at runtime before making or validating Project changes. Authoritative references, in order:
 
 - Published Topo Project Specification schema: `https://raw.githubusercontent.com/arm/topo/refs/heads/main/docs/project-specification/schema/topo-project-specification.json`.
-- Published Topo Project Specification docs: `https://github.com/arm/topo/docs/project-specification`, especially `README.md`, `01-authoring-projects.md`, `02-project-configuration.md`, and `03-schema.md`.
+- Published Topo Project Specification docs: `https://github.com/arm/topo/tree/main/docs/project-specification`, especially `README.md`, `01-authoring-projects.md`, `02-project-configuration.md`, and `03-schema.md`.
 - Published Topo glossary for domain terms: `https://github.com/arm/topo/blob/main/docs/introduction/glossary.md`.
 - Compose Spec for standard Compose semantics. Do not invent non-standard Compose keys except the root-level `x-topo` extension.
 


### PR DESCRIPTION
<!-- PR title should be formatted using conventional commits -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->
<!-- Example: feat: A very fancy feature -->

## Changes

<!-- List the changes this PR introduces -->

- Skills shared context had an invalid GH link that they waste tokens fixing, this fixes it in the source

## Checklist

<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->

- [x] 🤖 This change is covered by tests as required.
- [x] 🤹 All required manual testing has been performed.
- [x] 📖 All documentation updates are complete.
