### PR TITLE
ci: deploy docs to production on CLI release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -190,6 +190,36 @@ jobs:
             gh release create "$RELEASE_TAG" --title "$RELEASE_TAG" --notes-file combined_notes.md
           fi
 
+  publish-docs:
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-tags: true
+
+      - name: Generate docs config
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: ./docs/scripts/generate-docs-config.sh
+
+      - name: AWS GitHub OIDC Login
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
+        with:
+          role-to-assume: arn:aws:iam::930800959236:role/Proj-GHA-topo-s3-upload
+          aws-region: eu-west-1
+
+      - name: Publish docs site
+        uses: ARM-software/docs-action/publish@v0.2.0
+        with:
+          docs-root: docs
+          site-id: topo
+          environment: production
+
   cleanup:
     needs: release
     if: ${{ always() && needs.release.result != 'success' && needs.release.outputs.tag_created == 'true' }}


### PR DESCRIPTION
<!-- PR title should be formatted using conventional commits -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->
<!-- Example: feat: A very fancy feature -->

## Changes

<!-- List the changes this PR introduces -->

- Deploys docs to production when we release the CLI

## Checklist

<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->

- [x] 🤖 This change is covered by tests as required.
- [x] 🤹 All required manual testing has been performed.
- [x] 📖 All documentation updates are complete.
