### PR TITLE
fix: landing image by using useBaseUrl

### DIFF
--- a/docs/landing-page/index.tsx
+++ b/docs/landing-page/index.tsx
@@ -1,4 +1,5 @@
 import Link from "@docusaurus/Link";
+import useBaseUrl from "@docusaurus/useBaseUrl";
 import Layout from "@theme/Layout";
 import type { ReactElement } from "react";
 
@@ -11,6 +12,8 @@ function joinClasses(...parts: Array<string | undefined | false>): string {
 }
 
 export default function Home(): ReactElement {
+  const heroDiagramUrl = useBaseUrl("/img/topo-overview.svg");
+
   return (
     <Layout
       title={homepageContent.meta.title}
@@ -48,7 +51,7 @@ export default function Home(): ReactElement {
           <div className={styles.heroVisual}>
             <img
               className={styles.heroDiagram}
-              src="img/topo-overview.svg"
+              src={heroDiagramUrl}
               alt="Topo deployment and development loop"
             />
           </div>


### PR DESCRIPTION
<!-- PR title should be formatted using conventional commits -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->
<!-- Example: feat: A very fancy feature -->

The landing image wasn't loading in the pre-production environment because the base URL wasn't being set.

## Changes

<!-- List the changes this PR introduces -->
- Prefix the image url with base URL (https://docusaurus.io/docs/docusaurus-core#useBaseUrl)


## Checklist

<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->

- [ ] 🤖 This change is covered by tests as required.
- [x] 🤹 All required manual testing has been performed.
- [ ] 📖 All documentation updates are complete.
