### PR TITLE
refactor: use descriptive verbs for SSH config construction

### DIFF
--- a/cmd/topo/ps.go
+++ b/cmd/topo/ps.go
@@ -32,13 +32,9 @@ By default, Topo uses compose.yaml in the current working directory, then compos
 		}
 
 		dest := ssh.NewDestination(targetArg)
-		hostName := dest.Host
-		if !dest.IsPlainLocalhost() {
-			sshConfig, err := ssh.LoadConfig(dest)
-			if err != nil {
-				return err
-			}
-			hostName = sshConfig.HostName
+		hostName, err := ssh.ResolveHostName(dest)
+		if err != nil {
+			return err
 		}
 		allContainers, err := cmd.Flags().GetBool("all")
 		if err != nil {

--- a/cmd/topo/ps.go
+++ b/cmd/topo/ps.go
@@ -32,7 +32,7 @@ By default, Topo uses compose.yaml in the current working directory, then compos
 		}
 
 		dest := ssh.NewDestination(targetArg)
-		hostName, err := ssh.ResolveHostName(dest)
+		hostname, err := ssh.ResolveHostname(dest)
 		if err != nil {
 			return err
 		}
@@ -42,7 +42,7 @@ By default, Topo uses compose.yaml in the current working directory, then compos
 		}
 
 		host := docker.NewHostFromDestination(dest)
-		containers, err := docker.ListContainers(composeFile, host, hostName, allContainers)
+		containers, err := docker.ListContainers(composeFile, host, hostname, allContainers)
 		if err != nil {
 			return err
 		}

--- a/cmd/topo/ps.go
+++ b/cmd/topo/ps.go
@@ -32,7 +32,14 @@ By default, Topo uses compose.yaml in the current working directory, then compos
 		}
 
 		dest := ssh.NewDestination(targetArg)
