### PR TITLE
feat: support `topo stop` with `--engine podman`

### DIFF
--- a/cmd/topo/stop.go
+++ b/cmd/topo/stop.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	"github.com/arm/topo/internal/deploy/docker"
+	"github.com/arm/topo/internal/deploy/podman"
 	"github.com/arm/topo/internal/env"
 	"github.com/arm/topo/internal/ssh"
 
@@ -22,6 +23,10 @@ By default, Topo uses compose.yaml in the current working directory, then compos
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		cmd.SilenceUsage = true
 
+		selectedEngine, err := getSelectedEngine(cmd)
+		if err != nil {
+			return err
+		}
 		targetArg, err := requireTarget(cmd)
 		if err != nil {
 			return err
@@ -37,7 +42,9 @@ By default, Topo uses compose.yaml in the current working directory, then compos
 		}
 
 		dest := ssh.NewDestination(targetArg)
-
+		if selectedEngine == containerEnginePodman {
+			return podman.Stop(cmd.Context(), os.Stdout, composeFile, dest)
+		}
 		return docker.Stop(cmd.Context(), os.Stdout, composeFile, dest)
 	},
 }
@@ -45,5 +52,8 @@ By default, Topo uses compose.yaml in the current working directory, then compos
 func init() {
 	addTargetFlag(topoStopCmd)
 	addComposeFileFlag(topoStopCmd)
+	if experimentalFeaturesEnabled() {
+		addEngineFlag(topoStopCmd)
+	}
 	rootCmd.AddCommand(topoStopCmd)
 }

--- a/internal/deploy/podman/deploy_test.go
+++ b/internal/deploy/podman/deploy_test.go
@@ -1,9 +1,7 @@
 package podman_test
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"os/exec"
 	"path/filepath"
@@ -12,7 +10,6 @@ import (
 
 	"github.com/arm/topo/internal/deploy/podman"
 	"github.com/arm/topo/internal/ssh"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 )
@@ -85,26 +82,6 @@ func requireLocalPodman(t *testing.T) {
 	}
 	if output, err := exec.Command("podman", "info").CombinedOutput(); err != nil {
 		t.Skipf("local Podman engine is unavailable: %v: %s", err, output)
-	}
-}
-
-func assertContainersRunning(t *testing.T, projectName string, socket podman.Socket) {
-	t.Helper()
-	cmd := podman.Command(t.Context(), socket,
-		"ps", "--format", "json", "--all",
-		"--filter", "label=com.docker.compose.project="+projectName,
-	)
-	var diagnostics bytes.Buffer
-	cmd.Stderr = &diagnostics
-	output, err := cmd.Output()
-	require.NoError(t, err, "stdout: %s\nstderr: %s", output, diagnostics.String())
-
-	var containers []map[string]any
-	require.NoError(t, json.Unmarshal(output, &containers))
-	require.NotEmpty(t, containers, "no containers reported; stderr: %s", diagnostics.String())
-
-	for _, container := range containers {
-		assert.Equal(t, "running", container["State"], "container %s is not running: %s", container["Names"], container["State"])
 	}
 }
 

--- a/internal/deploy/podman/stop.go
+++ b/internal/deploy/podman/stop.go
@@ -1,0 +1,32 @@
+package podman
+
+import (
+	"context"
+	"errors"
+	"io"
+
+	"github.com/arm/topo/internal/output/term"
+	"github.com/arm/topo/internal/ssh"
+)
+
+func Stop(ctx context.Context, output io.Writer, composeFile string, target ssh.Destination) (stopErr error) {
+	if err := term.PrintHeader(output, "Stop services"); err != nil {
+		return err
+	}
+
+	socket := LocalSocket
+	if target.IsPlainLocalhost() {
+		return RunComposeCommand(ctx, output, socket, composeFile, "stop")
+	}
+
+	tunnel, err := TunnelRemoteSocketPath(ctx, output, target)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		stopErr = errors.Join(stopErr, closeRemoteTunnel(tunnel))
+	}()
+
+	socket = NewSocket(tunnel.SocketURL())
+	return RunComposeCommand(ctx, output, socket, composeFile, "stop")
+}

--- a/internal/deploy/podman/stop.go
+++ b/internal/deploy/podman/stop.go
@@ -10,23 +10,25 @@ import (
 )
 
 func Stop(ctx context.Context, output io.Writer, composeFile string, target ssh.Destination) (stopErr error) {
+	socket := LocalSocket
+	if !target.IsPlainLocalhost() {
+		if err := term.PrintHeader(output, "Open Podman socket SSH tunnel"); err != nil {
+			return err
+		}
+
+		tunnel, err := TunnelRemoteSocketPath(ctx, output, target)
+		if err != nil {
+			return err
+		}
+		defer func() {
+			stopErr = errors.Join(stopErr, closeRemoteTunnel(tunnel))
+		}()
+
+		socket = NewSocket(tunnel.SocketURL())
+	}
+
 	if err := term.PrintHeader(output, "Stop services"); err != nil {
 		return err
 	}
-
-	socket := LocalSocket
-	if target.IsPlainLocalhost() {
-		return RunComposeCommand(ctx, output, socket, composeFile, "stop")
-	}
-
-	tunnel, err := TunnelRemoteSocketPath(ctx, output, target)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		stopErr = errors.Join(stopErr, closeRemoteTunnel(tunnel))
-	}()
-
-	socket = NewSocket(tunnel.SocketURL())
 	return RunComposeCommand(ctx, output, socket, composeFile, "stop")
 }

