### PR TITLE
feat!: allow skipping optional params at configure time

### DIFF
--- a/e2e/configure_test.go
+++ b/e2e/configure_test.go
@@ -76,7 +76,7 @@ func TestConfigure(t *testing.T) {
 		out, err := cmd.CombinedOutput()
 
 		require.Error(t, err)
-		assert.Contains(t, string(out), "unknown argument: UNKNOWN")
+		assert.Contains(t, string(out), "unknown parameter: UNKNOWN")
 		got := testutil.RequireReadFile(t, composePath)
 		assert.Equal(t, original, got)
 	})

--- a/internal/arguments/cli_provider.go
+++ b/internal/arguments/cli_provider.go
@@ -36,7 +36,7 @@ func (p *CLIProvider) Provide(args []Arg) ([]ResolvedArg, error) {
 
 	for key := range p.input {
 		if !seen[key] {
-			return nil, fmt.Errorf("unknown argument: %s", key)
+			return nil, fmt.Errorf("unknown parameter: %s", key)
 		}
 	}
 

--- a/internal/arguments/cli_provider_test.go
+++ b/internal/arguments/cli_provider_test.go
@@ -52,7 +52,7 @@ func TestCLIProvider(t *testing.T) {
 		assert.Contains(t, err.Error(), "invalid argument format")
 	})
 
-	t.Run("errors on unknown argument", func(t *testing.T) {
+	t.Run("errors on unknown parameter", func(t *testing.T) {
 		provider, err := arguments.NewCLIProvider([]string{"UNKNOWN=value"})
 		require.NoError(t, err)
 
@@ -63,7 +63,7 @@ func TestCLIProvider(t *testing.T) {
 		_, err = provider.Provide(args)
 
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "unknown argument: UNKNOWN")
+		assert.Contains(t, err.Error(), "unknown parameter: UNKNOWN")
 	})
 
 	t.Run("returns arguments in requested order", func(t *testing.T) {

--- a/internal/arguments/interactive_provider.go
+++ b/internal/arguments/interactive_provider.go
@@ -47,12 +47,14 @@ func (p *InteractiveProvider) Provide(args []Arg) ([]ResolvedArg, error) {
 			}
 		}
 
-		requiredLabel := ""
+		label := ""
 		if arg.Required {
-			requiredLabel = " (required)"
+			label = " (required)"
+		} else {
+			label = " (optional, press enter to skip)"
 		}
 
-		_, err = fmt.Fprintf(p.output, "%s%s> ", arg.Name, requiredLabel)
+		_, err = fmt.Fprintf(p.output, "%s%s> ", arg.Name, label)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/arguments/strict_provider_chain.go
+++ b/internal/arguments/strict_provider_chain.go
@@ -1,8 +1,9 @@
 package arguments
 
-import "strings"
-
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 // StrictProviderChain chains multiple providers and ensures all required arguments are resolved.
 // It stops early once all required arguments are satisfied.
@@ -37,10 +38,6 @@ func (p *StrictProviderChain) Provide(args []Arg) ([]ResolvedArg, error) {
 		if allRequiredProvided(args, provided) {
 			break
 		}
-	}
-
-	if len(remaining) > 0 {
-		defaultNonProvided(remaining, provided)
 	}
 
 	if err := validateRequiredProvided(args, provided); err != nil {
@@ -91,14 +88,6 @@ func allRequiredProvided(args []Arg, provided map[string]string) bool {
 		}
 	}
 	return true
-}
-
-func defaultNonProvided(remaining []Arg, provided map[string]string) {
-	for _, arg := range remaining {
-		if arg.Default != "" {
-			provided[arg.Name] = arg.Default
-		}
-	}
 }
 
 func validateRequiredProvided(args []Arg, provided map[string]string) error {

--- a/internal/arguments/strict_provider_chain_test.go
+++ b/internal/arguments/strict_provider_chain_test.go
@@ -160,13 +160,13 @@ func TestStrictMultiProvider(t *testing.T) {
 		assert.Equal(t, want, got)
 	})
 
-	t.Run("provides resolved args when default provided", func(t *testing.T) {
-		provider1 := arguments.NewStaticProvider()
-		multi := arguments.NewStrictProviderChain(provider1)
+	t.Run("does not provide defaults for omitted optional arguments", func(t *testing.T) {
+		provider := arguments.NewStaticProvider()
+		multi := arguments.NewStrictProviderChain(provider)
 		args := []arguments.Arg{
 			{
 				Name:     "CINNAMON",
-				Required: true,
+				Required: false,
 				Default:  "filled",
 			},
 		}
@@ -174,10 +174,7 @@ func TestStrictMultiProvider(t *testing.T) {
 		got, err := multi.Provide(args)
 
 		require.NoError(t, err)
-		want := []arguments.ResolvedArg{
-			{Name: "CINNAMON", Value: "filled"},
-		}
-		assert.Equal(t, want, got)
+		assert.Empty(t, got)
 	})
 
 	t.Run("does not provide resolved args when no default provided", func(t *testing.T) {

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -159,4 +159,27 @@ x-topo:
 
 		assert.YAMLEq(t, want, got)
 	})
+
+	t.Run("leaves skipped optional parameters unchanged", func(t *testing.T) {
+		dir := t.TempDir()
+		composeFileContents := `services:
+  app:
+    build:
+      args:
+        FOO: current
+x-topo:
+  parameters:
+    FOO:
+      required: false
+      default: default
+`
+		composeFilePath := filepath.Join(dir, project.ComposeFilename)
+		testutil.RequireWriteFile(t, composeFilePath, composeFileContents)
+		argProvider := arguments.NewStrictProviderChain(arguments.NewStaticProvider())
+
+		err := project.ResolveAndApplyArgs(composeFilePath, argProvider)
+
+		require.NoError(t, err)
+		assert.Equal(t, composeFileContents, testutil.RequireReadFile(t, composeFilePath))
+	})
 }


### PR DESCRIPTION
<!-- PR title should be formatted using conventional commits -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->
<!-- Example: feat: A very fancy feature -->

## Changes

<!-- List the changes this PR introduces -->

- Allows the omission of optional parameters when running `topo configure` - both interactively and non-interactively with CLI args
- Renames "argument" in an error message to "parameter" as that's the current terminology. Not strictly atomic so can split if contentious.

Breaking as previously any omitted optional parameters would just be set to the topo-defined default value.

Note this doesn't affect required parameters, even if already set. This is because to achieve this we need to parse the compose file and grab all the current values but currently `topo configure` (and clone) already open the file twice in different ways each with their own issues. Suggest refactoring to read once up front, inspect, mutate and write before thinking about this. It'd also be nice to display the current build arg value(s) for a given parameter when running interactive `topo configure`.

<img width="589" height="80" alt="Screenshot 2026-08-11 at 16 02 45" src="https://github.com/user-attachments/assets/a533a9b1-8b1f-4d1e-9c1c-4e01ed55599e" />


## Checklist

<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->

- [x] 🤖 This change is covered by tests as required.
- [x] 🤹 All required manual testing has been performed.
- [x] 📖 All documentation updates are complete.