-		hostName := ssh.NewConfig(dest).HostName
+		hostName := dest.Host
+		if !dest.IsPlainLocalhost() {
+			sshConfig, err := ssh.LoadConfig(dest)
+			if err != nil {
+				return err
+			}
+			hostName = sshConfig.HostName
+		}
 		allContainers, err := cmd.Flags().GetBool("all")
 		if err != nil {
 			panic("internal error: all flag not registered: " + err.Error())

--- a/internal/env/target.go
+++ b/internal/env/target.go
@@ -14,9 +14,17 @@ const (
 
 func SetTargetEnv(target string) error {
 	destination := ssh.NewDestination(target)
+	hostName := destination.Host
+	if !destination.IsPlainLocalhost() {
+		sshConfig, err := ssh.LoadConfig(destination)
+		if err != nil {
+			return err
+		}
+		hostName = sshConfig.HostName
+	}
 	vars := map[string]string{
 		TargetVariable:         destination.String(),
-		TargetHostnameVariable: ssh.NewConfig(destination).HostName,
+		TargetHostnameVariable: hostName,
 	}
 	for name, value := range vars {
 		if err := os.Setenv(name, value); err != nil {

--- a/internal/env/target.go
+++ b/internal/env/target.go
@@ -14,13 +14,13 @@ const (
 
 func SetTargetEnv(target string) error {
 	destination := ssh.NewDestination(target)
-	hostName, err := ssh.ResolveHostName(destination)
+	hostname, err := ssh.ResolveHostname(destination)
 	if err != nil {
 		return err
 	}
 	vars := map[string]string{
 		TargetVariable:         destination.String(),
-		TargetHostnameVariable: hostName,
+		TargetHostnameVariable: hostname,
 	}
 	for name, value := range vars {
 		if err := os.Setenv(name, value); err != nil {

--- a/internal/env/target.go
+++ b/internal/env/target.go
@@ -14,13 +14,9 @@ const (
 
 func SetTargetEnv(target string) error {
 	destination := ssh.NewDestination(target)
-	hostName := destination.Host
-	if !destination.IsPlainLocalhost() {
-		sshConfig, err := ssh.LoadConfig(destination)
-		if err != nil {
-			return err
-		}
-		hostName = sshConfig.HostName
+	hostName, err := ssh.ResolveHostName(destination)
+	if err != nil {
+		return err
 	}
 	vars := map[string]string{
 		TargetVariable:         destination.String(),

--- a/internal/env/target_test.go
+++ b/internal/env/target_test.go
@@ -10,6 +10,18 @@ import (
 )
 
 func TestSetTargetEnv(t *testing.T) {
+	t.Run("sets plain localhost without querying SSH config", func(t *testing.T) {
+		t.Setenv("PATH", "")
+		t.Setenv(env.TargetVariable, "ssh://stale.example")
+		t.Setenv(env.TargetHostnameVariable, "stale.example")
+
+		err := env.SetTargetEnv("localhost")
+
+		require.NoError(t, err)
+		assert.Equal(t, "ssh://localhost", os.Getenv(env.TargetVariable))
+		assert.Equal(t, "localhost", os.Getenv(env.TargetHostnameVariable))
+	})
+
 	t.Run("sets the resolved target environment", func(t *testing.T) {
 		t.Setenv(env.TargetVariable, "ssh://stale.example")
 		t.Setenv(env.TargetHostnameVariable, "stale.example")

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -172,10 +172,14 @@ func connectivityCheck(status ConnectionStatus) HealthCheck {
 			Command:     fmt.Sprintf("topo health --target %s --accept-new-host-keys", status.Destination),
 		}
 	case errors.Is(status.Error, probe.ErrHostKeyChanged):
-		sshConfig := ssh.NewConfig(status.Destination)
+		sshConfig, err := ssh.LoadConfig(status.Destination)
+		var fixCommand string
+		if err == nil {
+			fixCommand = fmt.Sprintf("ssh-keygen -R %s", command.QuoteArg(sshConfig.AsKnownHostsEntry()))
+		}
 		check.Fix = &Fix{
 			Description: "Remove the old SSH host key from known_hosts, then retry",
-			Command:     fmt.Sprintf("ssh-keygen -R %s", command.QuoteArg(sshConfig.AsKnownHostsEntry())),
+			Command:     fixCommand,
 		}
 	}
 	return check

--- a/internal/ssh/config.go
+++ b/internal/ssh/config.go
@@ -23,6 +23,18 @@ func LoadConfig(dest Destination) (Config, error) {
 	return ParseConfigFromBytes(output), nil
 }
 
+func ResolveHostName(dest Destination) (string, error) {
+	if dest.IsPlainLocalhost() {
+		return dest.Host, nil
+	}
+
+	config, err := LoadConfig(dest)
+	if err != nil {
+		return "", err
+	}
+	return config.HostName, nil
+}
+
 func ParseConfigFromBytes(data []byte) Config {
 	var config Config
 	scanner := bufio.NewScanner(bytes.NewReader(data))

--- a/internal/ssh/config.go
+++ b/internal/ssh/config.go
@@ -15,28 +15,15 @@ type Config struct {
 	Port     string
 }
 
-func NewConfig(dest Destination) Config {
-	output, err := readConfig(dest)
+func LoadConfig(dest Destination) (Config, error) {
+	output, err := queryConfig(dest)
 	if err != nil {
-		return Config{}
+		return Config{}, fmt.Errorf("failed to query SSH config for '%s': %w", dest.String(), err)
 	}
-	return NewConfigFromBytes(output)
+	return ParseConfigFromBytes(output), nil
 }
 
-func ResolveHostName(ctx context.Context, dest Destination) (string, error) {
-	output, err := readConfigContext(ctx, dest)
-	if err != nil {
-		return "", fmt.Errorf("could not resolve SSH configuration for %q: %w", dest.String(), err)
-	}
-
-	hostName := NewConfigFromBytes(output).HostName
-	if hostName == "" {
-		return "", fmt.Errorf("could not resolve SSH hostname for %q: SSH configuration did not provide a hostname", dest.String())
-	}
-	return hostName, nil
-}
-
-func NewConfigFromBytes(data []byte) Config {
+func ParseConfigFromBytes(data []byte) Config {
 	var config Config
 	scanner := bufio.NewScanner(bytes.NewReader(data))
 	for scanner.Scan() {
@@ -67,7 +54,7 @@ func (c Config) AsKnownHostsEntry() string {
 }
 
 func GetUserFromConfig(dest Destination) (string, error) {
-	output, err := readConfig(Destination{Host: dest.Host, Port: dest.Port})
+	output, err := queryConfig(Destination{Host: dest.Host, Port: dest.Port})
 	if err != nil {
 		return "", err
 	}
@@ -75,7 +62,7 @@ func GetUserFromConfig(dest Destination) (string, error) {
 }
 
 func ResolveConfiguredUser(dest Destination, configOutput []byte) (string, error) {
-	hostConfig := NewConfigFromBytes(configOutput)
+	hostConfig := ParseConfigFromBytes(configOutput)
 
 	if IsExplicitHostConfig(dest.Host, configOutput) {
 		if hostConfig.User != "" && dest.User != "" && hostConfig.User != dest.User {
@@ -125,10 +112,10 @@ func IsExplicitHostConfig(host string, config []byte) bool {
 	return false
 }
 
-func readConfig(dest Destination) ([]byte, error) {
-	return readConfigContext(context.Background(), dest)
+func queryConfig(dest Destination) ([]byte, error) {
+	return queryConfigContext(context.Background(), dest)
 }
 
-func readConfigContext(ctx context.Context, dest Destination) ([]byte, error) {
+func queryConfigContext(ctx context.Context, dest Destination) ([]byte, error) {
 	return exec.CommandContext(ctx, "ssh", "-v", "-G", dest.String()).CombinedOutput()
 }

--- a/internal/ssh/config.go
+++ b/internal/ssh/config.go
@@ -20,7 +20,7 @@ func LoadConfig(dest Destination) (Config, error) {
 	if err != nil {
 		return Config{}, fmt.Errorf("failed to query SSH config for '%s': %w", dest.String(), err)
 	}
-	return ParseConfigFromBytes(output), nil
+	return ParseConfig(output), nil
 }
 
 func ResolveHostName(dest Destination) (string, error) {
@@ -35,7 +35,7 @@ func ResolveHostName(dest Destination) (string, error) {
 	return config.HostName, nil
 }
 
-func ParseConfigFromBytes(data []byte) Config {
+func ParseConfig(data []byte) Config {
 	var config Config
 	scanner := bufio.NewScanner(bytes.NewReader(data))
 	for scanner.Scan() {
@@ -74,7 +74,7 @@ func GetUserFromConfig(dest Destination) (string, error) {
 }
 
 func ResolveConfiguredUser(dest Destination, configOutput []byte) (string, error) {
-	hostConfig := ParseConfigFromBytes(configOutput)
+	hostConfig := ParseConfig(configOutput)
 
 	if IsExplicitHostConfig(dest.Host, configOutput) {
 		if hostConfig.User != "" && dest.User != "" && hostConfig.User != dest.User {

--- a/internal/ssh/config.go
+++ b/internal/ssh/config.go
@@ -10,7 +10,7 @@ import (
 )
 
 type Config struct {
-	HostName string
+	Hostname string
 	User     string
 	Port     string
 }
@@ -23,7 +23,7 @@ func LoadConfig(dest Destination) (Config, error) {
 	return ParseConfig(output), nil
 }
 
-func ResolveHostName(dest Destination) (string, error) {
+func ResolveHostname(dest Destination) (string, error) {
 	if dest.IsPlainLocalhost() {
 		return dest.Host, nil
 	}
@@ -32,7 +32,7 @@ func ResolveHostName(dest Destination) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return config.HostName, nil
+	return config.Hostname, nil
 }
 
 func ParseConfig(data []byte) Config {
@@ -47,7 +47,7 @@ func ParseConfig(data []byte) Config {
 		}
 		switch strings.ToLower(fields[0]) {
 		case "hostname":
-			config.HostName = fields[1]
+			config.Hostname = fields[1]
 		case "user":
 			config.User = fields[1]
 		case "port":
@@ -59,10 +59,10 @@ func ParseConfig(data []byte) Config {
 
 func (c Config) AsKnownHostsEntry() string {
 	if c.Port == "" || c.Port == "22" {
-		return c.HostName
+		return c.Hostname
 	}
 
-	return fmt.Sprintf("[%s]:%s", c.HostName, c.Port)
+	return fmt.Sprintf("[%s]:%s", c.Hostname, c.Port)
 }
 
 func GetUserFromConfig(dest Destination) (string, error) {

--- a/internal/ssh/config_test.go
+++ b/internal/ssh/config_test.go
@@ -5,7 +5,19 @@ import (
 
 	"github.com/arm/topo/internal/ssh"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestResolveHostName(t *testing.T) {
+	t.Run("does not execute ssh for plain localhost", func(t *testing.T) {
+		t.Setenv("PATH", "") // remove SSH from path
+
+		got, err := ssh.ResolveHostName(ssh.PlainLocalhost)
+
+		require.NoError(t, err)
+		assert.Equal(t, "localhost", got)
+	})
+}
 
 func TestParseConfigFromBytes(t *testing.T) {
 	t.Run("parses basic config fields", func(t *testing.T) {

--- a/internal/ssh/config_test.go
+++ b/internal/ssh/config_test.go
@@ -7,14 +7,14 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestNewConfigFromBytes(t *testing.T) {
+func TestParseConfigFromBytes(t *testing.T) {
 	t.Run("parses basic config fields", func(t *testing.T) {
 		input := []byte(`hostname springfield.nuclear.gov
 user homer
 port 1234
 `)
 
-		got := ssh.NewConfigFromBytes(input)
+		got := ssh.ParseConfigFromBytes(input)
 
 		want := ssh.Config{
 			HostName: "springfield.nuclear.gov",
@@ -30,7 +30,7 @@ identityfile ~/.ssh/id_ed25519
 user homer
 `)
 
-		got := ssh.NewConfigFromBytes(input)
+		got := ssh.ParseConfigFromBytes(input)
 
 		want := ssh.Config{
 			HostName: "springfield.nuclear.gov",
@@ -40,7 +40,7 @@ user homer
 	})
 
 	t.Run("returns empty config for empty input", func(t *testing.T) {
-		got := ssh.NewConfigFromBytes([]byte{})
+		got := ssh.ParseConfigFromBytes([]byte{})
 
 		want := ssh.Config{}
 		assert.Equal(t, want, got)
@@ -49,7 +49,7 @@ user homer
 	t.Run("matching is case-insensitive", func(t *testing.T) {
 		input := []byte(`HoStNaMe kwik.e.mart`)
 
-		got := ssh.NewConfigFromBytes(input)
+		got := ssh.ParseConfigFromBytes(input)
 
 		want := ssh.Config{
 			HostName: "kwik.e.mart",

--- a/internal/ssh/config_test.go
+++ b/internal/ssh/config_test.go
@@ -8,11 +8,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestResolveHostName(t *testing.T) {
+func TestResolveHostname(t *testing.T) {
 	t.Run("does not execute ssh for plain localhost", func(t *testing.T) {
 		t.Setenv("PATH", "") // remove SSH from path
 
-		got, err := ssh.ResolveHostName(ssh.PlainLocalhost)
+		got, err := ssh.ResolveHostname(ssh.PlainLocalhost)
 
 		require.NoError(t, err)
 		assert.Equal(t, "localhost", got)
@@ -29,7 +29,7 @@ port 1234
 		got := ssh.ParseConfig(input)
 
 		want := ssh.Config{
-			HostName: "springfield.nuclear.gov",
+			Hostname: "springfield.nuclear.gov",
 			User:     "homer",
 			Port:     "1234",
 		}
@@ -45,7 +45,7 @@ user homer
 		got := ssh.ParseConfig(input)
 
 		want := ssh.Config{
-			HostName: "springfield.nuclear.gov",
+			Hostname: "springfield.nuclear.gov",
 			User:     "homer",
 		}
 		assert.Equal(t, want, got)
@@ -64,7 +64,7 @@ user homer
 		got := ssh.ParseConfig(input)
 
 		want := ssh.Config{
-			HostName: "kwik.e.mart",
+			Hostname: "kwik.e.mart",
 		}
 		assert.Equal(t, want, got)
 	})
@@ -78,17 +78,17 @@ func TestAsKnownHostsEntry(t *testing.T) {
 	}{
 		{
 			desc: "hostname without port",
-			cfg:  ssh.Config{HostName: "my-target"},
+			cfg:  ssh.Config{Hostname: "my-target"},
 			want: "my-target",
 		},
 		{
 			desc: "hostname with default ssh port",
-			cfg:  ssh.Config{HostName: "my-target", Port: "22"},
+			cfg:  ssh.Config{Hostname: "my-target", Port: "22"},
 			want: "my-target",
 		},
 		{
 			desc: "hostname with non-standard port",
-			cfg:  ssh.Config{HostName: "my-target", Port: "2222"},
+			cfg:  ssh.Config{Hostname: "my-target", Port: "2222"},
 			want: "[my-target]:2222",
 		},
 	}

--- a/internal/ssh/config_test.go
+++ b/internal/ssh/config_test.go
@@ -19,14 +19,14 @@ func TestResolveHostName(t *testing.T) {
 	})
 }
 
-func TestParseConfigFromBytes(t *testing.T) {
+func TestParseConfig(t *testing.T) {
 	t.Run("parses basic config fields", func(t *testing.T) {
 		input := []byte(`hostname springfield.nuclear.gov
 user homer
 port 1234
 `)
 
-		got := ssh.ParseConfigFromBytes(input)
+		got := ssh.ParseConfig(input)
 
 		want := ssh.Config{
 			HostName: "springfield.nuclear.gov",
@@ -42,7 +42,7 @@ identityfile ~/.ssh/id_ed25519
 user homer
 `)
 
-		got := ssh.ParseConfigFromBytes(input)
+		got := ssh.ParseConfig(input)
 
 		want := ssh.Config{
 			HostName: "springfield.nuclear.gov",
@@ -52,7 +52,7 @@ user homer
 	})
 
 	t.Run("returns empty config for empty input", func(t *testing.T) {
-		got := ssh.ParseConfigFromBytes([]byte{})
+		got := ssh.ParseConfig([]byte{})
 
 		want := ssh.Config{}
 		assert.Equal(t, want, got)
@@ -61,7 +61,7 @@ user homer
 	t.Run("matching is case-insensitive", func(t *testing.T) {
 		input := []byte(`HoStNaMe kwik.e.mart`)
 
-		got := ssh.ParseConfigFromBytes(input)
+		got := ssh.ParseConfig(input)
 
 		want := ssh.Config{
 			HostName: "kwik.e.mart",


### PR DESCRIPTION
<!-- PR title should be formatted using conventional commits -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->
<!-- Example: feat: A very fancy feature -->

## Changes

I noticed that `ssh.NewConfig` has a stateful side effect (exec'ing `ssh`) and discarded its errors. Because stateful calls are so critical for performance and reliability, I prefer it when function names make it clear that they are stateful, which, IMHO `NewConfig` does not. I recognise this may go slightly against the conventions for the use of `New` for constructors in this repo, so happy to debate this.

<!-- List the changes this PR introduces -->

- Renames: `ssh.NewConfig` -> `ssh.LoadConfig`
- Renames: `ssh.NewConfigFromBytes` -> `ssh.ParseConfig`
- Repurposes the previously unused `ResolveHostName` function, and then uses it
- Makes `ssh.LoadConfig` return an error, forcing callers to handle it

## Checklist

<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->

- [x] 🤖 This change is covered by tests as required.
- [x] 🤹 All required manual testing has been performed.
- [x] 📖 All documentation updates are complete.