--- a/internal/deploy/podman/stop_test.go
+++ b/internal/deploy/podman/stop_test.go
@@ -17,9 +17,9 @@ func TestStop(t *testing.T) {
 		composeFile, projectName := deploymentFixture(t)
 		t.Cleanup(func() { cleanupComposeProject(t, composeFile) })
 		options := podman.DeployOptions{TargetHost: ssh.PlainLocalhost}
-		require.NoError(t, podman.Deploy(t.Context(), io.Discard, composeFile, options))
+		require.NoError(t, podman.Deploy(t.Context(), t.Output(), composeFile, options))
 
-		err := podman.Stop(t.Context(), io.Discard, composeFile, ssh.PlainLocalhost)
+		err := podman.Stop(t.Context(), t.Output(), composeFile, ssh.PlainLocalhost)
 
 		require.NoError(t, err)
 		assertContainersStopped(t, projectName, podman.LocalSocket)
@@ -29,9 +29,9 @@ func TestStop(t *testing.T) {
 		podmanContainer := startPodmanInContainer(t)
 		composeFile, projectName := deploymentFixture(t)
 		target := ssh.NewDestination(podmanContainer.SSHDestination)
-		require.NoError(t, podman.Deploy(t.Context(), io.Discard, composeFile, podman.DeployOptions{TargetHost: target}))
+		require.NoError(t, podman.Deploy(t.Context(), t.Output(), composeFile, podman.DeployOptions{TargetHost: target}))
 
-		err := podman.Stop(t.Context(), io.Discard, composeFile, target)
+		err := podman.Stop(t.Context(), t.Output(), composeFile, target)
 
 		require.NoError(t, err)
 		tunnel, err := podman.TunnelRemoteSocketPath(context.Background(), io.Discard, target)

--- a/internal/deploy/podman/stop_test.go
+++ b/internal/deploy/podman/stop_test.go
@@ -1,0 +1,42 @@
+package podman_test
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/arm/topo/internal/deploy/podman"
+	"github.com/arm/topo/internal/ssh"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStop(t *testing.T) {
+	requireLocalPodman(t)
+
+	t.Run("stops services on localhost", func(t *testing.T) {
+		composeFile, projectName := deploymentFixture(t)
+		t.Cleanup(func() { cleanupComposeProject(t, composeFile) })
+		options := podman.DeployOptions{TargetHost: ssh.PlainLocalhost}
+		require.NoError(t, podman.Deploy(t.Context(), io.Discard, composeFile, options))
+
+		err := podman.Stop(t.Context(), io.Discard, composeFile, ssh.PlainLocalhost)
+
+		require.NoError(t, err)
+		assertContainersStopped(t, projectName, podman.LocalSocket)
+	})
+
+	t.Run("stops services on a remote target", func(t *testing.T) {
+		podmanContainer := startPodmanInContainer(t)
+		composeFile, projectName := deploymentFixture(t)
+		target := ssh.NewDestination(podmanContainer.SSHDestination)
+		require.NoError(t, podman.Deploy(t.Context(), io.Discard, composeFile, podman.DeployOptions{TargetHost: target}))
+
+		err := podman.Stop(t.Context(), io.Discard, composeFile, target)
+
+		require.NoError(t, err)
+		tunnel, err := podman.TunnelRemoteSocketPath(context.Background(), io.Discard, target)
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, tunnel.Close()) })
+		assertContainersStopped(t, projectName, podman.NewSocket(tunnel.SocketURL()))
+	})
+}

--- a/internal/deploy/podman/testutil_test.go
+++ b/internal/deploy/podman/testutil_test.go
@@ -1,7 +1,9 @@
 package podman_test
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"path/filepath"
 	"testing"
@@ -9,6 +11,8 @@ import (
 
 	"github.com/arm/topo/internal/deploy/podman"
 	gtestutil "github.com/arm/topo/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func sanitiseTestName(t *testing.T) string {
@@ -29,6 +33,34 @@ func requireWriteFile(t *testing.T, path, content string) {
 func requireAvailableTCPPort(t *testing.T) string {
 	t.Helper()
 	return gtestutil.RequireAvailableTCPPort(t, "127.0.0.1")
+}
+
+func assertContainersRunning(t *testing.T, projectName string, socket podman.Socket) {
+	assertContainersInState(t, projectName, socket, "running")
+}
+
+func assertContainersStopped(t *testing.T, projectName string, socket podman.Socket) {
+	assertContainersInState(t, projectName, socket, "exited")
+}
+
+func assertContainersInState(t *testing.T, projectName string, socket podman.Socket, state string) {
+	t.Helper()
+	cmd := podman.Command(t.Context(), socket,
+		"ps", "--format", "json", "--all",
+		"--filter", "label=com.docker.compose.project="+projectName,
+	)
+	var diagnostics bytes.Buffer
+	cmd.Stderr = &diagnostics
+	output, err := cmd.Output()
+	require.NoError(t, err, "stdout: %s\nstderr: %s", output, diagnostics.String())
+
+	var containers []map[string]any
+	require.NoError(t, json.Unmarshal(output, &containers))
+	require.NotEmpty(t, containers, "no containers reported; stderr: %s", diagnostics.String())
+
+	for _, container := range containers {
+		assert.Equal(t, state, container["State"], "expected container %s to be %s (state=%s)", container["Names"], state, container["State"])
+	}
 }
 
 func imageTransferFixture(t *testing.T) (string, string) {


### PR DESCRIPTION
<!-- PR title should be formatted using conventional commits -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->
<!-- Example: feat: A very fancy feature -->

## Changes

<!-- List the changes this PR introduces -->

- Add experimental `topo stop --engine podman` support.

## Checklist

<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->

- [x] 🤖 This change is covered by tests as required.
- [ ] 🤹 All required manual testing has been performed.
- [ ] 📖 All documentation updates are complete.
