### PR TITLE
feat: Support `topo ps` with `--engine podman`

### DIFF
--- a/cmd/topo/deploy.go
+++ b/cmd/topo/deploy.go
@@ -203,7 +203,7 @@ func init() {
 	addTargetFlag(deployCmd)
 	addComposeFileFlag(deployCmd)
 	if experimentalFeaturesEnabled() {
-		addContainerEngineFlag(deployCmd)
+		addEngineFlag(deployCmd)
 	}
 	deployCmd.Flags().StringVarP(&registryPort, "registry-port", "p", docker.DefaultRegistryPort, fmt.Sprintf("registry and SSH tunnel port (can also be set via %s env var)", portEnvVar))
 	deployCmd.Flags().BoolVar(&noRegistry, "no-registry", false, "use full-image save/load transfer instead of delta-optimised registry transfer; for environments where registry transfer or reverse SSH forwarding is unavailable")

--- a/cmd/topo/deploy.go
+++ b/cmd/topo/deploy.go
@@ -20,20 +20,12 @@ import (
 )
 
 var (
-	engine              string
 	noRegistry          bool
 	registryPort        string
 	skipRemotePortCheck bool
 	skipProjectChecks   bool
 	forceRecreate       bool
 	noRecreate          bool
-)
-
-type containerEngine string
-
-const (
-	containerEngineDocker containerEngine = "docker"
-	containerEnginePodman containerEngine = "podman"
 )
 
 var deployCmd = &cobra.Command{
@@ -52,7 +44,7 @@ By default, Topo uses compose.yaml in the current working directory, then compos
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 
-		parsedEngine, err := parseContainerEngine(engine)
+		selectedEngine, err := getSelectedEngine(cmd)
 		if err != nil {
 			return err
 		}
@@ -64,7 +56,7 @@ By default, Topo uses compose.yaml in the current working directory, then compos
 		if err != nil {
 			return err
 		}
-		if parsedEngine == containerEnginePodman {
+		if selectedEngine == containerEnginePodman {
 			return deployWithPodman(cmd, targetArg)
 		}
 		return deployWithDocker(cmd, targetArg)
@@ -172,17 +164,6 @@ func executeDeployment(cmd *cobra.Command, deployment func(context.Context) erro
 	return nil
 }
 
-func parseContainerEngine(value string) (containerEngine, error) {
-	parsedEngine := containerEngine(value)
-	if parsedEngine == "" {
-		return containerEngineDocker, nil
-	}
-	if parsedEngine != containerEngineDocker && parsedEngine != containerEnginePodman {
-		return "", fmt.Errorf("invalid engine %q: must be docker or podman", value)
-	}
-	return parsedEngine, nil
-}
-
 func validatePort(port string) error {
 	portNum, err := strconv.Atoi(port)
 	if err != nil {
@@ -222,7 +203,7 @@ func init() {
 	addTargetFlag(deployCmd)
 	addComposeFileFlag(deployCmd)
 	if experimentalFeaturesEnabled() {
-		deployCmd.Flags().StringVar(&engine, "engine", string(containerEngineDocker), "container engine to use (docker or podman)")
+		addContainerEngineFlag(deployCmd)
 	}
 	deployCmd.Flags().StringVarP(&registryPort, "registry-port", "p", docker.DefaultRegistryPort, fmt.Sprintf("registry and SSH tunnel port (can also be set via %s env var)", portEnvVar))
 	deployCmd.Flags().BoolVar(&noRegistry, "no-registry", false, "use full-image save/load transfer instead of delta-optimised registry transfer; for environments where registry transfer or reverse SSH forwarding is unavailable")

--- a/cmd/topo/ps.go
+++ b/cmd/topo/ps.go
@@ -4,10 +4,13 @@ import (
 	"os"
 
 	"github.com/arm/topo/internal/deploy/docker"
+	"github.com/arm/topo/internal/deploy/podman"
 	"github.com/arm/topo/internal/output/views"
 	"github.com/arm/topo/internal/ssh"
 	"github.com/spf13/cobra"
 )
+
+var psEngine string
 
 var topoPsCmd = &cobra.Command{
 	Use:   "ps",
@@ -21,6 +24,10 @@ By default, Topo uses compose.yaml in the current working directory, then compos
 		cmd.SilenceUsage = true
 		outputFormat := resolveOutput(cmd)
 
+		parsedEngine, err := parseContainerEngine(psEngine)
+		if err != nil {
+			return err
+		}
 		targetArg, err := requireTarget(cmd)
 		if err != nil {
 			return err
@@ -41,12 +48,19 @@ By default, Topo uses compose.yaml in the current working directory, then compos
 			panic("internal error: all flag not registered: " + err.Error())
 		}
 
+		if parsedEngine == containerEnginePodman {
+			containers, err := podman.ListContainers(composeFile, dest, hostname, allContainers)
+			if err != nil {
+				return err
+			}
+			return views.Print(newPodmanContainerList(containers), os.Stdout, outputFormat)
+		}
+
 		host := docker.NewHostFromDestination(dest)
 		containers, err := docker.ListContainers(composeFile, host, hostname, allContainers)
 		if err != nil {
 			return err
 		}
-
 		return views.Print(newContainerList(containers), os.Stdout, outputFormat)
 	},
 }
@@ -67,9 +81,28 @@ func newContainerList(containers []docker.Container) views.ContainerList {
 	return views.ContainerList{Containers: items}
 }
 
+func newPodmanContainerList(containers []podman.Container) views.ContainerList {
+	items := make([]views.Container, len(containers))
+	for i, container := range containers {
+		items[i] = views.Container{
+			ID:               container.Id,
+			Names:            container.Names,
+			Image:            container.Image,
+			State:            container.State,
+			Status:           container.Status,
+			ProcessingDomain: container.ProcessingDomain,
+			Address:          container.Address,
+		}
+	}
+	return views.ContainerList{Containers: items}
+}
+
 func init() {
 	addTargetFlag(topoPsCmd)
 	addComposeFileFlag(topoPsCmd)
 	topoPsCmd.Flags().BoolP("all", "a", false, "show all containers, including stopped")
+	if experimentalFeaturesEnabled() {
+		topoPsCmd.Flags().StringVar(&psEngine, "engine", string(containerEngineDocker), "container engine to use (docker or podman)")
+	}
 	rootCmd.AddCommand(topoPsCmd)
 }

--- a/cmd/topo/ps.go
+++ b/cmd/topo/ps.go
@@ -100,7 +100,7 @@ func init() {
 	addComposeFileFlag(topoPsCmd)
 	topoPsCmd.Flags().BoolP("all", "a", false, "show all containers, including stopped")
 	if experimentalFeaturesEnabled() {
-		addContainerEngineFlag(topoPsCmd)
+		addEngineFlag(topoPsCmd)
 	}
 	rootCmd.AddCommand(topoPsCmd)
 }

--- a/cmd/topo/ps.go
+++ b/cmd/topo/ps.go
@@ -10,8 +10,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var psEngine string
-
 var topoPsCmd = &cobra.Command{
 	Use:   "ps",
 	Short: "List containers on the target for the current Compose project.",
@@ -24,7 +22,7 @@ By default, Topo uses compose.yaml in the current working directory, then compos
 		cmd.SilenceUsage = true
 		outputFormat := resolveOutput(cmd)
 
-		parsedEngine, err := parseContainerEngine(psEngine)
+		selectedEngine, err := getSelectedEngine(cmd)
 		if err != nil {
 			return err
 		}
@@ -48,7 +46,7 @@ By default, Topo uses compose.yaml in the current working directory, then compos
 			panic("internal error: all flag not registered: " + err.Error())
 		}
 
-		if parsedEngine == containerEnginePodman {
+		if selectedEngine == containerEnginePodman {
 			containers, err := podman.ListContainers(composeFile, dest, hostname, allContainers)
 			if err != nil {
 				return err
@@ -102,7 +100,7 @@ func init() {
 	addComposeFileFlag(topoPsCmd)
 	topoPsCmd.Flags().BoolP("all", "a", false, "show all containers, including stopped")
 	if experimentalFeaturesEnabled() {
-		topoPsCmd.Flags().StringVar(&psEngine, "engine", string(containerEngineDocker), "container engine to use (docker or podman)")
+		addContainerEngineFlag(topoPsCmd)
 	}
 	rootCmd.AddCommand(topoPsCmd)
 }

--- a/cmd/topo/root.go
+++ b/cmd/topo/root.go
@@ -82,6 +82,36 @@ func getComposeFileName(cmd *cobra.Command) (string, error) {
 
 const targetEnvVar = env.TargetVariable
 
+type containerEngine string
+
+const (
+	containerEngineDocker containerEngine = "docker"
+	containerEnginePodman containerEngine = "podman"
+)
+
+const containerEngineFlag = "engine"
+
+func addContainerEngineFlag(cmd *cobra.Command) {
+	cmd.Flags().String(
+		containerEngineFlag,
+		string(containerEngineDocker),
+		"container engine to use (docker or podman)",
+	)
+}
+
+func getSelectedEngine(cmd *cobra.Command) (containerEngine, error) {
+	value, err := cmd.Flags().GetString(containerEngineFlag)
+	if err != nil {
+		panic(fmt.Sprintf("internal error: container engine flag not registered: %v", err))
+	}
+
+	selectedEngine := containerEngine(value)
+	if selectedEngine != containerEngineDocker && selectedEngine != containerEnginePodman {
+		return "", fmt.Errorf("invalid engine %q: must be docker or podman", value)
+	}
+	return selectedEngine, nil
+}
+
 func addTargetFlag(cmd *cobra.Command) {
 	cmd.Flags().StringP(
 		"target", "t", "",

--- a/cmd/topo/root.go
+++ b/cmd/topo/root.go
@@ -91,7 +91,7 @@ const (
 
 const containerEngineFlag = "engine"
 
-func addContainerEngineFlag(cmd *cobra.Command) {
+func addEngineFlag(cmd *cobra.Command) {
 	cmd.Flags().String(
 		containerEngineFlag,
 		string(containerEngineDocker),

--- a/cmd/topo/root.go
+++ b/cmd/topo/root.go
@@ -100,9 +100,13 @@ func addContainerEngineFlag(cmd *cobra.Command) {
 }
 
 func getSelectedEngine(cmd *cobra.Command) (containerEngine, error) {
+	if cmd.Flags().Lookup(containerEngineFlag) == nil {
+		return containerEngineDocker, nil
+	}
+
 	value, err := cmd.Flags().GetString(containerEngineFlag)
 	if err != nil {
-		panic(fmt.Sprintf("internal error: container engine flag not registered: %v", err))
+		panic(fmt.Sprintf("internal error: container engine flag is not a string: %v", err))
 	}
 
 	selectedEngine := containerEngine(value)

--- a/internal/deploy/docker/ps.go
+++ b/internal/deploy/docker/ps.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"strings"
 )
 
@@ -89,9 +90,13 @@ func composePSArgs(all bool) []string {
 func ParseContainers(rawJSON string) ([]PSContainer, error) {
 	raws := []PSContainer{}
 	decoder := json.NewDecoder(strings.NewReader(rawJSON))
-	for decoder.More() {
+	for {
 		var raw PSContainer
-		if err := decoder.Decode(&raw); err != nil {
+		err := decoder.Decode(&raw)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
 			return nil, err
 		}
 		raws = append(raws, raw)

--- a/internal/deploy/podman/ps.go
+++ b/internal/deploy/podman/ps.go
@@ -83,9 +83,13 @@ func composePSArgs(all bool) []string {
 func ParseContainers(rawJSON string) ([]PSContainer, error) {
 	raws := []PSContainer{}
 	decoder := json.NewDecoder(strings.NewReader(rawJSON))
-	for decoder.More() {
+	for {
 		var raw PSContainer
-		if err := decoder.Decode(&raw); err != nil {
+		err := decoder.Decode(&raw)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
 			return nil, err
 		}
 		raws = append(raws, raw)

--- a/internal/deploy/podman/ps.go
+++ b/internal/deploy/podman/ps.go
@@ -1,0 +1,124 @@
+package podman
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/arm/topo/internal/ssh"
+)
+
+const hostProcessingDomain = "Linux Host"
+
+type PSContainer struct {
+	ID     string `json:"ID"`
+	Names  string `json:"Names"`
+	Image  string `json:"Image"`
+	State  string `json:"State"`
+	Status string `json:"Status"`
+	Ports  string `json:"Ports"`
+}
+
+type Container struct {
+	Id               string `json:"id"`
+	Names            string `json:"names"`
+	Image            string `json:"image"`
+	State            string `json:"state"`
+	Status           string `json:"status"`
+	ProcessingDomain string `json:"processingDomain"`
+	Address          string `json:"address"`
+}
+
+func ListContainers(composeFile string, target ssh.Destination, hostname string, all bool) (containers []Container, err error) {
+	socket := LocalSocket
+	var tunnel *ssh.TCPToUnixSocketTunnel
+	if !target.IsPlainLocalhost() {
+		tunnel, err = TunnelRemoteSocketPath(context.Background(), io.Discard, target)
+		if err != nil {
+			return nil, err
+		}
+		defer func() {
+			err = errors.Join(err, tunnel.Close())
+		}()
+		socket = NewSocket(tunnel.SocketURL())
+	}
+
+	rawJSON, err := getContainers(composeFile, socket, all)
+	if err != nil {
+		return nil, err
+	}
+	raws, err := ParseContainers(rawJSON)
+	if err != nil {
+		return nil, err
+	}
+	return RemapAddresses(raws, hostname), nil
+}
+
+func getContainers(composeFile string, socket Socket, all bool) (string, error) {
+	var stdout, stderr bytes.Buffer
+	cmd, err := ComposeCommand(context.Background(), socket, composeFile, composePSArgs(all)...)
+	if err != nil {
+		return "", err
+	}
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("podman compose ps: %w: %s", err, strings.TrimSpace(stderr.String()))
+	}
+	return stdout.String(), nil
+}
+
+func composePSArgs(all bool) []string {
+	args := []string{"ps", "--format", "json"}
+	if all {
+		args = append(args, "--all")
+	}
+	return args
+}
+
+func ParseContainers(rawJSON string) ([]PSContainer, error) {
+	raws := []PSContainer{}
+	decoder := json.NewDecoder(strings.NewReader(rawJSON))
+	for decoder.More() {
+		var raw PSContainer
+		if err := decoder.Decode(&raw); err != nil {
+			return nil, err
+		}
+		raws = append(raws, raw)
+	}
+	return raws, nil
+}
+
+func RemapAddresses(raws []PSContainer, hostname string) []Container {
+	containers := make([]Container, len(raws))
+	for i, raw := range raws {
+		containers[i] = Container{
+			Id:               raw.ID,
+			Names:            raw.Names,
+			Image:            raw.Image,
+			State:            raw.State,
+			Status:           raw.Status,
+			ProcessingDomain: hostProcessingDomain,
+			Address:          publishedAddress(raw.Ports, hostname),
+		}
+	}
+	return containers
+}
+
+func publishedAddress(rawPorts, hostname string) string {
+	if hostname == "" {
+		return rawPorts
+	}
+	parts := strings.Split(rawPorts, ", ")
+	for i, part := range parts {
+		if idx := strings.Index(part, "->"); idx != -1 {
+			part = part[:idx]
+		}
+		parts[i] = strings.ReplaceAll(part, "0.0.0.0", hostname)
+	}
+	return strings.Join(parts, ", ")
+}

--- a/internal/deploy/podman/ps_test.go
+++ b/internal/deploy/podman/ps_test.go
@@ -1,0 +1,64 @@
+package podman_test
+
+import (
+	"testing"
+
+	"github.com/arm/topo/internal/deploy/podman"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseContainers(t *testing.T) {
+	t.Run("decodes the JSON stream emitted by podman compose ps", func(t *testing.T) {
+		input := `{"ID":"abc123","Names":"project-web-1","Image":"web","State":"running","Status":"Up 5 minutes","Ports":"0.0.0.0:8080->80/tcp"}
+{"ID":"def456","Names":"project-db-1","Image":"db","State":"running","Status":"Up 5 minutes","Ports":""}`
+
+		got, err := podman.ParseContainers(input)
+
+		require.NoError(t, err)
+		want := []podman.PSContainer{
+			{ID: "abc123", Names: "project-web-1", Image: "web", State: "running", Status: "Up 5 minutes", Ports: "0.0.0.0:8080->80/tcp"},
+			{ID: "def456", Names: "project-db-1", Image: "db", State: "running", Status: "Up 5 minutes", Ports: ""},
+		}
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("returns an empty slice for empty input", func(t *testing.T) {
+		got, err := podman.ParseContainers("")
+
+		require.NoError(t, err)
+		assert.Equal(t, []podman.PSContainer{}, got)
+	})
+
+	t.Run("returns an error on malformed JSON", func(t *testing.T) {
+		_, err := podman.ParseContainers("{not json")
+
+		assert.Error(t, err)
+	})
+}
+
+func TestRemapAddresses(t *testing.T) {
+	t.Run("strips container ports, remaps the hostname, and sets Linux Host", func(t *testing.T) {
+		input := []podman.PSContainer{{Ports: "0.0.0.0:8080->80/tcp, 0.0.0.0:8443->443/tcp"}}
+
+		got := podman.RemapAddresses(input, "myhost")
+
+		want := []podman.Container{{
+			ProcessingDomain: "Linux Host",
+			Address:          "myhost:8080, myhost:8443",
+		}}
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("leaves ports untouched when hostname is empty", func(t *testing.T) {
+		input := []podman.PSContainer{{Ports: "0.0.0.0:8080->80/tcp"}}
+
+		got := podman.RemapAddresses(input, "")
+
+		want := []podman.Container{{
+			ProcessingDomain: "Linux Host",
+			Address:          "0.0.0.0:8080->80/tcp",
+		}}
+		assert.Equal(t, want, got)
+	})
+}


### PR DESCRIPTION
## Changes

- Add experimental `topo ps --engine podman` support.
- List Podman Compose project containers through the Podman socket, including remote targets via SSH tunnel.
- Common `--engine` resolution in the CLI layer.
- Improve `ps` output parsing

## Checklist

- [x] 🤖 This change is covered by tests as required.
- [ ] 🤹 All required manual testing has been performed.
- [ ] 📖 All documentation updates are complete.