### PR TITLE
feat: fail podman deployment when runtime is set

### DIFF
--- a/internal/deploy/podman/deploy.go
+++ b/internal/deploy/podman/deploy.go
@@ -31,6 +31,9 @@ type DeployOptions struct {
 }
 
 func Deploy(ctx context.Context, output io.Writer, composeFile string, options DeployOptions) (deployErr error) {
+	if err := EnsureNoRuntimeSet(composeFile); err != nil {
+		return err
+	}
 	if err := term.PrintHeader(output, "Build images"); err != nil {
 		return err
 	}

--- a/internal/deploy/podman/deploy_test.go
+++ b/internal/deploy/podman/deploy_test.go
@@ -27,7 +27,7 @@ services:
     runtime: io.containerd.remoteproc.v1
 `)
 
-		err := podman.Deploy(t.Context(), &bytes.Buffer{}, composeFile, podman.DeployOptions{TargetHost: ssh.PlainLocalhost})
+		err := podman.Deploy(t.Context(), &bytes.Buffer{}, composeFile, podman.DeployOptions{})
 
 		require.ErrorContains(t, err, `specifying "runtime:" in Compose files is unsupported for Podman deployments`)
 	})

--- a/internal/deploy/podman/deploy_test.go
+++ b/internal/deploy/podman/deploy_test.go
@@ -12,15 +12,28 @@ import (
 
 	"github.com/arm/topo/internal/deploy/podman"
 	"github.com/arm/topo/internal/ssh"
+	"github.com/arm/topo/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 )
 
 func TestDeploy(t *testing.T) {
-	requireLocalPodman(t)
+	t.Run("rejects runtime before accessing Podman", func(t *testing.T) {
+		composeFile := testutil.WriteComposeFile(t, t.TempDir(), `
+services:
+  firmware:
+    image: alpine
+    runtime: io.containerd.remoteproc.v1
+`)
+
+		err := podman.Deploy(t.Context(), &bytes.Buffer{}, composeFile, podman.DeployOptions{TargetHost: ssh.PlainLocalhost})
+
+		require.ErrorContains(t, err, `specifying "runtime:" in Compose files is unsupported for Podman deployments`)
+	})
 
 	t.Run("deploys to localhost", func(t *testing.T) {
+		requireLocalPodman(t)
 		composeFile, projectName := deploymentFixture(t)
 		t.Cleanup(func() { cleanupComposeProject(t, composeFile) })
 		options := podman.DeployOptions{TargetHost: ssh.PlainLocalhost}
@@ -32,6 +45,7 @@ func TestDeploy(t *testing.T) {
 	})
 
 	t.Run("transfers images to a remote host via pipe", func(t *testing.T) {
+		requireLocalPodman(t)
 		podmanContainer := startPodmanInContainer(t)
 		composeFile, projectName := deploymentFixture(t)
 		targetDestination := ssh.NewDestination(podmanContainer.SSHDestination)
@@ -49,6 +63,7 @@ func TestDeploy(t *testing.T) {
 	})
 
 	t.Run("transfers images to a remote host through a registry", func(t *testing.T) {
+		requireLocalPodman(t)
 		registryPort := requireAvailableTCPPort(t)
 		registryContainerName := "topo-test-registry-" + sanitiseTestName(t)
 		t.Cleanup(func() { cleanupRegistryContainer(t, registryContainerName) })

--- a/internal/deploy/podman/runtime.go
+++ b/internal/deploy/podman/runtime.go
@@ -1,0 +1,29 @@
+package podman
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/arm/topo/internal/compose"
+)
+
+func EnsureNoRuntimeSet(composePath string) error {
+	project, err := compose.ReadProject(composePath)
+	if err != nil {
+		return fmt.Errorf("failed to load compose project: %w", err)
+	}
+
+	var serviceRuntimes []string
+	for _, serviceName := range project.ServiceNames() {
+		runtime := strings.TrimSpace(project.Services[serviceName].Runtime)
+		if runtime != "" {
+			serviceRuntimes = append(serviceRuntimes, fmt.Sprintf("%q service uses %q", serviceName, runtime))
+		}
+	}
+	if len(serviceRuntimes) == 0 {
+		return nil
+	}
+
+	return errors.New(`specifying "runtime:" in Compose files is unsupported for Podman deployments: ` + strings.Join(serviceRuntimes, ", "))
+}

--- a/internal/deploy/podman/runtime.go
+++ b/internal/deploy/podman/runtime.go
@@ -9,21 +9,47 @@ import (
 )
 
 func EnsureNoRuntimeSet(composePath string) error {
-	project, err := compose.ReadProject(composePath)
+	runtimes, err := listCustomServiceRuntimes(composePath)
 	if err != nil {
-		return fmt.Errorf("failed to load compose project: %w", err)
+		return err
 	}
 
-	var serviceRuntimes []string
-	for _, serviceName := range project.ServiceNames() {
-		runtime := strings.TrimSpace(project.Services[serviceName].Runtime)
-		if runtime != "" {
-			serviceRuntimes = append(serviceRuntimes, fmt.Sprintf("%q service uses %q", serviceName, runtime))
-		}
-	}
-	if len(serviceRuntimes) == 0 {
+	if len(runtimes) == 0 {
 		return nil
 	}
 
-	return errors.New(`specifying "runtime:" in Compose files is unsupported for Podman deployments: ` + strings.Join(serviceRuntimes, ", "))
+	return errors.New(`specifying "runtime:" in Compose files is unsupported for Podman deployments: ` + formatServiceRuntimes(runtimes))
+}
+
+type serviceRuntime struct {
+	serviceName string
+	runtime     string
+}
+
+func listCustomServiceRuntimes(composePath string) ([]serviceRuntime, error) {
+	project, err := compose.ReadProject(composePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load compose project: %w", err)
+	}
+
+	var collected []serviceRuntime
+	for _, serviceName := range project.ServiceNames() {
+		runtime := strings.TrimSpace(project.Services[serviceName].Runtime)
+		if runtime != "" {
+			collected = append(collected, serviceRuntime{
+				serviceName: serviceName,
+				runtime:     runtime,
+			})
+		}
+	}
+
+	return collected, nil
+}
+
+func formatServiceRuntimes(runtimes []serviceRuntime) string {
+	formatted := make([]string, 0, len(runtimes))
+	for _, serviceRuntime := range runtimes {
+		formatted = append(formatted, fmt.Sprintf("%q service uses %q", serviceRuntime.serviceName, serviceRuntime.runtime))
+	}
+	return strings.Join(formatted, ", ")
 }

--- a/internal/deploy/podman/runtime_test.go
+++ b/internal/deploy/podman/runtime_test.go
@@ -1,0 +1,52 @@
+package podman_test
+
+import (
+	"testing"
+
+	"github.com/arm/topo/internal/deploy/podman"
+	"github.com/arm/topo/internal/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnsureNoRuntimeSet(t *testing.T) {
+	t.Run("succeeds when no service runtime is set", func(t *testing.T) {
+		composeFile := testutil.WriteComposeFile(t, t.TempDir(), `
+services:
+  app:
+    image: alpine
+`)
+
+		err := podman.EnsureNoRuntimeSet(composeFile)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("rejects a service with a runtime", func(t *testing.T) {
+		composeFile := testutil.WriteComposeFile(t, t.TempDir(), `
+services:
+  firmware:
+    image: alpine
+    runtime: io.containerd.remoteproc.v1
+`)
+
+		err := podman.EnsureNoRuntimeSet(composeFile)
+
+		require.EqualError(t, err, `specifying "runtime:" in Compose files is unsupported for Podman deployments: "firmware" service uses "io.containerd.remoteproc.v1"`)
+	})
+
+	t.Run("lists every service with a runtime", func(t *testing.T) {
+		composeFile := testutil.WriteComposeFile(t, t.TempDir(), `
+services:
+  application:
+    image: alpine
+    runtime: kata
+  firmware:
+    image: alpine
+    runtime: io.containerd.remoteproc.v1
+`)
+
+		err := podman.EnsureNoRuntimeSet(composeFile)
+
+		require.EqualError(t, err, `specifying "runtime:" in Compose files is unsupported for Podman deployments: "application" service uses "kata", "firmware" service uses "io.containerd.remoteproc.v1"`)
+	})
+}


### PR DESCRIPTION
<!-- PR title should be formatted using conventional commits -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->
<!-- Example: feat: A very fancy feature -->

## Changes

<!-- List the changes this PR introduces -->

- Error podman deployment when we detect `runtime:` is specified in the compose file

**Rationale**
- `podman compose` via `docker-compose` doesn't respect `runtime:`
- `podman compose` via `podman-compose` doesn't support `runtime:` when targeting remote deployments

The _only_ viable solution that doesn't involve bailing out is running `podman-compose` on the target, which means installing `podman-compose` python script (and it's dependencies) on a remote. Perhaps we'll get there eventually. For now, we can get basic podman deployment working w/o `runtime:` support.

## Checklist

<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->

- [x] 🤖 This change is covered by tests as required.
- [ ] 🤹 All required manual testing has been performed.
- [ ] 📖 All documentation updates are complete.
