### PR TITLE
feat!: avoid adding build args to services using `extends`

### DIFF
--- a/internal/compose/yaml.go
+++ b/internal/compose/yaml.go
@@ -49,7 +49,7 @@ func ApplyArgs(root *yaml.Node, toApply map[string]string) error {
 		if args == nil {
 			if find(svc, "extends") != nil {
 				name := services.Content[i].Value
-				logger.Warn(fmt.Sprintf("service %q uses `extends` without `build.args`; inherited build args will not be configured. Declare the required args on this service, or set `build.args: {}` to silence this warning", name))
+				logger.Warn(fmt.Sprintf("service %q uses `extends` without `build.args`; inherited build args will not be configured. declare the required args on this service, or set `build.args: {}` to silence this warning", name))
 			}
 
 			continue

--- a/internal/compose/yaml.go
+++ b/internal/compose/yaml.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"sort"
 	"strings"
 
 	"github.com/arm/topo/internal/output/logger"
@@ -44,27 +43,15 @@ func ApplyArgs(root *yaml.Node, toApply map[string]string) error {
 
 	for i := 0; i < len(services.Content); i += 2 {
 		svc := services.Content[i+1]
-		hasExtends := find(svc, "extends") != nil
 		build := find(svc, "build")
-
-		if build == nil {
-			if !hasExtends {
-				continue
-			}
-			argsNode := newArgsMappingNode(toApply, used)
-			build = &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
-			build.Content = append(build.Content, scalarNode("args"), argsNode)
-			svc.Content = append(svc.Content, scalarNode("build"), build)
-			continue
-		}
-
 		args := find(build, "args")
+
 		if args == nil {
-			if !hasExtends {
-				continue
+			if find(svc, "extends") != nil {
+				name := services.Content[i].Value
+				logger.Warn(fmt.Sprintf("service %q uses 'extends' but no build args. Topo requires services to explicitly define build args for configuration and as such this service may not be fully configured. Add an empty `build.args` entry to the service to suppress this message", name))
 			}
-			argsNode := newArgsMappingNode(toApply, used)
-			build.Content = append(build.Content, scalarNode("args"), argsNode)
+
 			continue
 		}
 
@@ -131,25 +118,11 @@ func applyArgsSequenceNode(args *yaml.Node, toApply map[string]string, used map[
 	}
 }
 
-func scalarNode(value string) *yaml.Node {
-	return &yaml.Node{Kind: yaml.ScalarNode, Value: value, Tag: "!!str"}
-}
-
-func newArgsMappingNode(toApply map[string]string, used map[string]bool) *yaml.Node {
-	node := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
-	keys := make([]string, 0, len(toApply))
-	for k := range toApply {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	for _, name := range keys {
-		node.Content = append(node.Content, scalarNode(name), scalarNode(toApply[name]))
-		used[name] = true
-	}
-	return node
-}
-
 func find(m *yaml.Node, key string) *yaml.Node {
+	if m == nil {
+		return nil
+	}
+
 	for i := 0; i < len(m.Content); i += 2 {
 		if m.Content[i].Value == key {
 			return m.Content[i+1]

--- a/internal/compose/yaml.go
+++ b/internal/compose/yaml.go
@@ -49,7 +49,7 @@ func ApplyArgs(root *yaml.Node, toApply map[string]string) error {
 		if args == nil {
 			if find(svc, "extends") != nil {
 				name := services.Content[i].Value
-				logger.Warn(fmt.Sprintf("service %q uses 'extends' but no build args. Topo requires services to explicitly define build args for configuration and as such this service may not be fully configured. Add an empty `build.args` entry to the service to suppress this message", name))
+				logger.Warn(fmt.Sprintf("service %q uses `extends` without `build.args`; inherited build args will not be configured. Declare the required args on this service, or set `build.args: {}` to silence this warning", name))
 			}
 
 			continue

--- a/internal/compose/yaml_test.go
+++ b/internal/compose/yaml_test.go
@@ -191,69 +191,6 @@ services:
 		require.NoError(t, err)
 	})
 
-	t.Run("when service has extends and no build injects build args", func(t *testing.T) {
-		project := yamlToNode(t, `
-services:
-  zephyr:
-    extends:
-      file: zephyr-application/compose.yaml
-      service: zephyr
-`)
-		args := map[string]string{
-			"PLATFORM":   "stm32mp257",
-			"REMOTEPROC": "m33",
-		}
-
-		err := compose.ApplyArgs(project, args)
-
-		require.NoError(t, err)
-		got, err := yaml.Marshal(project)
-		require.NoError(t, err)
-		want := `
-services:
-  zephyr:
-    extends:
-      file: zephyr-application/compose.yaml
-      service: zephyr
-    build:
-      args:
-        PLATFORM: stm32mp257
-        REMOTEPROC: m33
-`
-		assert.YAMLEq(t, want, string(got))
-	})
-
-	t.Run("when service has extends and build but no args injects args", func(t *testing.T) {
-		project := yamlToNode(t, `
-services:
-  zephyr:
-    extends:
-      file: zephyr-application/compose.yaml
-      service: zephyr
-    build:
-      context: .
-`)
-		args := map[string]string{"PLATFORM": "stm32mp257"}
-
-		err := compose.ApplyArgs(project, args)
-
-		require.NoError(t, err)
-		got, err := yaml.Marshal(project)
-		require.NoError(t, err)
-		want := `
-services:
-  zephyr:
-    extends:
-      file: zephyr-application/compose.yaml
-      service: zephyr
-    build:
-      context: .
-      args:
-        PLATFORM: stm32mp257
-`
-		assert.YAMLEq(t, want, string(got))
-	})
-
 	t.Run("when service has extends and existing build args updates in place", func(t *testing.T) {
 		project := yamlToNode(t, `
 services:
@@ -279,44 +216,6 @@ services:
       file: zephyr-application/compose.yaml
       service: zephyr
     build:
-      args:
-        PLATFORM: stm32mp257
-`
-		assert.YAMLEq(t, want, string(got))
-	})
-
-	t.Run("mixed services with extends and inline build args both get args applied", func(t *testing.T) {
-		project := yamlToNode(t, `
-services:
-  zephyr:
-    extends:
-      file: zephyr-application/compose.yaml
-      service: zephyr
-  inline-svc:
-    build:
-      context: .
-      args:
-        PLATFORM: old-value
-`)
-		args := map[string]string{"PLATFORM": "stm32mp257"}
-
-		err := compose.ApplyArgs(project, args)
-
-		require.NoError(t, err)
-		got, err := yaml.Marshal(project)
-		require.NoError(t, err)
-		want := `
-services:
-  zephyr:
-    extends:
-      file: zephyr-application/compose.yaml
-      service: zephyr
-    build:
-      args:
-        PLATFORM: stm32mp257
-  inline-svc:
-    build:
-      context: .
       args:
         PLATFORM: stm32mp257
 `


### PR DESCRIPTION
<!-- PR title should be formatted using conventional commits -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->
<!-- Example: feat: A very fancy feature -->

## Background

See #409. This PR presents a simpler alternative to the solution implemented in #409 where we never add `build.args` to any service and only mutate existing ones. This is a simpler, more predictable and explainable solution.

## Changes

<!-- List the changes this PR introduces -->

- Avoids adding `build.args` to `extends`ing services, instead warning the user on how this works

I'm open to this approach or something like #409 to address the root problem but this PR is my personal preference.

## Checklist

<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->

- [x] 🤖 This change is covered by tests as required.
- [x] 🤹 All required manual testing has been performed.
- [x] 📖 All documentation updates are complete.
