### PR TITLE
test: use compose file test util + consistent file name const

### DIFF
--- a/e2e/configure_test.go
+++ b/e2e/configure_test.go
@@ -15,8 +15,7 @@ func TestConfigure(t *testing.T) {
 
 	t.Run("updates compose yaml parameters", func(t *testing.T) {
 		projectDir := t.TempDir()
-		composePath := filepath.Join(projectDir, "compose.yaml")
-		testutil.RequireWriteFile(t, composePath, configurableCompose("Original"))
+		composePath := testutil.RequireWriteComposeFile(t, projectDir, configurableCompose("Original"))
 
 		cmd := exec.Command(topo, "configure", "GREETING_NAME=World")
 		cmd.Dir = projectDir
@@ -47,10 +46,9 @@ func TestConfigure(t *testing.T) {
 
 	t.Run("respect compose file flag", func(t *testing.T) {
 		projectDir := t.TempDir()
-		composePath := filepath.Join(projectDir, "compose.yaml")
 		customComposePath := filepath.Join(projectDir, "custom-compose.yaml")
 		originalCompose := configurableCompose("Original")
-		testutil.RequireWriteFile(t, composePath, originalCompose)
+		composePath := testutil.RequireWriteComposeFile(t, projectDir, originalCompose)
 		testutil.RequireWriteFile(t, customComposePath, configurableCompose("CustomOriginal"))
 
 		cmd := exec.Command(topo, "configure", "-f", "custom-compose.yaml", "GREETING_NAME=Custom")
@@ -67,9 +65,8 @@ func TestConfigure(t *testing.T) {
 
 	t.Run("rejects undeclared parameters without changing the compose file", func(t *testing.T) {
 		projectDir := t.TempDir()
-		composePath := filepath.Join(projectDir, "compose.yaml")
 		original := configurableCompose("Original")
-		testutil.RequireWriteFile(t, composePath, original)
+		composePath := testutil.RequireWriteComposeFile(t, projectDir, original)
 
 		cmd := exec.Command(topo, "configure", "UNKNOWN=value")
 		cmd.Dir = projectDir

--- a/e2e/deploy_test.go
+++ b/e2e/deploy_test.go
@@ -39,7 +39,7 @@ func TestDeploy(t *testing.T) {
 
 	t.Run("ps -a shows stopped containers", func(t *testing.T) {
 		projectDir := t.TempDir()
-		composeFile := testutil.WriteComposeFile(t, projectDir, `services:
+		composeFile := testutil.RequireWriteComposeFile(t, projectDir, `services:
   sleeper:
     image: busybox
     command: ["sleep", "300"]

--- a/internal/compose/compose_test.go
+++ b/internal/compose/compose_test.go
@@ -15,8 +15,7 @@ import (
 
 func TestImageNames(t *testing.T) {
 	t.Run("returns explicit and generated image names", func(t *testing.T) {
-		path := filepath.Join(t.TempDir(), "compose.yaml")
-		testutil.RequireWriteFile(t, path, `
+		path := testutil.RequireWriteComposeFile(t, t.TempDir(), `
 name: springfield
 services:
   api:
@@ -36,8 +35,7 @@ services:
 
 	t.Run("uses the compose file directory when project name is omitted", func(t *testing.T) {
 		dir := t.TempDir()
-		path := filepath.Join(dir, "compose.yaml")
-		testutil.RequireWriteFile(t, path, `
+		path := testutil.RequireWriteComposeFile(t, dir, `
 services:
   api:
     build: .
@@ -54,7 +52,6 @@ services:
 	t.Run("resolves image names from extended services", func(t *testing.T) {
 		dir := t.TempDir()
 		basePath := filepath.Join(dir, "base.yaml")
-		path := filepath.Join(dir, "compose.yaml")
 		testutil.RequireWriteFile(t, basePath, `
 services:
   image-base:
@@ -62,7 +59,7 @@ services:
   build-base:
     build: .
 `)
-		testutil.RequireWriteFile(t, path, `
+		path := testutil.RequireWriteComposeFile(t, dir, `
 name: springfield
 services:
   duff:
@@ -82,8 +79,7 @@ services:
 	})
 
 	t.Run("returns sorted output", func(t *testing.T) {
-		path := filepath.Join(t.TempDir(), "compose.yaml")
-		testutil.RequireWriteFile(t, path, `
+		path := testutil.RequireWriteComposeFile(t, t.TempDir(), `
 name: springfield
 services:
   zulu:
@@ -104,8 +100,7 @@ services:
 	})
 
 	t.Run("returns error for invalid yaml", func(t *testing.T) {
-		path := filepath.Join(t.TempDir(), "compose.yaml")
-		testutil.RequireWriteFile(t, path, `{invalid`)
+		path := testutil.RequireWriteComposeFile(t, t.TempDir(), `{invalid`)
 
 		_, err := compose.ImageNames(path)
 
@@ -115,8 +110,7 @@ services:
 
 func TestPullableServices(t *testing.T) {
 	t.Run("returns services without a build key", func(t *testing.T) {
-		path := filepath.Join(t.TempDir(), "compose.yaml")
-		testutil.RequireWriteFile(t, path, `
+		path := testutil.RequireWriteComposeFile(t, t.TempDir(), `
 services:
   duff-beer:
     image: duff:7
@@ -131,8 +125,7 @@ services:
 	})
 
 	t.Run("excludes services with a build key", func(t *testing.T) {
-		path := filepath.Join(t.TempDir(), "compose.yaml")
-		testutil.RequireWriteFile(t, path, `
+		path := testutil.RequireWriteComposeFile(t, t.TempDir(), `
 services:
   krusty-burger:
     build: .
@@ -148,8 +141,7 @@ services:
 	})
 
 	t.Run("returns empty slice when all services are buildable", func(t *testing.T) {
-		path := filepath.Join(t.TempDir(), "compose.yaml")
-		testutil.RequireWriteFile(t, path, `
+		path := testutil.RequireWriteComposeFile(t, t.TempDir(), `
 services:
   krusty-burger:
     build: .
@@ -166,8 +158,7 @@ services:
 	})
 
 	t.Run("excludes services that extend a buildable service", func(t *testing.T) {
-		path := filepath.Join(t.TempDir(), "compose.yaml")
-		testutil.RequireWriteFile(t, path, `
+		path := testutil.RequireWriteComposeFile(t, t.TempDir(), `
 services:
   krusty-burger:
     build: .
@@ -186,8 +177,7 @@ services:
 	})
 
 	t.Run("returns error for invalid yaml", func(t *testing.T) {
-		path := filepath.Join(t.TempDir(), "compose.yaml")
-		testutil.RequireWriteFile(t, path, `{invalid`)
+		path := testutil.RequireWriteComposeFile(t, t.TempDir(), `{invalid`)
 
 		_, err := compose.PullableServices(path)
 
@@ -216,7 +206,7 @@ services:
         FOO: new-foo
         BAR: new-bar
 `
-		composeFilePath := testutil.WriteComposeFile(t, dir, composeFileContents)
+		composeFilePath := testutil.RequireWriteComposeFile(t, dir, composeFileContents)
 		proj, err := compose.ReadProject(composeFilePath)
 		require.NoError(t, err)
 
@@ -235,7 +225,7 @@ services:
   %s:
     image: ${IMAGE_NAME}
 `, serviceName)
-		composeFilePath := testutil.WriteComposeFile(t, dir, composeFileContents)
+		composeFilePath := testutil.RequireWriteComposeFile(t, dir, composeFileContents)
 		imageName := "image-from-env"
 		testutil.RequireWriteFile(t, filepath.Join(dir, ".env"), fmt.Sprintf("IMAGE_NAME=%s", imageName))
 
@@ -255,7 +245,7 @@ services:
   %s:
     image: ${IMAGE_NAME}
 `, serviceName)
-		composeFilePath := testutil.WriteComposeFile(t, dir, composeFileContents)
+		composeFilePath := testutil.RequireWriteComposeFile(t, dir, composeFileContents)
 		imageName := "image-from-env"
 		t.Setenv("IMAGE_NAME", imageName)
 

--- a/internal/compose/file_test.go
+++ b/internal/compose/file_test.go
@@ -16,8 +16,7 @@ import (
 
 func TestRequireFile(t *testing.T) {
 	t.Run("returns path when compose file exists", func(t *testing.T) {
-		composeFile := filepath.Join(t.TempDir(), "compose.yaml")
-		testutil.RequireWriteFile(t, composeFile, "")
+		composeFile := testutil.RequireWriteComposeFile(t, t.TempDir(), "")
 
 		got, err := compose.RequireFile(composeFile)
 

--- a/internal/deploy/docker/compose_test.go
+++ b/internal/deploy/docker/compose_test.go
@@ -3,10 +3,10 @@ package docker_test
 import (
 	"bytes"
 	"context"
-	"path/filepath"
 	"testing"
 
 	"github.com/arm/topo/internal/deploy/docker"
+	"github.com/arm/topo/internal/testutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -14,16 +14,14 @@ func TestPullImages(t *testing.T) {
 	requireDocker(t)
 
 	t.Run("skips services that have a build context", func(t *testing.T) {
-		composeFilePath := filepath.Join(t.TempDir(), "compose.yaml")
-		composeFileContent := `
+		composeFilePath := testutil.RequireWriteComposeFile(t, t.TempDir(), `
 services:
   locally-built:
     build:
       context: .
       dockerfile_inline: "FROM alpine:latest"
     image: this-image-does-not-exist-on-docker-hub
-`
-		requireWriteFile(t, composeFilePath, composeFileContent)
+`)
 		var output bytes.Buffer
 
 		err := docker.PullImages(context.Background(), &output, docker.LocalHost, composeFilePath)

--- a/internal/deploy/docker/deploy_test.go
+++ b/internal/deploy/docker/deploy_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/arm/topo/internal/deploy/docker"
 	"github.com/arm/topo/internal/ssh"
+	"github.com/arm/topo/internal/testutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -71,16 +72,14 @@ func deploymentFixture(t *testing.T) (composeFilePath, imageName string) {
 	t.Helper()
 	temporaryDirectory := t.TempDir()
 	imageName = testImageName(t)
-	composeFilePath = filepath.Join(temporaryDirectory, "compose.yaml")
-	composeFileContent := fmt.Sprintf(`
+	composeFilePath = testutil.RequireWriteComposeFile(t, temporaryDirectory, fmt.Sprintf(`
 name: %s
 services:
   a-service:
     build: .
     image: %s
-`, testProjectName(t), imageName)
-	requireWriteFile(t, composeFilePath, composeFileContent)
-	requireWriteFile(t, filepath.Join(temporaryDirectory, "Dockerfile"), `
+`, testProjectName(t), imageName))
+	testutil.RequireWriteFile(t, filepath.Join(temporaryDirectory, "Dockerfile"), `
 FROM alpine:latest
 CMD ["tail", "-f", "/dev/null"]
 `)

--- a/internal/deploy/docker/image_transfer_pipe_test.go
+++ b/internal/deploy/docker/image_transfer_pipe_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/arm/topo/internal/deploy/docker"
 	"github.com/arm/topo/internal/ssh"
+	"github.com/arm/topo/internal/testutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -30,17 +31,15 @@ func TestTransferImagesViaPipe(t *testing.T) {
 func buildTransferTestImage(t *testing.T, host docker.Host) (string, string) {
 	t.Helper()
 	temporaryDirectory := t.TempDir()
-	composeFilePath := filepath.Join(temporaryDirectory, "compose.yaml")
 	dockerFilePath := filepath.Join(temporaryDirectory, "Dockerfile")
 	imageName := testImageName(t)
-	composeFileContent := fmt.Sprintf(`
+	composeFilePath := testutil.RequireWriteComposeFile(t, temporaryDirectory, fmt.Sprintf(`
 services:
   test:
     build: .
     image: %s
-`, imageName)
-	requireWriteFile(t, composeFilePath, composeFileContent)
-	requireWriteFile(t, dockerFilePath, "FROM alpine:latest")
+`, imageName))
+	testutil.RequireWriteFile(t, dockerFilePath, "FROM alpine:latest")
 
 	buildCommand := docker.ComposeCommand(t.Context(), host, composeFilePath, "build")
 	buildOutput, err := buildCommand.CombinedOutput()

--- a/internal/deploy/docker/stop_test.go
+++ b/internal/deploy/docker/stop_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/arm/topo/internal/deploy/docker"
 	"github.com/arm/topo/internal/ssh"
+	"github.com/arm/topo/internal/testutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -18,12 +19,11 @@ func TestStop(t *testing.T) {
 	remoteDockerHost := ssh.NewDestination(container.SSHDestination)
 	temporaryDirectory := t.TempDir()
 	dockerFilePath := filepath.Join(temporaryDirectory, "Dockerfile")
-	requireWriteFile(t, dockerFilePath, `
+	testutil.RequireWriteFile(t, dockerFilePath, `
 FROM alpine:latest
 CMD ["tail", "-f", "/dev/null"]
 `)
-	composeFilePath := filepath.Join(temporaryDirectory, "compose.yaml")
-	composeFileContent := fmt.Sprintf(`
+	composeFilePath := testutil.RequireWriteComposeFile(t, temporaryDirectory, fmt.Sprintf(`
 name: %s
 services:
   busybox:
@@ -31,8 +31,7 @@ services:
     command: ["tail", "-f", "/dev/null"]
   a-service:
     build: .
-`, testProjectName(t))
-	requireWriteFile(t, composeFilePath, composeFileContent)
+`, testProjectName(t)))
 	t.Cleanup(func() { forceComposeDown(t, composeFilePath) })
 	deployOptions := docker.DeployOptions{TargetHost: remoteDockerHost}
 	require.NoError(t, docker.Deploy(t.Context(), io.Discard, composeFilePath, deployOptions))

--- a/internal/deploy/docker/testutil_test.go
+++ b/internal/deploy/docker/testutil_test.go
@@ -31,11 +31,6 @@ func requireAvailableTCPPort(t *testing.T, host string) string {
 	return gtestutil.RequireAvailableTCPPort(t, host)
 }
 
-func requireWriteFile(t *testing.T, path, content string) {
-	t.Helper()
-	gtestutil.RequireWriteFile(t, path, content)
-}
-
 func startContainer(t *testing.T, spec gtestutil.ContainerSpec) *gtestutil.Container {
 	t.Helper()
 	return gtestutil.StartContainer(t, spec)

--- a/internal/deploy/podman/deploy_test.go
+++ b/internal/deploy/podman/deploy_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestDeploy(t *testing.T) {
 	t.Run("rejects runtime before accessing Podman", func(t *testing.T) {
-		composeFile := testutil.WriteComposeFile(t, t.TempDir(), `
+		composeFile := testutil.RequireWriteComposeFile(t, t.TempDir(), `
 services:
   firmware:
     image: alpine
@@ -106,7 +106,6 @@ func deploymentFixture(t *testing.T) (string, string) {
 	tempDir := t.TempDir()
 	testName := sanitiseTestName(t)
 	imageName := "test-image-" + testName
-	composeFile := filepath.Join(tempDir, "compose.yaml")
 	composeFileContent := fmt.Sprintf(`
 name: %s
 services:
@@ -119,8 +118,8 @@ services:
 `, "test-project-"+testName, imageName)
 	composeFileContent, err := fixPodmanInDockerQuirk(composeFileContent)
 	require.NoError(t, err)
-	requireWriteFile(t, composeFile, composeFileContent)
-	requireWriteFile(t, filepath.Join(tempDir, "Dockerfile"), `
+	composeFile := testutil.RequireWriteComposeFile(t, tempDir, composeFileContent)
+	testutil.RequireWriteFile(t, filepath.Join(tempDir, "Dockerfile"), `
 FROM docker.io/library/alpine:latest
 CMD ["tail", "-f", "/dev/null"]
 `)

--- a/internal/deploy/podman/runtime_test.go
+++ b/internal/deploy/podman/runtime_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestEnsureNoRuntimeSet(t *testing.T) {
 	t.Run("succeeds when no service runtime is set", func(t *testing.T) {
-		composeFile := testutil.WriteComposeFile(t, t.TempDir(), `
+		composeFile := testutil.RequireWriteComposeFile(t, t.TempDir(), `
 services:
   app:
     image: alpine
@@ -22,7 +22,7 @@ services:
 	})
 
 	t.Run("rejects a service with a runtime", func(t *testing.T) {
-		composeFile := testutil.WriteComposeFile(t, t.TempDir(), `
+		composeFile := testutil.RequireWriteComposeFile(t, t.TempDir(), `
 services:
   firmware:
     image: alpine
@@ -35,7 +35,7 @@ services:
 	})
 
 	t.Run("lists every service with a runtime", func(t *testing.T) {
-		composeFile := testutil.WriteComposeFile(t, t.TempDir(), `
+		composeFile := testutil.RequireWriteComposeFile(t, t.TempDir(), `
 services:
   application:
     image: alpine

--- a/internal/deploy/podman/testutil_test.go
+++ b/internal/deploy/podman/testutil_test.go
@@ -25,11 +25,6 @@ func startPodmanInContainer(t *testing.T) *gtestutil.Container {
 	return gtestutil.StartContainer(t, gtestutil.PodmanContainer)
 }
 
-func requireWriteFile(t *testing.T, path, content string) {
-	t.Helper()
-	gtestutil.RequireWriteFile(t, path, content)
-}
-
 func requireAvailableTCPPort(t *testing.T) string {
 	t.Helper()
 	return gtestutil.RequireAvailableTCPPort(t, "127.0.0.1")
@@ -66,15 +61,14 @@ func assertContainersInState(t *testing.T, projectName string, socket podman.Soc
 func imageTransferFixture(t *testing.T) (string, string) {
 	t.Helper()
 	temporaryDirectory := t.TempDir()
-	composeFile := filepath.Join(temporaryDirectory, "compose.yaml")
 	imageName := "test-image-" + sanitiseTestName(t)
-	requireWriteFile(t, composeFile, fmt.Sprintf(`
+	composeFile := gtestutil.RequireWriteComposeFile(t, temporaryDirectory, fmt.Sprintf(`
 services:
   test:
     build: .
     image: %s
 `, imageName))
-	requireWriteFile(t, filepath.Join(temporaryDirectory, "Dockerfile"), "FROM docker.io/library/alpine:latest\n")
+	gtestutil.RequireWriteFile(t, filepath.Join(temporaryDirectory, "Dockerfile"), "FROM docker.io/library/alpine:latest\n")
 	t.Cleanup(func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()

--- a/internal/deploy/post_deploy/post_deploy_test.go
+++ b/internal/deploy/post_deploy/post_deploy_test.go
@@ -2,7 +2,6 @@ package post_deploy_test
 
 import (
 	"bytes"
-	"path/filepath"
 	"testing"
 
 	"github.com/arm/topo/internal/deploy/post_deploy"
@@ -13,9 +12,7 @@ import (
 
 func TestPrintDeploySuccess(t *testing.T) {
 	t.Run("writes deployment_success_message from compose file", func(t *testing.T) {
-		dir := t.TempDir()
-		composeFile := filepath.Join(dir, "compose.yaml")
-		testutil.RequireWriteFile(t, composeFile, `
+		composeFile := testutil.RequireWriteComposeFile(t, t.TempDir(), `
 x-topo:
   deployment_success_message: "Deployment complete!"
 services:
@@ -31,9 +28,7 @@ services:
 	})
 
 	t.Run("writes default message when deployment_success_message is absent", func(t *testing.T) {
-		dir := t.TempDir()
-		composeFile := filepath.Join(dir, "compose.yaml")
-		testutil.RequireWriteFile(t, composeFile, `
+		composeFile := testutil.RequireWriteComposeFile(t, t.TempDir(), `
 services:
   app:
     image: nginx
@@ -47,9 +42,7 @@ services:
 	})
 
 	t.Run("interpolates env vars in deployment_success_message", func(t *testing.T) {
-		dir := t.TempDir()
-		composeFile := filepath.Join(dir, "compose.yaml")
-		testutil.RequireWriteFile(t, composeFile, `
+		composeFile := testutil.RequireWriteComposeFile(t, t.TempDir(), `
 name: test-project
 x-topo:
   deployment_success_message: "${COMPOSE_PROJECT_NAME} deployed - ${EXTRA_MESSAGE}"

--- a/internal/deploy/project_checks/project_checks_test.go
+++ b/internal/deploy/project_checks/project_checks_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestEnsureProjectIsLinuxArm64Ready(t *testing.T) {
 	t.Run("succeeds with valid platforms without variant", func(t *testing.T) {
-		composeFile := writeComposeFile(t, `
+		composeFile := testutil.RequireWriteComposeFile(t, t.TempDir(), `
 services:
   app:
     image: alpine
@@ -21,7 +21,7 @@ services:
 	})
 
 	t.Run("succeeds with valid platforms with variant", func(t *testing.T) {
-		composeFile := writeComposeFile(t, `
+		composeFile := testutil.RequireWriteComposeFile(t, t.TempDir(), `
 services:
   app:
     image: alpine
@@ -31,7 +31,7 @@ services:
 		require.NoError(t, checks.EnsureProjectIsLinuxArm64Ready(composeFile))
 	})
 	t.Run("fails when platform missing", func(t *testing.T) {
-		composeFile := writeComposeFile(t, `
+		composeFile := testutil.RequireWriteComposeFile(t, t.TempDir(), `
 services:
   api:
     image: busybox
@@ -42,7 +42,7 @@ services:
 		require.Contains(t, err.Error(), "missing platform declaration")
 	})
 	t.Run("fails when platform is not linux/arm64", func(t *testing.T) {
-		composeFile := writeComposeFile(t, `
+		composeFile := testutil.RequireWriteComposeFile(t, t.TempDir(), `
 services:
   api:
     image: busybox
@@ -54,7 +54,7 @@ services:
 		require.Contains(t, err.Error(), "linux/amd64")
 	})
 	t.Run("skips remoteproc-runtime without platform", func(t *testing.T) {
-		composeFile := writeComposeFile(t, `
+		composeFile := testutil.RequireWriteComposeFile(t, t.TempDir(), `
 services:
   firmware:
     image: zephyr
@@ -64,7 +64,7 @@ services:
 		require.NoError(t, checks.EnsureProjectIsLinuxArm64Ready(composeFile))
 	})
 	t.Run("succeeds with valid remoteproc-runtime", func(t *testing.T) {
-		composeFile := writeComposeFile(t, `
+		composeFile := testutil.RequireWriteComposeFile(t, t.TempDir(), `
 services:
   rtos-firmware:
     build:
@@ -74,9 +74,4 @@ services:
 
 		require.NoError(t, checks.EnsureProjectIsLinuxArm64Ready(composeFile))
 	})
-}
-
-func writeComposeFile(t *testing.T, contents string) string {
-	t.Helper()
-	return testutil.WriteComposeFile(t, t.TempDir(), contents)
 }

--- a/internal/project/definition.go
+++ b/internal/project/definition.go
@@ -9,8 +9,6 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-const ComposeFilename = "compose.yaml"
-
 type Project struct {
 	Metadata               Metadata
 	currentParameterValues map[string][]string

--- a/internal/project/operations.go
+++ b/internal/project/operations.go
@@ -130,7 +130,7 @@ func (o resolveArgsOperation) Description() string {
 }
 
 func (o resolveArgsOperation) Run(_ io.Writer) error {
-	composeFile := filepath.Join(o.path, ComposeFilename)
+	composeFile := filepath.Join(o.path, compose.DefaultFileName())
 	if err := ResolveAndApplyArgs(composeFile, o.argProvider); err != nil {
 		if rmErr := os.RemoveAll(o.path); rmErr != nil {
 			return errors.Join(err, rmErr)

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/arm/topo/internal/arguments"
+	"github.com/arm/topo/internal/compose"
 	"github.com/arm/topo/internal/project"
 	"github.com/arm/topo/internal/testutil"
 	"github.com/stretchr/testify/assert"
@@ -63,7 +64,7 @@ services:
 		err := project.Clone(destDir, mockSource, arguments.NewStrictProviderChain())
 
 		require.NoError(t, err)
-		composeFilePath := filepath.Join(destDir, project.ComposeFilename)
+		composeFilePath := filepath.Join(destDir, compose.DefaultFileName())
 		assert.FileExists(t, composeFilePath)
 	})
 
@@ -90,7 +91,7 @@ x-topo:
 		err := project.Clone(destDir, mockSource, arguments.NewStrictProviderChain(provider))
 
 		require.NoError(t, err)
-		composeFilePath := filepath.Join(destDir, project.ComposeFilename)
+		composeFilePath := filepath.Join(destDir, compose.DefaultFileName())
 		assert.Equal(t, composeFileContents, testutil.RequireReadFile(t, composeFilePath))
 	})
 
@@ -119,11 +120,12 @@ x-topo:
 }
 
 func mockSourceWithContent(t *testing.T, content string) *mockProjectSource {
+	t.Helper()
 	mockSource := &mockProjectSource{}
 	mockSource.On("CopyTo", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
 		destDir := args.String(0)
 		testutil.RequireMkdirAll(t, destDir)
-		testutil.RequireWriteFile(t, filepath.Join(destDir, project.ComposeFilename), content)
+		testutil.RequireWriteComposeFile(t, destDir, content)
 	})
 	t.Cleanup(func() {
 		mockSource.AssertExpectations(t)
@@ -142,7 +144,6 @@ func TestResolveAndApplyArgs(t *testing.T) {
 	})
 
 	t.Run("updates the compose file with resolved parameters", func(t *testing.T) {
-		dir := t.TempDir()
 		composeFileContents := `
 services:
   app:
@@ -159,8 +160,7 @@ x-topo:
       required: true
       example: bar
 `
-		composeFilePath := filepath.Join(dir, project.ComposeFilename)
-		testutil.RequireWriteFile(t, composeFilePath, composeFileContents)
+		composeFilePath := testutil.RequireWriteComposeFile(t, t.TempDir(), composeFileContents)
 		provider := arguments.NewStaticProvider(arguments.ResolvedArg{Name: "FOO", Value: "baz"})
 		argProvider := arguments.NewStrictProviderChain(provider)
 
@@ -189,7 +189,6 @@ x-topo:
 	})
 
 	t.Run("rejects empty input for required parameters when any current value is empty", func(t *testing.T) {
-		dir := t.TempDir()
 		composeFileContents := `services:
   configured:
     build:
@@ -205,8 +204,7 @@ x-topo:
       required: true
       default: default
 `
-		composeFilePath := filepath.Join(dir, project.ComposeFilename)
-		testutil.RequireWriteFile(t, composeFilePath, composeFileContents)
+		composeFilePath := testutil.RequireWriteComposeFile(t, t.TempDir(), composeFileContents)
 		argProvider := arguments.NewStrictProviderChain(arguments.NewStaticProvider())
 
 		err := project.ResolveAndApplyArgs(composeFilePath, argProvider)
@@ -216,7 +214,6 @@ x-topo:
 	})
 
 	t.Run("recognizes current values in sequence build args", func(t *testing.T) {
-		dir := t.TempDir()
 		composeFileContents := `services:
   app:
     build:
@@ -227,8 +224,7 @@ x-topo:
       required: true
       default: default
 `
-		composeFilePath := filepath.Join(dir, project.ComposeFilename)
-		testutil.RequireWriteFile(t, composeFilePath, composeFileContents)
+		composeFilePath := testutil.RequireWriteComposeFile(t, t.TempDir(), composeFileContents)
 		argProvider := arguments.NewStrictProviderChain(arguments.NewStaticProvider())
 
 		err := project.ResolveAndApplyArgs(composeFilePath, argProvider)

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/arm/topo/internal/project"
+	"github.com/arm/topo/internal/compose"
 	"github.com/stretchr/testify/require"
 )
 
@@ -62,9 +62,9 @@ func SanitiseTestName(t testing.TB) string {
 	return name
 }
 
-func WriteComposeFile(t *testing.T, dir, content string) string {
+func RequireWriteComposeFile(t testing.TB, dir, content string) string {
 	t.Helper()
-	composePath := filepath.Join(dir, project.ComposeFilename)
+	composePath := filepath.Join(dir, compose.DefaultFileName())
 	RequireWriteFile(t, composePath, content)
 	return composePath
 }


### PR DESCRIPTION
<!-- PR title should be formatted using conventional commits -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->
<!-- Example: feat: A very fancy feature -->

## Changes

<!-- List the changes this PR introduces -->

Starting pulling a thread on `project.ComposeFilename` and it kept going!

- Removes `project.ComposeFilename`, uses `compose.DefaultFileName()`
- Uses the existing compose file writer testutil consistently. Updates its signature to convey it asserts no error.
- Removes a lot of duplicate compose file writer test utils

## Checklist

<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->

- [x] 🤖 This change is covered by tests as required.
- [x] 🤹 All required manual testing has been performed.
- [x] 📖 All documentation updates are complete.
