### PR TITLE
fix: make compose file parsing env var aware

### DIFF
--- a/internal/compose/compose.go
+++ b/internal/compose/compose.go
@@ -47,7 +47,16 @@ func ReadProject(targetProjectFile string) (*types.Project, error) {
 		[]string{targetProjectFile},
 		cli.WithResolvedPaths(false),
 		cli.WithNormalization(false),
+		cli.WithEnvFiles(),
 	)
+	if err != nil {
+		return nil, err
+	}
+	err = cli.WithOsEnv(options)
+	if err != nil {
+		return nil, err
+	}
+	err = cli.WithDotEnv(options)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/compose/compose_test.go
+++ b/internal/compose/compose_test.go
@@ -1,6 +1,7 @@
 package compose_test
 
 import (
+	"fmt"
 	"path/filepath"
 	"sort"
 	"testing"
@@ -223,5 +224,45 @@ services:
 		require.NoError(t, err)
 
 		assert.YAMLEq(t, composeFileContents, string(got))
+	})
+
+	t.Run("inherits environment variables from .env file", func(t *testing.T) {
+		dir := t.TempDir()
+		serviceName := "test-service"
+		composeFileContents := fmt.Sprintf(`
+name: test
+services:
+  %s:
+    image: ${IMAGE_NAME}
+`, serviceName)
+		composeFilePath := testutil.WriteComposeFile(t, dir, composeFileContents)
+		imageName := "image-from-env"
+		testutil.RequireWriteFile(t, filepath.Join(dir, ".env"), fmt.Sprintf("IMAGE_NAME=%s", imageName))
+
+		proj, err := compose.ReadProject(composeFilePath)
+		require.NoError(t, err)
+
+		require.Contains(t, proj.Services, serviceName)
+		require.Equal(t, proj.Services[serviceName].Image, imageName)
+	})
+
+	t.Run("inherits env vars from environment", func(t *testing.T) {
+		dir := t.TempDir()
+		serviceName := "test-service"
+		composeFileContents := fmt.Sprintf(`
+name: test
+services:
+  %s:
+    image: ${IMAGE_NAME}
+`, serviceName)
+		composeFilePath := testutil.WriteComposeFile(t, dir, composeFileContents)
+		imageName := "image-from-env"
+		t.Setenv("IMAGE_NAME", imageName)
+
+		proj, err := compose.ReadProject(composeFilePath)
+		require.NoError(t, err)
+
+		require.Contains(t, proj.Services, serviceName)
+		require.Equal(t, proj.Services[serviceName].Image, imageName)
 	})
 }


### PR DESCRIPTION
<!-- PR title should be formatted using conventional commits -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->
<!-- Example: feat: A very fancy feature -->

## Changes

<!-- List the changes this PR introduces -->

- Passes env vars down from the environment or compose-sibling `.env` file to the manual file parsing we do to extract image names, build `platform`s and service names by setting the relevant options in our invocation of the compose go lib.

## Checklist

<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->

- [x] 🤖 This change is covered by tests as required.
- [x] 🤹 All required manual testing has been performed.
- [x] 📖 All documentation updates are complete.
