### PR TITLE
chore: Revert "fix: support `runtime:` when deploying via Podman"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -80,19 +80,31 @@ jobs:
           #  Windows ssh-keyscan has KexAlgorithm limitations so use ssh to add host key - https://github.com/PowerShell/Win32-OpenSSH/issues/2140
           ssh -p 2222 -o StrictHostKeyChecking=accept-new test@localhost "exit"
 
-      - name: Install Podman and podman-compose provider (Linux)
+      - name: Install Podman and Docker Compose provider (Linux)
         if: runner.os == 'Linux'
         shell: bash
+        env:
+          COMPOSE_VERSION: v2.32.4
         run: |
           sudo apt-get update
-          sudo apt-get install --yes podman python3-venv
-          python3 -m venv "$RUNNER_TEMP/podman-compose"
-          "$RUNNER_TEMP/podman-compose/bin/pip" install "podman-compose==1.6.0"
-          echo "$RUNNER_TEMP/podman-compose/bin" >> "$GITHUB_PATH"
+          sudo apt-get install --yes podman
 
-      - name: Install Podman and podman-compose provider (Windows)
+          case "$(uname -m)" in
+            x86_64) compose_arch=x86_64 ;;
+            aarch64|arm64) compose_arch=aarch64 ;;
+            *) echo "Unsupported architecture: $(uname -m)" >&2; exit 1 ;;
+          esac
+
+          curl --fail --location --show-error \
+            "https://github.com/docker/compose/releases/download/${COMPOSE_VERSION}/docker-compose-linux-${compose_arch}" \
+            --output /tmp/docker-compose
+          sudo install --mode 0755 /tmp/docker-compose /usr/local/bin/docker-compose
+
+      - name: Install Podman and Docker Compose provider (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
+        env:
+          COMPOSE_VERSION: v2.32.4
         run: |
           winget install --exact --id RedHat.Podman `
             --silent `
@@ -111,11 +123,14 @@ jobs:
             throw "Unable to locate podman.exe after installation"
           }
 
-          python -m pip install --user "podman-compose==1.6.0"
-          $pythonScriptsDirectory = python -c "import sysconfig; print(sysconfig.get_path('scripts', scheme='nt_user'))"
+          $toolsDirectory = Join-Path $env:RUNNER_TEMP "container-tools"
+          New-Item -ItemType Directory -Force $toolsDirectory | Out-Null
+          Invoke-WebRequest `
+            -Uri "https://github.com/docker/compose/releases/download/$env:COMPOSE_VERSION/docker-compose-windows-x86_64.exe" `
+            -OutFile (Join-Path $toolsDirectory "docker-compose.exe")
 
           $podmanDirectory | Out-File $env:GITHUB_PATH -Encoding utf8 -Append
-          $pythonScriptsDirectory | Out-File $env:GITHUB_PATH -Encoding utf8 -Append
+          $toolsDirectory | Out-File $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Start Podman machine (Windows)
         if: runner.os == 'Windows'
@@ -123,13 +138,40 @@ jobs:
         run: |
           podman machine init --cpus 2 --memory 2048 --now
 
+      - name: Start Podman API service (Linux)
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          runtime_dir="${XDG_RUNTIME_DIR:-$RUNNER_TEMP/podman-runtime}"
+          mkdir -p "$runtime_dir/podman"
+
+          if [ -z "${XDG_RUNTIME_DIR:-}" ]; then
+            chmod 700 "$runtime_dir"
+            echo "XDG_RUNTIME_DIR=$runtime_dir" >> "$GITHUB_ENV"
+            export XDG_RUNTIME_DIR="$runtime_dir"
+          fi
+
+          socket_path="$XDG_RUNTIME_DIR/podman/podman.sock"
+          if [ ! -S "$socket_path" ]; then
+            podman system service --time=0 "unix://$socket_path" >"$RUNNER_TEMP/podman-system-service.log" 2>&1 &
+          fi
+
+          for _ in {1..20}; do
+            [ -S "$socket_path" ] && exit 0
+            sleep 1
+          done
+
+          cat "$RUNNER_TEMP/podman-system-service.log" >&2 || true
+          exit 1
+
       - name: Verify Podman test prerequisites (Linux)
         if: runner.os == 'Linux'
         shell: bash
         run: |
           podman version
           podman info
