### PR TITLE
refactor: decouple health internals from presentation layer

### DIFF
--- a/cmd/topo/health.go
+++ b/cmd/topo/health.go
@@ -40,30 +40,30 @@ var healthCmd = &cobra.Command{
 			spinner = term.StartSpinner(os.Stderr, "Checking health...")
 		}
 
-		toPrint := views.HealthReport{
-			Host: health.CheckHost(health.CheckHostOptions{SkipVersionChecks: skipVersionCheck}),
-		}
+		hostReport := health.CheckHost(health.CheckHostOptions{SkipVersionChecks: skipVersionCheck})
+		var targetReport *health.TargetReport
+		var targetHint string
 
 		if targetArg, ok := lookupTarget(cmd); ok {
 			ctx, cancel := contextWithTimeout(cmd)
 			defer cancel()
-			targetReport, err := health.CheckTarget(ctx, ssh.NewDestination(targetArg), acceptNewHostKeys)
+			targetHealthReport, err := health.CheckTarget(ctx, ssh.NewDestination(targetArg), acceptNewHostKeys)
 			if err != nil {
 				if spinner != nil {
 					spinner.Stop()
 				}
 				return err
 			}
-			toPrint.Target = &targetReport
+			targetReport = &targetHealthReport
 		} else {
-			toPrint.TargetHint = "provide --target or set TOPO_TARGET to check target health"
+			targetHint = "provide --target or set TOPO_TARGET to check target health"
 		}
 
 		if spinner != nil {
 			spinner.Stop()
 		}
 
-		return views.Print(toPrint, os.Stdout, outputFormat)
+		return views.Print(views.NewHealthReport(hostReport, targetReport, targetHint), os.Stdout, outputFormat)
 	},
 }
 

