### PR TITLE
ci: retry macos signing if it fails

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -138,7 +138,7 @@ jobs:
         run: |
           publisher_run_url="$(gh workflow run sign-and-release.yml \
             --repo Arm-Debug/topo-publisher \
-            --ref v10 \
+            --ref retry-for-mac \
             --field source-run-id="${{ github.run_id }}" \
             --field release-version="$VERSION" \
             --field pre-release="${{ inputs.pre-release }}")"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -138,7 +138,7 @@ jobs:
         run: |
           publisher_run_url="$(gh workflow run sign-and-release.yml \
             --repo Arm-Debug/topo-publisher \
-            --ref retry-for-mac \
+            --ref v11 \
             --field source-run-id="${{ github.run_id }}" \
             --field release-version="$VERSION" \
             --field pre-release="${{ inputs.pre-release }}")"


### PR DESCRIPTION
<!-- PR title should be formatted using conventional commits -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->
<!-- Example: feat: A very fancy feature -->

## Changes

<!-- List the changes this PR introduces -->

- use the publisher that re-attempts macos-signing if it fails

## Checklist

<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->

- [x] 🤖 This change is covered by tests as required.
- [x] 🤹 All required manual testing has been performed.
- [x] 📖 All documentation updates are complete.