-          podman-compose version
+          docker-compose version
+          podman compose version
 
       - name: Verify Podman test prerequisites (Windows)
         if: runner.os == 'Windows'
@@ -137,7 +179,8 @@ jobs:
         run: |
           podman version
           podman info
-          podman-compose version
+          docker-compose version
+          podman compose version
 
       - name: Checkout repository
         uses: actions/checkout@v7

--- a/internal/deploy/podman/command.go
+++ b/internal/deploy/podman/command.go
@@ -9,7 +9,7 @@ import (
 	"github.com/arm/topo/internal/command"
 )
 
-const composeProvider = "podman-compose"
+const composeProvider = "docker-compose"
 
 func Command(ctx context.Context, socket Socket, args ...string) *exec.Cmd {
 	// #nosec G702 -- Podman arguments are passed directly, not interpreted by a shell.
@@ -28,19 +28,26 @@ func RunCommand(ctx context.Context, output io.Writer, socket Socket, args ...st
 	return nil
 }
 
-func ComposeCommand(ctx context.Context, socket Socket, composeFile string, args ...string) *exec.Cmd {
+func ComposeCommand(ctx context.Context, socket Socket, composeFile string, args ...string) (*exec.Cmd, error) {
 	composeArgs := append([]string{"compose", "-f", composeFile}, args...)
 	cmd := exec.CommandContext(ctx, "podman", composeArgs...)
 	cmd.Env = append(os.Environ(),
 		"PODMAN_COMPOSE_PROVIDER="+composeProvider,
 		"PODMAN_COMPOSE_WARNING_LOGS=false",
 	)
-	cmd.Env = socket.ConfigurePodmanEnv(cmd.Env)
-	return cmd
+	var err error
+	cmd.Env, err = socket.ConfigureComposeEnv(ctx, cmd.Env)
+	if err != nil {
+		return nil, err
+	}
+	return cmd, nil
 }
 
 func RunComposeCommand(ctx context.Context, output io.Writer, socket Socket, composeFile string, args ...string) error {
-	cmd := ComposeCommand(ctx, socket, composeFile, args...)
+	cmd, err := ComposeCommand(ctx, socket, composeFile, args...)
+	if err != nil {
+		return err
+	}
 	cmd.Stdout = output
 	cmd.Stderr = output
 	if err := cmd.Run(); err != nil {

--- a/internal/deploy/podman/command_test.go
+++ b/internal/deploy/podman/command_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/arm/topo/internal/deploy/podman"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCommand(t *testing.T) {
@@ -28,20 +29,26 @@ func TestCommand(t *testing.T) {
 
 func TestComposeCommand(t *testing.T) {
 	t.Run("sets args", func(t *testing.T) {
-		command := podman.ComposeCommand(context.Background(), podman.NewSocket("tcp://127.0.0.1:12345"), "compose.yaml", "up", "-d")
+		command, err := podman.ComposeCommand(context.Background(), podman.NewSocket("tcp://127.0.0.1:12345"), "compose.yaml", "up", "-d")
+
+		require.NoError(t, err)
 		assert.Equal(t, []string{"podman", "compose", "-f", "compose.yaml", "up", "-d"}, command.Args)
 	})
 
 	t.Run("configures compose provider", func(t *testing.T) {
-		command := podman.ComposeCommand(context.Background(), podman.NewSocket("tcp://127.0.0.1:12345"), "compose.yaml", "ps")
-		assert.Contains(t, command.Env, "PODMAN_COMPOSE_PROVIDER=podman-compose")
+		command, err := podman.ComposeCommand(context.Background(), podman.NewSocket("tcp://127.0.0.1:12345"), "compose.yaml", "ps")
+
+		require.NoError(t, err)
+		assert.Contains(t, command.Env, "PODMAN_COMPOSE_PROVIDER=docker-compose")
 	})
 
 	t.Run("configures remote socket", func(t *testing.T) {
-		t.Setenv("CONTAINER_HOST", "unix:///stale-podman.sock")
+		t.Setenv("DOCKER_HOST", "unix:///stale-docker.sock")
 		socket := podman.NewSocket("tcp://127.0.0.1:12345")
 
-		command := podman.ComposeCommand(context.Background(), socket, "compose.yaml", "ps")
-		assert.Contains(t, command.Env, "CONTAINER_HOST=tcp://127.0.0.1:12345")
+		command, err := podman.ComposeCommand(context.Background(), socket, "compose.yaml", "ps")
+
+		require.NoError(t, err)
+		assert.Contains(t, command.Env, "DOCKER_HOST=tcp://127.0.0.1:12345")
 	})
 }

--- a/internal/deploy/podman/deploy.go
+++ b/internal/deploy/podman/deploy.go
@@ -30,7 +30,7 @@ type DeployOptions struct {
 	Registry     *RegistryConfig
 }
 
-func Deploy(ctx context.Context, output io.Writer, composeFile string, options DeployOptions) error {
+func Deploy(ctx context.Context, output io.Writer, composeFile string, options DeployOptions) (deployErr error) {
 	if err := term.PrintHeader(output, "Build images"); err != nil {
 		return err
 	}
@@ -45,16 +45,24 @@ func Deploy(ctx context.Context, output io.Writer, composeFile string, options D
 	}
 
 	targetSocket := LocalSocket
+	var tunnel *ssh.TCPToUnixSocketTunnel
 	if !options.TargetHost.IsPlainLocalhost() {
-		if err := term.PrintHeader(output, "Discover Podman remote socket"); err != nil {
+		if err := term.PrintHeader(output, "Open Podman socket SSH tunnel"); err != nil {
 			return err
 		}
 
 		var err error
-		targetSocket, err = NewRemoteSocket(ctx, options.TargetHost)
+		tunnel, err = TunnelRemoteSocketPath(ctx, output, options.TargetHost)
 		if err != nil {
 			return err
 		}
+		defer func() {
+			if tunnel != nil {
+				deployErr = errors.Join(deployErr, closeRemoteTunnel(tunnel))
+			}
+		}()
+
+		targetSocket = NewSocket(tunnel.SocketURL())
 		if options.Registry == nil {
 			if err := transferImagesViaPipe(ctx, output, LocalSocket, targetSocket, composeFile); err != nil {
 				return err
@@ -69,6 +77,13 @@ func Deploy(ctx context.Context, output io.Writer, composeFile string, options D
 	}
 	if err := StartServices(ctx, output, targetSocket, composeFile, options.RecreateMode); err != nil {
 		return err
+	}
+
+	if tunnel != nil {
+		if err := closeRemoteTunnel(tunnel); err != nil {
+			return err
+		}
+		tunnel = nil
 	}
 
 	if err := term.PrintHeader(output, "Deployment Success"); err != nil {
@@ -135,4 +150,11 @@ func closeRegistryTunnel(output io.Writer, tunnel *ssh.Tunnel) error {
 		closeError = fmt.Errorf("failed to close SSH tunnel: %w", closeError)
 	}
 	return errors.Join(headerError, closeError)
+}
+
+func closeRemoteTunnel(tunnel *ssh.TCPToUnixSocketTunnel) error {
+	if err := tunnel.Close(); err != nil {
+		return fmt.Errorf("failed to close remote Podman socket tunnel: %w", err)
+	}
+	return nil
 }

--- a/internal/deploy/podman/deploy_test.go
+++ b/internal/deploy/podman/deploy_test.go
@@ -40,9 +40,12 @@ func TestDeploy(t *testing.T) {
 		err := podman.Deploy(t.Context(), t.Output(), composeFile, options)
 
 		require.NoError(t, err)
-		targetSocket, err := podman.NewRemoteSocket(context.Background(), targetDestination)
+		tunnel, err := podman.TunnelRemoteSocketPath(context.Background(), t.Output(), targetDestination)
 		require.NoError(t, err)
-		assertContainersRunning(t, projectName, targetSocket)
+		t.Cleanup(func() {
+			require.NoError(t, tunnel.Close())
+		})
+		assertContainersRunning(t, projectName, podman.NewSocket(tunnel.SocketURL()))
 	})
 
 	t.Run("transfers images to a remote host through a registry", func(t *testing.T) {
@@ -63,9 +66,12 @@ func TestDeploy(t *testing.T) {
 		err := podman.Deploy(t.Context(), t.Output(), composeFile, options)
 
 		require.NoError(t, err)
-		targetSocket, err := podman.NewRemoteSocket(context.Background(), targetDestination)
+		tunnel, err := podman.TunnelRemoteSocketPath(context.Background(), t.Output(), targetDestination)
 		require.NoError(t, err)
-		assertContainersRunning(t, projectName, targetSocket)
+		t.Cleanup(func() {
+			require.NoError(t, tunnel.Close())
+		})
+		assertContainersRunning(t, projectName, podman.NewSocket(tunnel.SocketURL()))
 	})
 }
 
@@ -74,8 +80,8 @@ func requireLocalPodman(t *testing.T) {
 	if _, err := exec.LookPath("podman"); err != nil {
 		t.Skip("podman is not installed")
 	}
-	if _, err := exec.LookPath("podman-compose"); err != nil {
-		t.Skip("podman-compose is not installed")
+	if _, err := exec.LookPath("docker-compose"); err != nil {
+		t.Skip("docker-compose is not installed")
 	}
 	if output, err := exec.Command("podman", "info").CombinedOutput(); err != nil {
 		t.Skipf("local Podman engine is unavailable: %v: %s", err, output)
@@ -182,7 +188,11 @@ func cleanupComposeProject(t *testing.T, composeFile string) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	cmd := podman.ComposeCommand(ctx, podman.LocalSocket, composeFile, "down", "-v", "--remove-orphans", "--rmi", "local")
+	cmd, err := podman.ComposeCommand(ctx, podman.LocalSocket, composeFile, "down", "-v", "--remove-orphans", "--rmi", "local")
+	if err != nil {
+		t.Logf("failed to configure Podman Compose: %v", err)
+		return
+	}
 	if output, err := cmd.CombinedOutput(); err != nil {
 		t.Logf("Podman Compose cleanup failed: %v: %s", err, output)
 	}

--- a/internal/deploy/podman/image_transfer_pipe_test.go
+++ b/internal/deploy/podman/image_transfer_pipe_test.go
@@ -16,8 +16,12 @@ func TestTransferImagesViaPipe(t *testing.T) {
 	composeFile, imageName := imageTransferFixture(t)
 	target := gtestutil.StartContainer(t, gtestutil.PodmanContainer)
 	targetDestination := ssh.NewDestination(target.SSHDestination)
-	remoteSocket, err := podman.NewRemoteSocket(context.Background(), targetDestination)
+	tunnel, err := podman.TunnelRemoteSocketPath(context.Background(), t.Output(), targetDestination)
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, tunnel.Close())
+	})
+	remoteSocket := podman.NewSocket(tunnel.SocketURL())
 	err = podman.BuildImages(t.Context(), t.Output(), podman.LocalSocket, composeFile)
 	require.NoError(t, err)
 

--- a/internal/deploy/podman/image_transfer_registry_test.go
+++ b/internal/deploy/podman/image_transfer_registry_test.go
@@ -23,8 +23,12 @@ func TestTransferImagesViaRegistry(t *testing.T) {
 	require.NoError(t, podman.BuildImages(t.Context(), t.Output(), podman.LocalSocket, composeFile))
 	podmanContainer := startPodmanInContainer(t)
 	targetDestination := ssh.NewDestination(podmanContainer.SSHDestination)
-	targetSocket, err := podman.NewRemoteSocket(context.Background(), targetDestination)
+	targetSocketTunnel, err := podman.TunnelRemoteSocketPath(context.Background(), t.Output(), targetDestination)
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, targetSocketTunnel.Close())
+	})
+	targetSocket := podman.NewSocket(targetSocketTunnel.SocketURL())
 	assertImageDoesNotExist(t, targetSocket, imageName)
 
 	registryTunnel, err := ssh.OpenTunnel(context.Background(), t.Output(), targetDestination, registryPort)

--- a/internal/deploy/podman/socket.go
+++ b/internal/deploy/podman/socket.go
@@ -2,30 +2,36 @@ package podman
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"os/exec"
 	"path"
+	"path/filepath"
+	"runtime"
 	"strings"
+	"sync"
 
+	"github.com/arm/topo/internal/output/logger"
 	"github.com/arm/topo/internal/ssh"
 )
 
 type Socket struct {
-	url string
+	url                string
+	localComposeSocket *localComposeSocket
 }
 
-var LocalSocket Socket
+type localComposeSocket struct {
+	mutex sync.Mutex
+	url   string
+}
+
+var LocalSocket = Socket{localComposeSocket: &localComposeSocket{}}
 
 func NewSocket(url string) Socket {
 	return Socket{url: url}
-}
-
-// NewRemoteSocket returns a Podman SSH connection to the target's API socket.
-func NewRemoteSocket(ctx context.Context, target ssh.Destination) (Socket, error) {
-	remoteSocketPath, err := ResolveRemoteSocketPath(ctx, target)
-	if err != nil {
-		return Socket{}, err
-	}
-	return NewSocket(target.String() + remoteSocketPath), nil
 }
 
 func (socket Socket) ConfigurePodmanEnv(environment []string) []string {
@@ -33,6 +39,67 @@ func (socket Socket) ConfigurePodmanEnv(environment []string) []string {
 		return environment
 	}
 	return append(environment, "CONTAINER_HOST="+socket.url)
+}
+
+func (socket Socket) ConfigureComposeEnv(ctx context.Context, environment []string) ([]string, error) {
+	socketURL, err := socket.getComposeSocketURL(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return append(environment, "DOCKER_HOST="+socketURL), nil
+}
+
+func (socket Socket) getComposeSocketURL(ctx context.Context) (string, error) {
+	if socket.localComposeSocket == nil {
+		return socket.url, nil
+	}
+	return socket.localComposeSocket.getURL(ctx)
+}
+
+func (socket *localComposeSocket) getURL(ctx context.Context) (string, error) {
+	socket.mutex.Lock()
+	defer socket.mutex.Unlock()
+
+	if socket.url == "" {
+		url, err := ResolveLocalComposeSocket(ctx)
+		if err != nil {
+			return "", err
+		}
+		socket.url = url
+	}
+	return socket.url, nil
+}
+
+type podmanConnection struct {
+	Name      string
+	URI       string
+	Default   bool
+	IsMachine bool
+}
+
+type machineConnectionInfo struct {
+	PodmanSocket *machineSocket
+	PodmanPipe   *machinePipe
+}
+
+type machineSocket struct {
+	Path string
+}
+
+type machinePipe struct {
+	Path string
+}
+
+// ResolveLocalComposeSocket returns the host-accessible Podman API endpoint
+// that the external Compose provider must use for a local deployment.
+func ResolveLocalComposeSocket(ctx context.Context) (string, error) {
+	if runtime.GOOS == "darwin" {
+		return resolveDarwinComposeSocket(ctx)
+	}
+	if runtime.GOOS == "windows" {
+		return resolveWindowsComposeSocket(ctx)
+	}
+	return resolveNativeComposeSocket(ctx)
 }
 
 // ResolveRemoteSocketPath returns the absolute Unix socket path reported by Podman
@@ -48,4 +115,160 @@ func ResolveRemoteSocketPath(ctx context.Context, target ssh.Destination) (strin
 		return "", fmt.Errorf("remote Podman reported a non-local API socket path %q", socketPath)
 	}
 	return socketPath, nil
+}
+
+// TunnelRemoteSocketPath resolves remote socket path on the target and tunnels it to a tcp endpoint on the host.
+func TunnelRemoteSocketPath(ctx context.Context, w io.Writer, target ssh.Destination) (*ssh.TCPToUnixSocketTunnel, error) {
+	remoteSocketPath, err := ResolveRemoteSocketPath(ctx, target)
+	if err != nil {
+		return nil, err
+	}
+	logger.Info(fmt.Sprintf("discovered remote Podman socket path: %s", remoteSocketPath))
+	tunnel, err := ssh.OpenTCPToUnixSocketTunnel(ctx, w, target, remoteSocketPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open remote Podman socket tunnel: %w", err)
+	}
+	return tunnel, nil
+}
+
+func resolveNativeComposeSocket(ctx context.Context) (string, error) {
+	output, err := exec.CommandContext(ctx, "podman", "info", "--format", "{{.Host.RemoteSocket.Path}}").Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to get Podman API socket: %w", err)
+	}
+
+	socketURL, err := unixSocketURL(strings.TrimSpace(string(output)))
+	if err != nil {
+		return "", err
+	}
+	if err := requireSocket(socketURL); err != nil {
+		return "", err
+	}
+	return socketURL, nil
+}
+
+func resolveDarwinComposeSocket(ctx context.Context) (string, error) {
+	connection, err := defaultPodmanConnection(ctx)
+	if err != nil {
+		return "", err
+	}
+	if !connection.IsMachine {
+		if isDarwinComposeEndpoint(connection.URI) {
+			return connection.URI, nil
+		}
+		return "", fmt.Errorf("default Podman connection %q has no Compose-compatible endpoint", connection.Name)
+	}
+
+	info, err := inspectPodmanMachine(ctx, connection)
+	if err != nil {
+		return "", err
+	}
+	if info.PodmanSocket == nil {
+		return "", fmt.Errorf("podman machine %q has no host-accessible API socket", connection.Name)
+	}
+	socketURL, err := unixSocketURL(info.PodmanSocket.Path)
+	if err != nil {
+		return "", err
+	}
+	return socketURL, nil
+}
+
+func resolveWindowsComposeSocket(ctx context.Context) (string, error) {
+	connection, err := defaultPodmanConnection(ctx)
+	if err != nil {
+		return "", err
+	}
+	if !connection.IsMachine {
+		if isWindowsComposeEndpoint(connection.URI) {
+			return connection.URI, nil
+		}
+		return "", fmt.Errorf("default Podman connection %q has no Compose-compatible endpoint", connection.Name)
+	}
+
+	info, err := inspectPodmanMachine(ctx, connection)
+	if err != nil {
+		return "", err
+	}
+	if info.PodmanPipe == nil {
+		return "", fmt.Errorf("podman machine %q has no host-accessible API pipe", connection.Name)
+	}
+	pipeURL, err := namedPipeURL(info.PodmanPipe.Path)
+	if err != nil {
+		return "", err
+	}
+	return pipeURL, nil
+}
+
+func inspectPodmanMachine(ctx context.Context, connection podmanConnection) (machineConnectionInfo, error) {
+	output, err := exec.CommandContext(ctx, "podman", "machine", "inspect", connection.Name, "--format", "{{json .ConnectionInfo}}").Output()
+	if err != nil {
+		return machineConnectionInfo{}, fmt.Errorf("failed to inspect Podman machine %q: %w", connection.Name, err)
+	}
+
+	var info machineConnectionInfo
+	if err := json.Unmarshal(output, &info); err != nil {
+		return machineConnectionInfo{}, fmt.Errorf("failed to parse Podman machine connection information: %w", err)
+	}
+	return info, nil
+}
+
+func defaultPodmanConnection(ctx context.Context) (podmanConnection, error) {
+	output, err := exec.CommandContext(ctx, "podman", "system", "connection", "list", "--format", "json").Output()
+	if err != nil {
+		return podmanConnection{}, fmt.Errorf("failed to list Podman connections: %w", err)
+	}
+
+	var connections []podmanConnection
+	if err := json.Unmarshal(output, &connections); err != nil {
+		return podmanConnection{}, fmt.Errorf("failed to parse Podman connections: %w", err)
+	}
+	for _, connection := range connections {
+		if connection.Default {
+			return connection, nil
+		}
+	}
+	return podmanConnection{}, fmt.Errorf("no default Podman connection is configured")
+}
+
+func isDarwinComposeEndpoint(endpoint string) bool {
+	return strings.HasPrefix(endpoint, "unix://") || strings.HasPrefix(endpoint, "tcp://")
+}
+
+func isWindowsComposeEndpoint(endpoint string) bool {
+	return strings.HasPrefix(endpoint, "npipe://") || strings.HasPrefix(endpoint, "tcp://")
+}
+
+func unixSocketURL(path string) (string, error) {
+	if path == "" {
+		return "", fmt.Errorf("podman did not report an API socket")
+	}
+	if strings.HasPrefix(path, "unix://") {
+		return path, nil
+	}
+	if !filepath.IsAbs(path) {
+		return "", fmt.Errorf("podman reported a non-local API socket path %q", path)
+	}
+	return "unix://" + path, nil
+}
+
+func namedPipeURL(path string) (string, error) {
+	path = strings.ReplaceAll(path, `\`, "/")
+	if !strings.HasPrefix(path, "//./pipe/") {
+		return "", fmt.Errorf("podman reported an invalid named pipe path %q", path)
+	}
+	return "npipe:////./pipe/" + strings.TrimPrefix(path, "//./pipe/"), nil
+}
+
+func requireSocket(socketURL string) error {
+	parsedURL, err := url.Parse(socketURL)
+	if err != nil {
+		return fmt.Errorf("failed to parse Podman API socket URL: %w", err)
+	}
+	if parsedURL.Scheme != "unix" {
+		return fmt.Errorf("podman reported an unsupported API socket URL %q", socketURL)
+	}
+	if _, err := os.Stat(parsedURL.Path); err != nil { // #nosec G703 -- socket URL comes from Podman.
+		return fmt.Errorf("podman API socket %s is unavailable; start podman.socket: %w", socketURL, err)
+	}
+	return nil
 }

--- a/internal/ssh/tcp_to_unix_socket_tunnel.go
+++ b/internal/ssh/tcp_to_unix_socket_tunnel.go
@@ -1,0 +1,100 @@
+package ssh
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os/exec"
+	"time"
+
+	"github.com/arm/topo/internal/command"
+)
+
+const tcpTunnelOpenTimeout = 10 * time.Second
+
+// TCPToUnixSocketTunnel forwards a loopback TCP endpoint to a Unix socket on an
+// SSH destination. A TCP endpoint is used locally so the transport works on
+// Unix and Windows hosts.
+type TCPToUnixSocketTunnel struct {
+	command   *exec.Cmd
+	socketURL string
+	closed    bool
+}
+
+func OpenTCPToUnixSocketTunnel(ctx context.Context, output io.Writer, dest Destination, remoteSocketPath string) (*TCPToUnixSocketTunnel, error) {
+	address, err := availableLoopbackAddress()
+	if err != nil {
+		return nil, err
+	}
+
+	args := []string{
+		"-N",
+		"-o", "ExitOnForwardFailure=yes",
+		"-L", fmt.Sprintf("%s:%s", address, remoteSocketPath),
+		dest.String(),
+	}
+	cmd := exec.CommandContext(ctx, "ssh", args...) // #nosec G204 -- arguments are not interpreted by a shell
+	cmd.Stdout = output
+	cmd.Stderr = output
+	if err := cmd.Start(); err != nil {
+		return nil, command.FormatError(cmd.Args, err)
+	}
+
+	tunnel := &TCPToUnixSocketTunnel{
+		command:   cmd,
+		socketURL: "tcp://" + address,
+	}
+	if err := waitForTCPListener(ctx, address); err != nil {
+		closeErr := tunnel.Close()
+		return nil, errors.Join(fmt.Errorf("failed to wait for SSH tunnel: %w", err), closeErr)
+	}
+	return tunnel, nil
+}
+
+func (t *TCPToUnixSocketTunnel) SocketURL() string {
+	return t.socketURL
+}
+
+func (t *TCPToUnixSocketTunnel) Close() error {
+	if t.closed {
+		return nil
+	}
+	t.closed = true
+	return killCommand(t.command)
+}
+
+func availableLoopbackAddress() (string, error) {
+	listener, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		return "", fmt.Errorf("failed to reserve a local loopback address for the SSH tunnel: %w", err)
+	}
+	address := listener.Addr().String()
+	if err := listener.Close(); err != nil {
+		return "", fmt.Errorf("failed to release local loopback address %s for the SSH tunnel: %w", address, err)
+	}
+	return address, nil
+}
+
+func waitForTCPListener(ctx context.Context, address string) error {
+	deadline := time.NewTimer(tcpTunnelOpenTimeout)
+	defer deadline.Stop()
+	ticker := time.NewTicker(25 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		connection, err := net.DialTimeout("tcp4", address, 100*time.Millisecond)
+		if err == nil {
+			return connection.Close()
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-deadline.C:
+			return fmt.Errorf("timed out waiting for %s", address)
+		case <-ticker.C:
+		}
+	}
+}


### PR DESCRIPTION
Reverts arm/topo#425

Turns out `podman-compose` doesn't work with `runtime:` either when targeting remote engines. We're going to solve this by being explicit about the fact `runtime:` will not work w/ podman by printing a warning and documenting the support tiers.