### PR TITLE
refactor: decide about control sockets down the stack

### DIFF
--- a/cmd/topo/deploy.go
+++ b/cmd/topo/deploy.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
-	"runtime"
 	"strconv"
 	"strings"
 	"syscall"
@@ -116,7 +115,6 @@ func deployWithDocker(cmd *cobra.Command) error {
 		deployOpts.Registry = &docker.RegistryConfig{
 			Port:                resolvedPort,
 			SkipRemotePortCheck: resolveSkipRemotePortCheck(cmd),
-			UseControlSockets:   docker.SupportsSSHControlSockets(runtime.GOOS),
 		}
 	}
 	switch {

--- a/internal/deploy/docker/deploy.go
+++ b/internal/deploy/docker/deploy.go
@@ -22,7 +22,6 @@ type RegistryConfig struct {
 	ContainerName       string
 	Port                string
 	SkipRemotePortCheck bool
-	UseControlSockets   bool
 }
 
 type DeployOptions struct {
@@ -33,10 +32,6 @@ type DeployOptions struct {
 
 func SupportsRegistry(noRegistry bool, dest ssh.Destination) bool {
 	return !noRegistry && !dest.IsPlainLocalhost()
-}
-
-func SupportsSSHControlSockets(goos string) bool {
-	return goos != "windows"
 }
 
 func Deploy(ctx context.Context, output io.Writer, composeFile string, opts DeployOptions) error {
@@ -104,7 +99,7 @@ func transferImagesViaRegistry(ctx context.Context, output io.Writer, sourceHost
 	if err := term.PrintHeader(output, "Open registry SSH tunnel"); err != nil {
 		return err
 	}
-	tunnel, err := ssh.OpenTunnel(ctx, output, targetHost, opts.Port, opts.UseControlSockets)
+	tunnel, err := ssh.OpenTunnel(ctx, output, targetHost, opts.Port)
 	if err != nil {
 		return fmt.Errorf("failed to open SSH tunnel: %w; ensure port %s is free or specify a different one with `--registry-port`", err, opts.Port)
 	}

--- a/internal/deploy/docker/image_transfer_registry_test.go
+++ b/internal/deploy/docker/image_transfer_registry_test.go
@@ -39,7 +39,7 @@ func TestTransferImagesViaRegistry(t *testing.T) {
 	destinationHost := docker.NewHostFromDestination(destination)
 	requireImageDoesNotExist(t, destinationHost, imageName)
 
-	tunnel, err := ssh.OpenTunnel(context.Background(), os.Stdout, destination, registryPort, false)
+	tunnel, err := ssh.OpenTunnel(context.Background(), os.Stdout, destination, registryPort)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		assert.NoError(t, tunnel.Close(context.Background(), os.Stdout))

--- a/internal/ssh/tunnel.go
+++ b/internal/ssh/tunnel.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 
 	"github.com/arm/topo/internal/command"
 )
@@ -27,9 +28,9 @@ type Tunnel struct {
 	closed  bool
 }
 
-func OpenTunnel(ctx context.Context, w io.Writer, dest Destination, port string, useControlSockets bool) (*Tunnel, error) {
+func OpenTunnel(ctx context.Context, w io.Writer, dest Destination, port string) (*Tunnel, error) {
 	t := &Tunnel{
-		useControlSockets: useControlSockets,
+		useControlSockets: areControlSocketsSupported(),
 		dest:              dest.String(),
 	}
 
@@ -49,7 +50,7 @@ func OpenTunnel(ctx context.Context, w io.Writer, dest Destination, port string,
 	cmd.Stdout = w
 	cmd.Stderr = w
 
-	if useControlSockets {
+	if t.useControlSockets {
 		if err := cmd.Run(); err != nil {
 			return nil, command.FormatError(cmd.Args, err)
 		}
@@ -92,6 +93,10 @@ func (t *Tunnel) Close(ctx context.Context, w io.Writer) error {
 
 	t.closed = true
 	return nil
+}
+
+func areControlSocketsSupported() bool {
+	return runtime.GOOS != "windows"
 }
 
 func killCommand(cmd *exec.Cmd) error {

--- a/internal/ssh/tunnel_unix_test.go
+++ b/internal/ssh/tunnel_unix_test.go
@@ -9,9 +9,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
-	"syscall"
 	"testing"
 	"time"
 
@@ -25,7 +23,7 @@ func TestTunnel(t *testing.T) {
 		logPath := installFakeSSH(t)
 		destination := ssh.NewDestination("user@remote")
 
-		tunnel, openErr := ssh.OpenTunnel(context.Background(), io.Discard, destination, "1337", true)
+		tunnel, openErr := ssh.OpenTunnel(context.Background(), io.Discard, destination, "1337")
 		require.NoError(t, openErr)
 		closeErr := tunnel.Close(context.Background(), io.Discard)
 
@@ -43,7 +41,7 @@ func TestTunnel(t *testing.T) {
 		destination := ssh.NewDestination("user@remote")
 		var output bytes.Buffer
 
-		tunnel, err := ssh.OpenTunnel(context.Background(), &output, destination, "1337", true)
+		tunnel, err := ssh.OpenTunnel(context.Background(), &output, destination, "1337")
 
 		require.NoError(t, err)
 		t.Cleanup(func() {
@@ -53,26 +51,11 @@ func TestTunnel(t *testing.T) {
 		assert.Contains(t, output.String(), "ssh stderr")
 	})
 
-	t.Run("closes a running tunnel process", func(t *testing.T) {
-		logPath := installFakeSSH(t)
-		destination := ssh.NewDestination("user@remote")
-
-		tunnel, openErr := ssh.OpenTunnel(context.Background(), io.Discard, destination, "1338", false)
-		require.NoError(t, openErr)
-		pid := readSSHPID(t, logPath+".pid")
-		closeErr := tunnel.Close(context.Background(), io.Discard)
-
-		require.NoError(t, closeErr)
-		// ESRCH means no process exists with the supplied PID.
-		processErr := syscall.Kill(pid, 0)
-		assert.ErrorIs(t, processErr, syscall.ESRCH)
-	})
-
 	t.Run("close is idempotent", func(t *testing.T) {
 		logPath := installFakeSSH(t)
 		destination := ssh.NewDestination("user@remote")
 
-		tunnel, openErr := ssh.OpenTunnel(context.Background(), nil, destination, "1339", true)
+		tunnel, openErr := ssh.OpenTunnel(context.Background(), nil, destination, "1339")
 		require.NoError(t, openErr)
 		firstCloseErr := tunnel.Close(context.Background(), nil)
 		secondCloseErr := tunnel.Close(context.Background(), nil)
@@ -108,21 +91,6 @@ esac
 	t.Setenv("TOPO_TEST_SSH_LOG", logPath)
 	t.Setenv("PATH", directory+string(os.PathListSeparator)+os.Getenv("PATH"))
 	return logPath
-}
-
-func readSSHPID(t *testing.T, pidPath string) int {
-	t.Helper()
-
-	var pid int
-	require.Eventually(t, func() bool {
-		content, err := os.ReadFile(pidPath)
-		if err != nil {
-			return false
-		}
-		pid, err = strconv.Atoi(strings.TrimSpace(string(content)))
-		return err == nil
-	}, time.Second, 10*time.Millisecond)
-	return pid
 }
 
 func readSSHInvocations(t *testing.T, logPath string, count int) []string {


### PR DESCRIPTION
<!-- PR title should be formatted using conventional commits -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->
<!-- Example: feat: A very fancy feature -->
## Background

We have this awkward situation where low level code supports opting in to using control sockets, while in reality we always use them unless the underlying OS/SSH doesn’t support it. This PR simplifies the code, to make that OS/SSH decision down. the stack, where the control sockets are used.


## Changes

<!-- List the changes this PR introduces -->

- Drop configurable control sockets
    - Unfortunate side effect: process path test is removed, I think it’s ok

## Checklist

<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->

- [x] 🤖 This change is covered by tests as required.
- [ ] 🤹 All required manual testing has been performed.
- [ ] 📖 All documentation updates are complete.
