### PR TITLE
refactor: model remoteproc as a health dependency

### DIFF
--- a/internal/health/dependencies.go
+++ b/internal/health/dependencies.go
@@ -3,7 +3,9 @@ package health
 import (
 	"context"
 	"fmt"
+	"strings"
 
+	"github.com/arm/topo/internal/probe"
 	"github.com/arm/topo/internal/runner"
 	"github.com/arm/topo/internal/ssh"
 )
@@ -23,7 +25,6 @@ type Dependency struct {
 	Label                 string
 	Check                 DependencyCheckFn
 	SoftwarePrerequisites []DependencyID
-	HardwarePrerequisites []HardwareCapability
 }
 
 type DependencyCheckFn func(ctx context.Context, r runner.Runner) DependencyCheckResult
@@ -148,11 +149,12 @@ func TargetRequiredDependencies(target ssh.Destination) []Dependency {
 		},
 	}
 
+	remoteproc := NewRemoteprocDependency()
+
 	remoteprocRuntime := Dependency{
 		ID:                    DependencyID("remoteproc-runtime"),
 		Label:                 "Remoteproc Runtime",
-		SoftwarePrerequisites: []DependencyID{docker.ID},
-		HardwarePrerequisites: []HardwareCapability{Remoteproc},
+		SoftwarePrerequisites: []DependencyID{docker.ID, remoteproc.ID},
 		Check: func(ctx context.Context, r runner.Runner) DependencyCheckResult {
 			if err := r.BinaryExists(ctx, "remoteproc-runtime"); err != nil {
 				return DependencyCheckResult{Failure: &DependencyCheckFailure{
@@ -171,8 +173,7 @@ func TargetRequiredDependencies(target ssh.Destination) []Dependency {
 	remoteprocRuntimeShim := Dependency{
 		ID:                    DependencyID("containerd-shim-remoteproc-v1"),
 		Label:                 "Remoteproc Shim",
-		SoftwarePrerequisites: []DependencyID{docker.ID},
-		HardwarePrerequisites: []HardwareCapability{Remoteproc},
+		SoftwarePrerequisites: []DependencyID{docker.ID, remoteproc.ID},
 		Check: func(ctx context.Context, r runner.Runner) DependencyCheckResult {
 			if err := r.BinaryExists(ctx, "containerd-shim-remoteproc-v1"); err != nil {
 				return DependencyCheckResult{Failure: &DependencyCheckFailure{
@@ -199,31 +200,45 @@ func TargetRequiredDependencies(target ssh.Destination) []Dependency {
 		},
 	}
 
-	return []Dependency{docker, remoteprocRuntime, remoteprocRuntimeShim, lscpu}
+	return []Dependency{docker, remoteproc, remoteprocRuntime, remoteprocRuntimeShim, lscpu}
+}
+
+func NewRemoteprocDependency() Dependency {
+	return Dependency{
+		ID:    DependencyID("remoteproc"),
+		Label: "Processing Domain Driver (remoteproc)",
+		Check: func(ctx context.Context, r runner.Runner) DependencyCheckResult {
+			remoteProcessors, err := probe.Remoteproc(ctx, r)
+			if err != nil {
+				return DependencyCheckResult{
+					Failure: &DependencyCheckFailure{
+						Severity: SeverityError,
+						Message:  err.Error(),
+					},
+				}
+			}
+			if len(remoteProcessors) > 0 {
+				names := make([]string, len(remoteProcessors))
+				for i, remoteProc := range remoteProcessors {
+					names[i] = remoteProc.Name
+				}
+				return DependencyCheckResult{
+					SuccessValue: strings.Join(names, ", "),
+				}
+			}
+			return DependencyCheckResult{
+				Failure: &DependencyCheckFailure{
+					Severity: SeverityInfo,
+					Message:  "no remoteproc devices found",
+				},
+			}
+		},
+	}
 }
 
 type DependencyStatus struct {
 	Dependency Dependency
 	Result     DependencyCheckResult
-}
-
-func FilterByHardware(deps []Dependency, hardware map[HardwareCapability]struct{}) []Dependency {
-	result := make([]Dependency, 0, len(deps))
-	for _, dep := range deps {
-		if len(dep.HardwarePrerequisites) == 0 || hardwareCapabilityMatches(dep.HardwarePrerequisites, hardware) {
-			result = append(result, dep)
-		}
-	}
-	return result
-}
-
-func hardwareCapabilityMatches(required []HardwareCapability, available map[HardwareCapability]struct{}) bool {
-	for _, capability := range required {
-		if _, exists := available[capability]; exists {
-			return true
-		}
-	}
-	return false
 }
 
 func PerformChecks(ctx context.Context, dependencies []Dependency, runner runner.Runner) []DependencyStatus {

--- a/internal/health/dependencies.go
+++ b/internal/health/dependencies.go
@@ -21,10 +21,10 @@ const containerEngineInstallURL = "https://github.com/arm/topo#install-a-contain
 type DependencyID string
 
 type Dependency struct {
-	ID                    DependencyID
-	Label                 string
-	Check                 DependencyCheckFn
-	SoftwarePrerequisites []DependencyID
+	ID            DependencyID
+	Label         string
+	Check         DependencyCheckFn
+	Prerequisites []DependencyID
 }
 
 type DependencyCheckFn func(ctx context.Context, r runner.Runner) DependencyCheckResult
@@ -120,7 +120,7 @@ func HostRequiredDependencies(skipVersionChecks bool) []Dependency {
 			}
 			return DependencyCheckResult{SuccessValue: "docker-compose"}
 		},
-		SoftwarePrerequisites: []DependencyID{docker.ID},
+		Prerequisites: []DependencyID{docker.ID},
 	}
 
 	return []Dependency{topo, ssh, docker, dockerCompose}
@@ -152,9 +152,9 @@ func TargetRequiredDependencies(target ssh.Destination) []Dependency {
 	remoteproc := NewRemoteprocDependency()
 
 	remoteprocRuntime := Dependency{
-		ID:                    DependencyID("remoteproc-runtime"),
-		Label:                 "Remoteproc Runtime",
-		SoftwarePrerequisites: []DependencyID{docker.ID, remoteproc.ID},
+		ID:            DependencyID("remoteproc-runtime"),
+		Label:         "Remoteproc Runtime",
+		Prerequisites: []DependencyID{docker.ID, remoteproc.ID},
 		Check: func(ctx context.Context, r runner.Runner) DependencyCheckResult {
 			if err := r.BinaryExists(ctx, "remoteproc-runtime"); err != nil {
 				return DependencyCheckResult{Failure: &DependencyCheckFailure{
@@ -171,9 +171,9 @@ func TargetRequiredDependencies(target ssh.Destination) []Dependency {
 	}
 
 	remoteprocRuntimeShim := Dependency{
-		ID:                    DependencyID("containerd-shim-remoteproc-v1"),
-		Label:                 "Remoteproc Shim",
-		SoftwarePrerequisites: []DependencyID{docker.ID, remoteproc.ID},
+		ID:            DependencyID("containerd-shim-remoteproc-v1"),
+		Label:         "Remoteproc Shim",
+		Prerequisites: []DependencyID{docker.ID, remoteproc.ID},
 		Check: func(ctx context.Context, r runner.Runner) DependencyCheckResult {
 			if err := r.BinaryExists(ctx, "containerd-shim-remoteproc-v1"); err != nil {
 				return DependencyCheckResult{Failure: &DependencyCheckFailure{
@@ -246,7 +246,7 @@ func PerformChecks(ctx context.Context, dependencies []Dependency, runner runner
 	result := make([]DependencyStatus, 0, len(dependencies))
 
 	for _, dep := range dependencies {
-		if !allPrerequisitesFulfilled(dep.SoftwarePrerequisites, healthy) {
+		if !allPrerequisitesFulfilled(dep.Prerequisites, healthy) {
 			continue
 		}
 

--- a/internal/health/dependencies_test.go
+++ b/internal/health/dependencies_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/arm/topo/internal/health"
@@ -143,54 +144,54 @@ func TestPerformChecks(t *testing.T) {
 	})
 }
 
-func TestFilterByHardware(t *testing.T) {
-	t.Run("includes dependencies with no hardware requirement", func(t *testing.T) {
-		deps := []health.Dependency{
-			{Label: "Container Engine"},
-		}
-		hardware := map[health.HardwareCapability]struct{}{}
-
-		got := health.FilterByHardware(deps, hardware)
-
-		assert.Equal(t, deps, got)
-	})
-
-	t.Run("includes dependencies when hardware is present", func(t *testing.T) {
-		deps := []health.Dependency{
-			{Label: "Runtime", HardwarePrerequisites: []health.HardwareCapability{health.Remoteproc}},
-		}
-		hardware := map[health.HardwareCapability]struct{}{health.Remoteproc: {}}
-
-		got := health.FilterByHardware(deps, hardware)
-
-		assert.Equal(t, deps, got)
-	})
-
-	t.Run("excludes dependencies when hardware is absent", func(t *testing.T) {
-		deps := []health.Dependency{
-			{Label: "Runtime", HardwarePrerequisites: []health.HardwareCapability{health.Remoteproc}},
-		}
-		hardware := map[health.HardwareCapability]struct{}{}
-
-		got := health.FilterByHardware(deps, hardware)
-
-		assert.Empty(t, got)
-	})
-
-	t.Run("filters mixed dependencies correctly", func(t *testing.T) {
-		deps := []health.Dependency{
-			{Label: "Food"},
-			{Label: "Runtime", HardwarePrerequisites: []health.HardwareCapability{health.Remoteproc}},
-			{Label: "Food"},
+func TestRemoteprocDependency(t *testing.T) {
+	t.Run("Check", func(t *testing.T) {
+		buildRunnerWithRemoteProcs := func(names []string) runner.Runner {
+			return &runner.Fake{Commands: map[string]runner.FakeResult{
+				"cat /sys/class/remoteproc/*/name": {Output: strings.Join(names, "\n")},
+			}}
 		}
 
-		got := health.FilterByHardware(deps, nil)
+		t.Run("fails when no remoteproc devices are found", func(t *testing.T) {
+			d := health.NewRemoteprocDependency()
+			r := buildRunnerWithRemoteProcs(nil)
 
-		want := []health.Dependency{
-			{Label: "Food"},
-			{Label: "Food"},
-		}
-		assert.Equal(t, want, got)
+			got := d.Check(context.Background(), r)
+
+			want := health.DependencyCheckResult{
+				Failure: &health.DependencyCheckFailure{
+					Severity: health.SeverityInfo,
+					Message:  "no remoteproc devices found",
+				},
+			}
+			assert.Equal(t, want, got)
+		})
+
+		t.Run("fails when remoteproc probe fails", func(t *testing.T) {
+			d := health.NewRemoteprocDependency()
+			r := &runner.Fake{Commands: map[string]runner.FakeResult{
+				"cat /sys/class/remoteproc/*/name": {Err: runner.ErrTimeout},
+			}}
+
+			got := d.Check(context.Background(), r)
+
+			want := health.DependencyCheckResult{
+				Failure: &health.DependencyCheckFailure{
+					Severity: health.SeverityError,
+					Message:  "timed out",
+				},
+			}
+			assert.Equal(t, want, got)
+		})
+
+		t.Run("reports remoteproc device names", func(t *testing.T) {
+			d := health.NewRemoteprocDependency()
+			r := buildRunnerWithRemoteProcs([]string{"m4_0", "m4_1"})
+
+			got := d.Check(context.Background(), r)
+
+			assert.Equal(t, health.DependencyCheckResult{SuccessValue: "m4_0, m4_1"}, got)
+		})
 	})
 }
 

--- a/internal/health/dependencies_test.go
+++ b/internal/health/dependencies_test.go
@@ -33,7 +33,7 @@ func TestDependencies(t *testing.T) {
 			ids := make([]health.DependencyID, 0, len(deps))
 			for _, dep := range deps {
 				ids = append(ids, dep.ID)
-				for _, prereq := range dep.SoftwarePrerequisites {
+				for _, prereq := range dep.Prerequisites {
 					require.Contains(t, ids, prereq)
 				}
 			}
@@ -46,7 +46,7 @@ func TestDependencies(t *testing.T) {
 			ids := make([]health.DependencyID, 0, len(deps))
 			for _, dep := range deps {
 				ids = append(ids, dep.ID)
-				for _, prereq := range dep.SoftwarePrerequisites {
+				for _, prereq := range dep.Prerequisites {
 					require.Contains(t, ids, prereq)
 				}
 			}
@@ -109,8 +109,8 @@ func TestPerformChecks(t *testing.T) {
 				Check: failingCheck,
 			}
 			pizzaWhichShouldBeOmitted := health.Dependency{
-				ID:                    "pizza",
-				SoftwarePrerequisites: []health.DependencyID{pineapple.ID, cheese.ID},
+				ID:            "pizza",
+				Prerequisites: []health.DependencyID{pineapple.ID, cheese.ID},
 			}
 			deps := []health.Dependency{
 				pineapple,
@@ -130,8 +130,8 @@ func TestPerformChecks(t *testing.T) {
 				Check: passingCheck,
 			}
 			luke := health.Dependency{
-				ID:                    "luke",
-				SoftwarePrerequisites: []health.DependencyID{vader.ID},
+				ID:            "luke",
+				Prerequisites: []health.DependencyID{vader.ID},
 			}
 			deps := []health.Dependency{vader, luke}
 

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/arm/topo/internal/command"
 	"github.com/arm/topo/internal/probe"
@@ -40,11 +39,10 @@ type HostReport struct {
 }
 
 type TargetReport struct {
-	Destination            string
-	IsLocalhost            bool
-	Connectivity           HealthCheck
-	Dependencies           []HealthCheck
-	ProcessingDomainDriver HealthCheck
+	Destination  string
+	IsLocalhost  bool
+	Connectivity HealthCheck
+	Dependencies []HealthCheck
 }
 
 type CheckHostOptions struct {
@@ -105,25 +103,6 @@ func GenerateTargetReport(targetStatus Status) TargetReport {
 	report := TargetReport{}
 	report.IsLocalhost = targetStatus.Connection.IsPlainLocalhost()
 	report.Connectivity = connectivityCheck(targetStatus.Connection)
-
-	report.ProcessingDomainDriver.Name = "Processing Domain Driver (remoteproc)"
-	remoteProcessors := targetStatus.Hardware.RemoteProcessors
-	switch {
-	case targetStatus.Hardware.Err != nil:
-		report.ProcessingDomainDriver.Status = CheckStatusError
-		report.ProcessingDomainDriver.Value = targetStatus.Hardware.Err.Error()
-	case len(remoteProcessors) > 0:
-		names := make([]string, len(remoteProcessors))
-		for i, remoteProc := range remoteProcessors {
-			names[i] = remoteProc.Name
-		}
-		report.ProcessingDomainDriver.Status = CheckStatusOK
-		report.ProcessingDomainDriver.Value = strings.Join(names, ", ")
-	default:
-		report.ProcessingDomainDriver.Status = CheckStatusInfo
-		report.ProcessingDomainDriver.Value = "no remoteproc devices found"
-	}
-
 	report.Dependencies = generateDependencyReport(targetStatus.Dependencies)
 	report.Destination = targetStatus.Connection.Destination.String()
 

--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -1,7 +1,6 @@
 package health_test
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/arm/topo/internal/health"
@@ -19,41 +18,6 @@ func TestGenerateHostReport(t *testing.T) {
 func TestGenerateTargetReport(t *testing.T) {
 	testDependencyReporting(t, func(statuses []health.DependencyStatus) []health.HealthCheck {
 		return health.GenerateTargetReport(health.Status{Dependencies: statuses}).Dependencies
-	})
-
-	t.Run("when no remoteproc devices are found, ProcessingDomainDriver health check an info message", func(t *testing.T) {
-		ts := health.Status{}
-
-		got := health.GenerateTargetReport(ts)
-
-		assert.Equal(t, health.CheckStatusInfo, got.ProcessingDomainDriver.Status)
-		assert.Equal(t, "no remoteproc devices found", got.ProcessingDomainDriver.Value)
-	})
-
-	t.Run("when remoteproc probe fails, ProcessingDomainDriver reports the error", func(t *testing.T) {
-		ts := health.Status{
-			Hardware: health.HardwareProfile{
-				Err: fmt.Errorf("timed out"),
-			},
-		}
-
-		got := health.GenerateTargetReport(ts)
-
-		assert.Equal(t, health.CheckStatusError, got.ProcessingDomainDriver.Status)
-		assert.Equal(t, "timed out", got.ProcessingDomainDriver.Value)
-	})
-
-	t.Run("when remoteproc devices are found, ProcessingDomainDriver status is ok and includes device names", func(t *testing.T) {
-		ts := health.Status{
-			Hardware: health.HardwareProfile{
-				RemoteProcessors: []probe.RemoteProcessor{{Name: "m4_0"}, {Name: "m4_1"}},
-			},
-		}
-
-		got := health.GenerateTargetReport(ts)
-
-		assert.Equal(t, health.CheckStatusOK, got.ProcessingDomainDriver.Status)
-		assert.Equal(t, "m4_0, m4_1", got.ProcessingDomainDriver.Value)
 	})
 
 	t.Run("when the target has a connection error, Connectivity status reports error", func(t *testing.T) {

--- a/internal/health/status.go
+++ b/internal/health/status.go
@@ -33,8 +33,7 @@ func ProbeHealthStatus(ctx context.Context, r runner.Runner, target ssh.Destinat
 	hs.Hardware.RemoteProcessors = remoteProcessors
 	hs.Hardware.Err = err
 
-	dependenciesToCheck := FilterByHardware(TargetRequiredDependencies(target), hs.Hardware.Capabilities())
-	hs.Dependencies = PerformChecks(ctx, dependenciesToCheck, r)
+	hs.Dependencies = PerformChecks(ctx, TargetRequiredDependencies(target), r)
 
 	return hs
 }

--- a/internal/output/views/health.go
+++ b/internal/output/views/health.go
@@ -52,7 +52,6 @@ const healthReportTemplate = `
     {{- range $targetCheckRow := .Target.Dependencies }}
 {{ template "checkRow" $targetCheckRow }}
     {{- end }}
-{{ template "checkRow" .Target.ProcessingDomainDriver }}
   {{- end }}
 {{- else -}}
 {{ sectionHeading "Target" }}
@@ -123,11 +122,10 @@ type hostReport struct {
 }
 
 type targetReport struct {
-	Destination            string        `json:"destination"`
-	IsLocalhost            bool          `json:"isLocalhost"`
-	Connectivity           healthCheck   `json:"connectivity"`
-	Dependencies           []healthCheck `json:"dependencies"`
-	ProcessingDomainDriver healthCheck   `json:"processingDomainDriver"`
+	Destination  string        `json:"destination"`
+	IsLocalhost  bool          `json:"isLocalhost"`
+	Connectivity healthCheck   `json:"connectivity"`
+	Dependencies []healthCheck `json:"dependencies"`
 }
 
 type healthCheck struct {
@@ -148,11 +146,10 @@ func toViewHostReport(report health.HostReport) hostReport {
 
 func toViewTargetReport(report health.TargetReport) targetReport {
 	return targetReport{
-		Destination:            report.Destination,
-		IsLocalhost:            report.IsLocalhost,
-		Connectivity:           toViewHealthCheck(report.Connectivity),
-		Dependencies:           toViewHealthCheckList(report.Dependencies),
-		ProcessingDomainDriver: toViewHealthCheck(report.ProcessingDomainDriver),
+		Destination:  report.Destination,
+		IsLocalhost:  report.IsLocalhost,
+		Connectivity: toViewHealthCheck(report.Connectivity),
+		Dependencies: toViewHealthCheckList(report.Dependencies),
 	}
 }
 

--- a/internal/output/views/health_test.go
+++ b/internal/output/views/health_test.go
@@ -53,13 +53,8 @@ func TestHealthReport(t *testing.T) {
 		t.Run("it renders a warning icon for warning checks", func(t *testing.T) {
 			toPrint := views.NewHealthReport(health.HostReport{}, &health.TargetReport{
 				Connectivity: health.HealthCheck{
-					Name:   "Connected",
-					Status: health.CheckStatusOK,
-				},
-				ProcessingDomainDriver: health.HealthCheck{
-					Name:   "Processing Domain Driver (remoteproc)",
+					Name:   "Pineapple on pizza",
 					Status: health.CheckStatusWarning,
-					Value:  "no remoteproc devices found",
 				},
 			}, "")
 			var out bytes.Buffer
@@ -67,19 +62,14 @@ func TestHealthReport(t *testing.T) {
 			err := views.Print(toPrint, &out, term.Plain)
 
 			require.NoError(t, err)
-			assert.Contains(t, out.String(), " ! Processing Domain Driver (remoteproc) (no remoteproc devices found)")
+			assert.Contains(t, out.String(), " ! Pineapple on pizza")
 		})
 
 		t.Run("it renders an info icon for info checks", func(t *testing.T) {
 			toPrint := views.NewHealthReport(health.HostReport{}, &health.TargetReport{
 				Connectivity: health.HealthCheck{
-					Name:   "Connected",
-					Status: health.CheckStatusOK,
-				},
-				ProcessingDomainDriver: health.HealthCheck{
-					Name:   "Processing Domain Driver (remoteproc)",
+					Name:   "Has potatoes",
 					Status: health.CheckStatusInfo,
-					Value:  "no remoteproc devices found",
 				},
 			}, "")
 			var out bytes.Buffer
@@ -87,7 +77,7 @@ func TestHealthReport(t *testing.T) {
 			err := views.Print(toPrint, &out, term.Plain)
 
 			require.NoError(t, err)
-			assert.Contains(t, out.String(), " i Processing Domain Driver (remoteproc) (no remoteproc devices found)")
+			assert.Contains(t, out.String(), " i Has potatoes")
 		})
 
 		t.Run("it renders connection failures", func(t *testing.T) {
@@ -199,9 +189,6 @@ func TestHealthReport(t *testing.T) {
 					Name:   "Connected",
 					Status: health.CheckStatusOK,
 				},
-				ProcessingDomainDriver: health.HealthCheck{
-					Status: health.CheckStatusWarning,
-				},
 			}, "")
 			var out bytes.Buffer
 
@@ -218,8 +205,7 @@ func TestHealthReport(t *testing.T) {
 					"destination": "ssh://user@my-target",
 					"isLocalhost": false,
 					"connectivity": {"name":"Connected","status":"ok","value":""},
-					"dependencies": [],
-					"processingDomainDriver": {"name":"","status":"warning","value":""}
+					"dependencies": []
 				}
 			}`
 			assert.JSONEq(t, want, out.String())


### PR DESCRIPTION
## Changes

Model the remoteproc driver check as a target dependency instead of a separate out of band hardware check. 
Once "connectivity" is also migrated in a subsequent PR, we'll have a simple collection of dependencies that can be set as prerequisites to each other and grouped independently into flows (deployment, general host/target health).

## Checklist

- [x] 🤖 This change is covered by tests as required.
- [ ] 🤹 All required manual testing has been performed.
- [ ] 📖 All documentation updates are complete.