### PR TITLE
docs: link out to container engine install from health

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,18 +63,18 @@ Not sure what these terms mean? The [glossary](docs/introduction/glossary.md) de
 
 **Host machine** (where you run `topo`):
 
-- [Docker](#install-docker)
+- [Docker](#install-a-container-engine)
 - OpenSSH Client
 
 **Target machine** (the remote Arm system):
 
 - Reachable with SSH
 - Linux on ARM64
-- [Docker](#install-docker)
+- [Docker](#install-a-container-engine)
 
 The host and target can be the same system. If you're working directly on an Arm Linux system, use `--target localhost`.
 
-### Install Docker
+### Install a Container Engine
 
 See [Install Docker for Topo](docs/introduction/container-engines.md) for supported installation methods and verification steps.
 

--- a/internal/health/check.go
+++ b/internal/health/check.go
@@ -116,7 +116,7 @@ func (c DockerComposeMinVersion) Run(ctx context.Context, r runner.Runner, _ Dep
 
 	if !version.IsAtLeastVersion(output.Version, c.MinVersion) {
 		return &Fix{
-			Description: fmt.Sprintf("Upgrade Docker Compose to version %s or later", c.MinVersion),
+			Description: fmt.Sprintf("Upgrade Docker Compose to version %s or later. See %s", c.MinVersion, containerEngineInstallURL),
 		}, fmt.Errorf("installed docker compose version %s is older than required version %s", output.Version, c.MinVersion)
 	}
 

--- a/internal/health/dependencies.go
+++ b/internal/health/dependencies.go
@@ -26,6 +26,8 @@ const (
 
 type SoftwareDependency int
 
+const containerEngineInstallURL = "https://github.com/arm/topo#install-a-container-engine"
+
 const (
 	UnsetSoftwareDependency SoftwareDependency = iota
 	Docker
@@ -84,10 +86,16 @@ var HostRequiredDependencies = []Dependency{
 		Label:          "Container Engine",
 		SoftwareEnumID: Docker,
 		Checks: []Check{
-			BinaryExists{},
+			BinaryExists{
+				Fix: &Fix{
+					Description: "Install a supported container engine. See " + containerEngineInstallURL,
+				},
+			},
 			CommandSuccessful{
 				Cmd: "docker info",
-				Fix: &Fix{Description: "Ensure current user can run docker commands"},
+				Fix: &Fix{
+					Description: "Ensure current user can run docker commands. See " + containerEngineInstallURL,
+				},
 			},
 		},
 	},
@@ -99,7 +107,7 @@ var HostRequiredDependencies = []Dependency{
 			CommandSuccessful{
 				Cmd: "docker compose",
 				Fix: &Fix{
-					Description: "Ensure Docker Compose is installed as a plugin for Docker",
+					Description: "Ensure Docker Compose is installed as a plugin for Docker. See " + containerEngineInstallURL,
 				},
 			},
 			DockerComposeMinVersion{
@@ -116,10 +124,16 @@ func TargetRequiredDependencies(target ssh.Destination) []Dependency {
 			Label:          "Container Engine",
 			SoftwareEnumID: Docker,
 			Checks: []Check{
-				BinaryExists{},
+				BinaryExists{
+					Fix: &Fix{
+						Description: "Install a supported container engine. See " + containerEngineInstallURL,
+					},
+				},
 				CommandSuccessful{
 					Cmd: "docker info",
-					Fix: &Fix{Description: "Ensure current user can run docker commands"},
+					Fix: &Fix{
+						Description: "Ensure current user can run docker commands. See " + containerEngineInstallURL,
+					},
 				},
 			},
 		},


### PR DESCRIPTION
<!-- PR title should be formatted using conventional commits -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->
<!-- Example: feat: A very fancy feature -->

## Changes

<!-- List the changes this PR introduces -->

- As title says
- Renames 'Install Docker' to 'Install a Container Engine' in `README.md` since it needs to be a bit more future-proof given the CLI links to it now. Considered using perma-links generated in the CLI but felt kinda nasty.

```
Host
----
Topo: ✅ (topo)
OpenSSH: ✅ (ssh)
Container Engine: ❌ ("docker" not found in $PATH)
  Fix:
    Install a supported container engine. See https://github.com/arm/topo#install-a-container-engine
```

```
Host
----
Topo: ✅ (topo)
OpenSSH: ✅ (ssh)
Container Engine: ✅ (docker)
Docker Compose: ❌ (local command failed: exit status 1 | stderr: docker: unknown command: docker compose

Run 'docker --help' for more information
)
  Fix:
    Ensure Docker Compose is installed as a plugin for Docker. See https://github.com/arm/topo#install-a-container-engine

Target
------
ℹ️ provide --target or set TOPO_TARGET to check target health
```


## Checklist

<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->

- [x] 🤖 This change is covered by tests as required.
- [x] 🤹 All required manual testing has been performed.
- [x] 📖 All documentation updates are complete.
