### PR TITLE
fix: ensure topo parameters are always applied to extending services

### DIFF
--- a/internal/compose/yaml.go
+++ b/internal/compose/yaml.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"sort"
 	"strings"
 
 	"github.com/arm/topo/internal/output/logger"
@@ -44,35 +43,31 @@ func ApplyArgs(root *yaml.Node, toApply map[string]string) error {
 
 	for i := 0; i < len(services.Content); i += 2 {
 		svc := services.Content[i+1]
-		hasExtends := find(svc, "extends") != nil
-		build := find(svc, "build")
+		addMissing := find(svc, "extends") != nil
 
+		build := find(svc, "build")
 		if build == nil {
-			if !hasExtends {
+			if !addMissing {
 				continue
 			}
-			argsNode := newArgsMappingNode(toApply, used)
-			build = &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
-			build.Content = append(build.Content, scalarNode("args"), argsNode)
+			build = mappingNode()
 			svc.Content = append(svc.Content, scalarNode("build"), build)
-			continue
 		}
 
 		args := find(build, "args")
 		if args == nil {
-			if !hasExtends {
+			if !addMissing {
 				continue
 			}
-			argsNode := newArgsMappingNode(toApply, used)
-			build.Content = append(build.Content, scalarNode("args"), argsNode)
-			continue
+			args = mappingNode()
+			build.Content = append(build.Content, scalarNode("args"), args)
 		}
 
 		switch args.Kind {
 		case yaml.MappingNode:
-			applyArgsMappingNode(args, toApply, used)
+			applyArgsMappingNode(args, toApply, used, addMissing)
 		case yaml.SequenceNode:
-			applyArgsSequenceNode(args, toApply, used)
+			applyArgsSequenceNode(args, toApply, used, addMissing)
 		default:
 			return fmt.Errorf("unsupported YAML node kind for build.args: %v", args.Kind)
 		}
@@ -100,7 +95,9 @@ func WriteNode(project *yaml.Node, target io.Writer) error {
 	return nil
 }
 
-func applyArgsMappingNode(args *yaml.Node, toApply map[string]string, used map[string]bool) {
+func applyArgsMappingNode(args *yaml.Node, toApply map[string]string, used map[string]bool, add bool) {
+	changed := map[string]bool{}
+
 	for j := 0; j < len(args.Content); j += 2 {
 		k := args.Content[j]
 		v := args.Content[j+1]
@@ -108,12 +105,24 @@ func applyArgsMappingNode(args *yaml.Node, toApply map[string]string, used map[s
 			if k.Value == argName {
 				v.Value = argValue
 				used[argName] = true
+				changed[argName] = true
+			}
+		}
+	}
+
+	if add && len(changed) < len(toApply) {
+		for argName, argValue := range toApply {
+			if !changed[argName] {
+				args.Content = append(args.Content, scalarNode(argName), scalarNode(argValue))
+				used[argName] = true
 			}
 		}
 	}
 }
 
-func applyArgsSequenceNode(args *yaml.Node, toApply map[string]string, used map[string]bool) {
+func applyArgsSequenceNode(args *yaml.Node, toApply map[string]string, used map[string]bool, add bool) {
+	changed := map[string]bool{}
+
 	for _, node := range args.Content {
 		name := node.Value
 
@@ -126,6 +135,16 @@ func applyArgsSequenceNode(args *yaml.Node, toApply map[string]string, used map[
 			if name == argName {
 				node.Value = fmt.Sprintf("%s=%s", argName, argValue)
 				used[argName] = true
+				changed[argName] = true
+			}
+		}
+	}
+
+	if add && len(changed) < len(toApply) {
+		for argName, argValue := range toApply {
+			if !changed[argName] {
+				args.Content = append(args.Content, scalarNode(fmt.Sprintf("%s=%s", argName, argValue)))
+				used[argName] = true
 			}
 		}
 	}
@@ -135,18 +154,8 @@ func scalarNode(value string) *yaml.Node {
 	return &yaml.Node{Kind: yaml.ScalarNode, Value: value, Tag: "!!str"}
 }
 
-func newArgsMappingNode(toApply map[string]string, used map[string]bool) *yaml.Node {
-	node := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
-	keys := make([]string, 0, len(toApply))
-	for k := range toApply {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	for _, name := range keys {
-		node.Content = append(node.Content, scalarNode(name), scalarNode(toApply[name]))
-		used[name] = true
-	}
-	return node
+func mappingNode() *yaml.Node {
+	return &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
 }
 
 func find(m *yaml.Node, key string) *yaml.Node {

--- a/internal/compose/yaml_test.go
+++ b/internal/compose/yaml_test.go
@@ -285,6 +285,46 @@ services:
 		assert.YAMLEq(t, want, string(got))
 	})
 
+	t.Run("extended services add resolved args missing from existing build args", func(t *testing.T) {
+		project := yamlToNode(t, `
+services:
+  mapping-args:
+    extends:
+      service: base
+    build:
+      args:
+        EXISTING: value
+  sequence-args:
+    extends:
+      service: base
+    build:
+      args: ["EXISTING=value"]
+`)
+		args := map[string]string{"PLATFORM": "my-cool-platform"}
+
+		err := compose.ApplyArgs(project, args)
+
+		require.NoError(t, err)
+		got, err := yaml.Marshal(project)
+		require.NoError(t, err)
+		want := `
+services:
+  mapping-args:
+    extends:
+      service: base
+    build:
+      args:
+        EXISTING: value
+        PLATFORM: my-cool-platform
+  sequence-args:
+    extends:
+      service: base
+    build:
+      args: ["EXISTING=value", "PLATFORM=my-cool-platform"]
+`
+		assert.YAMLEq(t, want, string(got))
+	})
+
 	t.Run("mixed services with extends and inline build args both get args applied", func(t *testing.T) {
 		project := yamlToNode(t, `
 services:


### PR DESCRIPTION
<!-- PR title should be formatted using conventional commits -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->
<!-- Example: feat: A very fancy feature -->

## Background

Currently when using `topo configure` (or clone) on a project which has services that extend other services, we create build args inconsistently e.g.

```yaml
services: 
  a-service: 
    platform: linux/arm64
    extends: 
      service: another-service
    build: 
      args: 
        SOMETHING: "test"
  a-second-service: 
    platform: linux/arm64
    extends: 
      service: another-service

x-topo: 
  parameters: 
    PARAM: 
      description: "a param"
```

Running `topo configure PARAM=a` here will yield the following result:

```yaml
services:
  a-service:
    platform: linux/arm64
    extends:
      service: another-service
    build:
      args:
        SOMETHING: "test"
  a-second-service:
    platform: linux/arm64
    extends:
      service: another-service
    build:
      args:
        PARAM: a
x-topo:
  parameters:
    PARAM:
      description: "a param"
```

The param was applied to `a-second-service` but not `a-service` because the latter already had some `build.args`! This could make `topo configure` unusable for more complex setups.

This PR ignores the fact that we indiscriminately write to services with `extends` clause regardless if the service being extended actually needs the arg because that's a can of worms that's not worth opening atm.


## Changes

<!-- List the changes this PR introduces -->

- Ensures we always add topo parameters to extending services regardless of the state of their current `build.args` block with a small refactor
  - We now ensure the existence of a `build.args` block in the outer loop but actually do the addition at the same time as mutating the args of each service, making the flow of the arg application more linear.

To address the indiscriminate writing to `compose.yaml` which the change exacerbates we can consider:
- Avoiding applying args to extending services entirely which I'm not sure we should be so opinionated about
- Parsing the compose project more intelligently to work out if the arg is specified anywhere in a service's inheritance stack. I _think_ we could achieve this with the compose Go library. Also presents an opportunity to ditch some custom yaml parsing/writing stuff which is a larger refactor hence not attempted here.

## Checklist

<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->

- [x] 🤖 This change is covered by tests as required.
- [x] 🤹 All required manual testing has been performed.
- [x] 📖 All documentation updates are complete.
