### PR TITLE
docs: tighten language in the `--no-registry` help string

### DIFF
--- a/cmd/topo/deploy.go
+++ b/cmd/topo/deploy.go
@@ -210,7 +210,7 @@ func init() {
 		deployCmd.Flags().StringVar(&engine, "engine", string(containerEngineDocker), "container engine to use (docker or podman)")
 	}
 	deployCmd.Flags().StringVarP(&registryPort, "registry-port", "p", docker.DefaultRegistryPort, fmt.Sprintf("registry and SSH tunnel port (can also be set via %s env var)", portEnvVar))
-	deployCmd.Flags().BoolVar(&noRegistry, "no-registry", false, "fall back to direct save/load transfer when registry transfer or reverse SSH forwarding is unavailable")
+	deployCmd.Flags().BoolVar(&noRegistry, "no-registry", false, "use full-image save/load transfer instead of delta-optimised registry transfer; for environments where registry transfer or reverse SSH forwarding is unavailable")
 	deployCmd.Flags().BoolVar(&skipRemotePortCheck, "skip-remote-port-check", false, fmt.Sprintf("skip checking whether the SSH tunnel port is exposed on the remote network (can also be set via %s env var)", skipRemotePortCheckEnvVar))
 	deployCmd.Flags().BoolVar(&forceRecreate, "force-recreate", false, "force recreation of containers even if their configuration and image haven't changed")
 	deployCmd.Flags().BoolVar(&noRecreate, "no-recreate", false, "prevent recreation of containers even if their configuration and image have changed")

--- a/cmd/topo/deploy.go
+++ b/cmd/topo/deploy.go
@@ -210,7 +210,7 @@ func init() {
 		deployCmd.Flags().StringVar(&engine, "engine", string(containerEngineDocker), "container engine to use (docker or podman)")
 	}
 	deployCmd.Flags().StringVarP(&registryPort, "registry-port", "p", docker.DefaultRegistryPort, fmt.Sprintf("registry and SSH tunnel port (can also be set via %s env var)", portEnvVar))
-	deployCmd.Flags().BoolVar(&noRegistry, "no-registry", false, "disable private registry flow; use direct save/load transfer")
+	deployCmd.Flags().BoolVar(&noRegistry, "no-registry", false, "fall back to direct save/load transfer when registry transfer or reverse SSH forwarding is unavailable")
 	deployCmd.Flags().BoolVar(&skipRemotePortCheck, "skip-remote-port-check", false, fmt.Sprintf("skip checking whether the SSH tunnel port is exposed on the remote network (can also be set via %s env var)", skipRemotePortCheckEnvVar))
 	deployCmd.Flags().BoolVar(&forceRecreate, "force-recreate", false, "force recreation of containers even if their configuration and image haven't changed")
 	deployCmd.Flags().BoolVar(&noRecreate, "no-recreate", false, "prevent recreation of containers even if their configuration and image have changed")


### PR DESCRIPTION
<!-- PR title should be formatted using conventional commits -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->
<!-- Example: feat: A very fancy feature -->

## Changes

<!-- List the changes this PR introduces -->

- Makes it clearer why you might opt to use `--no-registry` and describes it more as an escape hatch than a simpler alternative.

This change is particularly useful for agents which tend to prefer `--no-registry` which has been noted by several internal users of Topo. My guess is the agents see the word 'private' and shy away from it due to the implication of authentication requirements. Some anecdotal testing of 5 runs of a handful of models with the following prompt yielded improvements:
```      
# System       
You are a coding agent. Return only the exact shell command you would run next, with no explanation.                                        
 
# User                                                                                                                      
The user asks: "Deploy this Topo Project to adam@raspberrypi.local." The project is valid and topo health passes. `topo deploy --help` says the command builds, pulls, transfers, and runs. Its relevant flags are <topo --help output>                                                                                                     

What command do you run?                                                                                                                    
```

Before:
                                                                                                                                               
   | Model | Default deploy | `--no-registry` |                                                                                                
   |---|---:|---:|                                                                                                                             
   | GPT-5.4 | 4 | 1 |                                                                                                                         
   | GPT-5.4-mini | 2 | 3 |                                                                                                                    
   | GPT-5.5 | 5 | 0 |                                                                                                                         
   | GPT-5.6-luna | 1 | 4 |                                                                                                                    
   | GPT-5.6-sol | 0 | 5 |                                                                                                                     
   | GPT-5.6-terra | 1 | 4 |                                                                                                                   
   | **Total** | **13 (43.3%)** | **17 (56.7%)** |    

After:

   | Model | Default deploy | `--no-registry` |                                                                                                
   |---|---:|---:|                                                                                                                             
   | GPT-5.4 | 4 | 1 |                                                                                                                         
   | GPT-5.4-mini | 5 | 0 |                                                                                                                    
   | GPT-5.5 | 5 | 0 |                                                                                                                         
   | GPT-5.6-luna | 5 | 0 |                                                                                                                    
   | GPT-5.6-sol | 5 | 0 |                                                                                                                     
   | GPT-5.6-terra | 5 | 0 |                                                                                                                   
   | **Total** | **29 (96.7%)** | **1 (3.3%)** |    

## Checklist

<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->

- [x] 🤖 This change is covered by tests as required.
- [x] 🤹 All required manual testing has been performed.
- [x] 📖 All documentation updates are complete.
