### PR TITLE
refactor: simplify health dependency checks

### DIFF
--- a/e2e/health_test.go
+++ b/e2e/health_test.go
@@ -14,7 +14,7 @@ const targetDestinationPlaceholder = "TARGET_DESTINATION"
 
 func replaceNonDeterministicDestination(t *testing.T, out string) string {
 	t.Helper()
-	var obj map[string]map[string]interface{}
+	var obj map[string]map[string]any
 	err := json.Unmarshal([]byte(out), &obj)
 	require.NoError(t, err)
 

--- a/internal/health/check.go
+++ b/internal/health/check.go
@@ -13,7 +13,7 @@ import (
 )
 
 type Check interface {
-	Run(ctx context.Context, r runner.Runner, dep Dependency) *CheckFailure
+	Run(ctx context.Context, r runner.Runner) *CheckFailure
 }
 
 type CheckFailure struct {
@@ -40,7 +40,7 @@ type CommandSuccessful struct {
 	Fix *Fix
 }
 
-func (c CommandSuccessful) Run(ctx context.Context, r runner.Runner, dep Dependency) *CheckFailure {
+func (c CommandSuccessful) Run(ctx context.Context, r runner.Runner) *CheckFailure {
 	_, _, err := r.Run(ctx, c.Cmd)
 	if err != nil {
 		return &CheckFailure{Message: err.Error(), Fix: c.Fix}
@@ -49,12 +49,13 @@ func (c CommandSuccessful) Run(ctx context.Context, r runner.Runner, dep Depende
 }
 
 type BinaryExists struct {
+	Binary   string
 	Severity CheckSeverity
 	Fix      *Fix
 }
 
-func (b BinaryExists) Run(ctx context.Context, r runner.Runner, dep Dependency) *CheckFailure {
-	if err := r.BinaryExists(ctx, dep.Binary); err != nil {
+func (b BinaryExists) Run(ctx context.Context, r runner.Runner) *CheckFailure {
+	if err := r.BinaryExists(ctx, b.Binary); err != nil {
 		return &CheckFailure{Severity: b.Severity, Message: err.Error(), Fix: b.Fix}
 	}
 	return nil
@@ -66,7 +67,7 @@ type VersionMatches struct {
 	BuildFix       func() Fix
 }
 
-func (v VersionMatches) Run(ctx context.Context, _ runner.Runner, _ Dependency) *CheckFailure {
+func (v VersionMatches) Run(ctx context.Context, _ runner.Runner) *CheckFailure {
 	latest, err := v.FetchLatest(ctx)
 	if err != nil {
 		logger.Warn(fmt.Sprintf("failed to fetch latest version: %v", err))
@@ -88,16 +89,18 @@ func (v VersionMatches) Run(ctx context.Context, _ runner.Runner, _ Dependency) 
 	}
 }
 
-type OpenSSHAvailable struct{}
+type OpenSSHAvailable struct {
+	SSHBinary string
+}
 
-func (o OpenSSHAvailable) Run(ctx context.Context, r runner.Runner, dep Dependency) *CheckFailure {
-	_, stderr, err := r.Run(ctx, "ssh -V")
+func (o OpenSSHAvailable) Run(ctx context.Context, r runner.Runner) *CheckFailure {
+	_, stderr, err := r.Run(ctx, o.SSHBinary+" -V")
 	if err != nil {
 		return &CheckFailure{Message: err.Error()}
 	}
 	if !strings.Contains(stderr, "OpenSSH_") {
 		return &CheckFailure{
-			Message: fmt.Sprintf("%q does not resolve to OpenSSH: %s", dep.Binary, stderr),
+			Message: fmt.Sprintf("%q does not resolve to OpenSSH: %s", o.SSHBinary, stderr),
 			Fix: &Fix{
 				Description: "Install OpenSSH and ensure its ssh executable is first on PATH",
 			},
@@ -110,7 +113,7 @@ type DockerComposeMinVersion struct {
 	MinVersion string
 }
 
-func (c DockerComposeMinVersion) Run(ctx context.Context, r runner.Runner, _ Dependency) *CheckFailure {
+func (c DockerComposeMinVersion) Run(ctx context.Context, r runner.Runner) *CheckFailure {
 	stdout, _, err := r.Run(ctx, "docker compose version --format json")
 	if err != nil {
 		return &CheckFailure{Message: err.Error()}

--- a/internal/health/check.go
+++ b/internal/health/check.go
@@ -12,26 +12,7 @@ import (
 	"github.com/arm/topo/internal/version"
 )
 
-type CheckFailure struct {
-	Severity CheckSeverity
-	Message  string
-	Fix      *Fix
-}
-
-type Fix struct {
-	Description string `json:"description"`
-	Command     string `json:"command,omitempty"`
-}
-
-type CheckSeverity int
-
-const (
-	SeverityError CheckSeverity = iota
-	SeverityWarning
-	SeverityInfo
-)
-
-func CheckTopoIsUpToDate(ctx context.Context) *CheckFailure {
+func CheckTopoIsUpToDate(ctx context.Context) *DependencyCheckFailure {
 	if version.Version == version.Dev {
 		return nil
 	}
@@ -57,20 +38,20 @@ func CheckTopoIsUpToDate(ctx context.Context) *CheckFailure {
 	if binPathErr == nil {
 		_, fix.Command = upgrade.GetUpgradeCommand(binPath)
 	}
-	return &CheckFailure{
+	return &DependencyCheckFailure{
 		Severity: SeverityInfo,
 		Message:  fmt.Sprintf("out of date - current: %s, latest version: %s", version.Version, latest),
 		Fix:      &fix,
 	}
 }
 
-func CheckOpenSSHAvailable(ctx context.Context, r runner.Runner, sshBinary string) *CheckFailure {
+func CheckOpenSSHAvailable(ctx context.Context, r runner.Runner, sshBinary string) *DependencyCheckFailure {
 	_, stderr, err := r.Run(ctx, sshBinary+" -V")
 	if err != nil {
-		return &CheckFailure{Message: err.Error()}
+		return &DependencyCheckFailure{Message: err.Error()}
 	}
 	if !strings.Contains(stderr, "OpenSSH_") {
-		return &CheckFailure{
+		return &DependencyCheckFailure{
 			Message: fmt.Sprintf("%q does not resolve to OpenSSH: %s", sshBinary, stderr),
 			Fix: &Fix{
 				Description: "Install OpenSSH and ensure its ssh executable is first on PATH",
@@ -80,10 +61,10 @@ func CheckOpenSSHAvailable(ctx context.Context, r runner.Runner, sshBinary strin
 	return nil
 }
 
-func CheckDockerComposeMinVersion(ctx context.Context, r runner.Runner, minVersion string) *CheckFailure {
+func CheckDockerComposeMinVersion(ctx context.Context, r runner.Runner, minVersion string) *DependencyCheckFailure {
 	stdout, _, err := r.Run(ctx, "docker compose version --format json")
 	if err != nil {
-		return &CheckFailure{Message: err.Error()}
+		return &DependencyCheckFailure{Message: err.Error()}
 	}
 
 	var output struct {
@@ -91,11 +72,11 @@ func CheckDockerComposeMinVersion(ctx context.Context, r runner.Runner, minVersi
 	}
 	err = json.Unmarshal([]byte(stdout), &output)
 	if err != nil {
-		return &CheckFailure{Message: err.Error()}
+		return &DependencyCheckFailure{Message: err.Error()}
 	}
 
 	if !version.IsAtLeastVersion(output.Version, minVersion) {
-		return &CheckFailure{
+		return &DependencyCheckFailure{
 			Message: fmt.Sprintf("installed docker compose version %s is older than required version %s", output.Version, minVersion),
 			Fix: &Fix{
 				Description: fmt.Sprintf("Upgrade Docker Compose to version %s or later. See %s", minVersion, containerEngineInstallURL),

--- a/internal/health/check.go
+++ b/internal/health/check.go
@@ -31,11 +31,6 @@ const (
 	SeverityInfo
 )
 
-func CheckCommandSuccessful(ctx context.Context, r runner.Runner, command string) error {
-	_, _, err := r.Run(ctx, command)
-	return err
-}
-
 func CheckTopoIsUpToDate(ctx context.Context) *CheckFailure {
 	if version.Version == version.Dev {
 		return nil

--- a/internal/health/check.go
+++ b/internal/health/check.go
@@ -3,7 +3,6 @@ package health
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"slices"
 	"strings"
@@ -14,7 +13,13 @@ import (
 )
 
 type Check interface {
-	Run(ctx context.Context, r runner.Runner, dep Dependency) (*Fix, error)
+	Run(ctx context.Context, r runner.Runner, dep Dependency) *CheckFailure
+}
+
+type CheckFailure struct {
+	Severity CheckSeverity
+	Message  string
+	Fix      *Fix
 }
 
 type Fix struct {
@@ -27,6 +32,7 @@ type CheckSeverity int
 const (
 	SeverityError CheckSeverity = iota
 	SeverityWarning
+	SeverityInfo
 )
 
 type CommandSuccessful struct {
@@ -34,9 +40,12 @@ type CommandSuccessful struct {
 	Fix *Fix
 }
 
-func (c CommandSuccessful) Run(ctx context.Context, r runner.Runner, dep Dependency) (*Fix, error) {
+func (c CommandSuccessful) Run(ctx context.Context, r runner.Runner, dep Dependency) *CheckFailure {
 	_, _, err := r.Run(ctx, c.Cmd)
-	return c.Fix, err
+	if err != nil {
+		return &CheckFailure{Message: err.Error(), Fix: c.Fix}
+	}
+	return nil
 }
 
 type BinaryExists struct {
@@ -44,17 +53,11 @@ type BinaryExists struct {
 	Fix      *Fix
 }
 
-func (b BinaryExists) Run(ctx context.Context, r runner.Runner, dep Dependency) (*Fix, error) {
+func (b BinaryExists) Run(ctx context.Context, r runner.Runner, dep Dependency) *CheckFailure {
 	if err := r.BinaryExists(ctx, dep.Binary); err != nil {
-		if errors.Is(err, runner.ErrTimeout) {
-			return nil, err
-		}
-		if b.Severity == SeverityWarning {
-			err = WarningError{Err: err}
-		}
-		return b.Fix, err
+		return &CheckFailure{Severity: b.Severity, Message: err.Error(), Fix: b.Fix}
 	}
-	return nil, nil
+	return nil
 }
 
 type VersionMatches struct {
@@ -63,14 +66,14 @@ type VersionMatches struct {
 	BuildFix       func() Fix
 }
 
-func (v VersionMatches) Run(ctx context.Context, _ runner.Runner, _ Dependency) (*Fix, error) {
+func (v VersionMatches) Run(ctx context.Context, _ runner.Runner, _ Dependency) *CheckFailure {
 	latest, err := v.FetchLatest(ctx)
 	if err != nil {
 		logger.Warn(fmt.Sprintf("failed to fetch latest version: %v", err))
-		return nil, nil
+		return nil
 	}
 	if latest == v.CurrentVersion {
-		return nil, nil
+		return nil
 	}
 
 	fix := Fix{}
@@ -78,32 +81,39 @@ func (v VersionMatches) Run(ctx context.Context, _ runner.Runner, _ Dependency) 
 		fix = v.BuildFix()
 	}
 
-	return &fix, InfoError{Err: fmt.Errorf("out of date - current: %s, latest version: %s", v.CurrentVersion, latest)}
+	return &CheckFailure{
+		Severity: SeverityInfo,
+		Message:  fmt.Sprintf("out of date - current: %s, latest version: %s", v.CurrentVersion, latest),
+		Fix:      &fix,
+	}
 }
 
 type OpenSSHAvailable struct{}
 
-func (o OpenSSHAvailable) Run(ctx context.Context, r runner.Runner, dep Dependency) (*Fix, error) {
+func (o OpenSSHAvailable) Run(ctx context.Context, r runner.Runner, dep Dependency) *CheckFailure {
 	_, stderr, err := r.Run(ctx, "ssh -V")
 	if err != nil {
-		return nil, err
+		return &CheckFailure{Message: err.Error()}
 	}
 	if !strings.Contains(stderr, "OpenSSH_") {
-		return &Fix{
-			Description: "Install OpenSSH and ensure its ssh executable is first on PATH",
-		}, fmt.Errorf("%q does not resolve to OpenSSH: %s", dep.Binary, stderr)
+		return &CheckFailure{
+			Message: fmt.Sprintf("%q does not resolve to OpenSSH: %s", dep.Binary, stderr),
+			Fix: &Fix{
+				Description: "Install OpenSSH and ensure its ssh executable is first on PATH",
+			},
+		}
 	}
-	return nil, nil
+	return nil
 }
 
 type DockerComposeMinVersion struct {
 	MinVersion string
 }
 
-func (c DockerComposeMinVersion) Run(ctx context.Context, r runner.Runner, _ Dependency) (*Fix, error) {
+func (c DockerComposeMinVersion) Run(ctx context.Context, r runner.Runner, _ Dependency) *CheckFailure {
 	stdout, _, err := r.Run(ctx, "docker compose version --format json")
 	if err != nil {
-		return nil, err
+		return &CheckFailure{Message: err.Error()}
 	}
 
 	var output struct {
@@ -111,16 +121,19 @@ func (c DockerComposeMinVersion) Run(ctx context.Context, r runner.Runner, _ Dep
 	}
 	err = json.Unmarshal([]byte(stdout), &output)
 	if err != nil {
-		return nil, err
+		return &CheckFailure{Message: err.Error()}
 	}
 
 	if !version.IsAtLeastVersion(output.Version, c.MinVersion) {
-		return &Fix{
-			Description: fmt.Sprintf("Upgrade Docker Compose to version %s or later. See %s", c.MinVersion, containerEngineInstallURL),
-		}, fmt.Errorf("installed docker compose version %s is older than required version %s", output.Version, c.MinVersion)
+		return &CheckFailure{
+			Message: fmt.Sprintf("installed docker compose version %s is older than required version %s", output.Version, c.MinVersion),
+			Fix: &Fix{
+				Description: fmt.Sprintf("Upgrade Docker Compose to version %s or later. See %s", c.MinVersion, containerEngineInstallURL),
+			},
+		}
 	}
 
-	return nil, nil
+	return nil
 }
 
 func RemoveVersionChecks(deps []Dependency) []Dependency {

--- a/internal/health/check.go
+++ b/internal/health/check.go
@@ -41,9 +41,13 @@ type CommandSuccessful struct {
 }
 
 func (c CommandSuccessful) Run(ctx context.Context, r runner.Runner) *CheckFailure {
-	_, _, err := r.Run(ctx, c.Cmd)
+	return CheckCommandSuccessful(ctx, r, c.Cmd, c.Fix)
+}
+
+func CheckCommandSuccessful(ctx context.Context, r runner.Runner, command string, fix *Fix) *CheckFailure {
+	_, _, err := r.Run(ctx, command)
 	if err != nil {
-		return &CheckFailure{Message: err.Error(), Fix: c.Fix}
+		return &CheckFailure{Message: err.Error(), Fix: fix}
 	}
 	return nil
 }
@@ -55,8 +59,12 @@ type BinaryExists struct {
 }
 
 func (b BinaryExists) Run(ctx context.Context, r runner.Runner) *CheckFailure {
-	if err := r.BinaryExists(ctx, b.Binary); err != nil {
-		return &CheckFailure{Severity: b.Severity, Message: err.Error(), Fix: b.Fix}
+	return CheckBinaryExists(ctx, r, b.Binary, b.Severity, b.Fix)
+}
+
+func CheckBinaryExists(ctx context.Context, r runner.Runner, binary string, severity CheckSeverity, fix *Fix) *CheckFailure {
+	if err := r.BinaryExists(ctx, binary); err != nil {
+		return &CheckFailure{Severity: severity, Message: err.Error(), Fix: fix}
 	}
 	return nil
 }
@@ -68,23 +76,27 @@ type VersionMatches struct {
 }
 
 func (v VersionMatches) Run(ctx context.Context, _ runner.Runner) *CheckFailure {
-	latest, err := v.FetchLatest(ctx)
+	return CheckVersionMatches(ctx, v.CurrentVersion, v.FetchLatest, v.BuildFix)
+}
+
+func CheckVersionMatches(ctx context.Context, currentVersion string, fetchLatest func(context.Context) (string, error), buildFix func() Fix) *CheckFailure {
+	latest, err := fetchLatest(ctx)
 	if err != nil {
 		logger.Warn(fmt.Sprintf("failed to fetch latest version: %v", err))
 		return nil
 	}
-	if latest == v.CurrentVersion {
+	if latest == currentVersion {
 		return nil
 	}
 
 	fix := Fix{}
-	if v.BuildFix != nil {
-		fix = v.BuildFix()
+	if buildFix != nil {
+		fix = buildFix()
 	}
 
 	return &CheckFailure{
 		Severity: SeverityInfo,
-		Message:  fmt.Sprintf("out of date - current: %s, latest version: %s", v.CurrentVersion, latest),
+		Message:  fmt.Sprintf("out of date - current: %s, latest version: %s", currentVersion, latest),
 		Fix:      &fix,
 	}
 }
@@ -94,13 +106,17 @@ type OpenSSHAvailable struct {
 }
 
 func (o OpenSSHAvailable) Run(ctx context.Context, r runner.Runner) *CheckFailure {
-	_, stderr, err := r.Run(ctx, o.SSHBinary+" -V")
+	return CheckOpenSSHAvailable(ctx, r, o.SSHBinary)
+}
+
+func CheckOpenSSHAvailable(ctx context.Context, r runner.Runner, sshBinary string) *CheckFailure {
+	_, stderr, err := r.Run(ctx, sshBinary+" -V")
 	if err != nil {
 		return &CheckFailure{Message: err.Error()}
 	}
 	if !strings.Contains(stderr, "OpenSSH_") {
 		return &CheckFailure{
-			Message: fmt.Sprintf("%q does not resolve to OpenSSH: %s", o.SSHBinary, stderr),
+			Message: fmt.Sprintf("%q does not resolve to OpenSSH: %s", sshBinary, stderr),
 			Fix: &Fix{
 				Description: "Install OpenSSH and ensure its ssh executable is first on PATH",
 			},
@@ -114,6 +130,10 @@ type DockerComposeMinVersion struct {
 }
 
 func (c DockerComposeMinVersion) Run(ctx context.Context, r runner.Runner) *CheckFailure {
+	return CheckDockerComposeMinVersion(ctx, r, c.MinVersion)
+}
+
+func CheckDockerComposeMinVersion(ctx context.Context, r runner.Runner, minVersion string) *CheckFailure {
 	stdout, _, err := r.Run(ctx, "docker compose version --format json")
 	if err != nil {
 		return &CheckFailure{Message: err.Error()}
@@ -127,11 +147,11 @@ func (c DockerComposeMinVersion) Run(ctx context.Context, r runner.Runner) *Chec
 		return &CheckFailure{Message: err.Error()}
 	}
 
-	if !version.IsAtLeastVersion(output.Version, c.MinVersion) {
+	if !version.IsAtLeastVersion(output.Version, minVersion) {
 		return &CheckFailure{
-			Message: fmt.Sprintf("installed docker compose version %s is older than required version %s", output.Version, c.MinVersion),
+			Message: fmt.Sprintf("installed docker compose version %s is older than required version %s", output.Version, minVersion),
 			Fix: &Fix{
-				Description: fmt.Sprintf("Upgrade Docker Compose to version %s or later. See %s", c.MinVersion, containerEngineInstallURL),
+				Description: fmt.Sprintf("Upgrade Docker Compose to version %s or later. See %s", minVersion, containerEngineInstallURL),
 			},
 		}
 	}

--- a/internal/health/check.go
+++ b/internal/health/check.go
@@ -4,17 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"slices"
 	"strings"
 
 	"github.com/arm/topo/internal/output/logger"
 	"github.com/arm/topo/internal/runner"
+	"github.com/arm/topo/internal/upgrade"
 	"github.com/arm/topo/internal/version"
 )
-
-type Check interface {
-	Run(ctx context.Context, r runner.Runner) *CheckFailure
-}
 
 type CheckFailure struct {
 	Severity CheckSeverity
@@ -35,78 +31,42 @@ const (
 	SeverityInfo
 )
 
-type CommandSuccessful struct {
-	Cmd string
-	Fix *Fix
-}
-
-func (c CommandSuccessful) Run(ctx context.Context, r runner.Runner) *CheckFailure {
-	return CheckCommandSuccessful(ctx, r, c.Cmd, c.Fix)
-}
-
-func CheckCommandSuccessful(ctx context.Context, r runner.Runner, command string, fix *Fix) *CheckFailure {
+func CheckCommandSuccessful(ctx context.Context, r runner.Runner, command string) error {
 	_, _, err := r.Run(ctx, command)
-	if err != nil {
-		return &CheckFailure{Message: err.Error(), Fix: fix}
+	return err
+}
+
+func CheckTopoIsUpToDate(ctx context.Context) *CheckFailure {
+	if version.Version == version.Dev {
+		return nil
 	}
-	return nil
-}
 
-type BinaryExists struct {
-	Binary   string
-	Severity CheckSeverity
-	Fix      *Fix
-}
+	binPath, binPathErr := upgrade.CurrentBinaryPath()
 
-func (b BinaryExists) Run(ctx context.Context, r runner.Runner) *CheckFailure {
-	return CheckBinaryExists(ctx, r, b.Binary, b.Severity, b.Fix)
-}
-
-func CheckBinaryExists(ctx context.Context, r runner.Runner, binary string, severity CheckSeverity, fix *Fix) *CheckFailure {
-	if err := r.BinaryExists(ctx, binary); err != nil {
-		return &CheckFailure{Severity: severity, Message: err.Error(), Fix: fix}
+	var latest string
+	var err error
+	if binPathErr == nil && upgrade.IsBinaryManagedByHomebrew(binPath) {
+		latest, err = version.FetchLatestHomebrew(ctx, version.HomebrewFormulaURL)
+	} else {
+		latest, err = version.FetchLatestArtifactory(ctx, version.ArtifactoryBaseURL)
 	}
-	return nil
-}
-
-type VersionMatches struct {
-	CurrentVersion string
-	FetchLatest    func(ctx context.Context) (string, error)
-	BuildFix       func() Fix
-}
-
-func (v VersionMatches) Run(ctx context.Context, _ runner.Runner) *CheckFailure {
-	return CheckVersionMatches(ctx, v.CurrentVersion, v.FetchLatest, v.BuildFix)
-}
-
-func CheckVersionMatches(ctx context.Context, currentVersion string, fetchLatest func(context.Context) (string, error), buildFix func() Fix) *CheckFailure {
-	latest, err := fetchLatest(ctx)
 	if err != nil {
 		logger.Warn(fmt.Sprintf("failed to fetch latest version: %v", err))
 		return nil
 	}
-	if latest == currentVersion {
+	if latest == version.Version {
 		return nil
 	}
 
-	fix := Fix{}
-	if buildFix != nil {
-		fix = buildFix()
+	fix := Fix{Description: "Upgrade Topo"}
+	if binPathErr == nil {
+		_, fix.Command = upgrade.GetUpgradeCommand(binPath)
 	}
-
 	return &CheckFailure{
 		Severity: SeverityInfo,
-		Message:  fmt.Sprintf("out of date - current: %s, latest version: %s", currentVersion, latest),
+		Message:  fmt.Sprintf("out of date - current: %s, latest version: %s", version.Version, latest),
 		Fix:      &fix,
 	}
-}
-
-type OpenSSHAvailable struct {
-	SSHBinary string
-}
-
-func (o OpenSSHAvailable) Run(ctx context.Context, r runner.Runner) *CheckFailure {
-	return CheckOpenSSHAvailable(ctx, r, o.SSHBinary)
 }
 
 func CheckOpenSSHAvailable(ctx context.Context, r runner.Runner, sshBinary string) *CheckFailure {
@@ -123,14 +83,6 @@ func CheckOpenSSHAvailable(ctx context.Context, r runner.Runner, sshBinary strin
 		}
 	}
 	return nil
-}
-
-type DockerComposeMinVersion struct {
-	MinVersion string
-}
-
-func (c DockerComposeMinVersion) Run(ctx context.Context, r runner.Runner) *CheckFailure {
-	return CheckDockerComposeMinVersion(ctx, r, c.MinVersion)
 }
 
 func CheckDockerComposeMinVersion(ctx context.Context, r runner.Runner, minVersion string) *CheckFailure {
@@ -157,15 +109,4 @@ func CheckDockerComposeMinVersion(ctx context.Context, r runner.Runner, minVersi
 	}
 
 	return nil
-}
-
-func RemoveVersionChecks(deps []Dependency) []Dependency {
-	deps = slices.Clone(deps)
-	for i, dep := range deps {
-		deps[i].Checks = slices.DeleteFunc(dep.Checks, func(c Check) bool {
-			_, ok := c.(VersionMatches)
-			return ok
-		})
-	}
-	return deps
 }

--- a/internal/health/check_test.go
+++ b/internal/health/check_test.go
@@ -11,18 +11,30 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestBinaryExists(t *testing.T) {
+func TestCheckBinaryExists(t *testing.T) {
 	t.Run("returns a warning result when severity is warning", func(t *testing.T) {
-		check := health.BinaryExists{Binary: "nonexistent", Severity: health.SeverityWarning}
+		binary := "nonexistent"
 		runner := &runner.Fake{}
 
-		got := check.Run(context.Background(), runner)
+		got := health.CheckBinaryExists(context.Background(), runner, binary, health.SeverityWarning, nil)
 
 		want := &health.CheckFailure{
 			Severity: health.SeverityWarning,
-			Message:  runner.BinaryExists(context.Background(), check.Binary).Error(),
+			Message:  runner.BinaryExists(context.Background(), binary).Error(),
 		}
 		assert.Equal(t, want, got)
+	})
+}
+
+func TestCheckCommandSuccessful(t *testing.T) {
+	t.Run("returns a failure when the command fails", func(t *testing.T) {
+		err := errors.New("command failed")
+		r := &runner.Fake{Commands: map[string]runner.FakeResult{"command": {Err: err}}}
+		fix := &health.Fix{Description: "fix it"}
+
+		got := health.CheckCommandSuccessful(context.Background(), r, "command", fix)
+
+		assert.Equal(t, &health.CheckFailure{Message: err.Error(), Fix: fix}, got)
 	})
 }
 
@@ -39,14 +51,11 @@ func TestRemoveVersionChecks(t *testing.T) {
 	})
 }
 
-func TestVersionMatches(t *testing.T) {
+func TestCheckVersionMatches(t *testing.T) {
 	ctx := context.Background()
-	r := &runner.Fake{}
 
 	t.Run("returns an info result when version is outdated", func(t *testing.T) {
-		check := health.VersionMatches{FetchLatest: func(context.Context) (string, error) { return "2.0.0", nil }, CurrentVersion: "1.0.0"}
-
-		got := check.Run(ctx, r)
+		got := health.CheckVersionMatches(ctx, "1.0.0", func(context.Context) (string, error) { return "2.0.0", nil }, nil)
 		want := &health.CheckFailure{
 			Severity: health.SeverityInfo,
 			Message:  "out of date - current: 1.0.0, latest version: 2.0.0",
@@ -57,41 +66,35 @@ func TestVersionMatches(t *testing.T) {
 	})
 
 	t.Run("passes when version matches latest", func(t *testing.T) {
-		check := health.VersionMatches{FetchLatest: func(context.Context) (string, error) { return "2.0.0", nil }, CurrentVersion: "2.0.0"}
-
-		got := check.Run(ctx, r)
+		got := health.CheckVersionMatches(ctx, "2.0.0", func(context.Context) (string, error) { return "2.0.0", nil }, nil)
 		var want *health.CheckFailure
 
 		assert.Equal(t, want, got)
 	})
 
 	t.Run("passes when fetching the latest version fails", func(t *testing.T) {
-		check := health.VersionMatches{FetchLatest: func(context.Context) (string, error) { return "", fmt.Errorf("connection refused") }}
-
-		got := check.Run(ctx, r)
+		got := health.CheckVersionMatches(ctx, "", func(context.Context) (string, error) { return "", fmt.Errorf("connection refused") }, nil)
 		var want *health.CheckFailure
 
 		assert.Equal(t, want, got)
 	})
 }
 
-func TestOpenSSHAvailable(t *testing.T) {
+func TestCheckOpenSSHAvailable(t *testing.T) {
 	ctx := context.Background()
 	t.Run("accepts OpenSSH", func(t *testing.T) {
-		check := health.OpenSSHAvailable{SSHBinary: "ssh"}
 		r := &runner.Fake{Commands: map[string]runner.FakeResult{"ssh -V": {Stderr: "OpenSSH_9.9p1, OpenSSL 3.4.0"}}}
 
-		got := check.Run(ctx, r)
+		got := health.CheckOpenSSHAvailable(ctx, r, "ssh")
 		var want *health.CheckFailure
 
 		assert.Equal(t, want, got)
 	})
 
 	t.Run("rejects another SSH implementation", func(t *testing.T) {
-		check := health.OpenSSHAvailable{SSHBinary: "ssh"}
 		r := &runner.Fake{Commands: map[string]runner.FakeResult{"ssh -V": {Stderr: "Dropbear v2025.88"}}}
 
-		got := check.Run(ctx, r)
+		got := health.CheckOpenSSHAvailable(ctx, r, "ssh")
 		want := &health.CheckFailure{
 			Message: `"ssh" does not resolve to OpenSSH: Dropbear v2025.88`,
 			Fix:     &health.Fix{Description: "Install OpenSSH and ensure its ssh executable is first on PATH"},
@@ -101,45 +104,41 @@ func TestOpenSSHAvailable(t *testing.T) {
 	})
 
 	t.Run("fails when the version cannot be checked", func(t *testing.T) {
-		check := health.OpenSSHAvailable{SSHBinary: "ssh"}
 		versionErr := errors.New("version check failed")
 		r := &runner.Fake{Commands: map[string]runner.FakeResult{"ssh -V": {Err: versionErr}}}
 
-		got := check.Run(ctx, r)
+		got := health.CheckOpenSSHAvailable(ctx, r, "ssh")
 		want := &health.CheckFailure{Message: versionErr.Error()}
 
 		assert.Equal(t, want, got)
 	})
 }
 
-func TestDockerComposeCompatible(t *testing.T) {
+func TestCheckDockerComposeMinVersion(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("accepts Docker Compose at the minimum version", func(t *testing.T) {
-		check := health.DockerComposeMinVersion{MinVersion: "2.0.0"}
 		runner := &runner.Fake{Commands: map[string]runner.FakeResult{"docker compose version --format json": {Output: `{"version": "2.0.0"}`}}}
 
-		got := check.Run(ctx, runner)
+		got := health.CheckDockerComposeMinVersion(ctx, runner, "2.0.0")
 		var want *health.CheckFailure
 
 		assert.Equal(t, want, got)
 	})
 
 	t.Run("accepts Docker Compose newer than the minimum version", func(t *testing.T) {
-		check := health.DockerComposeMinVersion{MinVersion: "2.0.0"}
 		runner := &runner.Fake{Commands: map[string]runner.FakeResult{"docker compose version --format json": {Output: `{"version": "5.2.0"}`}}}
 
-		got := check.Run(ctx, runner)
+		got := health.CheckDockerComposeMinVersion(ctx, runner, "2.0.0")
 		var want *health.CheckFailure
 
 		assert.Equal(t, want, got)
 	})
 
 	t.Run("returns an upgrade fix when Docker Compose is too old", func(t *testing.T) {
-		check := health.DockerComposeMinVersion{MinVersion: "2.0.0"}
 		runner := &runner.Fake{Commands: map[string]runner.FakeResult{"docker compose version --format json": {Output: `{"version": "v1.9.0"}`}}}
 
-		got := check.Run(ctx, runner)
+		got := health.CheckDockerComposeMinVersion(ctx, runner, "2.0.0")
 		want := &health.CheckFailure{
 			Message: "installed docker compose version v1.9.0 is older than required version 2.0.0",
 			Fix:     &health.Fix{Description: "Upgrade Docker Compose to version 2.0.0 or later. See https://github.com/arm/topo#install-a-container-engine"},

--- a/internal/health/check_test.go
+++ b/internal/health/check_test.go
@@ -9,37 +9,34 @@ import (
 	"github.com/arm/topo/internal/health"
 	"github.com/arm/topo/internal/runner"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestBinaryExists(t *testing.T) {
-	t.Run("wraps error as WarningError when severity is warning", func(t *testing.T) {
-		check := health.BinaryExists{
-			Severity: health.SeverityWarning,
-		}
+	t.Run("returns a warning result when severity is warning", func(t *testing.T) {
+		check := health.BinaryExists{Severity: health.SeverityWarning}
 		dependency := health.Dependency{Binary: "nonexistent"}
 		runner := &runner.Fake{}
-		ctx := context.Background()
 
-		_, err := check.Run(ctx, runner, dependency)
+		got := check.Run(context.Background(), runner, dependency)
 
-		wantErr := health.WarningError{Err: runner.BinaryExists(ctx, dependency.Binary)}
-		assert.Equal(t, wantErr, err)
+		want := &health.CheckFailure{
+			Severity: health.SeverityWarning,
+			Message:  runner.BinaryExists(context.Background(), dependency.Binary).Error(),
+		}
+		assert.Equal(t, want, got)
 	})
 }
 
 func TestRemoveVersionChecks(t *testing.T) {
 	t.Run("removes checks of type VersionMatches", func(t *testing.T) {
-		dep := health.Dependency{
-			Binary: "mixed",
-			Label:  "Mixed",
-			Checks: []health.Check{health.BinaryExists{}, health.VersionMatches{}},
-		}
+		dep := health.Dependency{Binary: "mixed", Label: "Mixed", Checks: []health.Check{health.BinaryExists{}, health.VersionMatches{}}}
 
 		got := health.RemoveVersionChecks([]health.Dependency{dep})
 
+		want := []health.Check{health.BinaryExists{}}
+
 		assert.Len(t, got, 1)
-		assert.Equal(t, got[0].Checks, []health.Check{health.BinaryExists{}})
+		assert.Equal(t, want, got[0].Checks)
 	})
 }
 
@@ -48,46 +45,35 @@ func TestVersionMatches(t *testing.T) {
 	dep := health.Dependency{}
 	r := &runner.Fake{}
 
-	t.Run("returns error when version is outdated", func(t *testing.T) {
-		check := health.VersionMatches{
-			FetchLatest: func(ctx context.Context) (string, error) {
-				return "2.0.0", nil
-			},
-			CurrentVersion: "1.0.0",
+	t.Run("returns an info result when version is outdated", func(t *testing.T) {
+		check := health.VersionMatches{FetchLatest: func(context.Context) (string, error) { return "2.0.0", nil }, CurrentVersion: "1.0.0"}
+
+		got := check.Run(ctx, r, dep)
+		want := &health.CheckFailure{
+			Severity: health.SeverityInfo,
+			Message:  "out of date - current: 1.0.0, latest version: 2.0.0",
+			Fix:      &health.Fix{},
 		}
 
-		_, err := check.Run(ctx, r, dep)
-
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "1.0.0")
-		assert.Contains(t, err.Error(), "2.0.0")
+		assert.Equal(t, want, got)
 	})
 
-	t.Run("returns nil when version matches latest", func(t *testing.T) {
-		check := health.VersionMatches{
-			FetchLatest: func(ctx context.Context) (string, error) {
-				return "2.0.0", nil
-			},
-			CurrentVersion: "2.0.0",
-		}
+	t.Run("passes when version matches latest", func(t *testing.T) {
+		check := health.VersionMatches{FetchLatest: func(context.Context) (string, error) { return "2.0.0", nil }, CurrentVersion: "2.0.0"}
 
-		fix, err := check.Run(ctx, r, dep)
+		got := check.Run(ctx, r, dep)
+		var want *health.CheckFailure
 
-		assert.NoError(t, err)
-		assert.Empty(t, fix)
+		assert.Equal(t, want, got)
 	})
 
-	t.Run("degrades gracefully on fetch error", func(t *testing.T) {
-		check := health.VersionMatches{
-			FetchLatest: func(ctx context.Context) (string, error) {
-				return "", fmt.Errorf("connection refused")
-			},
-		}
+	t.Run("passes when fetching the latest version fails", func(t *testing.T) {
+		check := health.VersionMatches{FetchLatest: func(context.Context) (string, error) { return "", fmt.Errorf("connection refused") }}
 
-		fix, err := check.Run(ctx, r, dep)
+		got := check.Run(ctx, r, dep)
+		var want *health.CheckFailure
 
-		assert.NoError(t, err)
-		assert.Empty(t, fix)
+		assert.Equal(t, want, got)
 	})
 }
 
@@ -97,41 +83,36 @@ func TestOpenSSHAvailable(t *testing.T) {
 
 	t.Run("accepts OpenSSH", func(t *testing.T) {
 		check := health.OpenSSHAvailable{}
-		r := &runner.Fake{Commands: map[string]runner.FakeResult{
-			"ssh -V": {Stderr: "OpenSSH_9.9p1, OpenSSL 3.4.0"},
-		}}
+		r := &runner.Fake{Commands: map[string]runner.FakeResult{"ssh -V": {Stderr: "OpenSSH_9.9p1, OpenSSL 3.4.0"}}}
 
-		fix, err := check.Run(ctx, r, dependency)
+		got := check.Run(ctx, r, dependency)
+		var want *health.CheckFailure
 
-		assert.NoError(t, err)
-		assert.Nil(t, fix)
+		assert.Equal(t, want, got)
 	})
 
 	t.Run("rejects another SSH implementation", func(t *testing.T) {
 		check := health.OpenSSHAvailable{}
-		r := &runner.Fake{Commands: map[string]runner.FakeResult{
-			"ssh -V": {Stderr: "Dropbear v2025.88"},
-		}}
+		r := &runner.Fake{Commands: map[string]runner.FakeResult{"ssh -V": {Stderr: "Dropbear v2025.88"}}}
 
-		fix, err := check.Run(ctx, r, dependency)
+		got := check.Run(ctx, r, dependency)
+		want := &health.CheckFailure{
+			Message: `"ssh" does not resolve to OpenSSH: Dropbear v2025.88`,
+			Fix:     &health.Fix{Description: "Install OpenSSH and ensure its ssh executable is first on PATH"},
+		}
 
-		assert.EqualError(t, err, `"ssh" does not resolve to OpenSSH: Dropbear v2025.88`)
-		assert.Equal(t, &health.Fix{
-			Description: "Install OpenSSH and ensure its ssh executable is first on PATH",
-		}, fix)
+		assert.Equal(t, want, got)
 	})
 
-	t.Run("returns an error when the version cannot be checked", func(t *testing.T) {
+	t.Run("fails when the version cannot be checked", func(t *testing.T) {
 		check := health.OpenSSHAvailable{}
 		versionErr := errors.New("version check failed")
-		r := &runner.Fake{Commands: map[string]runner.FakeResult{
-			"ssh -V": {Err: versionErr},
-		}}
+		r := &runner.Fake{Commands: map[string]runner.FakeResult{"ssh -V": {Err: versionErr}}}
 
-		fix, err := check.Run(ctx, r, dependency)
+		got := check.Run(ctx, r, dependency)
+		want := &health.CheckFailure{Message: versionErr.Error()}
 
-		assert.ErrorIs(t, err, versionErr)
-		assert.Nil(t, fix)
+		assert.Equal(t, want, got)
 	})
 }
 
@@ -141,43 +122,34 @@ func TestDockerComposeCompatible(t *testing.T) {
 
 	t.Run("accepts Docker Compose at the minimum version", func(t *testing.T) {
 		check := health.DockerComposeMinVersion{MinVersion: "2.0.0"}
-		runner := &runner.Fake{
-			Commands: map[string]runner.FakeResult{
-				"docker compose version --format json": {Output: `{"version": "2.0.0"}`},
-			},
-		}
+		runner := &runner.Fake{Commands: map[string]runner.FakeResult{"docker compose version --format json": {Output: `{"version": "2.0.0"}`}}}
 
-		fix, err := check.Run(ctx, runner, dep)
+		got := check.Run(ctx, runner, dep)
+		var want *health.CheckFailure
 
-		assert.NoError(t, err)
-		assert.Nil(t, fix)
+		assert.Equal(t, want, got)
 	})
 
 	t.Run("accepts Docker Compose newer than the minimum version", func(t *testing.T) {
 		check := health.DockerComposeMinVersion{MinVersion: "2.0.0"}
-		runner := &runner.Fake{
-			Commands: map[string]runner.FakeResult{
-				"docker compose version --format json": {Output: `{"version": "5.2.0"}`},
-			},
-		}
+		runner := &runner.Fake{Commands: map[string]runner.FakeResult{"docker compose version --format json": {Output: `{"version": "5.2.0"}`}}}
 
-		fix, err := check.Run(ctx, runner, dep)
+		got := check.Run(ctx, runner, dep)
+		var want *health.CheckFailure
 
-		assert.NoError(t, err)
-		assert.Nil(t, fix)
+		assert.Equal(t, want, got)
 	})
 
 	t.Run("returns an upgrade fix when Docker Compose is too old", func(t *testing.T) {
 		check := health.DockerComposeMinVersion{MinVersion: "2.0.0"}
-		runner := &runner.Fake{
-			Commands: map[string]runner.FakeResult{
-				"docker compose version --format json": {Output: `{"version": "v1.9.0"}`},
-			},
+		runner := &runner.Fake{Commands: map[string]runner.FakeResult{"docker compose version --format json": {Output: `{"version": "v1.9.0"}`}}}
+
+		got := check.Run(ctx, runner, dep)
+		want := &health.CheckFailure{
+			Message: "installed docker compose version v1.9.0 is older than required version 2.0.0",
+			Fix:     &health.Fix{Description: "Upgrade Docker Compose to version 2.0.0 or later. See https://github.com/arm/topo#install-a-container-engine"},
 		}
 
-		fix, err := check.Run(ctx, runner, dep)
-
-		assert.EqualError(t, err, "installed docker compose version v1.9.0 is older than required version 2.0.0")
-		assert.Contains(t, fix.Description, "Upgrade Docker Compose")
+		assert.Equal(t, want, got)
 	})
 }

--- a/internal/health/check_test.go
+++ b/internal/health/check_test.go
@@ -11,17 +11,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestCheckCommandSuccessful(t *testing.T) {
-	t.Run("returns an error when the command fails", func(t *testing.T) {
-		err := errors.New("command failed")
-		r := &runner.Fake{Commands: map[string]runner.FakeResult{"command": {Err: err}}}
-
-		got := health.CheckCommandSuccessful(context.Background(), r, "command")
-
-		assert.Equal(t, err, got)
-	})
-}
-
 func TestCheckTopoIsUpToDate(t *testing.T) {
 	t.Run("passes for development builds", func(t *testing.T) {
 		originalVersion := version.Version

--- a/internal/health/check_test.go
+++ b/internal/health/check_test.go
@@ -13,15 +13,14 @@ import (
 
 func TestBinaryExists(t *testing.T) {
 	t.Run("returns a warning result when severity is warning", func(t *testing.T) {
-		check := health.BinaryExists{Severity: health.SeverityWarning}
-		dependency := health.Dependency{Binary: "nonexistent"}
+		check := health.BinaryExists{Binary: "nonexistent", Severity: health.SeverityWarning}
 		runner := &runner.Fake{}
 
-		got := check.Run(context.Background(), runner, dependency)
+		got := check.Run(context.Background(), runner)
 
 		want := &health.CheckFailure{
 			Severity: health.SeverityWarning,
-			Message:  runner.BinaryExists(context.Background(), dependency.Binary).Error(),
+			Message:  runner.BinaryExists(context.Background(), check.Binary).Error(),
 		}
 		assert.Equal(t, want, got)
 	})
@@ -42,13 +41,12 @@ func TestRemoveVersionChecks(t *testing.T) {
 
 func TestVersionMatches(t *testing.T) {
 	ctx := context.Background()
-	dep := health.Dependency{}
 	r := &runner.Fake{}
 
 	t.Run("returns an info result when version is outdated", func(t *testing.T) {
 		check := health.VersionMatches{FetchLatest: func(context.Context) (string, error) { return "2.0.0", nil }, CurrentVersion: "1.0.0"}
 
-		got := check.Run(ctx, r, dep)
+		got := check.Run(ctx, r)
 		want := &health.CheckFailure{
 			Severity: health.SeverityInfo,
 			Message:  "out of date - current: 1.0.0, latest version: 2.0.0",
@@ -61,7 +59,7 @@ func TestVersionMatches(t *testing.T) {
 	t.Run("passes when version matches latest", func(t *testing.T) {
 		check := health.VersionMatches{FetchLatest: func(context.Context) (string, error) { return "2.0.0", nil }, CurrentVersion: "2.0.0"}
 
-		got := check.Run(ctx, r, dep)
+		got := check.Run(ctx, r)
 		var want *health.CheckFailure
 
 		assert.Equal(t, want, got)
@@ -70,7 +68,7 @@ func TestVersionMatches(t *testing.T) {
 	t.Run("passes when fetching the latest version fails", func(t *testing.T) {
 		check := health.VersionMatches{FetchLatest: func(context.Context) (string, error) { return "", fmt.Errorf("connection refused") }}
 
-		got := check.Run(ctx, r, dep)
+		got := check.Run(ctx, r)
 		var want *health.CheckFailure
 
 		assert.Equal(t, want, got)
@@ -79,23 +77,21 @@ func TestVersionMatches(t *testing.T) {
 
 func TestOpenSSHAvailable(t *testing.T) {
 	ctx := context.Background()
-	dependency := health.Dependency{Binary: "ssh", Label: "OpenSSH"}
-
 	t.Run("accepts OpenSSH", func(t *testing.T) {
-		check := health.OpenSSHAvailable{}
+		check := health.OpenSSHAvailable{SSHBinary: "ssh"}
 		r := &runner.Fake{Commands: map[string]runner.FakeResult{"ssh -V": {Stderr: "OpenSSH_9.9p1, OpenSSL 3.4.0"}}}
 
-		got := check.Run(ctx, r, dependency)
+		got := check.Run(ctx, r)
 		var want *health.CheckFailure
 
 		assert.Equal(t, want, got)
 	})
 
 	t.Run("rejects another SSH implementation", func(t *testing.T) {
-		check := health.OpenSSHAvailable{}
+		check := health.OpenSSHAvailable{SSHBinary: "ssh"}
 		r := &runner.Fake{Commands: map[string]runner.FakeResult{"ssh -V": {Stderr: "Dropbear v2025.88"}}}
 
-		got := check.Run(ctx, r, dependency)
+		got := check.Run(ctx, r)
 		want := &health.CheckFailure{
 			Message: `"ssh" does not resolve to OpenSSH: Dropbear v2025.88`,
 			Fix:     &health.Fix{Description: "Install OpenSSH and ensure its ssh executable is first on PATH"},
@@ -105,11 +101,11 @@ func TestOpenSSHAvailable(t *testing.T) {
 	})
 
 	t.Run("fails when the version cannot be checked", func(t *testing.T) {
-		check := health.OpenSSHAvailable{}
+		check := health.OpenSSHAvailable{SSHBinary: "ssh"}
 		versionErr := errors.New("version check failed")
 		r := &runner.Fake{Commands: map[string]runner.FakeResult{"ssh -V": {Err: versionErr}}}
 
-		got := check.Run(ctx, r, dependency)
+		got := check.Run(ctx, r)
 		want := &health.CheckFailure{Message: versionErr.Error()}
 
 		assert.Equal(t, want, got)
@@ -118,13 +114,12 @@ func TestOpenSSHAvailable(t *testing.T) {
 
 func TestDockerComposeCompatible(t *testing.T) {
 	ctx := context.Background()
-	dep := health.Dependency{}
 
 	t.Run("accepts Docker Compose at the minimum version", func(t *testing.T) {
 		check := health.DockerComposeMinVersion{MinVersion: "2.0.0"}
 		runner := &runner.Fake{Commands: map[string]runner.FakeResult{"docker compose version --format json": {Output: `{"version": "2.0.0"}`}}}
 
-		got := check.Run(ctx, runner, dep)
+		got := check.Run(ctx, runner)
 		var want *health.CheckFailure
 
 		assert.Equal(t, want, got)
@@ -134,7 +129,7 @@ func TestDockerComposeCompatible(t *testing.T) {
 		check := health.DockerComposeMinVersion{MinVersion: "2.0.0"}
 		runner := &runner.Fake{Commands: map[string]runner.FakeResult{"docker compose version --format json": {Output: `{"version": "5.2.0"}`}}}
 
-		got := check.Run(ctx, runner, dep)
+		got := check.Run(ctx, runner)
 		var want *health.CheckFailure
 
 		assert.Equal(t, want, got)
@@ -144,7 +139,7 @@ func TestDockerComposeCompatible(t *testing.T) {
 		check := health.DockerComposeMinVersion{MinVersion: "2.0.0"}
 		runner := &runner.Fake{Commands: map[string]runner.FakeResult{"docker compose version --format json": {Output: `{"version": "v1.9.0"}`}}}
 
-		got := check.Run(ctx, runner, dep)
+		got := check.Run(ctx, runner)
 		want := &health.CheckFailure{
 			Message: "installed docker compose version v1.9.0 is older than required version 2.0.0",
 			Fix:     &health.Fix{Description: "Upgrade Docker Compose to version 2.0.0 or later. See https://github.com/arm/topo#install-a-container-engine"},

--- a/internal/health/check_test.go
+++ b/internal/health/check_test.go
@@ -29,7 +29,7 @@ func TestCheckOpenSSHAvailable(t *testing.T) {
 		r := &runner.Fake{Commands: map[string]runner.FakeResult{"ssh -V": {Stderr: "OpenSSH_9.9p1, OpenSSL 3.4.0"}}}
 
 		got := health.CheckOpenSSHAvailable(ctx, r, "ssh")
-		var want *health.CheckFailure
+		var want *health.DependencyCheckFailure
 
 		assert.Equal(t, want, got)
 	})
@@ -38,7 +38,7 @@ func TestCheckOpenSSHAvailable(t *testing.T) {
 		r := &runner.Fake{Commands: map[string]runner.FakeResult{"ssh -V": {Stderr: "Dropbear v2025.88"}}}
 
 		got := health.CheckOpenSSHAvailable(ctx, r, "ssh")
-		want := &health.CheckFailure{
+		want := &health.DependencyCheckFailure{
 			Message: `"ssh" does not resolve to OpenSSH: Dropbear v2025.88`,
 			Fix:     &health.Fix{Description: "Install OpenSSH and ensure its ssh executable is first on PATH"},
 		}
@@ -51,7 +51,7 @@ func TestCheckOpenSSHAvailable(t *testing.T) {
 		r := &runner.Fake{Commands: map[string]runner.FakeResult{"ssh -V": {Err: versionErr}}}
 
 		got := health.CheckOpenSSHAvailable(ctx, r, "ssh")
-		want := &health.CheckFailure{Message: versionErr.Error()}
+		want := &health.DependencyCheckFailure{Message: versionErr.Error()}
 
 		assert.Equal(t, want, got)
 	})
@@ -64,7 +64,7 @@ func TestCheckDockerComposeMinVersion(t *testing.T) {
 		runner := &runner.Fake{Commands: map[string]runner.FakeResult{"docker compose version --format json": {Output: `{"version": "2.0.0"}`}}}
 
 		got := health.CheckDockerComposeMinVersion(ctx, runner, "2.0.0")
-		var want *health.CheckFailure
+		var want *health.DependencyCheckFailure
 
 		assert.Equal(t, want, got)
 	})
@@ -73,7 +73,7 @@ func TestCheckDockerComposeMinVersion(t *testing.T) {
 		runner := &runner.Fake{Commands: map[string]runner.FakeResult{"docker compose version --format json": {Output: `{"version": "5.2.0"}`}}}
 
 		got := health.CheckDockerComposeMinVersion(ctx, runner, "2.0.0")
-		var want *health.CheckFailure
+		var want *health.DependencyCheckFailure
 
 		assert.Equal(t, want, got)
 	})
@@ -82,7 +82,7 @@ func TestCheckDockerComposeMinVersion(t *testing.T) {
 		runner := &runner.Fake{Commands: map[string]runner.FakeResult{"docker compose version --format json": {Output: `{"version": "v1.9.0"}`}}}
 
 		got := health.CheckDockerComposeMinVersion(ctx, runner, "2.0.0")
-		want := &health.CheckFailure{
+		want := &health.DependencyCheckFailure{
 			Message: "installed docker compose version v1.9.0 is older than required version 2.0.0",
 			Fix:     &health.Fix{Description: "Upgrade Docker Compose to version 2.0.0 or later. See https://github.com/arm/topo#install-a-container-engine"},
 		}

--- a/internal/health/check_test.go
+++ b/internal/health/check_test.go
@@ -3,80 +3,34 @@ package health_test
 import (
 	"context"
 	"errors"
-	"fmt"
 	"testing"
 
 	"github.com/arm/topo/internal/health"
 	"github.com/arm/topo/internal/runner"
+	"github.com/arm/topo/internal/version"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestCheckBinaryExists(t *testing.T) {
-	t.Run("returns a warning result when severity is warning", func(t *testing.T) {
-		binary := "nonexistent"
-		runner := &runner.Fake{}
-
-		got := health.CheckBinaryExists(context.Background(), runner, binary, health.SeverityWarning, nil)
-
-		want := &health.CheckFailure{
-			Severity: health.SeverityWarning,
-			Message:  runner.BinaryExists(context.Background(), binary).Error(),
-		}
-		assert.Equal(t, want, got)
-	})
-}
-
 func TestCheckCommandSuccessful(t *testing.T) {
-	t.Run("returns a failure when the command fails", func(t *testing.T) {
+	t.Run("returns an error when the command fails", func(t *testing.T) {
 		err := errors.New("command failed")
 		r := &runner.Fake{Commands: map[string]runner.FakeResult{"command": {Err: err}}}
-		fix := &health.Fix{Description: "fix it"}
 
-		got := health.CheckCommandSuccessful(context.Background(), r, "command", fix)
+		got := health.CheckCommandSuccessful(context.Background(), r, "command")
 
-		assert.Equal(t, &health.CheckFailure{Message: err.Error(), Fix: fix}, got)
+		assert.Equal(t, err, got)
 	})
 }
 
-func TestRemoveVersionChecks(t *testing.T) {
-	t.Run("removes checks of type VersionMatches", func(t *testing.T) {
-		dep := health.Dependency{Binary: "mixed", Label: "Mixed", Checks: []health.Check{health.BinaryExists{}, health.VersionMatches{}}}
+func TestCheckTopoIsUpToDate(t *testing.T) {
+	t.Run("passes for development builds", func(t *testing.T) {
+		originalVersion := version.Version
+		version.Version = version.Dev
+		t.Cleanup(func() { version.Version = originalVersion })
 
-		got := health.RemoveVersionChecks([]health.Dependency{dep})
+		got := health.CheckTopoIsUpToDate(context.Background())
 
-		want := []health.Check{health.BinaryExists{}}
-
-		assert.Len(t, got, 1)
-		assert.Equal(t, want, got[0].Checks)
-	})
-}
-
-func TestCheckVersionMatches(t *testing.T) {
-	ctx := context.Background()
-
-	t.Run("returns an info result when version is outdated", func(t *testing.T) {
-		got := health.CheckVersionMatches(ctx, "1.0.0", func(context.Context) (string, error) { return "2.0.0", nil }, nil)
-		want := &health.CheckFailure{
-			Severity: health.SeverityInfo,
-			Message:  "out of date - current: 1.0.0, latest version: 2.0.0",
-			Fix:      &health.Fix{},
-		}
-
-		assert.Equal(t, want, got)
-	})
-
-	t.Run("passes when version matches latest", func(t *testing.T) {
-		got := health.CheckVersionMatches(ctx, "2.0.0", func(context.Context) (string, error) { return "2.0.0", nil }, nil)
-		var want *health.CheckFailure
-
-		assert.Equal(t, want, got)
-	})
-
-	t.Run("passes when fetching the latest version fails", func(t *testing.T) {
-		got := health.CheckVersionMatches(ctx, "", func(context.Context) (string, error) { return "", fmt.Errorf("connection refused") }, nil)
-		var want *health.CheckFailure
-
-		assert.Equal(t, want, got)
+		assert.Nil(t, got)
 	})
 }
 

--- a/internal/health/dependencies.go
+++ b/internal/health/dependencies.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/arm/topo/internal/runner"
 	"github.com/arm/topo/internal/ssh"
-	"github.com/arm/topo/internal/upgrade"
-	"github.com/arm/topo/internal/version"
 )
 
 type HardwareCapability int
@@ -20,57 +18,39 @@ const containerEngineInstallURL = "https://github.com/arm/topo#install-a-contain
 
 type DependencyID string
 
+type DependencyCheck func(ctx context.Context, r runner.Runner) *CheckFailure
+
 type Dependency struct {
 	ID                    DependencyID
 	Binary                string
 	Label                 string
-	Checks                []Check
+	Check                 DependencyCheck
 	SoftwarePrerequisites []DependencyID
 	HardwarePrerequisites []HardwareCapability
 }
 
-func HostRequiredDependencies() []Dependency {
+func HostRequiredDependencies(skipVersionChecks bool) []Dependency {
 	topo := Dependency{
 		ID:     DependencyID("topo"),
 		Binary: "topo",
 		Label:  "Topo",
-		Checks: []Check{VersionMatches{
-			FetchLatest: func(ctx context.Context) (string, error) {
-				if version.Version == version.Dev {
-					return version.Version, nil
-				}
-
-				binPath, err := upgrade.CurrentBinaryPath()
-				if err == nil && upgrade.IsBinaryManagedByHomebrew(binPath) {
-					return version.FetchLatestHomebrew(ctx, version.HomebrewFormulaURL)
-				}
-
-				return version.FetchLatestArtifactory(ctx, version.ArtifactoryBaseURL)
-			},
-			CurrentVersion: version.Version,
-			BuildFix: func() Fix {
-				fix := Fix{
-					Description: "Upgrade Topo",
-				}
-
-				binPath, err := upgrade.CurrentBinaryPath()
-				if err != nil {
-					return fix
-				}
-
-				_, fix.Command = upgrade.GetUpgradeCommand(binPath)
-				return fix
-			},
-		}},
+		Check: func(ctx context.Context, _ runner.Runner) *CheckFailure {
+			if skipVersionChecks {
+				return nil
+			}
+			return CheckTopoIsUpToDate(ctx)
+		},
 	}
 
 	ssh := Dependency{
 		ID:     DependencyID("ssh"),
 		Binary: "ssh",
 		Label:  "OpenSSH",
-		Checks: []Check{
-			BinaryExists{Binary: "ssh"},
-			OpenSSHAvailable{SSHBinary: "ssh"},
+		Check: func(ctx context.Context, r runner.Runner) *CheckFailure {
+			if err := r.BinaryExists(ctx, "ssh"); err != nil {
+				return &CheckFailure{Severity: SeverityError, Message: err.Error()}
+			}
+			return CheckOpenSSHAvailable(ctx, r, "ssh")
 		},
 	}
 
@@ -78,19 +58,26 @@ func HostRequiredDependencies() []Dependency {
 		ID:     DependencyID("host-docker"),
 		Binary: "docker",
 		Label:  "Container Engine",
-		Checks: []Check{
-			BinaryExists{
-				Binary: "docker",
-				Fix: &Fix{
-					Description: "Install a supported container engine. See " + containerEngineInstallURL,
-				},
-			},
-			CommandSuccessful{
-				Cmd: "docker info",
-				Fix: &Fix{
-					Description: "Ensure current user can run docker commands. See " + containerEngineInstallURL,
-				},
-			},
+		Check: func(ctx context.Context, r runner.Runner) *CheckFailure {
+			if err := r.BinaryExists(ctx, "docker"); err != nil {
+				return &CheckFailure{
+					Severity: SeverityError,
+					Message:  err.Error(),
+					Fix: &Fix{
+						Description: "Install a supported container engine. See " + containerEngineInstallURL,
+					},
+				}
+			}
+			if err := CheckCommandSuccessful(ctx, r, "docker info"); err != nil {
+				return &CheckFailure{
+					Severity: SeverityError,
+					Message:  err.Error(),
+					Fix: &Fix{
+						Description: "Ensure current user can run docker commands. See " + containerEngineInstallURL,
+					},
+				}
+			}
+			return nil
 		},
 	}
 
@@ -98,16 +85,17 @@ func HostRequiredDependencies() []Dependency {
 		ID:     DependencyID("docker-compose"),
 		Binary: "docker-compose",
 		Label:  "Docker Compose",
-		Checks: []Check{
-			CommandSuccessful{
-				Cmd: "docker compose",
-				Fix: &Fix{
-					Description: "Ensure Docker Compose is installed as a plugin for Docker. See " + containerEngineInstallURL,
-				},
-			},
-			DockerComposeMinVersion{
-				MinVersion: "2.21.0",
-			},
+		Check: func(ctx context.Context, r runner.Runner) *CheckFailure {
+			if err := CheckCommandSuccessful(ctx, r, "docker compose"); err != nil {
+				return &CheckFailure{
+					Severity: SeverityError,
+					Message:  err.Error(),
+					Fix: &Fix{
+						Description: "Ensure Docker Compose is installed as a plugin for Docker. See " + containerEngineInstallURL,
+					},
+				}
+			}
+			return CheckDockerComposeMinVersion(ctx, r, "2.21.0")
 		},
 		SoftwarePrerequisites: []DependencyID{docker.ID},
 	}
@@ -125,19 +113,26 @@ func TargetRequiredDependencies(target ssh.Destination) []Dependency {
 		ID:     DependencyID("target-docker"),
 		Binary: "docker",
 		Label:  "Container Engine",
-		Checks: []Check{
-			BinaryExists{
-				Binary: "docker",
-				Fix: &Fix{
-					Description: "Install a supported container engine. See " + containerEngineInstallURL,
-				},
-			},
-			CommandSuccessful{
-				Cmd: "docker info",
-				Fix: &Fix{
-					Description: "Ensure current user can run docker commands. See " + containerEngineInstallURL,
-				},
-			},
+		Check: func(ctx context.Context, r runner.Runner) *CheckFailure {
+			if err := r.BinaryExists(ctx, "docker"); err != nil {
+				return &CheckFailure{
+					Severity: SeverityError,
+					Message:  err.Error(),
+					Fix: &Fix{
+						Description: "Install a supported container engine. See " + containerEngineInstallURL,
+					},
+				}
+			}
+			if err := CheckCommandSuccessful(ctx, r, "docker info"); err != nil {
+				return &CheckFailure{
+					Severity: SeverityError,
+					Message:  err.Error(),
+					Fix: &Fix{
+						Description: "Ensure current user can run docker commands. See " + containerEngineInstallURL,
+					},
+				}
+			}
+			return nil
 		},
 	}
 
@@ -147,15 +142,18 @@ func TargetRequiredDependencies(target ssh.Destination) []Dependency {
 		Label:                 "Remoteproc Runtime",
 		SoftwarePrerequisites: []DependencyID{docker.ID},
 		HardwarePrerequisites: []HardwareCapability{Remoteproc},
-		Checks: []Check{
-			BinaryExists{
-				Binary:   "remoteproc-runtime",
-				Severity: SeverityWarning,
-				Fix: &Fix{
-					Description: "Install the Remoteproc Runtime",
-					Command:     fmt.Sprintf("topo install remoteproc-runtime --target %s", target),
-				},
-			},
+		Check: func(ctx context.Context, r runner.Runner) *CheckFailure {
+			if err := r.BinaryExists(ctx, "remoteproc-runtime"); err != nil {
+				return &CheckFailure{
+					Severity: SeverityWarning,
+					Message:  err.Error(),
+					Fix: &Fix{
+						Description: "Install the Remoteproc Runtime",
+						Command:     fmt.Sprintf("topo install remoteproc-runtime --target %s", target),
+					},
+				}
+			}
+			return nil
 		},
 	}
 	remoteprocRuntimeShim := Dependency{
@@ -164,15 +162,18 @@ func TargetRequiredDependencies(target ssh.Destination) []Dependency {
 		Label:                 "Remoteproc Shim",
 		SoftwarePrerequisites: []DependencyID{docker.ID},
 		HardwarePrerequisites: []HardwareCapability{Remoteproc},
-		Checks: []Check{
-			BinaryExists{
-				Binary:   "containerd-shim-remoteproc-v1",
-				Severity: SeverityWarning,
-				Fix: &Fix{
-					Description: "Install the Remoteproc Runtime",
-					Command:     fmt.Sprintf("topo install remoteproc-runtime --target %s", target),
-				},
-			},
+		Check: func(ctx context.Context, r runner.Runner) *CheckFailure {
+			if err := r.BinaryExists(ctx, "containerd-shim-remoteproc-v1"); err != nil {
+				return &CheckFailure{
+					Severity: SeverityWarning,
+					Message:  err.Error(),
+					Fix: &Fix{
+						Description: "Install the Remoteproc Runtime",
+						Command:     fmt.Sprintf("topo install remoteproc-runtime --target %s", target),
+					},
+				}
+			}
+			return nil
 		},
 	}
 
@@ -180,7 +181,12 @@ func TargetRequiredDependencies(target ssh.Destination) []Dependency {
 		ID:     DependencyID("lscpu"),
 		Binary: "lscpu",
 		Label:  "Hardware Info",
-		Checks: []Check{BinaryExists{Binary: "lscpu"}},
+		Check: func(ctx context.Context, r runner.Runner) *CheckFailure {
+			if err := r.BinaryExists(ctx, "lscpu"); err != nil {
+				return &CheckFailure{Severity: SeverityError, Message: err.Error()}
+			}
+			return nil
+		},
 	}
 
 	return []Dependency{
@@ -225,11 +231,8 @@ func PerformChecks(ctx context.Context, dependencies []Dependency, runner runner
 		}
 
 		var failure *CheckFailure
-		for _, check := range dep.Checks {
-			failure = check.Run(ctx, runner)
-			if failure != nil {
-				break
-			}
+		if dep.Check != nil {
+			failure = dep.Check(ctx, runner)
 		}
 
 		if failure == nil {

--- a/internal/health/dependencies.go
+++ b/internal/health/dependencies.go
@@ -73,7 +73,7 @@ func HostRequiredDependencies(skipVersionChecks bool) []Dependency {
 					Fix:      &Fix{Description: "Install a supported container engine. See " + containerEngineInstallURL},
 				}}
 			}
-			if err := CheckCommandSuccessful(ctx, r, "docker info"); err != nil {
+			if _, _, err := r.Run(ctx, "docker info"); err != nil {
 				return CheckResult{Failure: &CheckFailure{
 					Severity: SeverityError,
 					Message:  err.Error(),
@@ -88,7 +88,7 @@ func HostRequiredDependencies(skipVersionChecks bool) []Dependency {
 		ID:    DependencyID("docker-compose"),
 		Label: "Docker Compose",
 		Check: func(ctx context.Context, r runner.Runner) CheckResult {
-			if err := CheckCommandSuccessful(ctx, r, "docker compose"); err != nil {
+			if _, _, err := r.Run(ctx, "docker compose"); err != nil {
 				return CheckResult{Failure: &CheckFailure{
 					Severity: SeverityError,
 					Message:  err.Error(),
@@ -118,7 +118,7 @@ func TargetRequiredDependencies(target ssh.Destination) []Dependency {
 					Fix:      &Fix{Description: "Install a supported container engine. See " + containerEngineInstallURL},
 				}}
 			}
-			if err := CheckCommandSuccessful(ctx, r, "docker info"); err != nil {
+			if _, _, err := r.Run(ctx, "docker info"); err != nil {
 				return CheckResult{Failure: &CheckFailure{
 					Severity: SeverityError,
 					Message:  err.Error(),

--- a/internal/health/dependencies.go
+++ b/internal/health/dependencies.go
@@ -23,12 +23,12 @@ type CheckResult struct {
 	Failure      *CheckFailure
 }
 
-type DependencyCheck func(ctx context.Context, r runner.Runner) CheckResult
+type DependencyCheckFn func(ctx context.Context, r runner.Runner) CheckResult
 
 type Dependency struct {
 	ID                    DependencyID
 	Label                 string
-	Check                 DependencyCheck
+	Check                 DependencyCheckFn
 	SoftwarePrerequisites []DependencyID
 	HardwarePrerequisites []HardwareCapability
 }

--- a/internal/health/dependencies.go
+++ b/internal/health/dependencies.go
@@ -68,7 +68,10 @@ func HostRequiredDependencies() []Dependency {
 		ID:     DependencyID("ssh"),
 		Binary: "ssh",
 		Label:  "OpenSSH",
-		Checks: []Check{BinaryExists{}, OpenSSHAvailable{}},
+		Checks: []Check{
+			BinaryExists{Binary: "ssh"},
+			OpenSSHAvailable{SSHBinary: "ssh"},
+		},
 	}
 
 	docker := Dependency{
@@ -77,6 +80,7 @@ func HostRequiredDependencies() []Dependency {
 		Label:  "Container Engine",
 		Checks: []Check{
 			BinaryExists{
+				Binary: "docker",
 				Fix: &Fix{
 					Description: "Install a supported container engine. See " + containerEngineInstallURL,
 				},
@@ -123,6 +127,7 @@ func TargetRequiredDependencies(target ssh.Destination) []Dependency {
 		Label:  "Container Engine",
 		Checks: []Check{
 			BinaryExists{
+				Binary: "docker",
 				Fix: &Fix{
 					Description: "Install a supported container engine. See " + containerEngineInstallURL,
 				},
@@ -144,6 +149,7 @@ func TargetRequiredDependencies(target ssh.Destination) []Dependency {
 		HardwarePrerequisites: []HardwareCapability{Remoteproc},
 		Checks: []Check{
 			BinaryExists{
+				Binary:   "remoteproc-runtime",
 				Severity: SeverityWarning,
 				Fix: &Fix{
 					Description: "Install the Remoteproc Runtime",
@@ -160,6 +166,7 @@ func TargetRequiredDependencies(target ssh.Destination) []Dependency {
 		HardwarePrerequisites: []HardwareCapability{Remoteproc},
 		Checks: []Check{
 			BinaryExists{
+				Binary:   "containerd-shim-remoteproc-v1",
 				Severity: SeverityWarning,
 				Fix: &Fix{
 					Description: "Install the Remoteproc Runtime",
@@ -173,7 +180,7 @@ func TargetRequiredDependencies(target ssh.Destination) []Dependency {
 		ID:     DependencyID("lscpu"),
 		Binary: "lscpu",
 		Label:  "Hardware Info",
-		Checks: []Check{BinaryExists{}},
+		Checks: []Check{BinaryExists{Binary: "lscpu"}},
 	}
 
 	return []Dependency{
@@ -219,7 +226,7 @@ func PerformChecks(ctx context.Context, dependencies []Dependency, runner runner
 
 		var failure *CheckFailure
 		for _, check := range dep.Checks {
-			failure = check.Run(ctx, runner, dep)
+			failure = check.Run(ctx, runner)
 			if failure != nil {
 				break
 			}

--- a/internal/health/dependencies.go
+++ b/internal/health/dependencies.go
@@ -10,14 +10,6 @@ import (
 	"github.com/arm/topo/internal/version"
 )
 
-type WarningError struct{ Err error }
-
-func (w WarningError) Error() string { return w.Err.Error() }
-
-type InfoError struct{ Err error }
-
-func (i InfoError) Error() string { return i.Err.Error() }
-
 type HardwareCapability int
 
 const (
@@ -194,8 +186,7 @@ func TargetRequiredDependencies(target ssh.Destination) []Dependency {
 
 type DependencyStatus struct {
 	Dependency Dependency
-	Error      error
-	Fix        *Fix
+	Failure    *CheckFailure
 }
 
 func FilterByHardware(deps []Dependency, hardware map[HardwareCapability]struct{}) []Dependency {
@@ -226,23 +217,21 @@ func PerformChecks(ctx context.Context, dependencies []Dependency, runner runner
 			continue
 		}
 
-		var fix *Fix
-		var err error
+		var failure *CheckFailure
 		for _, check := range dep.Checks {
-			fix, err = check.Run(ctx, runner, dep)
-			if err != nil {
+			failure = check.Run(ctx, runner, dep)
+			if failure != nil {
 				break
 			}
 		}
 
-		if err == nil {
+		if failure == nil {
 			healthy[dep.ID] = struct{}{}
 		}
 
 		result = append(result, DependencyStatus{
 			Dependency: dep,
-			Error:      err,
-			Fix:        fix,
+			Failure:    failure,
 		})
 	}
 	return result

--- a/internal/health/dependencies.go
+++ b/internal/health/dependencies.go
@@ -18,13 +18,6 @@ const containerEngineInstallURL = "https://github.com/arm/topo#install-a-contain
 
 type DependencyID string
 
-type CheckResult struct {
-	SuccessValue string
-	Failure      *CheckFailure
-}
-
-type DependencyCheckFn func(ctx context.Context, r runner.Runner) CheckResult
-
 type Dependency struct {
 	ID                    DependencyID
 	Label                 string
@@ -33,72 +26,98 @@ type Dependency struct {
 	HardwarePrerequisites []HardwareCapability
 }
 
+type DependencyCheckFn func(ctx context.Context, r runner.Runner) DependencyCheckResult
+
+type DependencyCheckResult struct {
+	SuccessValue string
+	Failure      *DependencyCheckFailure
+}
+
+type DependencyCheckFailure struct {
+	Severity CheckSeverity
+	Message  string
+	Fix      *Fix
+}
+
+type CheckSeverity int
+
+const (
+	SeverityError CheckSeverity = iota
+	SeverityWarning
+	SeverityInfo
+)
+
+type Fix struct {
+	Description string `json:"description"`
+	Command     string `json:"command,omitempty"`
+}
+
 func HostRequiredDependencies(skipVersionChecks bool) []Dependency {
 	topo := Dependency{
 		ID:    DependencyID("topo"),
 		Label: "Topo",
-		Check: func(ctx context.Context, _ runner.Runner) CheckResult {
+		Check: func(ctx context.Context, _ runner.Runner) DependencyCheckResult {
 			if skipVersionChecks {
-				return CheckResult{SuccessValue: "topo"}
+				return DependencyCheckResult{SuccessValue: "topo"}
 			}
 			if failure := CheckTopoIsUpToDate(ctx); failure != nil {
-				return CheckResult{Failure: failure}
+				return DependencyCheckResult{Failure: failure}
 			}
-			return CheckResult{SuccessValue: "topo"}
+			return DependencyCheckResult{SuccessValue: "topo"}
 		},
 	}
 
 	ssh := Dependency{
 		ID:    DependencyID("ssh"),
 		Label: "OpenSSH",
-		Check: func(ctx context.Context, r runner.Runner) CheckResult {
+		Check: func(ctx context.Context, r runner.Runner) DependencyCheckResult {
 			if err := r.BinaryExists(ctx, "ssh"); err != nil {
-				return CheckResult{Failure: &CheckFailure{Severity: SeverityError, Message: err.Error()}}
+				return DependencyCheckResult{Failure: &DependencyCheckFailure{Severity: SeverityError, Message: err.Error()}}
 			}
 			if failure := CheckOpenSSHAvailable(ctx, r, "ssh"); failure != nil {
-				return CheckResult{Failure: failure}
+				return DependencyCheckResult{Failure: failure}
 			}
-			return CheckResult{SuccessValue: "ssh"}
+			return DependencyCheckResult{SuccessValue: "ssh"}
 		},
 	}
 
 	docker := Dependency{
 		ID:    DependencyID("host-docker"),
 		Label: "Container Engine",
-		Check: func(ctx context.Context, r runner.Runner) CheckResult {
+		Check: func(ctx context.Context, r runner.Runner) DependencyCheckResult {
 			if err := r.BinaryExists(ctx, "docker"); err != nil {
-				return CheckResult{Failure: &CheckFailure{
+				return DependencyCheckResult{Failure: &DependencyCheckFailure{
 					Severity: SeverityError,
 					Message:  err.Error(),
 					Fix:      &Fix{Description: "Install a supported container engine. See " + containerEngineInstallURL},
 				}}
 			}
 			if _, _, err := r.Run(ctx, "docker info"); err != nil {
-				return CheckResult{Failure: &CheckFailure{
+				return DependencyCheckResult{Failure: &DependencyCheckFailure{
 					Severity: SeverityError,
 					Message:  err.Error(),
 					Fix:      &Fix{Description: "Ensure current user can run docker commands. See " + containerEngineInstallURL},
 				}}
 			}
-			return CheckResult{SuccessValue: "docker"}
+			return DependencyCheckResult{SuccessValue: "docker"}
 		},
 	}
 
 	dockerCompose := Dependency{
 		ID:    DependencyID("docker-compose"),
 		Label: "Docker Compose",
-		Check: func(ctx context.Context, r runner.Runner) CheckResult {
+		Check: func(ctx context.Context, r runner.Runner) DependencyCheckResult {
 			if _, _, err := r.Run(ctx, "docker compose"); err != nil {
-				return CheckResult{Failure: &CheckFailure{
+				return DependencyCheckResult{Failure: &DependencyCheckFailure{
 					Severity: SeverityError,
 					Message:  err.Error(),
 					Fix:      &Fix{Description: "Ensure Docker Compose is installed as a plugin for Docker. See " + containerEngineInstallURL},
 				}}
 			}
 			if failure := CheckDockerComposeMinVersion(ctx, r, "2.21.0"); failure != nil {
-				return CheckResult{Failure: failure}
+				return DependencyCheckResult{Failure: failure}
 			}
-			return CheckResult{SuccessValue: "docker compose"}
+			return DependencyCheckResult{SuccessValue: "docker compose"}
 		},
 		SoftwarePrerequisites: []DependencyID{docker.ID},
 	}
@@ -110,22 +129,22 @@ func TargetRequiredDependencies(target ssh.Destination) []Dependency {
 	docker := Dependency{
 		ID:    DependencyID("target-docker"),
 		Label: "Container Engine",
-		Check: func(ctx context.Context, r runner.Runner) CheckResult {
+		Check: func(ctx context.Context, r runner.Runner) DependencyCheckResult {
 			if err := r.BinaryExists(ctx, "docker"); err != nil {
-				return CheckResult{Failure: &CheckFailure{
+				return DependencyCheckResult{Failure: &DependencyCheckFailure{
 					Severity: SeverityError,
 					Message:  err.Error(),
 					Fix:      &Fix{Description: "Install a supported container engine. See " + containerEngineInstallURL},
 				}}
 			}
 			if _, _, err := r.Run(ctx, "docker info"); err != nil {
-				return CheckResult{Failure: &CheckFailure{
+				return DependencyCheckResult{Failure: &DependencyCheckFailure{
 					Severity: SeverityError,
 					Message:  err.Error(),
 					Fix:      &Fix{Description: "Ensure current user can run docker commands. See " + containerEngineInstallURL},
 				}}
 			}
-			return CheckResult{SuccessValue: "docker"}
+			return DependencyCheckResult{SuccessValue: "docker"}
 		},
 	}
 
@@ -134,9 +153,9 @@ func TargetRequiredDependencies(target ssh.Destination) []Dependency {
 		Label:                 "Remoteproc Runtime",
 		SoftwarePrerequisites: []DependencyID{docker.ID},
 		HardwarePrerequisites: []HardwareCapability{Remoteproc},
-		Check: func(ctx context.Context, r runner.Runner) CheckResult {
+		Check: func(ctx context.Context, r runner.Runner) DependencyCheckResult {
 			if err := r.BinaryExists(ctx, "remoteproc-runtime"); err != nil {
-				return CheckResult{Failure: &CheckFailure{
+				return DependencyCheckResult{Failure: &DependencyCheckFailure{
 					Severity: SeverityWarning,
 					Message:  err.Error(),
 					Fix: &Fix{
@@ -145,7 +164,7 @@ func TargetRequiredDependencies(target ssh.Destination) []Dependency {
 					},
 				}}
 			}
-			return CheckResult{SuccessValue: "remoteproc-runtime"}
+			return DependencyCheckResult{SuccessValue: "remoteproc-runtime"}
 		},
 	}
 
@@ -154,9 +173,9 @@ func TargetRequiredDependencies(target ssh.Destination) []Dependency {
 		Label:                 "Remoteproc Shim",
 		SoftwarePrerequisites: []DependencyID{docker.ID},
 		HardwarePrerequisites: []HardwareCapability{Remoteproc},
-		Check: func(ctx context.Context, r runner.Runner) CheckResult {
+		Check: func(ctx context.Context, r runner.Runner) DependencyCheckResult {
 			if err := r.BinaryExists(ctx, "containerd-shim-remoteproc-v1"); err != nil {
-				return CheckResult{Failure: &CheckFailure{
+				return DependencyCheckResult{Failure: &DependencyCheckFailure{
 					Severity: SeverityWarning,
 					Message:  err.Error(),
 					Fix: &Fix{
@@ -165,18 +184,18 @@ func TargetRequiredDependencies(target ssh.Destination) []Dependency {
 					},
 				}}
 			}
-			return CheckResult{SuccessValue: "containerd-shim-remoteproc-v1"}
+			return DependencyCheckResult{SuccessValue: "containerd-shim-remoteproc-v1"}
 		},
 	}
 
 	lscpu := Dependency{
 		ID:    DependencyID("lscpu"),
 		Label: "Hardware Info",
-		Check: func(ctx context.Context, r runner.Runner) CheckResult {
+		Check: func(ctx context.Context, r runner.Runner) DependencyCheckResult {
 			if err := r.BinaryExists(ctx, "lscpu"); err != nil {
-				return CheckResult{Failure: &CheckFailure{Severity: SeverityError, Message: err.Error()}}
+				return DependencyCheckResult{Failure: &DependencyCheckFailure{Severity: SeverityError, Message: err.Error()}}
 			}
-			return CheckResult{SuccessValue: "lscpu"}
+			return DependencyCheckResult{SuccessValue: "lscpu"}
 		},
 	}
 
@@ -185,7 +204,7 @@ func TargetRequiredDependencies(target ssh.Destination) []Dependency {
 
 type DependencyStatus struct {
 	Dependency Dependency
-	Result     CheckResult
+	Result     DependencyCheckResult
 }
 
 func FilterByHardware(deps []Dependency, hardware map[HardwareCapability]struct{}) []Dependency {
@@ -216,7 +235,7 @@ func PerformChecks(ctx context.Context, dependencies []Dependency, runner runner
 			continue
 		}
 
-		checkResult := CheckResult{}
+		checkResult := DependencyCheckResult{}
 		if dep.Check != nil {
 			checkResult = dep.Check(ctx, runner)
 		}

--- a/internal/health/dependencies.go
+++ b/internal/health/dependencies.go
@@ -107,7 +107,7 @@ func HostRequiredDependencies(skipVersionChecks bool) []Dependency {
 		ID:    DependencyID("docker-compose"),
 		Label: "Docker Compose",
 		Check: func(ctx context.Context, r runner.Runner) DependencyCheckResult {
-			if _, _, err := r.Run(ctx, "docker compose"); err != nil {
+			if _, _, err := r.Run(ctx, "docker-compose"); err != nil {
 				return DependencyCheckResult{Failure: &DependencyCheckFailure{
 					Severity: SeverityError,
 					Message:  err.Error(),
@@ -117,7 +117,7 @@ func HostRequiredDependencies(skipVersionChecks bool) []Dependency {
 			if failure := CheckDockerComposeMinVersion(ctx, r, "2.21.0"); failure != nil {
 				return DependencyCheckResult{Failure: failure}
 			}
-			return DependencyCheckResult{SuccessValue: "docker compose"}
+			return DependencyCheckResult{SuccessValue: "docker-compose"}
 		},
 		SoftwarePrerequisites: []DependencyID{docker.ID},
 	}

--- a/internal/health/dependencies.go
+++ b/internal/health/dependencies.go
@@ -18,11 +18,15 @@ const containerEngineInstallURL = "https://github.com/arm/topo#install-a-contain
 
 type DependencyID string
 
-type DependencyCheck func(ctx context.Context, r runner.Runner) *CheckFailure
+type CheckResult struct {
+	SuccessValue string
+	Failure      *CheckFailure
+}
+
+type DependencyCheck func(ctx context.Context, r runner.Runner) CheckResult
 
 type Dependency struct {
 	ID                    DependencyID
-	Binary                string
 	Label                 string
 	Check                 DependencyCheck
 	SoftwarePrerequisites []DependencyID
@@ -31,175 +35,157 @@ type Dependency struct {
 
 func HostRequiredDependencies(skipVersionChecks bool) []Dependency {
 	topo := Dependency{
-		ID:     DependencyID("topo"),
-		Binary: "topo",
-		Label:  "Topo",
-		Check: func(ctx context.Context, _ runner.Runner) *CheckFailure {
+		ID:    DependencyID("topo"),
+		Label: "Topo",
+		Check: func(ctx context.Context, _ runner.Runner) CheckResult {
 			if skipVersionChecks {
-				return nil
+				return CheckResult{SuccessValue: "topo"}
 			}
-			return CheckTopoIsUpToDate(ctx)
+			if failure := CheckTopoIsUpToDate(ctx); failure != nil {
+				return CheckResult{Failure: failure}
+			}
+			return CheckResult{SuccessValue: "topo"}
 		},
 	}
 
 	ssh := Dependency{
-		ID:     DependencyID("ssh"),
-		Binary: "ssh",
-		Label:  "OpenSSH",
-		Check: func(ctx context.Context, r runner.Runner) *CheckFailure {
+		ID:    DependencyID("ssh"),
+		Label: "OpenSSH",
+		Check: func(ctx context.Context, r runner.Runner) CheckResult {
 			if err := r.BinaryExists(ctx, "ssh"); err != nil {
-				return &CheckFailure{Severity: SeverityError, Message: err.Error()}
+				return CheckResult{Failure: &CheckFailure{Severity: SeverityError, Message: err.Error()}}
 			}
-			return CheckOpenSSHAvailable(ctx, r, "ssh")
+			if failure := CheckOpenSSHAvailable(ctx, r, "ssh"); failure != nil {
+				return CheckResult{Failure: failure}
+			}
+			return CheckResult{SuccessValue: "ssh"}
 		},
 	}
 
 	docker := Dependency{
-		ID:     DependencyID("host-docker"),
-		Binary: "docker",
-		Label:  "Container Engine",
-		Check: func(ctx context.Context, r runner.Runner) *CheckFailure {
+		ID:    DependencyID("host-docker"),
+		Label: "Container Engine",
+		Check: func(ctx context.Context, r runner.Runner) CheckResult {
 			if err := r.BinaryExists(ctx, "docker"); err != nil {
-				return &CheckFailure{
+				return CheckResult{Failure: &CheckFailure{
 					Severity: SeverityError,
 					Message:  err.Error(),
-					Fix: &Fix{
-						Description: "Install a supported container engine. See " + containerEngineInstallURL,
-					},
-				}
+					Fix:      &Fix{Description: "Install a supported container engine. See " + containerEngineInstallURL},
+				}}
 			}
 			if err := CheckCommandSuccessful(ctx, r, "docker info"); err != nil {
-				return &CheckFailure{
+				return CheckResult{Failure: &CheckFailure{
 					Severity: SeverityError,
 					Message:  err.Error(),
-					Fix: &Fix{
-						Description: "Ensure current user can run docker commands. See " + containerEngineInstallURL,
-					},
-				}
+					Fix:      &Fix{Description: "Ensure current user can run docker commands. See " + containerEngineInstallURL},
+				}}
 			}
-			return nil
+			return CheckResult{SuccessValue: "docker"}
 		},
 	}
 
 	dockerCompose := Dependency{
-		ID:     DependencyID("docker-compose"),
-		Binary: "docker-compose",
-		Label:  "Docker Compose",
-		Check: func(ctx context.Context, r runner.Runner) *CheckFailure {
+		ID:    DependencyID("docker-compose"),
+		Label: "Docker Compose",
+		Check: func(ctx context.Context, r runner.Runner) CheckResult {
 			if err := CheckCommandSuccessful(ctx, r, "docker compose"); err != nil {
-				return &CheckFailure{
+				return CheckResult{Failure: &CheckFailure{
 					Severity: SeverityError,
 					Message:  err.Error(),
-					Fix: &Fix{
-						Description: "Ensure Docker Compose is installed as a plugin for Docker. See " + containerEngineInstallURL,
-					},
-				}
+					Fix:      &Fix{Description: "Ensure Docker Compose is installed as a plugin for Docker. See " + containerEngineInstallURL},
+				}}
 			}
-			return CheckDockerComposeMinVersion(ctx, r, "2.21.0")
+			if failure := CheckDockerComposeMinVersion(ctx, r, "2.21.0"); failure != nil {
+				return CheckResult{Failure: failure}
+			}
+			return CheckResult{SuccessValue: "docker compose"}
 		},
 		SoftwarePrerequisites: []DependencyID{docker.ID},
 	}
 
-	return []Dependency{
-		topo,
-		ssh,
-		docker,
-		dockerCompose,
-	}
+	return []Dependency{topo, ssh, docker, dockerCompose}
 }
 
 func TargetRequiredDependencies(target ssh.Destination) []Dependency {
 	docker := Dependency{
-		ID:     DependencyID("target-docker"),
-		Binary: "docker",
-		Label:  "Container Engine",
-		Check: func(ctx context.Context, r runner.Runner) *CheckFailure {
+		ID:    DependencyID("target-docker"),
+		Label: "Container Engine",
+		Check: func(ctx context.Context, r runner.Runner) CheckResult {
 			if err := r.BinaryExists(ctx, "docker"); err != nil {
-				return &CheckFailure{
+				return CheckResult{Failure: &CheckFailure{
 					Severity: SeverityError,
 					Message:  err.Error(),
-					Fix: &Fix{
-						Description: "Install a supported container engine. See " + containerEngineInstallURL,
-					},
-				}
+					Fix:      &Fix{Description: "Install a supported container engine. See " + containerEngineInstallURL},
+				}}
 			}
 			if err := CheckCommandSuccessful(ctx, r, "docker info"); err != nil {
-				return &CheckFailure{
+				return CheckResult{Failure: &CheckFailure{
 					Severity: SeverityError,
 					Message:  err.Error(),
-					Fix: &Fix{
-						Description: "Ensure current user can run docker commands. See " + containerEngineInstallURL,
-					},
-				}
+					Fix:      &Fix{Description: "Ensure current user can run docker commands. See " + containerEngineInstallURL},
+				}}
 			}
-			return nil
+			return CheckResult{SuccessValue: "docker"}
 		},
 	}
 
 	remoteprocRuntime := Dependency{
 		ID:                    DependencyID("remoteproc-runtime"),
-		Binary:                "remoteproc-runtime",
 		Label:                 "Remoteproc Runtime",
 		SoftwarePrerequisites: []DependencyID{docker.ID},
 		HardwarePrerequisites: []HardwareCapability{Remoteproc},
-		Check: func(ctx context.Context, r runner.Runner) *CheckFailure {
+		Check: func(ctx context.Context, r runner.Runner) CheckResult {
 			if err := r.BinaryExists(ctx, "remoteproc-runtime"); err != nil {
-				return &CheckFailure{
+				return CheckResult{Failure: &CheckFailure{
 					Severity: SeverityWarning,
 					Message:  err.Error(),
 					Fix: &Fix{
 						Description: "Install the Remoteproc Runtime",
 						Command:     fmt.Sprintf("topo install remoteproc-runtime --target %s", target),
 					},
-				}
+				}}
 			}
-			return nil
+			return CheckResult{SuccessValue: "remoteproc-runtime"}
 		},
 	}
+
 	remoteprocRuntimeShim := Dependency{
 		ID:                    DependencyID("containerd-shim-remoteproc-v1"),
-		Binary:                "containerd-shim-remoteproc-v1",
 		Label:                 "Remoteproc Shim",
 		SoftwarePrerequisites: []DependencyID{docker.ID},
 		HardwarePrerequisites: []HardwareCapability{Remoteproc},
-		Check: func(ctx context.Context, r runner.Runner) *CheckFailure {
+		Check: func(ctx context.Context, r runner.Runner) CheckResult {
 			if err := r.BinaryExists(ctx, "containerd-shim-remoteproc-v1"); err != nil {
-				return &CheckFailure{
+				return CheckResult{Failure: &CheckFailure{
 					Severity: SeverityWarning,
 					Message:  err.Error(),
 					Fix: &Fix{
 						Description: "Install the Remoteproc Runtime",
 						Command:     fmt.Sprintf("topo install remoteproc-runtime --target %s", target),
 					},
-				}
+				}}
 			}
-			return nil
+			return CheckResult{SuccessValue: "containerd-shim-remoteproc-v1"}
 		},
 	}
 
 	lscpu := Dependency{
-		ID:     DependencyID("lscpu"),
-		Binary: "lscpu",
-		Label:  "Hardware Info",
-		Check: func(ctx context.Context, r runner.Runner) *CheckFailure {
+		ID:    DependencyID("lscpu"),
+		Label: "Hardware Info",
+		Check: func(ctx context.Context, r runner.Runner) CheckResult {
 			if err := r.BinaryExists(ctx, "lscpu"); err != nil {
-				return &CheckFailure{Severity: SeverityError, Message: err.Error()}
+				return CheckResult{Failure: &CheckFailure{Severity: SeverityError, Message: err.Error()}}
 			}
-			return nil
+			return CheckResult{SuccessValue: "lscpu"}
 		},
 	}
 
-	return []Dependency{
-		docker,
-		remoteprocRuntime,
-		remoteprocRuntimeShim,
-		lscpu,
-	}
+	return []Dependency{docker, remoteprocRuntime, remoteprocRuntimeShim, lscpu}
 }
 
 type DependencyStatus struct {
 	Dependency Dependency
-	Failure    *CheckFailure
+	Result     CheckResult
 }
 
 func FilterByHardware(deps []Dependency, hardware map[HardwareCapability]struct{}) []Dependency {
@@ -230,19 +216,15 @@ func PerformChecks(ctx context.Context, dependencies []Dependency, runner runner
 			continue
 		}
 
-		var failure *CheckFailure
+		checkResult := CheckResult{}
 		if dep.Check != nil {
-			failure = dep.Check(ctx, runner)
+			checkResult = dep.Check(ctx, runner)
 		}
-
-		if failure == nil {
+		if checkResult.Failure == nil {
 			healthy[dep.ID] = struct{}{}
 		}
 
-		result = append(result, DependencyStatus{
-			Dependency: dep,
-			Failure:    failure,
-		})
+		result = append(result, DependencyStatus{Dependency: dep, Result: checkResult})
 	}
 	return result
 }

--- a/internal/health/dependencies_test.go
+++ b/internal/health/dependencies_test.go
@@ -6,7 +6,6 @@ import (
 	"slices"
 	"testing"
 
-	"github.com/arm/topo/internal/command"
 	"github.com/arm/topo/internal/health"
 	"github.com/arm/topo/internal/runner"
 	"github.com/arm/topo/internal/ssh"
@@ -24,15 +23,6 @@ func TestDependencies(t *testing.T) {
 			require.NotEmpty(t, dep.ID, "%#v has empty id", dep)
 			require.NotContains(t, ids, dep.ID)
 			ids = append(ids, dep.ID)
-		}
-	})
-
-	t.Run("binary names are of the correct format", func(t *testing.T) {
-		hostDeps := health.HostRequiredDependencies(false)
-		targetDeps := health.TargetRequiredDependencies(ssh.NewDestination("whatever"))
-
-		for _, dep := range slices.Concat(hostDeps, targetDeps) {
-			assert.NoError(t, command.ValidateBinaryName(dep.Binary))
 		}
 	})
 
@@ -64,9 +54,9 @@ func TestDependencies(t *testing.T) {
 		t.Run("remoteproc install fix command includes the target", func(t *testing.T) {
 			deps := health.TargetRequiredDependencies(ssh.NewDestination("user@my-target"))
 
-			dep, err := findDependencyByBinary(t, deps, "remoteproc-runtime")
+			dep, err := findDependencyByID(t, deps, "remoteproc-runtime")
 			assert.NoError(t, err)
-			failure := dep.Check(context.Background(), &runner.Fake{})
+			result := dep.Check(context.Background(), &runner.Fake{})
 
 			assert.Equal(t, &health.CheckFailure{
 				Severity: health.SeverityWarning,
@@ -75,7 +65,7 @@ func TestDependencies(t *testing.T) {
 					Description: "Install the Remoteproc Runtime",
 					Command:     "topo install remoteproc-runtime --target ssh://user@my-target",
 				},
-			}, failure)
+			}, result.Failure)
 		})
 	})
 }
@@ -83,27 +73,27 @@ func TestDependencies(t *testing.T) {
 func TestPerformChecks(t *testing.T) {
 	t.Run("dependency status reflects the result of running the check", func(t *testing.T) {
 		t.Run("when check passes", func(t *testing.T) {
-			dep := health.Dependency{Binary: "foo", Label: "bar", Check: passingCheck}
+			dep := health.Dependency{Label: "bar", Check: passingCheck}
 			deps := []health.Dependency{dep}
 
 			got := health.PerformChecks(context.Background(), deps, &runner.Fake{})
 
 			require.Len(t, got, 1)
 			assert.Equal(t, dep.ID, got[0].Dependency.ID)
-			assert.Nil(t, got[0].Failure)
+			assert.Nil(t, got[0].Result.Failure)
 		})
 
 		t.Run("when a check fails", func(t *testing.T) {
 			check := health.DependencyCheck(failingCheck)
-			dep := health.Dependency{Binary: "foo", Label: "bar", Check: check}
+			dep := health.Dependency{Label: "bar", Check: check}
 			deps := []health.Dependency{dep}
 
 			got := health.PerformChecks(context.Background(), deps, &runner.Fake{})
 
-			wantFailure := check(context.Background(), &runner.Fake{})
+			wantResult := check(context.Background(), &runner.Fake{})
 			require.Len(t, got, 1)
 			assert.Equal(t, dep.ID, got[0].Dependency.ID)
-			assert.Equal(t, wantFailure, got[0].Failure)
+			assert.Equal(t, wantResult, got[0].Result)
 		})
 	})
 
@@ -135,9 +125,8 @@ func TestPerformChecks(t *testing.T) {
 
 		t.Run("checks dependency when all of its software prerequisites are installed", func(t *testing.T) {
 			vader := health.Dependency{
-				ID:     health.DependencyID("vader"),
-				Binary: "vader",
-				Check:  passingCheck,
+				ID:    health.DependencyID("vader"),
+				Check: passingCheck,
 			}
 			luke := health.Dependency{
 				ID:                    "luke",
@@ -157,7 +146,7 @@ func TestPerformChecks(t *testing.T) {
 func TestFilterByHardware(t *testing.T) {
 	t.Run("includes dependencies with no hardware requirement", func(t *testing.T) {
 		deps := []health.Dependency{
-			{Binary: "docker", Label: "Container Engine"},
+			{Label: "Container Engine"},
 		}
 		hardware := map[health.HardwareCapability]struct{}{}
 
@@ -168,7 +157,7 @@ func TestFilterByHardware(t *testing.T) {
 
 	t.Run("includes dependencies when hardware is present", func(t *testing.T) {
 		deps := []health.Dependency{
-			{Binary: "remoteproc-runtime", Label: "Runtime", HardwarePrerequisites: []health.HardwareCapability{health.Remoteproc}},
+			{Label: "Runtime", HardwarePrerequisites: []health.HardwareCapability{health.Remoteproc}},
 		}
 		hardware := map[health.HardwareCapability]struct{}{health.Remoteproc: {}}
 
@@ -179,7 +168,7 @@ func TestFilterByHardware(t *testing.T) {
 
 	t.Run("excludes dependencies when hardware is absent", func(t *testing.T) {
 		deps := []health.Dependency{
-			{Binary: "remoteproc-runtime", Label: "Runtime", HardwarePrerequisites: []health.HardwareCapability{health.Remoteproc}},
+			{Label: "Runtime", HardwarePrerequisites: []health.HardwareCapability{health.Remoteproc}},
 		}
 		hardware := map[health.HardwareCapability]struct{}{}
 
@@ -190,26 +179,26 @@ func TestFilterByHardware(t *testing.T) {
 
 	t.Run("filters mixed dependencies correctly", func(t *testing.T) {
 		deps := []health.Dependency{
-			{Binary: "spaghetti", Label: "Food"},
-			{Binary: "remoteproc-runtime", Label: "Runtime", HardwarePrerequisites: []health.HardwareCapability{health.Remoteproc}},
-			{Binary: "pizza", Label: "Food"},
+			{Label: "Food"},
+			{Label: "Runtime", HardwarePrerequisites: []health.HardwareCapability{health.Remoteproc}},
+			{Label: "Food"},
 		}
 
 		got := health.FilterByHardware(deps, nil)
 
 		want := []health.Dependency{
-			{Binary: "spaghetti", Label: "Food"},
-			{Binary: "pizza", Label: "Food"},
+			{Label: "Food"},
+			{Label: "Food"},
 		}
 		assert.Equal(t, want, got)
 	})
 }
 
-func findDependencyByBinary(t *testing.T, deps []health.Dependency, binary string) (health.Dependency, error) {
+func findDependencyByID(t *testing.T, deps []health.Dependency, id string) (health.Dependency, error) {
 	t.Helper()
 
 	for _, dep := range deps {
-		if dep.Binary == binary {
+		if dep.ID == health.DependencyID(id) {
 			return dep, nil
 		}
 	}
@@ -217,13 +206,14 @@ func findDependencyByBinary(t *testing.T, deps []health.Dependency, binary strin
 	return health.Dependency{}, errors.New("dependency not found")
 }
 
-func passingCheck(_ context.Context, _ runner.Runner) *health.CheckFailure {
-	return nil
+func passingCheck(_ context.Context, _ runner.Runner) health.CheckResult {
+	return health.CheckResult{SuccessValue: "passed"}
 }
 
-func failingCheck(_ context.Context, _ runner.Runner) *health.CheckFailure {
-	return &health.CheckFailure{
-		Message: "very broken",
-		Fix:     &health.Fix{Description: "fix me please", Command: "rm -rf /"},
-	}
+func failingCheck(_ context.Context, _ runner.Runner) health.CheckResult {
+	return health.CheckResult{Failure: &health.CheckFailure{
+		Severity: health.SeverityError,
+		Message:  "very broken",
+		Fix:      &health.Fix{Description: "fix me please", Command: "rm -rf /"},
+	}}
 }

--- a/internal/health/dependencies_test.go
+++ b/internal/health/dependencies_test.go
@@ -84,7 +84,7 @@ func TestPerformChecks(t *testing.T) {
 		})
 
 		t.Run("when a check fails", func(t *testing.T) {
-			check := health.CheckFn(failingCheck)
+			check := health.DependencyCheckFn(failingCheck)
 			dep := health.Dependency{Label: "bar", Check: check}
 			deps := []health.Dependency{dep}
 

--- a/internal/health/dependencies_test.go
+++ b/internal/health/dependencies_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestDependencies(t *testing.T) {
 	t.Run("ids are unique across all dependencies", func(t *testing.T) {
-		hostDeps := health.HostRequiredDependencies()
+		hostDeps := health.HostRequiredDependencies(false)
 		targetDeps := health.TargetRequiredDependencies(ssh.NewDestination("whatever"))
 
 		ids := make([]health.DependencyID, 0, len(hostDeps)+len(targetDeps))
@@ -28,7 +28,7 @@ func TestDependencies(t *testing.T) {
 	})
 
 	t.Run("binary names are of the correct format", func(t *testing.T) {
-		hostDeps := health.HostRequiredDependencies()
+		hostDeps := health.HostRequiredDependencies(false)
 		targetDeps := health.TargetRequiredDependencies(ssh.NewDestination("whatever"))
 
 		for _, dep := range slices.Concat(hostDeps, targetDeps) {
@@ -38,7 +38,7 @@ func TestDependencies(t *testing.T) {
 
 	t.Run("host dependencies", func(t *testing.T) {
 		t.Run("prerequisites are fulfillable", func(t *testing.T) {
-			deps := health.HostRequiredDependencies()
+			deps := health.HostRequiredDependencies(false)
 			ids := make([]health.DependencyID, 0, len(deps))
 			for _, dep := range deps {
 				ids = append(ids, dep.ID)
@@ -66,15 +66,16 @@ func TestDependencies(t *testing.T) {
 
 			dep, err := findDependencyByBinary(t, deps, "remoteproc-runtime")
 			assert.NoError(t, err)
-			wantBinaryExistsCheck := health.BinaryExists{
-				Binary:   "remoteproc-runtime",
+			failure := dep.Check(context.Background(), &runner.Fake{})
+
+			assert.Equal(t, &health.CheckFailure{
 				Severity: health.SeverityWarning,
+				Message:  `"remoteproc-runtime" not found in $PATH`,
 				Fix: &health.Fix{
 					Description: "Install the Remoteproc Runtime",
 					Command:     "topo install remoteproc-runtime --target ssh://user@my-target",
 				},
-			}
-			assert.Contains(t, dep.Checks, wantBinaryExistsCheck)
+			}, failure)
 		})
 	})
 }
@@ -82,39 +83,39 @@ func TestDependencies(t *testing.T) {
 func TestPerformChecks(t *testing.T) {
 	t.Run("dependency status reflects the result of running the check", func(t *testing.T) {
 		t.Run("when check passes", func(t *testing.T) {
-			dep := health.Dependency{Binary: "foo", Label: "bar", Checks: []health.Check{passingCheck{}}}
+			dep := health.Dependency{Binary: "foo", Label: "bar", Check: passingCheck}
 			deps := []health.Dependency{dep}
 
 			got := health.PerformChecks(context.Background(), deps, &runner.Fake{})
 
-			wantStatus := health.DependencyStatus{Dependency: dep, Failure: nil}
-			want := []health.DependencyStatus{wantStatus}
-			assert.Equal(t, want, got)
+			require.Len(t, got, 1)
+			assert.Equal(t, dep.ID, got[0].Dependency.ID)
+			assert.Nil(t, got[0].Failure)
 		})
 
 		t.Run("when a check fails", func(t *testing.T) {
-			check := failingCheck{}
-			dep := health.Dependency{Binary: "foo", Label: "bar", Checks: []health.Check{check}}
+			check := health.DependencyCheck(failingCheck)
+			dep := health.Dependency{Binary: "foo", Label: "bar", Check: check}
 			deps := []health.Dependency{dep}
 
 			got := health.PerformChecks(context.Background(), deps, &runner.Fake{})
 
-			wantFailure := check.Run(context.Background(), &runner.Fake{})
-			wantStatus := health.DependencyStatus{Dependency: dep, Failure: wantFailure}
-			want := []health.DependencyStatus{wantStatus}
-			assert.Equal(t, want, got)
+			wantFailure := check(context.Background(), &runner.Fake{})
+			require.Len(t, got, 1)
+			assert.Equal(t, dep.ID, got[0].Dependency.ID)
+			assert.Equal(t, wantFailure, got[0].Failure)
 		})
 	})
 
 	t.Run("prerequisites", func(t *testing.T) {
 		t.Run("omits dependency when any of its software prerequisites are not installed", func(t *testing.T) {
 			pineapple := health.Dependency{
-				ID:     health.DependencyID("pineapple"),
-				Checks: []health.Check{passingCheck{}},
+				ID:    health.DependencyID("pineapple"),
+				Check: passingCheck,
 			}
 			cheese := health.Dependency{
-				ID:     health.DependencyID("cheese"),
-				Checks: []health.Check{failingCheck{}},
+				ID:    health.DependencyID("cheese"),
+				Check: failingCheck,
 			}
 			pizzaWhichShouldBeOmitted := health.Dependency{
 				ID:                    "pizza",
@@ -136,7 +137,7 @@ func TestPerformChecks(t *testing.T) {
 			vader := health.Dependency{
 				ID:     health.DependencyID("vader"),
 				Binary: "vader",
-				Checks: []health.Check{passingCheck{}},
+				Check:  passingCheck,
 			}
 			luke := health.Dependency{
 				ID:                    "luke",
@@ -146,11 +147,9 @@ func TestPerformChecks(t *testing.T) {
 
 			got := health.PerformChecks(context.Background(), deps, &runner.Fake{})
 
-			want := []health.DependencyStatus{
-				{Dependency: vader},
-				{Dependency: luke},
-			}
-			assert.Equal(t, want, got)
+			require.Len(t, got, 2)
+			assert.Equal(t, vader.ID, got[0].Dependency.ID)
+			assert.Equal(t, luke.ID, got[1].Dependency.ID)
 		})
 	})
 }
@@ -218,15 +217,11 @@ func findDependencyByBinary(t *testing.T, deps []health.Dependency, binary strin
 	return health.Dependency{}, errors.New("dependency not found")
 }
 
-type passingCheck struct{}
-
-func (p passingCheck) Run(_ context.Context, _ runner.Runner) *health.CheckFailure {
+func passingCheck(_ context.Context, _ runner.Runner) *health.CheckFailure {
 	return nil
 }
 
-type failingCheck struct{}
-
-func (p failingCheck) Run(_ context.Context, _ runner.Runner) *health.CheckFailure {
+func failingCheck(_ context.Context, _ runner.Runner) *health.CheckFailure {
 	return &health.CheckFailure{
 		Message: "very broken",
 		Fix:     &health.Fix{Description: "fix me please", Command: "rm -rf /"},

--- a/internal/health/dependencies_test.go
+++ b/internal/health/dependencies_test.go
@@ -67,6 +67,7 @@ func TestDependencies(t *testing.T) {
 			dep, err := findDependencyByBinary(t, deps, "remoteproc-runtime")
 			assert.NoError(t, err)
 			wantBinaryExistsCheck := health.BinaryExists{
+				Binary:   "remoteproc-runtime",
 				Severity: health.SeverityWarning,
 				Fix: &health.Fix{
 					Description: "Install the Remoteproc Runtime",
@@ -98,7 +99,7 @@ func TestPerformChecks(t *testing.T) {
 
 			got := health.PerformChecks(context.Background(), deps, &runner.Fake{})
 
-			wantFailure := check.Run(context.Background(), &runner.Fake{}, dep)
+			wantFailure := check.Run(context.Background(), &runner.Fake{})
 			wantStatus := health.DependencyStatus{Dependency: dep, Failure: wantFailure}
 			want := []health.DependencyStatus{wantStatus}
 			assert.Equal(t, want, got)
@@ -219,13 +220,13 @@ func findDependencyByBinary(t *testing.T, deps []health.Dependency, binary strin
 
 type passingCheck struct{}
 
-func (p passingCheck) Run(_ context.Context, _ runner.Runner, _ health.Dependency) *health.CheckFailure {
+func (p passingCheck) Run(_ context.Context, _ runner.Runner) *health.CheckFailure {
 	return nil
 }
 
 type failingCheck struct{}
 
-func (p failingCheck) Run(_ context.Context, _ runner.Runner, _ health.Dependency) *health.CheckFailure {
+func (p failingCheck) Run(_ context.Context, _ runner.Runner) *health.CheckFailure {
 	return &health.CheckFailure{
 		Message: "very broken",
 		Fix:     &health.Fix{Description: "fix me please", Command: "rm -rf /"},

--- a/internal/health/dependencies_test.go
+++ b/internal/health/dependencies_test.go
@@ -58,7 +58,7 @@ func TestDependencies(t *testing.T) {
 			assert.NoError(t, err)
 			result := dep.Check(context.Background(), &runner.Fake{})
 
-			assert.Equal(t, &health.CheckFailure{
+			assert.Equal(t, &health.DependencyCheckFailure{
 				Severity: health.SeverityWarning,
 				Message:  `"remoteproc-runtime" not found in $PATH`,
 				Fix: &health.Fix{
@@ -206,12 +206,12 @@ func findDependencyByID(t *testing.T, deps []health.Dependency, id string) (heal
 	return health.Dependency{}, errors.New("dependency not found")
 }
 
-func passingCheck(_ context.Context, _ runner.Runner) health.CheckResult {
-	return health.CheckResult{SuccessValue: "passed"}
+func passingCheck(_ context.Context, _ runner.Runner) health.DependencyCheckResult {
+	return health.DependencyCheckResult{SuccessValue: "passed"}
 }
 
-func failingCheck(_ context.Context, _ runner.Runner) health.CheckResult {
-	return health.CheckResult{Failure: &health.CheckFailure{
+func failingCheck(_ context.Context, _ runner.Runner) health.DependencyCheckResult {
+	return health.DependencyCheckResult{Failure: &health.DependencyCheckFailure{
 		Severity: health.SeverityError,
 		Message:  "very broken",
 		Fix:      &health.Fix{Description: "fix me please", Command: "rm -rf /"},

--- a/internal/health/dependencies_test.go
+++ b/internal/health/dependencies_test.go
@@ -214,6 +214,6 @@ func failingCheck(_ context.Context, _ runner.Runner) health.DependencyCheckResu
 	return health.DependencyCheckResult{Failure: &health.DependencyCheckFailure{
 		Severity: health.SeverityError,
 		Message:  "very broken",
-		Fix:      &health.Fix{Description: "fix me please", Command: "rm -rf /"},
+		Fix:      &health.Fix{Description: "fix me please", Command: "echo fixed"},
 	}}
 }

--- a/internal/health/dependencies_test.go
+++ b/internal/health/dependencies_test.go
@@ -84,7 +84,7 @@ func TestPerformChecks(t *testing.T) {
 		})
 
 		t.Run("when a check fails", func(t *testing.T) {
-			check := health.DependencyCheck(failingCheck)
+			check := health.CheckFn(failingCheck)
 			dep := health.Dependency{Label: "bar", Check: check}
 			deps := []health.Dependency{dep}
 

--- a/internal/health/dependencies_test.go
+++ b/internal/health/dependencies_test.go
@@ -86,7 +86,7 @@ func TestPerformChecks(t *testing.T) {
 
 			got := health.PerformChecks(context.Background(), deps, &runner.Fake{})
 
-			wantStatus := health.DependencyStatus{Dependency: dep, Error: nil, Fix: nil}
+			wantStatus := health.DependencyStatus{Dependency: dep, Failure: nil}
 			want := []health.DependencyStatus{wantStatus}
 			assert.Equal(t, want, got)
 		})
@@ -98,8 +98,8 @@ func TestPerformChecks(t *testing.T) {
 
 			got := health.PerformChecks(context.Background(), deps, &runner.Fake{})
 
-			wantFix, wantErr := check.Run(context.Background(), &runner.Fake{}, dep)
-			wantStatus := health.DependencyStatus{Dependency: dep, Error: wantErr, Fix: wantFix}
+			wantFailure := check.Run(context.Background(), &runner.Fake{}, dep)
+			wantStatus := health.DependencyStatus{Dependency: dep, Failure: wantFailure}
 			want := []health.DependencyStatus{wantStatus}
 			assert.Equal(t, want, got)
 		})
@@ -219,12 +219,15 @@ func findDependencyByBinary(t *testing.T, deps []health.Dependency, binary strin
 
 type passingCheck struct{}
 
-func (p passingCheck) Run(_ context.Context, _ runner.Runner, _ health.Dependency) (*health.Fix, error) {
-	return nil, nil
+func (p passingCheck) Run(_ context.Context, _ runner.Runner, _ health.Dependency) *health.CheckFailure {
+	return nil
 }
 
 type failingCheck struct{}
 
-func (p failingCheck) Run(_ context.Context, _ runner.Runner, _ health.Dependency) (*health.Fix, error) {
-	return &health.Fix{Description: "fix me please", Command: "echo fixed"}, errors.New("very broken")
+func (p failingCheck) Run(_ context.Context, _ runner.Runner, _ health.Dependency) *health.CheckFailure {
+	return &health.CheckFailure{
+		Message: "very broken",
+		Fix:     &health.Fix{Description: "fix me please", Command: "rm -rf /"},
+	}
 }

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -189,21 +189,26 @@ func generateDependencyReport(statuses []DependencyStatus) []HealthCheck {
 	res := []HealthCheck{}
 	for _, ds := range statuses {
 		hc := HealthCheck{Name: ds.Dependency.Label}
-		if ds.Error == nil {
+		if ds.Failure == nil {
 			hc.Status = CheckStatusOK
 			hc.Value = ds.Dependency.Binary
 		} else {
-			if _, ok := errors.AsType[WarningError](ds.Error); ok {
-				hc.Status = CheckStatusWarning
-			} else if _, ok := errors.AsType[InfoError](ds.Error); ok {
-				hc.Status = CheckStatusInfo
-			} else {
-				hc.Status = CheckStatusError
-			}
-			hc.Value = ds.Error.Error()
-			hc.Fix = ds.Fix
+			hc.Status = checkStatusFromSeverity(ds.Failure.Severity)
+			hc.Value = ds.Failure.Message
+			hc.Fix = ds.Failure.Fix
 		}
 		res = append(res, hc)
 	}
 	return res
+}
+
+func checkStatusFromSeverity(severity CheckSeverity) CheckStatus {
+	switch severity {
+	case SeverityWarning:
+		return CheckStatusWarning
+	case SeverityInfo:
+		return CheckStatusInfo
+	default:
+		return CheckStatusError
+	}
 }

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -70,10 +70,7 @@ type CheckHostOptions struct {
 
 func CheckHost(opts CheckHostOptions) HostReport {
 	r := runner.NewLocal()
-	deps := HostRequiredDependencies()
-	if opts.SkipVersionChecks {
-		deps = RemoveVersionChecks(deps)
-	}
+	deps := HostRequiredDependencies(opts.SkipVersionChecks)
 	dependencyStatuses := PerformChecks(context.Background(), deps, r)
 	return GenerateHostReport(dependencyStatuses)
 }

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -186,13 +186,13 @@ func generateDependencyReport(statuses []DependencyStatus) []HealthCheck {
 	res := []HealthCheck{}
 	for _, ds := range statuses {
 		hc := HealthCheck{Name: ds.Dependency.Label}
-		if ds.Failure == nil {
+		if ds.Result.Failure == nil {
 			hc.Status = CheckStatusOK
-			hc.Value = ds.Dependency.Binary
+			hc.Value = ds.Result.SuccessValue
 		} else {
-			hc.Status = checkStatusFromSeverity(ds.Failure.Severity)
-			hc.Value = ds.Failure.Message
-			hc.Fix = ds.Failure.Fix
+			hc.Status = checkStatusFromSeverity(ds.Result.Failure.Severity)
+			hc.Value = ds.Result.Failure.Message
+			hc.Fix = ds.Result.Failure.Fix
 		}
 		res = append(res, hc)
 	}

--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -2,7 +2,6 @@ package health_test
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"testing"
 
@@ -199,9 +198,12 @@ func TestTargetReport(t *testing.T) {
 func testDependencyReporting(t *testing.T, extract func([]health.DependencyStatus) []health.HealthCheck) {
 	t.Helper()
 
-	t.Run("when a dependency is not installed, health check reports error", func(t *testing.T) {
+	t.Run("when a dependency has an error result, health check reports error", func(t *testing.T) {
 		statuses := []health.DependencyStatus{
-			{Dependency: health.Dependency{Binary: "whatever", Label: "Rube Goldberg"}, Error: fmt.Errorf("whatever not found on path")},
+			{
+				Dependency: health.Dependency{Binary: "whatever", Label: "Rube Goldberg"},
+				Failure:    &health.CheckFailure{Severity: health.SeverityError, Message: "whatever not found on path"},
+			},
 		}
 
 		got := extract(statuses)
@@ -211,9 +213,12 @@ func testDependencyReporting(t *testing.T, extract func([]health.DependencyStatu
 		}, got)
 	})
 
-	t.Run("when a dependency has a warning error, health check reports warning", func(t *testing.T) {
+	t.Run("when a dependency has a warning result, health check reports warning", func(t *testing.T) {
 		statuses := []health.DependencyStatus{
-			{Dependency: health.Dependency{Binary: "remoteproc-runtime", Label: "Remoteproc Runtime"}, Error: health.WarningError{Err: fmt.Errorf("remoteproc-runtime not found on path")}},
+			{
+				Dependency: health.Dependency{Binary: "remoteproc-runtime", Label: "Remoteproc Runtime"},
+				Failure:    &health.CheckFailure{Severity: health.SeverityWarning, Message: "remoteproc-runtime not found on path"},
+			},
 		}
 
 		got := extract(statuses)
@@ -223,14 +228,17 @@ func testDependencyReporting(t *testing.T, extract func([]health.DependencyStatu
 		}, got)
 	})
 
-	t.Run("propagates Fix from DependencyStatus to HealthCheck", func(t *testing.T) {
+	t.Run("propagates Fix from CheckFailure to HealthCheck", func(t *testing.T) {
 		statuses := []health.DependencyStatus{
 			{
 				Dependency: health.Dependency{Binary: "pizza", Label: "Food"},
-				Error:      health.WarningError{Err: errors.New("not enough pineapple")},
-				Fix: &health.Fix{
-					Description: "add more pineapple",
-					Command:     "pizza --pineapple",
+				Failure: &health.CheckFailure{
+					Severity: health.SeverityWarning,
+					Message:  "not enough pineapple",
+					Fix: &health.Fix{
+						Description: "add more pineapple",
+						Command:     "pizza --pineapple",
+					},
 				},
 			},
 		}

--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -201,7 +201,7 @@ func testDependencyReporting(t *testing.T, extract func([]health.DependencyStatu
 	t.Run("when a dependency has a successful result, health check reports its value", func(t *testing.T) {
 		statuses := []health.DependencyStatus{{
 			Dependency: health.Dependency{Label: "Container Engine"},
-			Result:     health.CheckResult{SuccessValue: "docker"},
+			Result:     health.DependencyCheckResult{SuccessValue: "docker"},
 		}}
 
 		got := extract(statuses)
@@ -213,7 +213,7 @@ func testDependencyReporting(t *testing.T, extract func([]health.DependencyStatu
 		statuses := []health.DependencyStatus{
 			{
 				Dependency: health.Dependency{Label: "Rube Goldberg"},
-				Result: health.CheckResult{Failure: &health.CheckFailure{
+				Result: health.DependencyCheckResult{Failure: &health.DependencyCheckFailure{
 					Severity: health.SeverityError,
 					Message:  "whatever not found on path",
 				}},
@@ -231,7 +231,7 @@ func testDependencyReporting(t *testing.T, extract func([]health.DependencyStatu
 		statuses := []health.DependencyStatus{
 			{
 				Dependency: health.Dependency{Label: "Remoteproc Runtime"},
-				Result: health.CheckResult{Failure: &health.CheckFailure{
+				Result: health.DependencyCheckResult{Failure: &health.DependencyCheckFailure{
 					Severity: health.SeverityWarning,
 					Message:  "remoteproc-runtime not found on path",
 				}},
@@ -249,7 +249,7 @@ func testDependencyReporting(t *testing.T, extract func([]health.DependencyStatu
 		statuses := []health.DependencyStatus{
 			{
 				Dependency: health.Dependency{Label: "Food"},
-				Result: health.CheckResult{Failure: &health.CheckFailure{
+				Result: health.DependencyCheckResult{Failure: &health.DependencyCheckFailure{
 					Severity: health.SeverityWarning,
 					Message:  "not enough pineapple",
 					Fix: &health.Fix{

--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -198,11 +198,25 @@ func TestTargetReport(t *testing.T) {
 func testDependencyReporting(t *testing.T, extract func([]health.DependencyStatus) []health.HealthCheck) {
 	t.Helper()
 
+	t.Run("when a dependency has a successful result, health check reports its value", func(t *testing.T) {
+		statuses := []health.DependencyStatus{{
+			Dependency: health.Dependency{Label: "Container Engine"},
+			Result:     health.CheckResult{SuccessValue: "docker"},
+		}}
+
+		got := extract(statuses)
+
+		assert.Equal(t, []health.HealthCheck{{Name: "Container Engine", Status: health.CheckStatusOK, Value: "docker"}}, got)
+	})
+
 	t.Run("when a dependency has an error result, health check reports error", func(t *testing.T) {
 		statuses := []health.DependencyStatus{
 			{
-				Dependency: health.Dependency{Binary: "whatever", Label: "Rube Goldberg"},
-				Failure:    &health.CheckFailure{Severity: health.SeverityError, Message: "whatever not found on path"},
+				Dependency: health.Dependency{Label: "Rube Goldberg"},
+				Result: health.CheckResult{Failure: &health.CheckFailure{
+					Severity: health.SeverityError,
+					Message:  "whatever not found on path",
+				}},
 			},
 		}
 
@@ -216,8 +230,11 @@ func testDependencyReporting(t *testing.T, extract func([]health.DependencyStatu
 	t.Run("when a dependency has a warning result, health check reports warning", func(t *testing.T) {
 		statuses := []health.DependencyStatus{
 			{
-				Dependency: health.Dependency{Binary: "remoteproc-runtime", Label: "Remoteproc Runtime"},
-				Failure:    &health.CheckFailure{Severity: health.SeverityWarning, Message: "remoteproc-runtime not found on path"},
+				Dependency: health.Dependency{Label: "Remoteproc Runtime"},
+				Result: health.CheckResult{Failure: &health.CheckFailure{
+					Severity: health.SeverityWarning,
+					Message:  "remoteproc-runtime not found on path",
+				}},
 			},
 		}
 
@@ -231,15 +248,15 @@ func testDependencyReporting(t *testing.T, extract func([]health.DependencyStatu
 	t.Run("propagates Fix from CheckFailure to HealthCheck", func(t *testing.T) {
 		statuses := []health.DependencyStatus{
 			{
-				Dependency: health.Dependency{Binary: "pizza", Label: "Food"},
-				Failure: &health.CheckFailure{
+				Dependency: health.Dependency{Label: "Food"},
+				Result: health.CheckResult{Failure: &health.CheckFailure{
 					Severity: health.SeverityWarning,
 					Message:  "not enough pineapple",
 					Fix: &health.Fix{
 						Description: "add more pineapple",
 						Command:     "pizza --pineapple",
 					},
-				},
+				}},
 			},
 		}
 


### PR DESCRIPTION
## Changes

- Replace composable check types with dependency check functions and **explicit results**.
  - Single return value from each check (`(*Fix, error)` was confusing)
  - Remove abstract `MatchesVersionCheck` w/ topo version specific check
  - Drop `Binary` struct field, use **explicit result** to carry the passing check value

## Checklist

- [x] 🤖 This change is covered by tests as required.
- [ ] 🤹 All required manual testing has been performed.
- [ ] 📖 All documentation updates are complete.