### PR TITLE
fix: remove misleading registry transfer warning

### DIFF
--- a/cmd/topo/deploy.go
+++ b/cmd/topo/deploy.go
@@ -94,14 +94,11 @@ func deployWithPodman(cmd *cobra.Command, targetArg string) error {
 
 	targetHost := ssh.NewDestination(targetArg)
 	options := podman.DeployOptions{TargetHost: targetHost}
-	if podman.SupportsRegistry(noRegistry, targetHost) {
+	if !noRegistry {
 		options.Registry = &podman.RegistryConfig{
 			Port:                resolvedPort,
 			SkipRemotePortCheck: resolveSkipRemotePortCheck(cmd),
 		}
-	}
-	if options.Registry == nil {
-		logger.Warn("registry transfer is not yet supported with this configuration. Falling back to direct transfer.")
 	}
 
 	return executeDeployment(cmd, func(ctx context.Context) error {
@@ -131,7 +128,7 @@ func deployWithDocker(cmd *cobra.Command, targetArg string) error {
 	}
 
 	deployOpts := docker.DeployOptions{TargetHost: ssh.NewDestination(targetArg)}
-	if docker.SupportsRegistry(noRegistry, deployOpts.TargetHost) {
+	if !noRegistry {
 		deployOpts.Registry = &docker.RegistryConfig{
 			Port:                resolvedPort,
 			SkipRemotePortCheck: resolveSkipRemotePortCheck(cmd),
@@ -142,10 +139,6 @@ func deployWithDocker(cmd *cobra.Command, targetArg string) error {
 		deployOpts.RecreateMode = docker.RecreateModeForce
 	case noRecreate:
 		deployOpts.RecreateMode = docker.RecreateModeNone
-	}
-
-	if deployOpts.Registry == nil {
-		logger.Warn("registry transfer is not yet supported with this configuration. Falling back to direct transfer.")
 	}
 
 	return executeDeployment(cmd, func(ctx context.Context) error {

--- a/internal/deploy/docker/deploy.go
+++ b/internal/deploy/docker/deploy.go
@@ -31,10 +31,6 @@ type DeployOptions struct {
 	Registry     *RegistryConfig
 }
 
-func SupportsRegistry(noRegistry bool, dest ssh.Destination) bool {
-	return !noRegistry && !dest.IsPlainLocalhost()
-}
-
 func Deploy(ctx context.Context, output io.Writer, composeFile string, opts DeployOptions) error {
 	sourceHost := LocalHost
 

--- a/internal/deploy/podman/deploy.go
+++ b/internal/deploy/podman/deploy.go
@@ -29,10 +29,6 @@ type DeployOptions struct {
 	Registry   *RegistryConfig
 }
 
-func SupportsRegistry(noRegistry bool, destination ssh.Destination) bool {
-	return !noRegistry && !destination.IsPlainLocalhost()
-}
-
 func Deploy(ctx context.Context, output io.Writer, composeFile string, options DeployOptions) (deployErr error) {
 	if err := term.PrintHeader(output, "Build images"); err != nil {
 		return err


### PR DESCRIPTION
## Changes

- Configure registry transfer based only on `--no-registry`
    - The deployment flow checks for `localhost` anyway 
- Remove the inaccurate fallback warning
    - It displayed when `--no-registry` was passed, which was odd
    - It claimed defaulting to direct transfer, while in reality it was no transfer at all

## Checklist

- [ ] 🤖 This change is covered by tests as required.
- [ ] 🤹 All required manual testing has been performed.
- [ ] 📖 All documentation updates are complete.