### PR TITLE
fix: single-quote known_hosts entries in fix commands

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -24,7 +24,7 @@ func QuoteArg(s string) string {
 		return "''"
 	}
 
-	if strings.ContainsAny(s, " \t\n\"'\\$`") {
+	if strings.ContainsAny(s, " \t\n\"'\\/[/]$`") {
 		return "'" + strings.ReplaceAll(s, "'", `'"'"'`) + "'"
 	}
 

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -55,6 +55,11 @@ func TestQuoteArg(t *testing.T) {
 			arg:  `C:\Users\runner\AppData\Local\Temp\custom-compose.yaml`,
 			want: `'C:\Users\runner\AppData\Local\Temp\custom-compose.yaml'`,
 		},
+		{
+			name: "arg with square brackets",
+			arg:  "custom[compose].yaml",
+			want: "'custom[compose].yaml'",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/arm/topo/internal/command"
 	"github.com/arm/topo/internal/probe"
 	"github.com/arm/topo/internal/runner"
 	"github.com/arm/topo/internal/ssh"
@@ -174,7 +175,7 @@ func connectivityCheck(status ConnectionStatus) HealthCheck {
 		sshConfig := ssh.NewConfig(status.Destination)
 		check.Fix = &Fix{
 			Description: "Remove the old SSH host key from known_hosts, then retry",
-			Command:     fmt.Sprintf("ssh-keygen -R %q", sshConfig.AsKnownHostsEntry()),
+			Command:     fmt.Sprintf("ssh-keygen -R %s", command.QuoteArg(sshConfig.AsKnownHostsEntry())),
 		}
 	}
 	return check

--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -133,7 +133,7 @@ func TestGenerateTargetReport(t *testing.T) {
 
 		assert.Equal(t, health.CheckStatusError, got.Connectivity.Status)
 		assert.Equal(t, "Remove the old SSH host key from known_hosts, then retry", got.Connectivity.Fix.Description)
-		assert.Equal(t, "ssh-keygen -R \"[my-target]:2222\"", got.Connectivity.Fix.Command)
+		assert.Equal(t, "ssh-keygen -R '[my-target]:2222'", got.Connectivity.Fix.Command)
 	})
 }
 


### PR DESCRIPTION
## Background

> All tested on Ubuntu 25 which contains [this downstreamed patch](https://sources.debian.org/patches/openssh/1%3A7.9p1-10%2Bdeb10u2/mention-ssh-keygen-on-keychange.patch/) that adds `-f` to the `ssh-keygen` help string. It's unrelated to the problem/fix but thought it was interesting!

Currently, the suggested fix quotes the known_hosts entry to avoid shells interpreting the square brackets in [ip]:port e.g. the user sees:
```
  Fix:
    Remove the old SSH host key from known_hosts, then retry
  Command:
    ssh-keygen -R "[x.y.z.w]:2222"
```

However, when you set -o json, since the value is itself in a JSON string and we use Go's `%q` fmt string quoting, the quotes get escaped:
```
      "fix": {
        "description": "Remove the old SSH host key from known_hosts, then retry",
        "command": "ssh-keygen -R \"[x.y.z.w]:2222\""
      }
```
Thus if a user copy-pastes out of the JSON output, the command will fail and if you're not well-versed in the escaping semantics of your shell of choice or not paying too much attention, it's hard to tell why:
```
> ssh-keygen -R \"[x.y.z.w]:2222\"
Host "[x.y.z.w]:2222" not found in /home/adahod01.guest/.ssh/known_hosts
```

## Changes

- Swaps the shell-escaping in the fix command to use the single quote arg util and not double. Adjusts the existing `command.QuoteArg` to quote when square brackets are included as these gets interpreted by shells like zsh. This means the JSON output fix can still be copy-pasted!

As a result, this does mean the copy-pastable command will not work in `cmd.exe` as it does not support single-quote escaping. However, we already use this quoting elsewhere and don't support installation of Topo from `cmd.exe` so this seems like a fair compromise.

## Checklist

<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->

- [x] 🤖 This change is covered by tests as required.
- [x] 🤹 All required manual testing has been performed.
- [x] 📖 All documentation updates are complete.
