### PR TITLE
feat: Experimental support for transferring images through registry via Podman

### DIFF
--- a/cmd/topo/deploy.go
+++ b/cmd/topo/deploy.go
@@ -36,8 +36,6 @@ const (
 	containerEnginePodman containerEngine = "podman"
 )
 
-var deployOpts docker.DeployOptions
-
 var deployCmd = &cobra.Command{
 	Use:   "deploy",
 	Short: "Deploy services using the compose file",
@@ -132,7 +130,7 @@ func deployWithDocker(cmd *cobra.Command, targetArg string) error {
 		return err
 	}
 
-	deployOpts.TargetHost = ssh.NewDestination(targetArg)
+	deployOpts := docker.DeployOptions{TargetHost: ssh.NewDestination(targetArg)}
 	if docker.SupportsRegistry(noRegistry, deployOpts.TargetHost) {
 		deployOpts.Registry = &docker.RegistryConfig{
 			Port:                resolvedPort,

--- a/cmd/topo/deploy.go
+++ b/cmd/topo/deploy.go
@@ -74,6 +74,10 @@ By default, Topo uses compose.yaml in the current working directory, then compos
 }
 
 func deployWithPodman(cmd *cobra.Command, targetArg string) error {
+	if cmd.Flags().Changed("registry-port") && noRegistry {
+		logger.Warn("--registry-port has no effect when --no-registry is set. Define a port in your ssh config instead.")
+	}
+
 	composeFile, err := getComposeFileName(cmd)
 	if err != nil {
 		return err
@@ -82,8 +86,27 @@ func deployWithPodman(cmd *cobra.Command, targetArg string) error {
 		return err
 	}
 
+	resolvedPort, err := resolvePort(cmd, registryPort)
+	if err != nil {
+		return err
+	}
+	if err := validatePort(resolvedPort); err != nil {
+		return err
+	}
+
+	targetHost := ssh.NewDestination(targetArg)
+	options := podman.DeployOptions{TargetHost: targetHost}
+	if podman.SupportsRegistry(noRegistry, targetHost) {
+		options.Registry = &podman.RegistryConfig{
+			Port:                resolvedPort,
+			SkipRemotePortCheck: resolveSkipRemotePortCheck(cmd),
+		}
+	}
+	if options.Registry == nil {
+		logger.Warn("registry transfer is not yet supported with this configuration. Falling back to direct transfer.")
+	}
+
 	return executeDeployment(cmd, func(ctx context.Context) error {
-		options := podman.DeployOptions{TargetHost: ssh.NewDestination(targetArg)}
 		return podman.Deploy(ctx, os.Stdout, composeFile, options)
 	})
 }

--- a/internal/deploy/docker/deploy.go
+++ b/internal/deploy/docker/deploy.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"time"
 
+	"github.com/arm/topo/internal/deploy"
 	"github.com/arm/topo/internal/deploy/post_deploy"
 	"github.com/arm/topo/internal/output/term"
 	"github.com/arm/topo/internal/ssh"
@@ -111,7 +112,7 @@ func transferImagesViaRegistry(ctx context.Context, output io.Writer, sourceHost
 		if err := term.PrintHeader(output, "Check registry tunnel is not exposed on remote network"); err != nil {
 			return err
 		}
-		if err := CheckTunnelExposure(ctx, output, targetHost, opts.Port); err != nil {
+		if err := deploy.CheckTunnelExposure(ctx, output, targetHost, opts.Port); err != nil {
 			return err
 		}
 	}

--- a/internal/deploy/docker/testutil_test.go
+++ b/internal/deploy/docker/testutil_test.go
@@ -14,10 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var (
-	dinDContainer            = gtestutil.DinDContainer
-	passwordlessSSHContainer = gtestutil.PasswordlessSSHContainer
-)
+var dinDContainer = gtestutil.DinDContainer
 
 func requireDocker(t *testing.T) {
 	t.Helper()

--- a/internal/deploy/podman/command.go
+++ b/internal/deploy/podman/command.go
@@ -12,6 +12,7 @@ import (
 const composeProvider = "docker-compose"
 
 func Command(ctx context.Context, socket Socket, args ...string) *exec.Cmd {
+	// #nosec G702 -- Podman arguments are passed directly, not interpreted by a shell.
 	cmd := exec.CommandContext(ctx, "podman", args...)
 	cmd.Env = socket.ConfigurePodmanEnv(os.Environ())
 	return cmd

--- a/internal/deploy/podman/command.go
+++ b/internal/deploy/podman/command.go
@@ -17,6 +17,16 @@ func Command(ctx context.Context, socket Socket, args ...string) *exec.Cmd {
 	return cmd
 }
 
+func RunCommand(ctx context.Context, output io.Writer, socket Socket, args ...string) error {
+	cmd := Command(ctx, socket, args...)
+	cmd.Stdout = output
+	cmd.Stderr = output
+	if err := cmd.Run(); err != nil {
+		return command.FormatError(cmd.Args, err)
+	}
+	return nil
+}
+
 func ComposeCommand(ctx context.Context, socket Socket, composeFile string, args ...string) (*exec.Cmd, error) {
 	composeArgs := append([]string{"compose", "-f", composeFile}, args...)
 	cmd := exec.CommandContext(ctx, "podman", composeArgs...)

--- a/internal/deploy/podman/deploy.go
+++ b/internal/deploy/podman/deploy.go
@@ -5,14 +5,28 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"time"
 
+	"github.com/arm/topo/internal/deploy/docker"
 	"github.com/arm/topo/internal/deploy/post_deploy"
 	"github.com/arm/topo/internal/output/term"
 	"github.com/arm/topo/internal/ssh"
 )
 
+const (
+	DefaultRegistryContainerName = "topo-registry"
+	tunnelCleanupTimeout         = 5 * time.Second
+)
+
+type RegistryConfig struct {
+	ContainerName       string
+	Port                string
+	SkipRemotePortCheck bool
+}
+
 type DeployOptions struct {
 	TargetHost ssh.Destination
+	Registry   *RegistryConfig
 }
 
 func Deploy(ctx context.Context, output io.Writer, composeFile string, options DeployOptions) (deployErr error) {
@@ -48,7 +62,11 @@ func Deploy(ctx context.Context, output io.Writer, composeFile string, options D
 		}()
 
 		targetSocket = NewSocket(tunnel.SocketURL())
-		if err := transferImagesViaPipe(ctx, output, LocalSocket, targetSocket, composeFile); err != nil {
+		if options.Registry == nil {
+			if err := transferImagesViaPipe(ctx, output, LocalSocket, targetSocket, composeFile); err != nil {
+				return err
+			}
+		} else if err := transferImagesViaRegistry(ctx, output, LocalSocket, options.TargetHost, targetSocket, composeFile, *options.Registry); err != nil {
 			return err
 		}
 	}
@@ -78,6 +96,59 @@ func transferImagesViaPipe(ctx context.Context, output io.Writer, sourceSocket, 
 		return err
 	}
 	return TransferImagesViaPipe(ctx, output, sourceSocket, targetSocket, composeFile)
+}
+
+func transferImagesViaRegistry(ctx context.Context, output io.Writer, sourceSocket Socket, targetDestination ssh.Destination, targetSocket Socket, composeFile string, options RegistryConfig) (transferErr error) {
+	if err := term.PrintHeader(output, "Run registry"); err != nil {
+		return err
+	}
+	registryContainerName := options.ContainerName
+	if registryContainerName == "" {
+		registryContainerName = DefaultRegistryContainerName
+	}
+	if err := EnsureRegistryRunning(ctx, output, registryContainerName, options.Port); err != nil {
+		return err
+	}
+
+	if err := term.PrintHeader(output, "Open registry SSH tunnel"); err != nil {
+		return err
+	}
+	registryTunnel, err := ssh.OpenTunnel(ctx, output, targetDestination, options.Port)
+	if err != nil {
+		return fmt.Errorf("failed to open SSH tunnel: %w; ensure port %s is free or specify a different one with --registry-port", err, options.Port)
+	}
+	defer func() {
+		transferErr = errors.Join(transferErr, closeRegistryTunnel(output, registryTunnel))
+	}()
+
+	if !targetDestination.IsLocalhost() && !options.SkipRemotePortCheck {
+		if err := term.PrintHeader(output, "Check registry tunnel is not exposed on remote network"); err != nil {
+			return err
+		}
+		if err := docker.CheckTunnelExposure(ctx, output, targetDestination, options.Port); err != nil {
+			return err
+		}
+	}
+
+	if err := term.PrintHeader(output, "Transfer via registry"); err != nil {
+		return err
+	}
+	return TransferImagesViaRegistry(ctx, output, sourceSocket, targetSocket, composeFile, options.Port)
+}
+
+func closeRegistryTunnel(output io.Writer, tunnel *ssh.Tunnel) error {
+	ctx, cancel := context.WithTimeout(context.Background(), tunnelCleanupTimeout)
+	defer cancel()
+
+	var headerError error
+	if output != nil {
+		headerError = term.PrintHeader(output, "Close registry SSH tunnel")
+	}
+	closeError := tunnel.Close(ctx, output)
+	if closeError != nil {
+		closeError = fmt.Errorf("failed to close SSH tunnel: %w", closeError)
+	}
+	return errors.Join(headerError, closeError)
 }
 
 func closeRemoteTunnel(tunnel *ssh.TCPToUnixSocketTunnel) error {

--- a/internal/deploy/podman/deploy.go
+++ b/internal/deploy/podman/deploy.go
@@ -29,6 +29,10 @@ type DeployOptions struct {
 	Registry   *RegistryConfig
 }
 
+func SupportsRegistry(noRegistry bool, destination ssh.Destination) bool {
+	return !noRegistry && !destination.IsPlainLocalhost()
+}
+
 func Deploy(ctx context.Context, output io.Writer, composeFile string, options DeployOptions) (deployErr error) {
 	if err := term.PrintHeader(output, "Build images"); err != nil {
 		return err

--- a/internal/deploy/podman/deploy.go
+++ b/internal/deploy/podman/deploy.go
@@ -73,11 +73,11 @@ func Deploy(ctx context.Context, output io.Writer, composeFile string, options D
 	return post_deploy.PrintDeploySuccess(output, composeFile, post_deploy.DefaultMessage(composeFile))
 }
 
-func transferImagesViaPipe(ctx context.Context, output io.Writer, source, destination Socket, composeFile string) error {
+func transferImagesViaPipe(ctx context.Context, output io.Writer, sourceSocket, targetSocket Socket, composeFile string) error {
 	if err := term.PrintHeader(output, "Transfer images"); err != nil {
 		return err
 	}
-	return TransferImagesViaPipe(ctx, output, source, destination, composeFile)
+	return TransferImagesViaPipe(ctx, output, sourceSocket, targetSocket, composeFile)
 }
 
 func closeRemoteTunnel(tunnel *ssh.TCPToUnixSocketTunnel) error {

--- a/internal/deploy/podman/deploy.go
+++ b/internal/deploy/podman/deploy.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"time"
 
-	"github.com/arm/topo/internal/deploy/docker"
+	"github.com/arm/topo/internal/deploy"
 	"github.com/arm/topo/internal/deploy/post_deploy"
 	"github.com/arm/topo/internal/output/term"
 	"github.com/arm/topo/internal/ssh"
@@ -129,7 +129,7 @@ func transferImagesViaRegistry(ctx context.Context, output io.Writer, sourceSock
 		if err := term.PrintHeader(output, "Check registry tunnel is not exposed on remote network"); err != nil {
 			return err
 		}
-		if err := docker.CheckTunnelExposure(ctx, output, targetDestination, options.Port); err != nil {
+		if err := deploy.CheckTunnelExposure(ctx, output, targetDestination, options.Port); err != nil {
 			return err
 		}
 	}

--- a/internal/deploy/podman/deploy_test.go
+++ b/internal/deploy/podman/deploy_test.go
@@ -51,7 +51,7 @@ func TestDeploy(t *testing.T) {
 	t.Run("transfers images to a remote host through a registry", func(t *testing.T) {
 		registryPort := requireAvailableTCPPort(t)
 		registryContainerName := "topo-test-registry-" + sanitiseTestName(t)
-		cleanupRegistryContainer(t, registryContainerName)
+		t.Cleanup(func() { cleanupRegistryContainer(t, registryContainerName) })
 		target := startContainer(t)
 		composeFile, projectName := deploymentFixture(t)
 		targetDestination := ssh.NewDestination(target.SSHDestination)
@@ -177,13 +177,10 @@ func fixPodmanInDockerQuirk(contents string) (string, error) {
 
 func cleanupRegistryContainer(t *testing.T, containerName string) {
 	t.Helper()
-	_ = podman.Command(t.Context(), podman.LocalSocket, "rm", "-f", containerName).Run()
-	t.Cleanup(func() {
-		output, err := podman.Command(context.Background(), podman.LocalSocket, "rm", "-f", containerName).CombinedOutput()
-		if err != nil {
-			t.Logf("failed to remove registry container: %v: %s", err, output)
-		}
-	})
+	output, err := podman.Command(context.Background(), podman.LocalSocket, "rm", "-f", containerName).CombinedOutput()
+	if err != nil {
+		t.Logf("failed to remove registry container: %v: %s", err, output)
+	}
 }
 
 func cleanupComposeProject(t *testing.T, composeFile string) {

--- a/internal/deploy/podman/deploy_test.go
+++ b/internal/deploy/podman/deploy_test.go
@@ -35,13 +35,13 @@ func TestDeploy(t *testing.T) {
 	t.Run("transfers images to a remote host via pipe", func(t *testing.T) {
 		target := gtestutil.StartContainer(t, gtestutil.PodmanContainer)
 		composeFile, projectName := deploymentFixture(t)
-		targetHost := ssh.NewDestination(target.SSHDestination)
-		options := podman.DeployOptions{TargetHost: targetHost}
+		targetDestination := ssh.NewDestination(target.SSHDestination)
+		options := podman.DeployOptions{TargetHost: targetDestination}
 
 		err := podman.Deploy(t.Context(), t.Output(), composeFile, options)
 
 		require.NoError(t, err)
-		tunnel, err := podman.TunnelRemoteSocketPath(context.Background(), t.Output(), targetHost)
+		tunnel, err := podman.TunnelRemoteSocketPath(context.Background(), t.Output(), targetDestination)
 		require.NoError(t, err)
 		t.Cleanup(func() {
 			require.NoError(t, tunnel.Close())

--- a/internal/deploy/podman/deploy_test.go
+++ b/internal/deploy/podman/deploy_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/arm/topo/internal/deploy/podman"
 	"github.com/arm/topo/internal/ssh"
-	gtestutil "github.com/arm/topo/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
@@ -33,10 +32,36 @@ func TestDeploy(t *testing.T) {
 	})
 
 	t.Run("transfers images to a remote host via pipe", func(t *testing.T) {
-		target := gtestutil.StartContainer(t, gtestutil.PodmanContainer)
+		target := startContainer(t)
 		composeFile, projectName := deploymentFixture(t)
 		targetDestination := ssh.NewDestination(target.SSHDestination)
 		options := podman.DeployOptions{TargetHost: targetDestination}
+
+		err := podman.Deploy(t.Context(), t.Output(), composeFile, options)
+
+		require.NoError(t, err)
+		tunnel, err := podman.TunnelRemoteSocketPath(context.Background(), t.Output(), targetDestination)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			require.NoError(t, tunnel.Close())
+		})
+		assertContainersRunning(t, projectName, podman.NewSocket(tunnel.SocketURL()))
+	})
+
+	t.Run("transfers images to a remote host through a registry", func(t *testing.T) {
+		registryPort := requireAvailableTCPPort(t)
+		registryContainerName := "topo-test-registry-" + sanitiseTestName(t)
+		cleanupRegistryContainer(t, registryContainerName)
+		target := startContainer(t)
+		composeFile, projectName := deploymentFixture(t)
+		targetDestination := ssh.NewDestination(target.SSHDestination)
+		options := podman.DeployOptions{
+			TargetHost: targetDestination,
+			Registry: &podman.RegistryConfig{
+				ContainerName: registryContainerName,
+				Port:          registryPort,
+			},
+		}
 
 		err := podman.Deploy(t.Context(), t.Output(), composeFile, options)
 
@@ -148,6 +173,17 @@ func fixPodmanInDockerQuirk(contents string) (string, error) {
 		return "", err
 	}
 	return string(updatedContents), nil
+}
+
+func cleanupRegistryContainer(t *testing.T, containerName string) {
+	t.Helper()
+	_ = podman.Command(t.Context(), podman.LocalSocket, "rm", "-f", containerName).Run()
+	t.Cleanup(func() {
+		output, err := podman.Command(context.Background(), podman.LocalSocket, "rm", "-f", containerName).CombinedOutput()
+		if err != nil {
+			t.Logf("failed to remove registry container: %v: %s", err, output)
+		}
+	})
 }
 
 func cleanupComposeProject(t *testing.T, composeFile string) {

--- a/internal/deploy/podman/deploy_test.go
+++ b/internal/deploy/podman/deploy_test.go
@@ -32,9 +32,9 @@ func TestDeploy(t *testing.T) {
 	})
 
 	t.Run("transfers images to a remote host via pipe", func(t *testing.T) {
-		target := startContainer(t)
+		podmanContainer := startPodmanInContainer(t)
 		composeFile, projectName := deploymentFixture(t)
-		targetDestination := ssh.NewDestination(target.SSHDestination)
+		targetDestination := ssh.NewDestination(podmanContainer.SSHDestination)
 		options := podman.DeployOptions{TargetHost: targetDestination}
 
 		err := podman.Deploy(t.Context(), t.Output(), composeFile, options)
@@ -52,9 +52,9 @@ func TestDeploy(t *testing.T) {
 		registryPort := requireAvailableTCPPort(t)
 		registryContainerName := "topo-test-registry-" + sanitiseTestName(t)
 		t.Cleanup(func() { cleanupRegistryContainer(t, registryContainerName) })
-		target := startContainer(t)
+		podmanContainer := startPodmanInContainer(t)
 		composeFile, projectName := deploymentFixture(t)
-		targetDestination := ssh.NewDestination(target.SSHDestination)
+		targetDestination := ssh.NewDestination(podmanContainer.SSHDestination)
 		options := podman.DeployOptions{
 			TargetHost: targetDestination,
 			Registry: &podman.RegistryConfig{

--- a/internal/deploy/podman/image_transfer_pipe.go
+++ b/internal/deploy/podman/image_transfer_pipe.go
@@ -9,7 +9,7 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-func TransferImagesViaPipe(ctx context.Context, output io.Writer, source, destination Socket, composeFile string) error {
+func TransferImagesViaPipe(ctx context.Context, output io.Writer, sourceSocket, targetSocket Socket, composeFile string) error {
 	images, err := compose.ImageNames(composeFile)
 	if err != nil {
 		return err
@@ -18,16 +18,16 @@ func TransferImagesViaPipe(ctx context.Context, output io.Writer, source, destin
 	var group errgroup.Group
 	for _, image := range images {
 		group.Go(func() error {
-			return transferImageViaPipe(ctx, output, source, destination, image)
+			return transferImageViaPipe(ctx, output, sourceSocket, targetSocket, image)
 		})
 	}
 	return group.Wait()
 }
 
-func transferImageViaPipe(ctx context.Context, output io.Writer, source, destination Socket, image string) error {
+func transferImageViaPipe(ctx context.Context, output io.Writer, sourceSocket, targetSocket Socket, image string) error {
 	pipeReader, pipeWriter := io.Pipe()
-	saveCommand := Command(ctx, source, "save", image)
-	loadCommand := Command(ctx, destination, "load")
+	saveCommand := Command(ctx, sourceSocket, "save", image)
+	loadCommand := Command(ctx, targetSocket, "load")
 	saveCommand.Stdout = pipeWriter
 	saveCommand.Stderr = output
 	loadCommand.Stdin = pipeReader

--- a/internal/deploy/podman/image_transfer_pipe_test.go
+++ b/internal/deploy/podman/image_transfer_pipe_test.go
@@ -18,8 +18,8 @@ func TestTransferImagesViaPipe(t *testing.T) {
 	requireLocalPodman(t)
 	composeFile, imageName := imageTransferFixture(t)
 	target := gtestutil.StartContainer(t, gtestutil.PodmanContainer)
-	targetHost := ssh.NewDestination(target.SSHDestination)
-	tunnel, err := podman.TunnelRemoteSocketPath(context.Background(), t.Output(), targetHost)
+	targetDestination := ssh.NewDestination(target.SSHDestination)
+	tunnel, err := podman.TunnelRemoteSocketPath(context.Background(), t.Output(), targetDestination)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		require.NoError(t, tunnel.Close())

--- a/internal/deploy/podman/image_transfer_pipe_test.go
+++ b/internal/deploy/podman/image_transfer_pipe_test.go
@@ -2,10 +2,7 @@ package podman_test
 
 import (
 	"context"
-	"fmt"
-	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/arm/topo/internal/deploy/podman"
 	"github.com/arm/topo/internal/ssh"
@@ -38,24 +35,4 @@ func assertImageExists(t *testing.T, socket podman.Socket, imageName string) {
 	t.Helper()
 	err := podman.Command(t.Context(), socket, "image", "exists", imageName).Run()
 	assert.NoError(t, err)
-}
-
-func imageTransferFixture(t *testing.T) (string, string) {
-	t.Helper()
-	temporaryDirectory := t.TempDir()
-	composeFile := filepath.Join(temporaryDirectory, "compose.yaml")
-	imageName := "test-image-" + sanitiseTestName(t)
-	requireWriteFile(t, composeFile, fmt.Sprintf(`
-services:
-  test:
-    build: .
-    image: %s
-`, imageName))
-	requireWriteFile(t, filepath.Join(temporaryDirectory, "Dockerfile"), "FROM docker.io/library/alpine:latest\n")
-	t.Cleanup(func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer cancel()
-		_ = podman.Command(ctx, podman.LocalSocket, "image", "rm", "-f", imageName).Run()
-	})
-	return composeFile, imageName
 }

--- a/internal/deploy/podman/image_transfer_registry.go
+++ b/internal/deploy/podman/image_transfer_registry.go
@@ -2,6 +2,7 @@ package podman
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -46,7 +47,7 @@ func tagImageForRegistry(ctx context.Context, output io.Writer, sourceSocket Soc
 	return RunCommand(ctx, output, sourceSocket, "tag", image, registryTag)
 }
 
-func pushImageToRegistry(ctx context.Context, output io.Writer, sourceSocket Socket, registryTag string) (string, error) {
+func pushImageToRegistry(ctx context.Context, output io.Writer, sourceSocket Socket, registryTag string) (digestReference string, pushErr error) {
 	digestFile, err := os.CreateTemp("", "topo-registry-digest-*")
 	if err != nil {
 		return "", fmt.Errorf("create registry digest file: %w", err)
@@ -55,11 +56,17 @@ func pushImageToRegistry(ctx context.Context, output io.Writer, sourceSocket Soc
 	if err := digestFile.Close(); err != nil {
 		return "", fmt.Errorf("close registry digest file: %w", err)
 	}
-	defer os.Remove(digestFilePath)
+	defer func() {
+		// #nosec G703 -- digestFilePath is returned by os.CreateTemp.
+		if err := os.Remove(digestFilePath); err != nil {
+			pushErr = errors.Join(pushErr, fmt.Errorf("remove registry digest file: %w", err))
+		}
+	}()
 
 	if err := RunCommand(ctx, output, sourceSocket, "push", "--tls-verify=false", "--digestfile", digestFilePath, registryTag); err != nil {
 		return "", err
 	}
+	// #nosec G703 -- digestFilePath is returned by os.CreateTemp.
 	digestBytes, err := os.ReadFile(digestFilePath)
 	if err != nil {
 		return "", fmt.Errorf("read registry digest file: %w", err)

--- a/internal/deploy/podman/image_transfer_registry.go
+++ b/internal/deploy/podman/image_transfer_registry.go
@@ -1,0 +1,80 @@
+package podman
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/arm/topo/internal/compose"
+)
+
+func TransferImagesViaRegistry(ctx context.Context, output io.Writer, sourceSocket, targetSocket Socket, composeFile, port string) error {
+	images, err := compose.ImageNames(composeFile)
+	if err != nil {
+		return err
+	}
+
+	for _, image := range images {
+		if err := transferImageViaRegistry(ctx, output, sourceSocket, targetSocket, port, image); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func transferImageViaRegistry(ctx context.Context, output io.Writer, sourceSocket, targetSocket Socket, port, image string) error {
+	registryTag := fmt.Sprintf("localhost:%s/%s", port, image)
+	if err := tagImageForRegistry(ctx, output, sourceSocket, image, registryTag); err != nil {
+		return err
+	}
+
+	digestReference, err := pushImageToRegistry(ctx, output, sourceSocket, registryTag)
+	if err != nil {
+		return err
+	}
+
+	if err := pullImageByDigest(ctx, output, targetSocket, digestReference); err != nil {
+		return err
+	}
+
+	return restoreOriginalImageTag(ctx, output, targetSocket, digestReference, image)
+}
+
+func tagImageForRegistry(ctx context.Context, output io.Writer, sourceSocket Socket, image, registryTag string) error {
+	return RunCommand(ctx, output, sourceSocket, "tag", image, registryTag)
+}
+
+func pushImageToRegistry(ctx context.Context, output io.Writer, sourceSocket Socket, registryTag string) (string, error) {
+	digestFile, err := os.CreateTemp("", "topo-registry-digest-*")
+	if err != nil {
+		return "", fmt.Errorf("create registry digest file: %w", err)
+	}
+	digestFilePath := digestFile.Name()
+	if err := digestFile.Close(); err != nil {
+		return "", fmt.Errorf("close registry digest file: %w", err)
+	}
+	defer os.Remove(digestFilePath)
+
+	if err := RunCommand(ctx, output, sourceSocket, "push", "--tls-verify=false", "--digestfile", digestFilePath, registryTag); err != nil {
+		return "", err
+	}
+	digestBytes, err := os.ReadFile(digestFilePath)
+	if err != nil {
+		return "", fmt.Errorf("read registry digest file: %w", err)
+	}
+	digest := strings.TrimSpace(string(digestBytes))
+	if digest == "" {
+		return "", fmt.Errorf("registry push did not write an image digest")
+	}
+	return fmt.Sprintf("%s@%s", registryTag, digest), nil
+}
+
+func pullImageByDigest(ctx context.Context, output io.Writer, targetSocket Socket, digestReference string) error {
+	return RunCommand(ctx, output, targetSocket, "pull", "--tls-verify=false", digestReference)
+}
+
+func restoreOriginalImageTag(ctx context.Context, output io.Writer, targetSocket Socket, digestReference, image string) error {
+	return RunCommand(ctx, output, targetSocket, "tag", digestReference, image)
+}

--- a/internal/deploy/podman/image_transfer_registry_test.go
+++ b/internal/deploy/podman/image_transfer_registry_test.go
@@ -1,0 +1,50 @@
+package podman_test
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/arm/topo/internal/deploy/podman"
+	"github.com/arm/topo/internal/ssh"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTransferImagesViaRegistry(t *testing.T) {
+	requireLocalPodman(t)
+	registryContainerName := "topo-test-registry-transfer-" + sanitiseTestName(t)
+	requireRegistryContainerAbsent(t, registryContainerName)
+	registryPort := requireAvailableTCPPort(t)
+	var output bytes.Buffer
+	require.NoError(t, podman.EnsureRegistryRunning(t.Context(), &output, registryContainerName, registryPort), output.String())
+
+	composeFile, imageName := imageTransferFixture(t)
+	require.NoError(t, podman.BuildImages(t.Context(), t.Output(), podman.LocalSocket, composeFile))
+	target := startContainer(t)
+	targetDestination := ssh.NewDestination(target.SSHDestination)
+	targetSocketTunnel, err := podman.TunnelRemoteSocketPath(context.Background(), t.Output(), targetDestination)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, targetSocketTunnel.Close())
+	})
+	targetSocket := podman.NewSocket(targetSocketTunnel.SocketURL())
+	assertImageDoesNotExist(t, targetSocket, imageName)
+
+	registryTunnel, err := ssh.OpenTunnel(context.Background(), t.Output(), targetDestination, registryPort, false)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		assert.NoError(t, registryTunnel.Close(context.Background(), t.Output()))
+	})
+
+	err = podman.TransferImagesViaRegistry(t.Context(), t.Output(), podman.LocalSocket, targetSocket, composeFile, registryPort)
+
+	require.NoError(t, err)
+	assertImageExists(t, targetSocket, imageName)
+}
+
+func assertImageDoesNotExist(t *testing.T, socket podman.Socket, imageName string) {
+	t.Helper()
+	err := podman.Command(t.Context(), socket, "image", "exists", imageName).Run()
+	assert.Error(t, err)
+}

--- a/internal/deploy/podman/image_transfer_registry_test.go
+++ b/internal/deploy/podman/image_transfer_registry_test.go
@@ -21,8 +21,8 @@ func TestTransferImagesViaRegistry(t *testing.T) {
 
 	composeFile, imageName := imageTransferFixture(t)
 	require.NoError(t, podman.BuildImages(t.Context(), t.Output(), podman.LocalSocket, composeFile))
-	target := startContainer(t)
-	targetDestination := ssh.NewDestination(target.SSHDestination)
+	podmanContainer := startPodmanInContainer(t)
+	targetDestination := ssh.NewDestination(podmanContainer.SSHDestination)
 	targetSocketTunnel, err := podman.TunnelRemoteSocketPath(context.Background(), t.Output(), targetDestination)
 	require.NoError(t, err)
 	t.Cleanup(func() {

--- a/internal/deploy/podman/image_transfer_registry_test.go
+++ b/internal/deploy/podman/image_transfer_registry_test.go
@@ -31,7 +31,7 @@ func TestTransferImagesViaRegistry(t *testing.T) {
 	targetSocket := podman.NewSocket(targetSocketTunnel.SocketURL())
 	assertImageDoesNotExist(t, targetSocket, imageName)
 
-	registryTunnel, err := ssh.OpenTunnel(context.Background(), t.Output(), targetDestination, registryPort, false)
+	registryTunnel, err := ssh.OpenTunnel(context.Background(), t.Output(), targetDestination, registryPort)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		assert.NoError(t, registryTunnel.Close(context.Background(), t.Output()))

--- a/internal/deploy/podman/registry.go
+++ b/internal/deploy/podman/registry.go
@@ -92,8 +92,8 @@ func runRegistryContainer(ctx context.Context, containerName, port string, outpu
 		return nil
 	}
 	commandErrorOutput := strings.ToLower(commandOutput.String())
-	// Linux's pasta backend reports "Address in use", while Podman machine's
-	// macOS port-forwarding proxy reports "proxy already running".
+	// Linux's pasta backend reports "Address in use",
+	// while Podman machine's macOS port-forwarding proxy reports "proxy already running".
 	if strings.Contains(commandErrorOutput, "address in use") || strings.Contains(commandErrorOutput, "proxy already running") {
 		return fmt.Errorf("%w\nport is already in use, this could be an existing %s or another process", err, containerName)
 	}

--- a/internal/deploy/podman/registry.go
+++ b/internal/deploy/podman/registry.go
@@ -92,9 +92,11 @@ func runRegistryContainer(ctx context.Context, containerName, port string, outpu
 		return nil
 	}
 	commandErrorOutput := strings.ToLower(commandOutput.String())
-	// Linux's pasta backend reports "Address in use",
+	// pasta reports either "Address in use" or "Address already in use",
 	// while Podman machine's macOS port-forwarding proxy reports "proxy already running".
-	if strings.Contains(commandErrorOutput, "address in use") || strings.Contains(commandErrorOutput, "proxy already running") {
+	if strings.Contains(commandErrorOutput, "address in use") ||
+		strings.Contains(commandErrorOutput, "address already in use") ||
+		strings.Contains(commandErrorOutput, "proxy already running") {
 		return fmt.Errorf("%w\nport is already in use, this could be an existing %s or another process", err, containerName)
 	}
 	return err

--- a/internal/deploy/podman/registry.go
+++ b/internal/deploy/podman/registry.go
@@ -1,0 +1,101 @@
+package podman
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+)
+
+const registryImage = "registry:2"
+
+// EnsureRegistryRunning pulls the registry image and starts the existing local
+// registry container, or creates it when it does not yet exist.
+func EnsureRegistryRunning(ctx context.Context, output io.Writer, containerName, port string) error {
+	if err := RunCommand(ctx, output, LocalSocket, "pull", registryImage); err != nil {
+		return err
+	}
+
+	if registryContainerExists(ctx, containerName) {
+		if err := validateRegistryPort(ctx, containerName, port); err != nil {
+			return err
+		}
+		return RunCommand(ctx, output, LocalSocket, "start", containerName)
+	}
+
+	return runRegistryContainer(ctx, containerName, port, output)
+}
+
+func registryContainerExists(ctx context.Context, containerName string) bool {
+	return RunCommand(ctx, io.Discard, LocalSocket, "inspect", containerName) == nil
+}
+
+func validateRegistryPort(ctx context.Context, containerName, requestedPort string) error {
+	cmd := Command(ctx, LocalSocket, "inspect", containerName)
+	output, err := cmd.Output()
+	if err != nil {
+		return fmt.Errorf("failed to execute %s: %w", strings.Join(cmd.Args, " "), err)
+	}
+
+	actualPort, err := registryHostPort(output)
+	if err != nil {
+		return fmt.Errorf("failed to inspect existing registry %s: %w", containerName, err)
+	}
+	if actualPort == requestedPort {
+		return nil
+	}
+	return fmt.Errorf("registry port mismatch (running: %s, requested: %s)\nyou may need to stop the existing %s: podman rm -f %s", actualPort, requestedPort, containerName, containerName)
+}
+
+func registryHostPort(inspectOutput []byte) (string, error) {
+	type portBinding struct {
+		HostPort string `json:"HostPort"`
+	}
+	type containerInspect struct {
+		HostConfig struct {
+			PortBindings map[string][]portBinding `json:"PortBindings"`
+		} `json:"HostConfig"`
+	}
+
+	var containers []containerInspect
+	if err := json.Unmarshal(inspectOutput, &containers); err != nil {
+		return "", fmt.Errorf("decode podman inspect output: %w", err)
+	}
+	if len(containers) != 1 {
+		return "", fmt.Errorf("expected one inspected container, got %d", len(containers))
+	}
+
+	bindings := containers[0].HostConfig.PortBindings["5000/tcp"]
+	if len(bindings) == 0 || bindings[0].HostPort == "" {
+		return "", fmt.Errorf("container port 5000 is not published")
+	}
+	return bindings[0].HostPort, nil
+}
+
+func runRegistryContainer(ctx context.Context, containerName, port string, output io.Writer) error {
+	var commandOutput bytes.Buffer
+	combinedOutput := io.MultiWriter(output, &commandOutput)
+	err := RunCommand(
+		ctx,
+		combinedOutput,
+		LocalSocket,
+		"run",
+		"-d",
+		"--restart", "always",
+		"-p", fmt.Sprintf("127.0.0.1:%s:5000", port),
+		"--name", containerName,
+		registryImage,
+	)
+	if err == nil {
+		return nil
+	}
+	commandErrorOutput := strings.ToLower(commandOutput.String())
+	// Linux's pasta backend reports "Address in use", while Podman machine's
+	// macOS port-forwarding proxy reports "proxy already running".
+	if strings.Contains(commandErrorOutput, "address in use") || strings.Contains(commandErrorOutput, "proxy already running") {
+		return fmt.Errorf("%w\nport is already in use, this could be an existing %s or another process", err, containerName)
+	}
+	return err
+}

--- a/internal/deploy/podman/registry_test.go
+++ b/internal/deploy/podman/registry_test.go
@@ -84,7 +84,6 @@ func TestEnsureRegistryRunning(t *testing.T) {
 
 		err = podman.EnsureRegistryRunning(t.Context(), &output, containerName, port)
 
-		t.Logf("registry port-conflict command output: %s", output.String())
 		require.Error(t, err)
 		assert.ErrorContains(t, err, fmt.Sprintf("port is already in use, this could be an existing %s or another process", containerName))
 	})

--- a/internal/deploy/podman/registry_test.go
+++ b/internal/deploy/podman/registry_test.go
@@ -1,0 +1,118 @@
+package podman_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/arm/topo/internal/deploy/podman"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnsureRegistryRunning(t *testing.T) {
+	requireLocalPodman(t)
+
+	t.Run("creates a registry when its container does not exist", func(t *testing.T) {
+		const containerName = "topo-test-registry-create"
+		requireRegistryContainerAbsent(t, containerName)
+		port := requireAvailableTCPPort(t)
+		var output bytes.Buffer
+
+		err := podman.EnsureRegistryRunning(t.Context(), &output, containerName, port)
+
+		require.NoError(t, err, output.String())
+		assertRegistryContainerRunning(t, containerName)
+		assertRegistryContainerPort(t, containerName, port)
+	})
+
+	t.Run("starts an existing stopped registry", func(t *testing.T) {
+		const containerName = "topo-test-registry-start"
+		requireRegistryContainerAbsent(t, containerName)
+		port := requireAvailableTCPPort(t)
+		var output bytes.Buffer
+		require.NoError(t, podman.EnsureRegistryRunning(t.Context(), &output, containerName, port), output.String())
+		stopOutput, err := podman.Command(t.Context(), podman.LocalSocket, "stop", containerName).CombinedOutput()
+		require.NoError(t, err, string(stopOutput))
+		output.Reset()
+
+		err = podman.EnsureRegistryRunning(t.Context(), &output, containerName, port)
+
+		require.NoError(t, err, output.String())
+		assertRegistryContainerRunning(t, containerName)
+		assertRegistryContainerPort(t, containerName, port)
+	})
+
+	t.Run("returns an error when an existing registry uses a different port", func(t *testing.T) {
+		const containerName = "topo-test-registry-port-mismatch"
+		requireRegistryContainerAbsent(t, containerName)
+		alreadyRunningOnPort := requireAvailableTCPPort(t)
+		newlyRequestedPort := requireAvailableTCPPort(t)
+		for newlyRequestedPort == alreadyRunningOnPort {
+			newlyRequestedPort = requireAvailableTCPPort(t)
+		}
+		var output bytes.Buffer
+		require.NoError(t, podman.EnsureRegistryRunning(t.Context(), &output, containerName, alreadyRunningOnPort), output.String())
+		output.Reset()
+
+		err := podman.EnsureRegistryRunning(t.Context(), &output, containerName, newlyRequestedPort)
+
+		require.Error(t, err)
+		assert.ErrorContains(t, err, fmt.Sprintf("registry port mismatch (running: %s, requested: %s)", alreadyRunningOnPort, newlyRequestedPort))
+		assert.ErrorContains(t, err, fmt.Sprintf("podman rm -f %s", containerName))
+	})
+
+	t.Run("adds a diagnostic when the registry port is already in use", func(t *testing.T) {
+		const containerName = "topo-test-registry-port-conflict"
+		requireRegistryContainerAbsent(t, containerName)
+		const portOwnerContainerName = "topo-test-registry-port-owner"
+		requireRegistryContainerAbsent(t, portOwnerContainerName)
+		port := requireAvailableTCPPort(t)
+		portOwnerOutput, err := podman.Command(
+			t.Context(),
+			podman.LocalSocket,
+			"run",
+			"-d",
+			"-p", fmt.Sprintf("127.0.0.1:%s:5000", port),
+			"--name", portOwnerContainerName,
+			"registry:2",
+		).CombinedOutput()
+		require.NoError(t, err, string(portOwnerOutput))
+		var output bytes.Buffer
+
+		err = podman.EnsureRegistryRunning(t.Context(), &output, containerName, port)
+
+		require.Error(t, err)
+		assert.ErrorContains(t, err, fmt.Sprintf("port is already in use, this could be an existing %s or another process", containerName))
+	})
+}
+
+func requireRegistryContainerAbsent(t *testing.T, containerName string) {
+	t.Helper()
+	inspectCommand := podman.Command(t.Context(), podman.LocalSocket, "inspect", containerName)
+	require.Error(t, inspectCommand.Run(), "container %s already exists", containerName)
+	t.Cleanup(func() {
+		removeOutput, err := podman.Command(context.Background(), podman.LocalSocket, "rm", "-f", containerName).CombinedOutput()
+		if err != nil && !strings.Contains(string(removeOutput), "no container with name or ID") {
+			t.Logf("failed to remove registry container: %v: %s", err, removeOutput)
+		}
+	})
+}
+
+func assertRegistryContainerRunning(t *testing.T, containerName string) {
+	t.Helper()
+	inspectCommand := podman.Command(t.Context(), podman.LocalSocket, "inspect", "--format", "{{.State.Running}}", containerName)
+	output, err := inspectCommand.CombinedOutput()
+	require.NoError(t, err, string(output))
+	assert.Equal(t, "true", strings.TrimSpace(string(output)))
+}
+
+func assertRegistryContainerPort(t *testing.T, containerName, port string) {
+	t.Helper()
+	portCommand := podman.Command(t.Context(), podman.LocalSocket, "port", containerName, "5000")
+	output, err := portCommand.CombinedOutput()
+	require.NoError(t, err, string(output))
+	assert.Equal(t, "127.0.0.1:"+port, strings.TrimSpace(string(output)))
+}

--- a/internal/deploy/podman/registry_test.go
+++ b/internal/deploy/podman/registry_test.go
@@ -84,6 +84,7 @@ func TestEnsureRegistryRunning(t *testing.T) {
 
 		err = podman.EnsureRegistryRunning(t.Context(), &output, containerName, port)
 
+		t.Logf("registry port-conflict command output: %s", output.String())
 		require.Error(t, err)
 		assert.ErrorContains(t, err, fmt.Sprintf("port is already in use, this could be an existing %s or another process", containerName))
 	})

--- a/internal/deploy/podman/testutil_test.go
+++ b/internal/deploy/podman/testutil_test.go
@@ -1,8 +1,13 @@
 package podman_test
 
 import (
+	"context"
+	"fmt"
+	"path/filepath"
 	"testing"
+	"time"
 
+	"github.com/arm/topo/internal/deploy/podman"
 	gtestutil "github.com/arm/topo/internal/testutil"
 )
 
@@ -24,4 +29,24 @@ func requireWriteFile(t *testing.T, path, content string) {
 func requireAvailableTCPPort(t *testing.T) string {
 	t.Helper()
 	return gtestutil.RequireAvailableTCPPort(t, "127.0.0.1")
+}
+
+func imageTransferFixture(t *testing.T) (string, string) {
+	t.Helper()
+	temporaryDirectory := t.TempDir()
+	composeFile := filepath.Join(temporaryDirectory, "compose.yaml")
+	imageName := "test-image-" + sanitiseTestName(t)
+	requireWriteFile(t, composeFile, fmt.Sprintf(`
+services:
+  test:
+    build: .
+    image: %s
+`, imageName))
+	requireWriteFile(t, filepath.Join(temporaryDirectory, "Dockerfile"), "FROM docker.io/library/alpine:latest\n")
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		_ = podman.Command(ctx, podman.LocalSocket, "image", "rm", "-f", imageName).Run()
+	})
+	return composeFile, imageName
 }

--- a/internal/deploy/podman/testutil_test.go
+++ b/internal/deploy/podman/testutil_test.go
@@ -16,7 +16,7 @@ func sanitiseTestName(t *testing.T) string {
 	return gtestutil.SanitiseTestName(t)
 }
 
-func startContainer(t *testing.T) *gtestutil.Container {
+func startPodmanInContainer(t *testing.T) *gtestutil.Container {
 	t.Helper()
 	return gtestutil.StartContainer(t, gtestutil.PodmanContainer)
 }

--- a/internal/deploy/podman/testutil_test.go
+++ b/internal/deploy/podman/testutil_test.go
@@ -11,7 +11,17 @@ func sanitiseTestName(t *testing.T) string {
 	return gtestutil.SanitiseTestName(t)
 }
 
+func startContainer(t *testing.T) *gtestutil.Container {
+	t.Helper()
+	return gtestutil.StartContainer(t, gtestutil.PodmanContainer)
+}
+
 func requireWriteFile(t *testing.T, path, content string) {
 	t.Helper()
 	gtestutil.RequireWriteFile(t, path, content)
+}
+
+func requireAvailableTCPPort(t *testing.T) string {
+	t.Helper()
+	return gtestutil.RequireAvailableTCPPort(t, "127.0.0.1")
 }

--- a/internal/deploy/tunnel_exposure_check.go
+++ b/internal/deploy/tunnel_exposure_check.go
@@ -1,4 +1,4 @@
-package docker
+package deploy
 
 import (
 	"context"

--- a/internal/deploy/tunnel_exposure_check_test.go
+++ b/internal/deploy/tunnel_exposure_check_test.go
@@ -1,4 +1,4 @@
-package docker_test
+package deploy_test
 
 import (
 	"context"
@@ -9,15 +9,16 @@ import (
 	"testing"
 	"time"
 
-	"github.com/arm/topo/internal/deploy/docker"
+	"github.com/arm/topo/internal/deploy"
 	"github.com/arm/topo/internal/ssh"
+	gtestutil "github.com/arm/topo/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestCheckTunnelExposure(t *testing.T) {
 	t.Run("fails when the SSH hostname cannot be resolved", func(t *testing.T) {
-		err := docker.CheckTunnelExposure(context.Background(), io.Discard, ssh.Destination{
+		err := deploy.CheckTunnelExposure(context.Background(), io.Discard, ssh.Destination{
 			Host: "not-a-host",
 		}, "12345")
 
@@ -27,25 +28,25 @@ func TestCheckTunnelExposure(t *testing.T) {
 	})
 
 	t.Run("succeeds when the remote port refuses the connection", func(t *testing.T) {
-		target := startContainer(t, passwordlessSSHContainer)
+		target := gtestutil.StartContainer(t, gtestutil.PasswordlessSSHContainer)
 		dest := ssh.NewDestination(target.SSHDestination)
 		port := "12345"
 		openSocket(t, dest, "127.0.0.1", port)
 		var output strings.Builder
 
-		err := docker.CheckTunnelExposure(context.Background(), &output, dest, port)
+		err := deploy.CheckTunnelExposure(context.Background(), &output, dest, port)
 
 		assert.NoError(t, err)
 		assert.Equal(t, fmt.Sprintf("Registry port %s is bound to remote loopback only\n", port), output.String())
 	})
 
 	t.Run("fails when the remote port accepts a connection", func(t *testing.T) {
-		target := startContainer(t, passwordlessSSHContainer)
+		target := gtestutil.StartContainer(t, gtestutil.PasswordlessSSHContainer)
 		dest := ssh.NewDestination(target.SSHDestination)
 		port := "12345"
 		openSocket(t, dest, "0.0.0.0", port)
 
-		err := docker.CheckTunnelExposure(context.Background(), io.Discard, dest, port)
+		err := deploy.CheckTunnelExposure(context.Background(), io.Discard, dest, port)
 
 		assert.EqualError(t, err, fmt.Sprintf("the remote SSH server is exposing forwarded registry port %s beyond remote loopback; configure the SSH server to bind remote forwards to loopback only, or use `--skip-remote-port-check` if you understand that the registry may be reachable without SSH authentication", port))
 	})


### PR DESCRIPTION
<!-- PR title should be formatted using conventional commits -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->
<!-- Example: feat: A very fancy feature -->

## Changes

<!-- List the changes this PR introduces —>

- Add Podman registry-backed image transfer, modelled as an almost like-for-like implementation of the Docker flow.
😱 I’m way outside of my comfort zone with the amount of undryness.

## Checklist

<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->

- [x] 🤖 This change is covered by tests as required.
- [ ] 🤹 All required manual testing has been performed.
- [ ] 📖 All documentation updates are complete.