--- a/internal/health/dependencies.go
+++ b/internal/health/dependencies.go
@@ -48,8 +48,8 @@ const (
 )
 
 type Fix struct {
-	Description string `json:"description"`
-	Command     string `json:"command,omitempty"`
+	Description string
+	Command     string
 }
 
 func HostRequiredDependencies(skipVersionChecks bool) []Dependency {

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -2,7 +2,6 @@ package health
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -30,38 +29,22 @@ const (
 )
 
 type HealthCheck struct {
-	Name   string      `json:"name"`
-	Status CheckStatus `json:"status"`
-	Value  string      `json:"value"`
-	Fix    *Fix        `json:"fix,omitempty"`
+	Name   string
+	Status CheckStatus
+	Value  string
+	Fix    *Fix
 }
 
 type HostReport struct {
-	Dependencies []HealthCheck `json:"dependencies"`
-}
-
-func (r HostReport) MarshalJSON() ([]byte, error) {
-	type Alias HostReport
-	if r.Dependencies == nil {
-		r.Dependencies = []HealthCheck{}
-	}
-	return json.Marshal(Alias(r))
+	Dependencies []HealthCheck
 }
 
 type TargetReport struct {
-	Destination            string        `json:"destination"`
-	IsLocalhost            bool          `json:"isLocalhost"`
-	Connectivity           HealthCheck   `json:"connectivity"`
-	Dependencies           []HealthCheck `json:"dependencies"`
-	ProcessingDomainDriver HealthCheck   `json:"processingDomainDriver"`
-}
-
-func (r TargetReport) MarshalJSON() ([]byte, error) {
-	type Alias TargetReport
-	if r.Dependencies == nil {
-		r.Dependencies = []HealthCheck{}
-	}
-	return json.Marshal(Alias(r))
+	Destination            string
+	IsLocalhost            bool
+	Connectivity           HealthCheck
+	Dependencies           []HealthCheck
+	ProcessingDomainDriver HealthCheck
 }
 
 type CheckHostOptions struct {

--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -1,7 +1,6 @@
 package health_test
 
 import (
-	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -9,7 +8,6 @@ import (
 	"github.com/arm/topo/internal/probe"
 	"github.com/arm/topo/internal/ssh"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestGenerateHostReport(t *testing.T) {
@@ -133,65 +131,6 @@ func TestGenerateTargetReport(t *testing.T) {
 		assert.Equal(t, health.CheckStatusError, got.Connectivity.Status)
 		assert.Equal(t, "Remove the old SSH host key from known_hosts, then retry", got.Connectivity.Fix.Description)
 		assert.Equal(t, "ssh-keygen -R '[my-target]:2222'", got.Connectivity.Fix.Command)
-	})
-}
-
-func TestHostReport(t *testing.T) {
-	t.Run("MarshalJSON", func(t *testing.T) {
-		t.Run("nil dependencies are [] not null", func(t *testing.T) {
-			tr := health.HostReport{Dependencies: nil}
-
-			b, err := json.Marshal(tr)
-
-			require.NoError(t, err)
-			want := `{ "dependencies": [] }`
-			assert.JSONEq(t, want, string(b))
-		})
-
-		t.Run("omits command when fix has no command", func(t *testing.T) {
-			tr := health.HostReport{Dependencies: []health.HealthCheck{
-				{
-					Name:   "Container Engine",
-					Status: health.CheckStatusError,
-					Value:  "permission denied",
-					Fix: &health.Fix{
-						Description: "Ensure current user can run docker commands",
-					},
-				},
-			}}
-
-			b, err := json.Marshal(tr)
-
-			require.NoError(t, err)
-			want := `{
-				"dependencies": [
-					{
-						"name": "Container Engine",
-						"status": "error",
-						"value": "permission denied",
-						"fix": {
-							"description": "Ensure current user can run docker commands"
-						}
-					}
-				]
-			}`
-			assert.JSONEq(t, want, string(b))
-		})
-	})
-}
-
-func TestTargetReport(t *testing.T) {
-	t.Run("MarshalJSON", func(t *testing.T) {
-		t.Run("nil dependencies are [] not null", func(t *testing.T) {
-			tr := health.TargetReport{Dependencies: nil}
-
-			b, err := json.Marshal(tr)
-
-			require.NoError(t, err)
-			var result map[string]json.RawMessage
-			require.NoError(t, json.Unmarshal(b, &result))
-			assert.JSONEq(t, `[]`, string(result["dependencies"]))
-		})
 	})
 }
 

--- a/internal/output/views/container_list.go
+++ b/internal/output/views/container_list.go
@@ -2,8 +2,6 @@ package views
 
 import (
 	"bytes"
-	"encoding/json"
-	"fmt"
 	"text/tabwriter"
 	"text/template"
 )
@@ -49,9 +47,5 @@ func (r ContainerList) AsPlain(isTTY bool) (string, error) {
 }
 
 func (r ContainerList) AsJSON() (string, error) {
-	b, err := json.MarshalIndent(r, "", "  ")
-	if err != nil {
-		return "", fmt.Errorf("encode report as json: %w", err)
-	}
-	return string(b), nil
+	return asJSON(r)
 }

--- a/internal/output/views/health.go
+++ b/internal/output/views/health.go
@@ -17,11 +17,11 @@ type HealthReport struct {
 
 func NewHealthReport(host health.HostReport, target *health.TargetReport, targetHint string) HealthReport {
 	report := HealthReport{
-		Host:       hostReportFromHealth(host),
+		Host:       toViewHostReport(host),
 		TargetHint: targetHint,
 	}
 	if target != nil {
-		viewTarget := targetReportFromHealth(*target)
+		viewTarget := toViewTargetReport(*target)
 		report.Target = &viewTarget
 	}
 	return report
@@ -142,29 +142,29 @@ type fix struct {
 	Command     string `json:"command,omitempty"`
 }
 
-func hostReportFromHealth(report health.HostReport) hostReport {
-	return hostReport{Dependencies: healthChecksFromHealth(report.Dependencies)}
+func toViewHostReport(report health.HostReport) hostReport {
+	return hostReport{Dependencies: toViewHealthCheckList(report.Dependencies)}
 }
 
-func targetReportFromHealth(report health.TargetReport) targetReport {
+func toViewTargetReport(report health.TargetReport) targetReport {
 	return targetReport{
 		Destination:            report.Destination,
 		IsLocalhost:            report.IsLocalhost,
-		Connectivity:           healthCheckFromHealth(report.Connectivity),
-		Dependencies:           healthChecksFromHealth(report.Dependencies),
-		ProcessingDomainDriver: healthCheckFromHealth(report.ProcessingDomainDriver),
+		Connectivity:           toViewHealthCheck(report.Connectivity),
+		Dependencies:           toViewHealthCheckList(report.Dependencies),
+		ProcessingDomainDriver: toViewHealthCheck(report.ProcessingDomainDriver),
 	}
 }
 
-func healthChecksFromHealth(checks []health.HealthCheck) []healthCheck {
+func toViewHealthCheckList(checks []health.HealthCheck) []healthCheck {
 	viewChecks := make([]healthCheck, len(checks))
 	for index, check := range checks {
-		viewChecks[index] = healthCheckFromHealth(check)
+		viewChecks[index] = toViewHealthCheck(check)
 	}
 	return viewChecks
 }
 
-func healthCheckFromHealth(check health.HealthCheck) healthCheck {
+func toViewHealthCheck(check health.HealthCheck) healthCheck {
 	viewCheck := healthCheck{Name: check.Name, Status: check.Status, Value: check.Value}
 	if check.Fix != nil {
 		viewCheck.Fix = &fix{Description: check.Fix.Description, Command: check.Fix.Command}

--- a/internal/output/views/health.go
+++ b/internal/output/views/health.go
@@ -11,9 +11,21 @@ import (
 )
 
 type HealthReport struct {
-	Host       health.HostReport    `json:"host"`
-	Target     *health.TargetReport `json:"target,omitempty"`
-	TargetHint string               `json:"-"`
+	Host       hostReport    `json:"host"`
+	Target     *targetReport `json:"target,omitempty"`
+	TargetHint string        `json:"-"`
+}
+
+func NewHealthReport(host health.HostReport, target *health.TargetReport, targetHint string) HealthReport {
+	report := HealthReport{
+		Host:       hostReportFromHealth(host),
+		TargetHint: targetHint,
+	}
+	if target != nil {
+		viewTarget := targetReportFromHealth(*target)
+		report.Target = &viewTarget
+	}
+	return report
 }
 
 const healthReportTemplate = `
@@ -77,6 +89,14 @@ func (r HealthReport) AsPlain(isTTY bool) (string, error) {
 	return buf.String(), nil
 }
 
+func (r HealthReport) AsJSON() (string, error) {
+	b, err := json.MarshalIndent(r, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("encode report as json: %w", err)
+	}
+	return string(b), nil
+}
+
 func sectionHeading(heading string, isTTY bool) string {
 	return term.Header(heading, isTTY)
 }
@@ -103,10 +123,56 @@ func healthStatusFormatter(isTTY bool) func(health.CheckStatus) string {
 	}
 }
 
-func (r HealthReport) AsJSON() (string, error) {
-	b, err := json.MarshalIndent(r, "", "  ")
-	if err != nil {
-		return "", fmt.Errorf("encode report as json: %w", err)
+type hostReport struct {
+	Dependencies []healthCheck `json:"dependencies"`
+}
+
+type targetReport struct {
+	Destination            string        `json:"destination"`
+	IsLocalhost            bool          `json:"isLocalhost"`
+	Connectivity           healthCheck   `json:"connectivity"`
+	Dependencies           []healthCheck `json:"dependencies"`
+	ProcessingDomainDriver healthCheck   `json:"processingDomainDriver"`
+}
+
+type healthCheck struct {
+	Name   string             `json:"name"`
+	Status health.CheckStatus `json:"status"`
+	Value  string             `json:"value"`
+	Fix    *fix               `json:"fix,omitempty"`
+}
+
+type fix struct {
+	Description string `json:"description"`
+	Command     string `json:"command,omitempty"`
+}
+
+func hostReportFromHealth(report health.HostReport) hostReport {
+	return hostReport{Dependencies: healthChecksFromHealth(report.Dependencies)}
+}
+
+func targetReportFromHealth(report health.TargetReport) targetReport {
+	return targetReport{
+		Destination:            report.Destination,
+		IsLocalhost:            report.IsLocalhost,
+		Connectivity:           healthCheckFromHealth(report.Connectivity),
+		Dependencies:           healthChecksFromHealth(report.Dependencies),
+		ProcessingDomainDriver: healthCheckFromHealth(report.ProcessingDomainDriver),
 	}
-	return string(b), nil
+}
+
+func healthChecksFromHealth(checks []health.HealthCheck) []healthCheck {
+	viewChecks := make([]healthCheck, len(checks))
+	for index, check := range checks {
+		viewChecks[index] = healthCheckFromHealth(check)
+	}
+	return viewChecks
+}
+
+func healthCheckFromHealth(check health.HealthCheck) healthCheck {
+	viewCheck := healthCheck{Name: check.Name, Status: check.Status, Value: check.Value}
+	if check.Fix != nil {
+		viewCheck.Fix = &fix{Description: check.Fix.Description, Command: check.Fix.Command}
+	}
+	return viewCheck
 }

--- a/internal/output/views/health.go
+++ b/internal/output/views/health.go
@@ -2,7 +2,6 @@ package views
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"text/template"
 
@@ -90,11 +89,7 @@ func (r HealthReport) AsPlain(isTTY bool) (string, error) {
 }
 
 func (r HealthReport) AsJSON() (string, error) {
-	b, err := json.MarshalIndent(r, "", "  ")
-	if err != nil {
-		return "", fmt.Errorf("encode report as json: %w", err)
-	}
-	return string(b), nil
+	return asJSON(r)
 }
 
 func sectionHeading(heading string, isTTY bool) string {

--- a/internal/output/views/health_test.go
+++ b/internal/output/views/health_test.go
@@ -14,17 +14,15 @@ import (
 func TestHealthReport(t *testing.T) {
 	t.Run("PlainFormat", func(t *testing.T) {
 		t.Run("it renders the healthy host dependencies", func(t *testing.T) {
-			toPrint := views.HealthReport{
-				Host: health.HostReport{
-					Dependencies: []health.HealthCheck{
-						{
-							Name:   "Flux Capacitor",
-							Status: health.CheckStatusOK,
-							Value:  "flux",
-						},
+			toPrint := views.NewHealthReport(health.HostReport{
+				Dependencies: []health.HealthCheck{
+					{
+						Name:   "Flux Capacitor",
+						Status: health.CheckStatusOK,
+						Value:  "flux",
 					},
 				},
-			}
+			}, nil, "")
 			var out bytes.Buffer
 
 			err := views.Print(toPrint, &out, term.Plain)
@@ -35,17 +33,15 @@ func TestHealthReport(t *testing.T) {
 		})
 
 		t.Run("it renders the details when dependencies fail the health check", func(t *testing.T) {
-			toPrint := views.HealthReport{
-				Host: health.HostReport{
-					Dependencies: []health.HealthCheck{
-						{
-							Name:   "Container Engine",
-							Status: health.CheckStatusError,
-							Value:  "docker not found on path",
-						},
+			toPrint := views.NewHealthReport(health.HostReport{
+				Dependencies: []health.HealthCheck{
+					{
+						Name:   "Container Engine",
+						Status: health.CheckStatusError,
+						Value:  "docker not found on path",
 					},
 				},
-			}
+			}, nil, "")
 			var out bytes.Buffer
 
 			err := views.Print(toPrint, &out, term.Plain)
@@ -55,19 +51,17 @@ func TestHealthReport(t *testing.T) {
 		})
 
 		t.Run("it renders a warning icon for warning checks", func(t *testing.T) {
-			toPrint := views.HealthReport{
-				Target: &health.TargetReport{
-					Connectivity: health.HealthCheck{
-						Name:   "Connected",
-						Status: health.CheckStatusOK,
-					},
-					ProcessingDomainDriver: health.HealthCheck{
-						Name:   "Processing Domain Driver (remoteproc)",
-						Status: health.CheckStatusWarning,
-						Value:  "no remoteproc devices found",
-					},
+			toPrint := views.NewHealthReport(health.HostReport{}, &health.TargetReport{
+				Connectivity: health.HealthCheck{
+					Name:   "Connected",
+					Status: health.CheckStatusOK,
 				},
-			}
+				ProcessingDomainDriver: health.HealthCheck{
+					Name:   "Processing Domain Driver (remoteproc)",
+					Status: health.CheckStatusWarning,
+					Value:  "no remoteproc devices found",
+				},
+			}, "")
 			var out bytes.Buffer
 
 			err := views.Print(toPrint, &out, term.Plain)
@@ -77,19 +71,17 @@ func TestHealthReport(t *testing.T) {
 		})
 
 		t.Run("it renders an info icon for info checks", func(t *testing.T) {
-			toPrint := views.HealthReport{
-				Target: &health.TargetReport{
-					Connectivity: health.HealthCheck{
-						Name:   "Connected",
-						Status: health.CheckStatusOK,
-					},
-					ProcessingDomainDriver: health.HealthCheck{
-						Name:   "Processing Domain Driver (remoteproc)",
-						Status: health.CheckStatusInfo,
-						Value:  "no remoteproc devices found",
-					},
+			toPrint := views.NewHealthReport(health.HostReport{}, &health.TargetReport{
+				Connectivity: health.HealthCheck{
+					Name:   "Connected",
+					Status: health.CheckStatusOK,
 				},
-			}
+				ProcessingDomainDriver: health.HealthCheck{
+					Name:   "Processing Domain Driver (remoteproc)",
+					Status: health.CheckStatusInfo,
+					Value:  "no remoteproc devices found",
+				},
+			}, "")
 			var out bytes.Buffer
 
 			err := views.Print(toPrint, &out, term.Plain)
@@ -99,14 +91,12 @@ func TestHealthReport(t *testing.T) {
 		})
 
 		t.Run("it renders connection failures", func(t *testing.T) {
-			toPrint := views.HealthReport{
-				Target: &health.TargetReport{
-					Connectivity: health.HealthCheck{
-						Name:   "Connected",
-						Status: health.CheckStatusError,
-					},
+			toPrint := views.NewHealthReport(health.HostReport{}, &health.TargetReport{
+				Connectivity: health.HealthCheck{
+					Name:   "Connected",
+					Status: health.CheckStatusError,
 				},
-			}
+			}, "")
 			var out bytes.Buffer
 
 			err := views.Print(toPrint, &out, term.Plain)
@@ -116,9 +106,7 @@ func TestHealthReport(t *testing.T) {
 		})
 
 		t.Run("it renders the target destination", func(t *testing.T) {
-			toPrint := views.HealthReport{
-				Target: &health.TargetReport{Destination: "ssh://user@my-target"},
-			}
+			toPrint := views.NewHealthReport(health.HostReport{}, &health.TargetReport{Destination: "ssh://user@my-target"}, "")
 			var out bytes.Buffer
 
 			err := views.Print(toPrint, &out, term.Plain)
@@ -128,14 +116,12 @@ func TestHealthReport(t *testing.T) {
 		})
 
 		t.Run("when not connected, it does not render cpu features", func(t *testing.T) {
-			toPrint := views.HealthReport{
-				Target: &health.TargetReport{
-					Connectivity: health.HealthCheck{
-						Name:   "Connected",
-						Status: health.CheckStatusError,
-					},
+			toPrint := views.NewHealthReport(health.HostReport{}, &health.TargetReport{
+				Connectivity: health.HealthCheck{
+					Name:   "Connected",
+					Status: health.CheckStatusError,
 				},
-			}
+			}, "")
 			var out bytes.Buffer
 
 			err := views.Print(toPrint, &out, term.Plain)
@@ -145,20 +131,18 @@ func TestHealthReport(t *testing.T) {
 		})
 
 		t.Run("it renders the fix hint when a check has a fix", func(t *testing.T) {
-			toPrint := views.HealthReport{
-				Host: health.HostReport{
-					Dependencies: []health.HealthCheck{
-						{
-							Name:   "Skin Care",
-							Status: health.CheckStatusWarning,
-							Fix: &health.Fix{
-								Description: "Apply Working Hands Cream",
-								Command:     "topo moisturise",
-							},
+			toPrint := views.NewHealthReport(health.HostReport{
+				Dependencies: []health.HealthCheck{
+					{
+						Name:   "Skin Care",
+						Status: health.CheckStatusWarning,
+						Fix: &health.Fix{
+							Description: "Apply Working Hands Cream",
+							Command:     "topo moisturise",
 						},
 					},
 				},
-			}
+			}, nil, "")
 			var out bytes.Buffer
 
 			err := views.Print(toPrint, &out, term.Plain)
@@ -170,14 +154,12 @@ func TestHealthReport(t *testing.T) {
 		})
 
 		t.Run("it colors status labels when writing to a terminal", func(t *testing.T) {
-			toPrint := views.HealthReport{
-				Host: health.HostReport{Dependencies: []health.HealthCheck{
-					{Name: "Healthy", Status: health.CheckStatusOK},
-					{Name: "Broken", Status: health.CheckStatusError},
-					{Name: "Deprecated", Status: health.CheckStatusWarning},
-					{Name: "Skipped", Status: health.CheckStatusInfo},
-				}},
-			}
+			toPrint := views.NewHealthReport(health.HostReport{Dependencies: []health.HealthCheck{
+				{Name: "Healthy", Status: health.CheckStatusOK},
+				{Name: "Broken", Status: health.CheckStatusError},
+				{Name: "Deprecated", Status: health.CheckStatusWarning},
+				{Name: "Skipped", Status: health.CheckStatusInfo},
+			}}, nil, "")
 
 			out, err := toPrint.AsPlain(true)
 
@@ -191,7 +173,7 @@ func TestHealthReport(t *testing.T) {
 
 		t.Run("when no target is specified, prints the hint", func(t *testing.T) {
 			hint := "Need to work on your aim"
-			toPrint := views.HealthReport{TargetHint: hint}
+			toPrint := views.NewHealthReport(health.HostReport{}, nil, hint)
 			var out bytes.Buffer
 
 			err := views.Print(toPrint, &out, term.Plain)
@@ -203,26 +185,24 @@ func TestHealthReport(t *testing.T) {
 
 	t.Run("JSONFormat", func(t *testing.T) {
 		t.Run("renders report as valid JSON with expected fields", func(t *testing.T) {
-			toPrint := views.HealthReport{
-				Host: health.HostReport{
-					Dependencies: []health.HealthCheck{
-						{
-							Name:   "Flux Capacitor",
-							Status: health.CheckStatusOK,
-						},
-					},
-				},
-				Target: &health.TargetReport{
-					Destination: "ssh://user@my-target",
-					Connectivity: health.HealthCheck{
-						Name:   "Connected",
+			toPrint := views.NewHealthReport(health.HostReport{
+				Dependencies: []health.HealthCheck{
+					{
+						Name:   "Flux Capacitor",
 						Status: health.CheckStatusOK,
-					},
-					ProcessingDomainDriver: health.HealthCheck{
-						Status: health.CheckStatusWarning,
+						Fix:    &health.Fix{Description: "Recharge the flux"},
 					},
 				},
-			}
+			}, &health.TargetReport{
+				Destination: "ssh://user@my-target",
+				Connectivity: health.HealthCheck{
+					Name:   "Connected",
+					Status: health.CheckStatusOK,
+				},
+				ProcessingDomainDriver: health.HealthCheck{
+					Status: health.CheckStatusWarning,
+				},
+			}, "")
 			var out bytes.Buffer
 
 			err := views.Print(toPrint, &out, term.JSON)
@@ -231,7 +211,7 @@ func TestHealthReport(t *testing.T) {
 			want := `{
 				"host": {
 					"dependencies": [
-						{"name":"Flux Capacitor","status":"ok","value":""}
+						{"name":"Flux Capacitor","status":"ok","value":"","fix":{"description":"Recharge the flux"}}
 					]
 				},
 				"target": {

--- a/internal/output/views/health_test.go
+++ b/internal/output/views/health_test.go
@@ -188,9 +188,9 @@ func TestHealthReport(t *testing.T) {
 			toPrint := views.NewHealthReport(health.HostReport{
 				Dependencies: []health.HealthCheck{
 					{
-						Name:   "Flux Capacitor",
+						Name:   "Time Circuit",
 						Status: health.CheckStatusOK,
-						Fix:    &health.Fix{Description: "Recharge the flux"},
+						Fix:    &health.Fix{Description: "Set destination time to 1985"},
 					},
 				},
 			}, &health.TargetReport{
@@ -211,7 +211,7 @@ func TestHealthReport(t *testing.T) {
 			want := `{
 				"host": {
 					"dependencies": [
-						{"name":"Flux Capacitor","status":"ok","value":"","fix":{"description":"Recharge the flux"}}
+						{"name":"Time Circuit","status":"ok","value":"","fix":{"description":"Set destination time to 1985"}}
 					]
 				},
 				"target": {

--- a/internal/output/views/project_list.go
+++ b/internal/output/views/project_list.go
@@ -2,7 +2,6 @@ package views
 
 import (
 	"bytes"
-	"encoding/json"
 	"text/template"
 
 	"github.com/arm/topo/internal/catalog"
@@ -35,11 +34,7 @@ const projectListTemplate = `
 {{- end }}`
 
 func (r ProjectList) AsJSON() (string, error) {
-	b, err := json.MarshalIndent(r, "", "  ")
-	if err != nil {
-		return "", err
-	}
-	return string(b), nil
+	return asJSON(r)
 }
 
 func (r ProjectList) AsPlain(isTTY bool) (string, error) {

--- a/internal/output/views/view.go
+++ b/internal/output/views/view.go
@@ -1,6 +1,7 @@
 package views
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -32,4 +33,12 @@ func Print(p View, w io.Writer, f term.Format) error {
 		return fmt.Errorf("write view output: %w", err)
 	}
 	return nil
+}
+
+func asJSON(value any) (string, error) {
+	bytes, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("encode view as JSON: %w", err)
+	}
+	return string(bytes), nil
 }


### PR DESCRIPTION
- Decouple health-check domain models from output view and JSON serialization, so health logic can evolve independently of CLI presentation and output formats.

## Checklist

- [x] 🤖 This change is covered by tests as required.
- [ ] 🤹 All required manual testing has been performed.
- [ ] 📖 All documentation updates are complete.